### PR TITLE
Reflect change of 9ae2096 on the redirection param

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -21,7 +21,7 @@ fortunately migration tools are provided to ease the task.
 * The configuration mostly remained the same, only one major key has been added: `jwt_secret`
 and one key removed: `secure` from the SMTP notifier as the Go SMTP library default to TLS
 if available.
-* The Hash router has been removed and replaced by a Browser router. This means that the weird characters
+* The Hash router has been removed and replaced with a Browser router. This means that the weird characters
 /%23/ and /#/ in the redirection URL can now be safely removed.
 * The local storage used for dev purpose was a `nedb` database which was implementing the
 same interface as mongo but was not really standard. It has been replaced by a good old

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -21,8 +21,8 @@ fortunately migration tools are provided to ease the task.
 * The configuration mostly remained the same, only one major key has been added: `jwt_secret`
 and one key removed: `secure` from the SMTP notifier as the Go SMTP library default to TLS
 if available.
-* The Hash router has been replaced by a Browser router. This means that the weird characters
-/%23/ in the URL could now be safely removed.
+* The Hash router has been removed and replaced by a Browser router. This means that the weird characters
+/%23/ and /#/ in the redirection URL can now be safely removed.
 * The local storage used for dev purpose was a `nedb` database which was implementing the
 same interface as mongo but was not really standard. It has been replaced by a good old
 sqlite3 database.
@@ -32,7 +32,6 @@ with Golang libraries.
 available like allowing device cloning detection.
 * Furthermore, a top-notch web server implementation (fasthttp) has been selected to allow a
 large performance gain in order to use Authelia in demanding environments.
-* Redirect parameter for Nginx is now changed to `http://Authelia/?rd=RedirectURL`
 
 ### Data migration tools
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -32,6 +32,7 @@ with Golang libraries.
 available like allowing device cloning detection.
 * Furthermore, a top-notch web server implementation (fasthttp) has been selected to allow a
 large performance gain in order to use Authelia in demanding environments.
+* Redirect parameter for Nginx is now changed to `http://Authelia/?rd=RedirectURL`
 
 ### Data migration tools
 

--- a/docs/proxies/nginx.md
+++ b/docs/proxies/nginx.md
@@ -44,7 +44,7 @@ Here is a commented example of configuration
             # If it returns 200, then the request pass through to the backend.
             # For other type of errors, nginx will handle them as usual.
             # NOTE: do not forget to include /#/ representing the hash router of the web application.
-            error_page                  401 =302 https://login.example.com:8080/#/?rd=$target_url;
+            error_page                  401 =302 https://login.example.com:8080/?rd=$target_url;
 
             proxy_pass                  $upstream_endpoint;
         }

--- a/docs/proxies/nginx.md
+++ b/docs/proxies/nginx.md
@@ -43,7 +43,6 @@ Here is a commented example of configuration
             # If Authelia returns 401, then nginx redirects the user to the login portal.
             # If it returns 200, then the request pass through to the backend.
             # For other type of errors, nginx will handle them as usual.
-            # NOTE: do not forget to include /#/ representing the hash router of the web application.
             error_page                  401 =302 https://login.example.com:8080/?rd=$target_url;
 
             proxy_pass                  $upstream_endpoint;


### PR DESCRIPTION
In commit 9ae2096, the redirection parameter is changed in the example `nginx.conf`, and also in other places like `internal/middlewares/identity_verification.go`:

```
- link := fmt.Sprintf("%s://%s/#%s?token=%s", ctx.XForwardedProto(),
+ link := fmt.Sprintf("%s://%s%s?token=%s", ctx.XForwardedProto(),
```