### PR TITLE
[MISC] Utilise Probot for PR commentary

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -14,17 +14,6 @@ if [[ $BUILDKITE_LABEL =~ ":docker: Deploy" ]]; then
   docker logout
 fi
 
-if [[ $BUILDKITE_LABEL == ":docker: Deploy Manifests" ]] && [[ $BUILDKITE_PULL_REQUEST != "false" ]]; then
-  if [[ ! $(curl -fs --retry 3 "https://api.github.com/repos/authelia/authelia/issues/${BUILDKITE_PULL_REQUEST}/comments" | jq '.[].user.login') =~ autheliabot ]]; then
-    echo "--- :github: Add deployment commentary"
-    if [[ $BUILDKITE_PULL_REQUEST_REPO == "git://github.com/authelia/authelia.git" ]]; then
-      curl -fs --retry 3 -H "Authorization: token ${GITHUB_COMMENT_TOKEN}" -X "POST" -d "{\"body\": \"# Docker Container\nThese changes are published for testing at the following location:\n* \`docker pull authelia/authelia:${BUILDKITE_BRANCH}\`\"}" "https://api.github.com/repos/authelia/authelia/issues/${BUILDKITE_PULL_REQUEST}/comments"
-    else
-      curl -fs --retry 3 -H "Authorization: token ${GITHUB_COMMENT_TOKEN}" -X "POST" -d "{\"body\": \"# Docker Container\nThese changes are published for testing at the following location:\n* \`docker pull authelia/authelia:PR${BUILDKITE_PULL_REQUEST}\`\"}" "https://api.github.com/repos/authelia/authelia/issues/${BUILDKITE_PULL_REQUEST}/comments"
-    fi
-  fi
-fi
-
 if [[ $BUILDKITE_LABEL == ":docker: Deploy Manifests" ]] && [[ $BUILDKITE_BRANCH == "master" ]] && [[ $BUILDKITE_PULL_REQUEST == "false" ]]; then
   echo "--- :docker: Removing tags for deleted branches"
   anontoken=$(curl -fsL --retry 3 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:authelia/authelia:pull' | jq -r .token)

--- a/.github/probot.js
+++ b/.github/probot.js
@@ -1,0 +1,19 @@
+// PR commentary for Authelia branch based contributions
+on('pull_request.opened')
+    .filter(
+        context =>
+            context.payload.pull_request.head.label.slice(0, 9) === 'authelia:'
+    )
+    .comment(`# Docker Container
+These changes are published for testing at the following location:
+* \`docker pull authelia/authelia:{{ pull_request.head.ref }}\``)
+
+// PR commentary for third party based contributions
+on('pull_request.opened')
+    .filter(
+        context =>
+            context.payload.pull_request.head.label.slice(0, 9) !== 'authelia:'
+    )
+    .comment(`# Docker Container
+These changes once approved by a team member will be published for testing at the following location:
+* \`docker pull authelia/authelia:PR{{ pull_request.number }}\``)


### PR DESCRIPTION
This also removes the Buildkite trigger for commentary.

@clems4ever we need to do a couple things before this is merged.