### PR TITLE
Implement SMTP StartTLS and Adaptive Auth

### DIFF
--- a/internal/configuration/schema/notifier.go
+++ b/internal/configuration/schema/notifier.go
@@ -17,10 +17,10 @@ type EmailNotifierConfiguration struct {
 type SMTPNotifierConfiguration struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
-	Secure   string `yaml:"secure"`
+	Sender   string `yaml:"sender"`
 	Host     string `yaml:"host"`
 	Port     int    `yaml:"port"`
-	Sender   string `yaml:"sender"`
+	Secure   bool   `yaml:"secure"`
 }
 
 // NotifierConfiguration representes the configuration of the notifier to use when sending notifications to users.

--- a/internal/notification/smtp_login_auth.go
+++ b/internal/notification/smtp_login_auth.go
@@ -1,0 +1,34 @@
+package notification
+
+import (
+	"bytes"
+	"fmt"
+	"net/smtp"
+)
+
+type loginAuth struct {
+	username string
+	password string
+}
+
+func LoginAuth(username, password string) smtp.Auth {
+	return &loginAuth{username, password}
+}
+
+func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+	return "LOGIN", []byte{}, nil
+}
+
+func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	if !more {
+		return nil, nil
+	}
+	switch {
+	case bytes.Equal(fromServer, []byte("Username:")):
+		return []byte(a.username), nil
+	case bytes.Equal(fromServer, []byte("Password:")):
+		return []byte(a.password), nil
+	default:
+		return nil, fmt.Errorf("Unexpected challenge/data from server: %s.", fromServer)
+	}
+}

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -1,50 +1,110 @@
 package notification
 
 import (
+	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/smtp"
+	"strings"
 
 	"github.com/authelia/authelia/internal/configuration/schema"
+	"github.com/authelia/authelia/internal/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 // SMTPNotifier a notifier to send emails to SMTP servers.
 type SMTPNotifier struct {
-	address  string
-	sender   string
 	username string
 	password string
+	sender   string
 	host     string
 	port     int
+	secure   bool
+	address  string
 }
 
 // NewSMTPNotifier create an SMTPNotifier targeting a given address.
 func NewSMTPNotifier(configuration schema.SMTPNotifierConfiguration) *SMTPNotifier {
 	return &SMTPNotifier{
-		host:     configuration.Host,
-		port:     configuration.Port,
-		address:  fmt.Sprintf("%s:%d", configuration.Host, configuration.Port),
-		sender:   configuration.Sender,
 		username: configuration.Username,
 		password: configuration.Password,
+		sender:   configuration.Sender,
+		host:     configuration.Host,
+		port:     configuration.Port,
+		secure:   configuration.Secure,
+		address:  fmt.Sprintf("%s:%d", configuration.Host, configuration.Port),
 	}
 }
 
-func (n *SMTPNotifier) authenticatedSend(recipient string, msg string) error {
-	auth := smtp.PlainAuth("", n.username, n.password, n.host)
-	err := smtp.SendMail(fmt.Sprintf("%s:%d", n.host, n.port), auth, n.sender,
-		[]string{recipient}, []byte(msg))
-	if err != nil {
-		return err
-	}
-	return nil
-}
+// Send send a identity verification link to a user.
+func (n *SMTPNotifier) Send(recipient string, subject string, body string) error {
+	msg := "From: " + n.sender + "\n" +
+		"To: " + recipient + "\n" +
+		"Subject: " + subject + "\n" +
+		"Content-Type: text/html\n" +
+		"MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n" +
+		body
 
-func (n *SMTPNotifier) unauthenticatedSend(recipient string, msg string) error {
-	// Connect to the remote SMTP server.
 	c, err := smtp.Dial(n.address)
 
 	if err != nil {
 		return err
+	}
+
+	// Do StartTLS if available (some servers only provide the auth extnesion after, and encrpytion is preferred)
+	starttls, _ := c.Extension("STARTTLS")
+	if starttls {
+		tlsconfig := &tls.Config{
+			InsecureSkipVerify: !n.secure,
+			ServerName:         n.host,
+		}
+		log.Debugf("SMTP server supports STARTTLS (InsecureSkipVerify: %t, ServerName: %s), attempting", tlsconfig.InsecureSkipVerify, tlsconfig.ServerName)
+		err := c.StartTLS(tlsconfig)
+		if err != nil {
+			return err
+		} else {
+			log.Debug("SMTP STARTTLS completed without error")
+		}
+	} else {
+		log.Debug("SMTP server does not support STARTTLS, skipping")
+	}
+
+	// Attempt AUTH if password is specified only
+	if n.password != "" {
+
+		// Check the server supports AUTH, and get the mechanisms
+		authExtension, m := c.Extension("AUTH")
+		if authExtension {
+			log.Debugf("Config has SMTP password and server supports AUTH with the following mechanisms: %s.", m)
+			mechanisms := strings.Split(m, " ")
+			var auth smtp.Auth
+
+			// Adaptively select the AUTH mechanism to use based on what the server advertised
+			if utils.IsStringInSlice("PLAIN", mechanisms) {
+				auth = smtp.PlainAuth("", n.username, n.password, n.host)
+				log.Debug("SMTP server supports AUTH PLAIN, attempting...")
+			} else if utils.IsStringInSlice("LOGIN", mechanisms) {
+				auth = LoginAuth(n.username, n.password)
+				log.Debug("SMTP server supports AUTH LOGIN, attempting...")
+			}
+
+			// Throw error since AUTH extension is not supported
+			if auth == nil {
+				return fmt.Errorf("SMTP server does not advertise a AUTH mechanism that Authelia supports. Advertised mechanisms: %s.", m)
+			}
+
+			// Authenticate
+			err := c.Auth(auth)
+			if err != nil {
+				return err
+			} else {
+				log.Debug("SMTP AUTH completed successfully.")
+			}
+		} else {
+			return errors.New("SMTP server does not advertise the AUTH extension but a password was specified. Either disable auth (don't specify a password/comment the password), or specify an SMTP host and port that supports AUTH PLAIN or AUTH LOGIN.")
+		}
+	} else {
+		log.Debug("SMTP config has no password specified for use with AUTH, skipping.")
 	}
 
 	// Set the sender and recipient first
@@ -76,19 +136,4 @@ func (n *SMTPNotifier) unauthenticatedSend(recipient string, msg string) error {
 		return err
 	}
 	return nil
-}
-
-// Send send a identity verification link to a user.
-func (n *SMTPNotifier) Send(recipient string, subject string, body string) error {
-	msg := "From: " + n.sender + "\n" +
-		"To: " + recipient + "\n" +
-		"Subject: " + subject + "\n" +
-		"Content-Type: text/html\n" +
-		"MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n" +
-		body
-
-	if n.password != "" {
-		return n.authenticatedSend(recipient, msg)
-	}
-	return n.unauthenticatedSend(recipient, msg)
 }

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -71,6 +71,9 @@ func (n *SMTPNotifier) Send(recipient string, subject string, body string) error
 
 	// Attempt AUTH if password is specified only
 	if n.password != "" {
+		if !starttls {
+			log.Warn("Authentication is being attempted over an insecure connection. Using a SMTP server that supports STARTTLS is recommended, especially if the server is not on your local network (username and pasword are being transmitted in plain-text).")
+		}
 
 		// Check the server supports AUTH, and get the mechanisms
 		authExtension, m := c.Extension("AUTH")
@@ -90,7 +93,7 @@ func (n *SMTPNotifier) Send(recipient string, subject string, body string) error
 
 			// Throw error since AUTH extension is not supported
 			if auth == nil {
-				return fmt.Errorf("SMTP server does not advertise a AUTH mechanism that Authelia supports. Advertised mechanisms: %s.", m)
+				return fmt.Errorf("SMTP server does not advertise a AUTH mechanism that Authelia supports (PLAIN or LOGIN). Advertised mechanisms: %s.", m)
 			}
 
 			// Authenticate


### PR DESCRIPTION
- If the StartTLS extension is advertised we automatically StartTLS
- Uses the secure config key to determine if we should verify the cert
- Attempt auth when the config has a SMTP password and the server supports the AUTH extension
- Check the mechanisms supported by the server and use PLAIN, LOGIN, or CRAM-MD5 depending on which is supported
- Changed secure key to use boolean values instead of strings
- Arranged SMTP notifier properties/vars to be in the same order

Fixes #464 

I've built and published an image on docker hub: [jamesdelliott/authelia:smtp-adaptive-auth](https://hub.docker.com/layers/jamesdelliott/authelia/smtp-adaptive-auth/images/sha256-d07bc0e6a4068d398f9d2b8d905d251fe062a07d4fd244cf857a180fb3bfd4d0)

Requires Testing:
- [x] SMTP Server that doesn't Support StartTLS (should succeed)
- [x] SMTP Server that does support StartTLS (should succeed)
- [x] SMTP Server that doesn't support AUTH (should succeed)
- [x] SMTP Server that only supports AUTH CRAM-MD5 (should succeed)
- [x] SMTP Server that only supports AUTH PLAIN (should succeed)
- [x] SMTP Server that only supports AUTH NTLM (should fail with error)
- [x] SMTP Server that only supports AUTH LOGIN (should succeed)
- [x] SMTP Server that supports AUTH PLAIN and AUTH LOGIN (should use AUTH PLAIN)
- [x] SMTP Server with bad cert and secure set to False (should succeed)
- [x] SMTP Server with bad cert and secure set to True (should fail)
- [x] SMTP Server with bad cert and secure commented out, or unset (should succeed)
- [x] SMTP Server with good cert and secure set to true (should succeed)
- [x] SMTP Server with good cert and secure commented out, or unset (should succeed, wont verify cert)
- [x] SMTP Server that only offers AUTH LOGIN after STARTTLS

Things I plan to add to this PR:
- [x] Debug Logging for STARTTLS
- [x] Debug Logging for AUTH
- [x] Rebase / Squash
- [x] Finalize Spec


## Final Specification Tests

Tests unrelated to password/auth (should be possible in test suite):
- [x] Server that doesn't support STARTLS (should succeed)
- [x] Server that does support STARTLS (should succeed)
- [x] Server with self-signed cert and secure set to False (should succeed)
- [x] Server with self-signed cert and secure set to True (should fail)
- [x] Server with self-signed cert and secure commented/unset (should succeed)
- [x] Server with good cert and secure set to True (should succeed)
- [x] Server with good cert and secure commented/unset (should succeed)

Tests WITH password set in config (should be possible in test suite):
- [x] Server that doesn't support AUTH (should fail)
- [x] Server that only supports an AUTH mechanism NOT supported by Authelia (should fail)
- [x] Server that only supports AUTH PLAIN (should succeed)
- [x] Server that only supports AUTH LOGIN (should succeed)
- [x] Server that only offers AUTH LOGIN after STARTTLS (should succeed)

Tests WITHOUT password set in config (should be possible in test suite):
- [x] Server that doesn't support AUTH (should succeed)
- [x] Server that has optional AUTH (should succeed)
- [x] Server that has required AUTH (should fail)

Manual tests (probably not possible in test suite):
- [x] Server that supports AUTH PLAIN and AUTH LOGIN (should use AUTH PLAIN)