### PR TITLE
Automatically retry failed Buildkite integration tests

### DIFF
--- a/.buildkite/steps/e2etests.sh
+++ b/.buildkite/steps/e2etests.sh
@@ -6,6 +6,8 @@ do
   echo "  - label: \":selenium: ${SUITE_NAME} Suite\""
   echo "    commands:"
   echo "      - \"authelia-scripts --log-level debug suites test ${SUITE_NAME} --headless\""
+  echo "    retry:"
+  echo "      "automatic: true""
   if [[ "${SUITE_NAME}" != "Kubernetes" ]];
   then
     echo "    agents:"


### PR DESCRIPTION
Default parameters retry on exit_status=* and a single step is retried a maximum of 2 times (3 total runs including initial failure)