### PR TITLE
[FIX] Disable regulation when max_retries set to 0 (#584)

### DIFF
--- a/internal/regulation/regulator.go
+++ b/internal/regulation/regulator.go
@@ -18,7 +18,8 @@ func NewRegulator(configuration *schema.RegulationConfiguration, provider storag
 		if configuration.FindTime > configuration.BanTime {
 			panic(fmt.Errorf("find_time cannot be greater than ban_time"))
 		}
-		regulator.enabled = true
+		// Set regulator enabled only if MaxRetries is not 0.
+		regulator.enabled = configuration.MaxRetries > 0
 		regulator.maxRetries = configuration.MaxRetries
 		regulator.findTime = time.Duration(configuration.FindTime) * time.Second
 		regulator.banTime = time.Duration(configuration.BanTime) * time.Second


### PR DESCRIPTION
- Only set regulator to enabled if max_retries is not set to 0, default is false (zero value). See 
https://tour.golang.org/basics/12.
- Added test for the scenario.
- Fixes #584


I have PR's #588 and #589 open, and will rebase & force push which ever one is not merged first (and this is to be expected behaviour from me unless you have an alternate preference).