### PR TITLE
Fixes Remember Me functionality

### DIFF
--- a/internal/handlers/handler_firstfactor.go
+++ b/internal/handlers/handler_firstfactor.go
@@ -76,9 +76,9 @@ func FirstFactorPost(ctx *middlewares.AutheliaCtx) {
 		return
 	}
 
-	// and avoid the cookie to expire if "Remember me" was ticked.
+	// set the cookie to expire in 1 year if "Remember me" was ticked.
 	if *bodyJSON.KeepMeLoggedIn {
-		err = ctx.Providers.SessionProvider.UpdateExpiration(ctx.RequestCtx, time.Duration(0))
+		err = ctx.Providers.SessionProvider.UpdateExpiration(ctx.RequestCtx, time.Duration(31556952 * time.Second))
 		if err != nil {
 			ctx.Error(fmt.Errorf("Unable to update expiration timer for user %s: %s", bodyJSON.Username, err), authenticationFailedMessage)
 			return


### PR DESCRIPTION
Adjust the remember me duration to 1 year. Was originally set to 0 which expires at the end of the user agents session. Usually this is when the browser is closed, tab is closed.

This functionality can still likely be reached by not selecting remember me, and having the expiration set to 0.

The behavior after this commit will be as follows (tested by me):
  Remember Me unchecked: duration set as expiration config.
  Remember me checked: duration set to 1 year.