### PR TITLE
Build static Go binary

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,8 @@ steps:
 
   - label: ":docker: Image Builds"
     command: ".buildkite/steps/buildimages.sh | buildkite-agent pipeline upload"
+    agents:
+      build: "true"
     branches: "master v*"
     depends_on:
       - "build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
     sed -i "s/__BUILD_TIME__/${BUILD_TIME}/" cmd/authelia/constants.go
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
-RUN cd cmd/authelia && GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags netgo -ldflags '-w' -o authelia && cd ../../
+RUN cd cmd/authelia && GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags netgo -ldflags '-w -linkmode external -extldflags -static' -o authelia && cd ../../
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
-RUN cd cmd/authelia-scripts && GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -o authelia-scripts
+RUN cd cmd/authelia-scripts && GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -o authelia-scripts -ldflags '-w -linkmode external -extldflags -static'
 
 
 # ========================================

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -28,10 +28,10 @@ RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
     sed -i "s/__BUILD_TIME__/${BUILD_TIME}/" cmd/authelia/constants.go
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
-RUN cd cmd/authelia && GOOS=linux GOARCH=arm CGO_ENABLED=1 go build -tags netgo -ldflags '-w' -o authelia && cd ../../
+RUN cd cmd/authelia && GOOS=linux GOARCH=arm CGO_ENABLED=1 go build -tags netgo -ldflags '-w -linkmode external -extldflags -static' -o authelia && cd ../../
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
-RUN cd cmd/authelia-scripts && GOOS=linux GOARCH=arm CGO_ENABLED=1 go build -o authelia-scripts
+RUN cd cmd/authelia-scripts && GOOS=linux GOARCH=arm CGO_ENABLED=1 go build -o authelia-scripts -ldflags '-w -linkmode external -extldflags -static'
 
 
 # ========================================

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -28,10 +28,10 @@ RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
     sed -i "s/__BUILD_TIME__/${BUILD_TIME}/" cmd/authelia/constants.go
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
-RUN cd cmd/authelia && GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -tags netgo -ldflags '-w' -o authelia && cd ../../
+RUN cd cmd/authelia && GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -tags netgo -ldflags '-w -linkmode external -extldflags -static' -o authelia && cd ../../
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
-RUN cd cmd/authelia-scripts && GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -o authelia-scripts
+RUN cd cmd/authelia-scripts && GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build -o authelia-scripts -ldflags '-w -linkmode external -extldflags -static'
 
 
 # ========================================


### PR DESCRIPTION
@clems4ever: I don't believe there's an actual requirement to have a Debian based container now that this the binary is truly static.
If there was another reason behind the Debian based container, let me know as I still have https://github.com/authelia/authelia/tree/docker-debian-variant sitting around.

Closes #496