### PR TITLE
Optimise Travis build and deploy steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ jobs:
 
     - &build-images
       stage: build images
+      if: branch = "master" && type != "pull_request" || branch =~ /^v/
       env:
         - ARCH=amd64
       script:
@@ -115,6 +116,7 @@ jobs:
       env:
         - ARCH=arm64v8
     - stage: deploy manifests
+      if: branch = "master" && type != "pull_request" || branch =~ /^v/
       env:
         - DOCKER_CLI_EXPERIMENTAL=enabled
       script:


### PR DESCRIPTION
These steps should only run on the master or tagged branches.
This change also means that while we are utilising Travis that there aren't long 20-30 minute blocks waiting on a PR to go green due to the build steps.