### PR TITLE
Use keep me logged in bool

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,8 @@ steps:
   - label: ":hammer_and_wrench: Unit Test"
     command: "authelia-scripts --log-level debug ci"
 
+  - wait
+
   - label: ":docker: Image Builds"
     command: ".buildkite/steps/buildimages.sh | buildkite-agent pipeline upload"
     agents:

--- a/internal/handlers/handler_firstfactor.go
+++ b/internal/handlers/handler_firstfactor.go
@@ -102,6 +102,7 @@ func FirstFactorPost(ctx *middlewares.AutheliaCtx) {
 	userSession.Emails = userDetails.Emails
 	userSession.AuthenticationLevel = authentication.OneFactor
 	userSession.LastActivity = time.Now().Unix()
+	userSession.KeepMeLoggedIn = *bodyJSON.KeepMeLoggedIn
 	err = ctx.SaveSession(userSession)
 
 	if err != nil {

--- a/internal/handlers/handler_firstfactor_test.go
+++ b/internal/handlers/handler_firstfactor_test.go
@@ -171,10 +171,10 @@ func (s *FirstFactorSuite) TestShouldAuthenticateUserWithRememberMeChecked() {
 		Return(nil)
 
 	s.mock.Ctx.Request.SetBodyString(`{
-			"username": "test",
-			"password": "hello",
-			"keepMeLoggedIn": true
-		}`)
+		"username": "test",
+		"password": "hello",
+		"keepMeLoggedIn": true
+	}`)
 	FirstFactorPost(s.mock.Ctx)
 
 	// Respond with 200.
@@ -210,10 +210,10 @@ func (s *FirstFactorSuite) TestShouldAuthenticateUserWithRememberMeUnchecked() {
 		Return(nil)
 
 	s.mock.Ctx.Request.SetBodyString(`{
-			"username": "test",
-			"password": "hello",
-			"keepMeLoggedIn": false
-		}`)
+		"username": "test",
+		"password": "hello",
+		"keepMeLoggedIn": false
+	}`)
 	FirstFactorPost(s.mock.Ctx)
 
 	// Respond with 200.

--- a/internal/handlers/handler_firstfactor_test.go
+++ b/internal/handlers/handler_firstfactor_test.go
@@ -151,7 +151,7 @@ func (s *FirstFactorSuite) TestShouldFailIfAuthenticationMarkFail() {
 	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
 }
 
-func (s *FirstFactorSuite) TestShouldAuthenticateUser() {
+func (s *FirstFactorSuite) TestShouldAuthenticateUserWithRememberMeChecked() {
 	s.mock.UserProviderMock.
 		EXPECT().
 		CheckUserPassword(gomock.Eq("test"), gomock.Eq("hello")).
@@ -171,10 +171,10 @@ func (s *FirstFactorSuite) TestShouldAuthenticateUser() {
 		Return(nil)
 
 	s.mock.Ctx.Request.SetBodyString(`{
-		"username": "test",
-		"password": "hello",
-		"keepMeLoggedIn": true
-	}`)
+			"username": "test",
+			"password": "hello",
+			"keepMeLoggedIn": true
+		}`)
 	FirstFactorPost(s.mock.Ctx)
 
 	// Respond with 200.
@@ -184,10 +184,49 @@ func (s *FirstFactorSuite) TestShouldAuthenticateUser() {
 	// And store authentication in session.
 	session := s.mock.Ctx.GetSession()
 	assert.Equal(s.T(), "test", session.Username)
+	assert.Equal(s.T(), true, session.KeepMeLoggedIn)
 	assert.Equal(s.T(), authentication.OneFactor, session.AuthenticationLevel)
 	assert.Equal(s.T(), []string{"test@example.com"}, session.Emails)
 	assert.Equal(s.T(), []string{"dev", "admins"}, session.Groups)
+}
 
+func (s *FirstFactorSuite) TestShouldAuthenticateUserWithRememberMeUnchecked() {
+	s.mock.UserProviderMock.
+		EXPECT().
+		CheckUserPassword(gomock.Eq("test"), gomock.Eq("hello")).
+		Return(true, nil)
+
+	s.mock.UserProviderMock.
+		EXPECT().
+		GetDetails(gomock.Eq("test")).
+		Return(&authentication.UserDetails{
+			Emails: []string{"test@example.com"},
+			Groups: []string{"dev", "admins"},
+		}, nil)
+
+	s.mock.StorageProviderMock.
+		EXPECT().
+		AppendAuthenticationLog(gomock.Any()).
+		Return(nil)
+
+	s.mock.Ctx.Request.SetBodyString(`{
+			"username": "test",
+			"password": "hello",
+			"keepMeLoggedIn": false
+		}`)
+	FirstFactorPost(s.mock.Ctx)
+
+	// Respond with 200.
+	assert.Equal(s.T(), 200, s.mock.Ctx.Response.StatusCode())
+	assert.Equal(s.T(), []byte("{\"status\":\"OK\"}"), s.mock.Ctx.Response.Body())
+
+	// And store authentication in session.
+	session := s.mock.Ctx.GetSession()
+	assert.Equal(s.T(), "test", session.Username)
+	assert.Equal(s.T(), false, session.KeepMeLoggedIn)
+	assert.Equal(s.T(), authentication.OneFactor, session.AuthenticationLevel)
+	assert.Equal(s.T(), []string{"test@example.com"}, session.Emails)
+	assert.Equal(s.T(), []string{"dev", "admins"}, session.Groups)
 }
 
 func TestFirstFactorSuite(t *testing.T) {

--- a/internal/middlewares/types.go
+++ b/internal/middlewares/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authelia/authelia/internal/regulation"
 	"github.com/authelia/authelia/internal/session"
 	"github.com/authelia/authelia/internal/storage"
+	"github.com/authelia/authelia/internal/utils"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
@@ -20,7 +21,8 @@ type AutheliaCtx struct {
 	Logger        *logrus.Entry
 	Providers     Providers
 	Configuration schema.Configuration
-	userSession   session.UserSession
+
+	Clock utils.Clock
 }
 
 // Providers contain all provider provided to Authelia.

--- a/internal/session/provider_test.go
+++ b/internal/session/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authelia/authelia/internal/authentication"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/valyala/fasthttp"
 
@@ -20,7 +21,8 @@ func TestShouldInitializerSession(t *testing.T) {
 	configuration.Expiration = 40
 
 	provider := NewProvider(configuration)
-	session, _ := provider.GetSession(ctx)
+	session, err := provider.GetSession(ctx)
+	require.NoError(t, err)
 
 	assert.Equal(t, NewDefaultUserSession(), session)
 }
@@ -38,12 +40,45 @@ func TestShouldUpdateSession(t *testing.T) {
 	session.Username = "john"
 	session.AuthenticationLevel = authentication.TwoFactor
 
-	_ = provider.SaveSession(ctx, session)
+	err := provider.SaveSession(ctx, session)
+	require.NoError(t, err)
 
-	session, _ = provider.GetSession(ctx)
+	session, err = provider.GetSession(ctx)
+	require.NoError(t, err)
 
 	assert.Equal(t, UserSession{
 		Username:            "john",
 		AuthenticationLevel: authentication.TwoFactor,
 	}, session)
+}
+
+func TestShouldDestroySessionAndWipeSessionData(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	configuration := schema.SessionConfiguration{}
+	configuration.Domain = "example.com"
+	configuration.Name = "my_session"
+	configuration.Expiration = 40
+
+	provider := NewProvider(configuration)
+	session, err := provider.GetSession(ctx)
+	require.NoError(t, err)
+
+	session.Username = "john"
+	session.AuthenticationLevel = authentication.TwoFactor
+
+	err = provider.SaveSession(ctx, session)
+	require.NoError(t, err)
+
+	newUserSession, err := provider.GetSession(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "john", newUserSession.Username)
+	assert.Equal(t, authentication.TwoFactor, newUserSession.AuthenticationLevel)
+
+	err = provider.DestroySession(ctx)
+	require.NoError(t, err)
+
+	newUserSession, err = provider.GetSession(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "", newUserSession.Username)
+	assert.Equal(t, authentication.NotAuthenticated, newUserSession.AuthenticationLevel)
 }

--- a/internal/suites/scenario_inactivity_test.go
+++ b/internal/suites/scenario_inactivity_test.go
@@ -106,7 +106,7 @@ func (s *InactivityScenario) TestShouldDisableCookieExpirationAndInactivity() {
 	s.doVisit(s.T(), HomeBaseURL)
 	s.verifyIsHome(ctx, s.T())
 
-	time.Sleep(9 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	s.doVisit(s.T(), targetURL)
 	s.verifySecretAuthorized(ctx, s.T())

--- a/internal/suites/webdriver.go
+++ b/internal/suites/webdriver.go
@@ -31,6 +31,8 @@ func StartWebDriverWithProxy(proxy string, port int) (*WebDriverSession, error) 
 		Path: "/usr/bin/chromium-browser",
 	}
 
+	chromeCaps.Args = append(chromeCaps.Args, "--ignore-certificate-errors")
+
 	if os.Getenv("HEADLESS") != "" {
 		chromeCaps.Args = append(chromeCaps.Args, "--headless")
 		chromeCaps.Args = append(chromeCaps.Args, "--no-sandbox")


### PR DESCRIPTION
This must be merged prior to https://github.com/authelia/authelia/pull/554 to fix the tests.

This PR uses keep me logged boolean stored in the user session instead of relying on the expiration value stored in the cookie. That way we will be able to set an expiration to 1 year instead of 0.

This PR also removes user session caching in AutheliaCtx to make sure that user session is correctly wiped when inactivity timeout is reached.