### PR TITLE
[Docker] Include docker-compose.yml examples to run Authelia

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,24 @@ Docker or on top of [Kubernetes].
 
 ## Getting Started
 
-You can start off with
+You can start utilising Authelia with the provided `docker-compose` bundles:
 
-    git clone https://github.com/authelia/authelia.git && cd authelia
-    source bootstrap.sh
+##### Local
+The Local compose bundle is intended for scenarios where the server will not be exposed to the internet, domains will be defined in the local hosts file and self-signed certificates will be utilised.  
+
+##### Lite
+The Lite compose bundle is intended for scenarios where the server will be exposed to the internet, domains and DNS will need to be setup accordingly and certificates will be generated through LetsEncrypt.
+The Lite element refers to minimal external dependencies; File based user storage, SQLite based configuration storage. In this configuration, the service will not scale well.
+
+##### Full
+The Full compose bundle is intended for scenarios where the server will be exposed to the internet, domains and DNS will need to be setup accordingly and certificates will be generated through LetsEncrypt.
+The Full element refers to a scalable setup which includes external dependencies; LDAP based user storage, Database based configuration storage (MariaDB or Postgres). 
+
+- `git clone https://github.com/authelia/authelia.git`
+- `cd authelia/compose/{local,lite,full}` based on the bundle you plan to run
+- If running Local or Lite modify the `users_database.yml` the default username and password is `authelia`
+- Modify the `configuration.yml` and `docker-compose.yml` with your respective domains and secrets
+- `docker-compose up -d`
 
 If you want to go further, please read [Getting Started](https://docs.authelia.com/getting-started).
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ Docker or on top of [Kubernetes].
 You can start utilising Authelia with the provided `docker-compose` bundles:
 
 ##### Local
-The Local compose bundle is intended for scenarios where the server will not be exposed to the internet, domains will be defined in the local hosts file and self-signed certificates will be utilised.
-This bundle includes a script to generate all the required configuration and is intended as the quickest method to demo Authelia.
+The Local compose bundle is intended to test Authelia without worrying about configuration.
+It's meant to be used for scenarios where the server is not be exposed to the internet.
+Domains will be defined in the local hosts file and self-signed certificates will be utilised.
 
 ##### Lite
 The Lite compose bundle is intended for scenarios where the server will be exposed to the internet, domains and DNS will need to be setup accordingly and certificates will be generated through LetsEncrypt.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Docker or on top of [Kubernetes].
 You can start utilising Authelia with the provided `docker-compose` bundles:
 
 ##### Local
-The Local compose bundle is intended for scenarios where the server will not be exposed to the internet, domains will be defined in the local hosts file and self-signed certificates will be utilised.  
+The Local compose bundle is intended for scenarios where the server will not be exposed to the internet, domains will be defined in the local hosts file and self-signed certificates will be utilised.
+This bundle includes a script to generate all the required configuration and is intended as the quickest method to demo Authelia.
 
 ##### Lite
 The Lite compose bundle is intended for scenarios where the server will be exposed to the internet, domains and DNS will need to be setup accordingly and certificates will be generated through LetsEncrypt.
@@ -90,13 +91,7 @@ The Lite element refers to minimal external dependencies; File based user storag
 
 ##### Full
 The Full compose bundle is intended for scenarios where the server will be exposed to the internet, domains and DNS will need to be setup accordingly and certificates will be generated through LetsEncrypt.
-The Full element refers to a scalable setup which includes external dependencies; LDAP based user storage, Database based configuration storage (MariaDB or Postgres). 
-
-- `git clone https://github.com/authelia/authelia.git`
-- `cd authelia/compose/{local,lite,full}` based on the bundle you plan to run
-- If running Local or Lite modify the `users_database.yml` the default username and password is `authelia`
-- Modify the `configuration.yml` and `docker-compose.yml` with your respective domains and secrets
-- `docker-compose up -d`
+The Full element refers to a scalable setup which includes external dependencies; LDAP based user storage, Database based configuration storage (MariaDB, MySQL or Postgres). 
 
 If you want to go further, please read [Getting Started](https://docs.authelia.com/getting-started).
 

--- a/README.md
+++ b/README.md
@@ -81,20 +81,18 @@ Docker or on top of [Kubernetes].
 
 You can start utilising Authelia with the provided `docker-compose` bundles:
 
-##### Local
+##### [Local](https://docs.authelia.com/getting-started)
 The Local compose bundle is intended to test Authelia without worrying about configuration.
 It's meant to be used for scenarios where the server is not be exposed to the internet.
 Domains will be defined in the local hosts file and self-signed certificates will be utilised.
 
-##### Lite
+##### [Lite](https://docs.authelia.com/deployment/deployment-lite)
 The Lite compose bundle is intended for scenarios where the server will be exposed to the internet, domains and DNS will need to be setup accordingly and certificates will be generated through LetsEncrypt.
 The Lite element refers to minimal external dependencies; File based user storage, SQLite based configuration storage. In this configuration, the service will not scale well.
 
-##### Full
+##### [Full](https://docs.authelia.com/deployment/deployment-ha)
 The Full compose bundle is intended for scenarios where the server will be exposed to the internet, domains and DNS will need to be setup accordingly and certificates will be generated through LetsEncrypt.
 The Full element refers to a scalable setup which includes external dependencies; LDAP based user storage, Database based configuration storage (MariaDB, MySQL or Postgres). 
-
-If you want to go further, please read [Getting Started](https://docs.authelia.com/getting-started).
 
 ## Deployment
 

--- a/compose/lite/configuration.yml
+++ b/compose/lite/configuration.yml
@@ -1,0 +1,65 @@
+###############################################################
+#                   Authelia configuration                    #
+###############################################################
+
+host: 0.0.0.0
+port: 9091
+log_level: debug
+# This secret can also be set using the env variables AUTHELIA_JWT_SECRET
+jwt_secret: a_very_important_secret
+default_redirection_url: https://public.example.com
+totp:
+  issuer: authelia.com
+
+#duo_api:
+#  hostname: api-123456789.example.com
+#  integration_key: ABCDEF
+#  # This secret can also be set using the env variables AUTHELIA_DUO_API_SECRET_KEY
+#  secret_key: 1234567890abcdefghifjkl
+
+authentication_backend:
+  file:
+    path: /etc/authelia/users_database.yml
+
+access_control:
+  default_policy: deny
+  rules:
+    # Rules applied to everyone
+    - domain: public.example.com
+      policy: bypass
+    - domain: traefik.example.com
+      policy: one_factor
+    - domain: secure.example.com
+      policy: two_factor
+
+session:
+  name: authelia_session
+  # This secret can also be set using the env variables AUTHELIA_SESSION_SECRET
+  secret: unsecure_session_secret
+  expiration: 3600 # 1 hour
+  inactivity: 300 # 5 minutes
+  domain: example.com # Should match whatever your root protected domain is
+
+  redis:
+    host: redis
+    port: 6379
+    # This secret can also be set using the env variables AUTHELIA_SESSION_REDIS_PASSWORD
+    password: authelia
+
+regulation:
+  max_retries: 3
+  find_time: 120
+  ban_time: 300
+
+storage:
+  local:
+    path: /var/lib/authelia/db.sqlite3
+
+notifier:
+  smtp:
+    username: test
+    # This secret can also be set using the env variables AUTHELIA_NOTIFIER_SMTP_PASSWORD
+    password: password
+    host: mail.example.com
+    port: 25
+    sender: admin@example.com

--- a/compose/lite/docker-compose.yml
+++ b/compose/lite/docker-compose.yml
@@ -1,0 +1,108 @@
+version: '3.7'
+
+networks:
+  net:
+    driver: bridge
+
+services:
+  authelia:
+    image: authelia/authelia
+    container_name: authelia
+    volumes:
+      - ./authelia:/var/lib/authelia
+      - ./configuration.yml:/etc/authelia/configuration.yml:ro
+      - ./users_database.yml:/etc/authelia/users_database.yml:ro
+    networks:
+      - net
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.authelia.rule=Host(`auth.example.com`)'
+      - 'traefik.http.routers.authelia.entrypoints=https'
+      - 'traefik.http.routers.authelia.tls=true'
+      - 'traefik.http.routers.authelia.tls.certresolver=letsencrypt'
+      - 'traefik.http.middlewares.authelia.forwardauth.address=http://authelia:9091/api/verify?rd=https://auth.example.com'
+      - 'traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true'
+    expose:
+      - 9091
+    restart: unless-stopped
+    environment:
+      - TZ=Australia/Melbourne
+
+  redis:
+    image: redis:alpine
+    container_name: redis
+    volumes:
+      - ./redis:/data
+    networks:
+      - net
+    expose:
+      - 6379
+    restart: unless-stopped
+    environment:
+      - TZ=Australia/Melbourne
+
+  traefik:
+    image: traefik:v2.1.3
+    container_name: traefik
+    volumes:
+      - ./traefik/acme.json:/acme.json
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - net
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.api.rule=Host(`traefik.example.com`)'
+      - 'traefik.http.routers.api.entrypoints=https'
+      - 'traefik.http.routers.api.service=api@internal'
+      - 'traefik.http.routers.api.tls=true'
+      - 'traefik.http.routers.api.tls.certresolver=letsencrypt'
+      - 'traefik.http.routers.api.middlewares=authelia@docker'
+    ports:
+      - 80:80
+      - 443:443
+    command:
+      - '--api'
+      - '--providers.docker=true'
+      - '--providers.docker.exposedByDefault=false'
+      - '--entrypoints.http=true'
+      - '--entrypoints.http.address=:80'
+      - '--entrypoints.https=true'
+      - '--entrypoints.https.address=:443'
+      - '--certificatesResolvers.letsencrypt.acme.email=your-email@your-domain.com'
+      - '--certificatesResolvers.letsencrypt.acme.storage=acme.json'
+      - '--certificatesResolvers.letsencrypt.acme.httpChallenge.entryPoint=http'
+      - '--log=true'
+      - '--log.level=DEBUG'
+      - '--log.filepath=/var/log/traefik.log'
+
+  secure:
+    image: containous/whoami
+    container_name: secure
+    networks:
+      - net
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.secure.rule=Host(`secure.example.com`)'
+      - 'traefik.http.routers.secure.entrypoints=https'
+      - 'traefik.http.routers.secure.tls=true'
+      - 'traefik.http.routers.secure.tls.certresolver=letsencrypt'
+      - 'traefik.http.routers.secure.middlewares=authelia@docker'
+    expose:
+      - 80
+    restart: unless-stopped
+
+    public:
+      image: containous/whoami
+      container_name: public
+      networks:
+        - net
+      labels:
+        - 'traefik.enable=true'
+        - 'traefik.http.routers.public.rule=Host(`public.example.com`)'
+        - 'traefik.http.routers.public.entrypoints=https'
+        - 'traefik.http.routers.public.tls=true'
+        - 'traefik.http.routers.public.tls.certresolver=letsencrypt'
+        - 'traefik.http.routers.public.middlewares=authelia@docker'
+      expose:
+        - 80
+      restart: unless-stopped

--- a/compose/lite/docker-compose.yml
+++ b/compose/lite/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - TZ=Australia/Melbourne
 
   traefik:
-    image: traefik:v2.1.3
+    image: traefik:v2.2
     container_name: traefik
     volumes:
       - ./traefik/acme.json:/acme.json
@@ -66,6 +66,8 @@ services:
       - '--providers.docker.exposedByDefault=false'
       - '--entrypoints.http=true'
       - '--entrypoints.http.address=:80'
+      - '--entrypoints.http.http.redirections.entrypoint.to=https'
+      - '--entrypoints.http.http.redirections.entrypoint.scheme=https'
       - '--entrypoints.https=true'
       - '--entrypoints.https.address=:443'
       - '--certificatesResolvers.letsencrypt.acme.email=your-email@your-domain.com'

--- a/compose/lite/docker-compose.yml
+++ b/compose/lite/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.3'
 
 networks:
   net:

--- a/compose/lite/docker-compose.yml
+++ b/compose/lite/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./authelia:/var/lib/authelia
       - ./configuration.yml:/etc/authelia/configuration.yml:ro
-      - ./users_database.yml:/etc/authelia/users_database.yml:ro
+      - ./users_database.yml:/etc/authelia/users_database.yml
     networks:
       - net
     labels:

--- a/compose/lite/users_database.yml
+++ b/compose/lite/users_database.yml
@@ -1,0 +1,14 @@
+###############################################################
+#                         Users Database                      #
+###############################################################
+
+# This file can be used if you do not have an LDAP set up.
+
+# List of users
+users:
+  authelia:
+    password: "$6$rounds=50000$BpLnfgDsc2WD8F2q$Zis.ixdg9s/UOJYrs56b5QEZFiZECu0qZVNsIYxBaNJ7ucIL.nlxVCT5tqh8KHG8X4tlwCFm5r6NTOZZ5qRFN/" # Password is 'authelia'
+    email: authelia@authelia.com
+    groups:
+      - admins
+      - dev

--- a/compose/local/configuration.yml
+++ b/compose/local/configuration.yml
@@ -1,0 +1,45 @@
+###############################################################
+#                   Authelia configuration                    #
+###############################################################
+
+host: 0.0.0.0
+port: 9091
+log_level: debug
+jwt_secret: a_very_important_secret
+default_redirection_url: https://public.example.com
+totp:
+  issuer: authelia.com
+
+authentication_backend:
+  file:
+    path: /etc/authelia/users_database.yml
+
+access_control:
+  default_policy: deny
+  rules:
+    - domain: public.example.com
+      policy: bypass
+    - domain: traefik.example.com
+      policy: one_factor
+    - domain: secure.example.com
+      policy: two_factor
+
+session:
+  name: authelia_session
+  secret: unsecure_session_secret
+  expiration: 3600 # 1 hour
+  inactivity: 300 # 5 minutes
+  domain: example.com # Should match whatever your root protected domain is
+
+regulation:
+  max_retries: 3
+  find_time: 120
+  ban_time: 300
+
+storage:
+  local:
+    path: /var/lib/authelia/db.sqlite3
+
+notifier:
+  filesystem:
+    filename: /var/lib/authelia/notification.txt

--- a/compose/local/docker-compose.yml
+++ b/compose/local/docker-compose.yml
@@ -1,0 +1,97 @@
+version: '3.7'
+
+networks:
+  net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.31.255.0/24
+
+services:
+  authelia:
+    image: authelia/authelia
+    container_name: authelia
+    volumes:
+      - ./authelia:/var/lib/authelia
+      - ./configuration.yml:/etc/authelia/configuration.yml:ro
+      - ./users_database.yml:/etc/authelia/users_database.yml:ro
+    networks:
+      - net
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.authelia.rule=Host(`authelia.example.com`)'
+      - 'traefik.http.routers.authelia.entrypoints=https'
+      - 'traefik.http.routers.authelia.tls=true'
+      - 'traefik.http.routers.authelia.tls.options=default'
+      - 'traefik.http.middlewares.authelia.forwardauth.address=http://authelia:9091/api/verify?rd=https://authelia.example.com'
+      - 'traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true'
+    expose:
+      - 9091
+    restart: unless-stopped
+    environment:
+      - TZ=Australia/Melbourne
+
+  traefik:
+    image: traefik:v2.1.3
+    container_name: traefik
+    volumes:
+      - ./traefik:/etc/traefik
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      net:
+        ipv4_address: 172.31.255.100
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.api.rule=Host(`traefik.example.com`)'
+      - 'traefik.http.routers.api.entrypoints=https'
+      - 'traefik.http.routers.api.service=api@internal'
+      - 'traefik.http.routers.api.tls=true'
+      - 'traefik.http.routers.api.tls.options=default'
+      - 'traefik.http.routers.api.middlewares=authelia@docker'
+    ports:
+      - 80:80
+      - 443:443
+    command:
+      - '--api'
+      - '--providers.docker=true'
+      - '--providers.docker.exposedByDefault=false'
+      - '--providers.file.filename=/etc/traefik/certificates.yml'
+      - '--entrypoints.http=true'
+      - '--entrypoints.http.address=:80'
+      - '--entrypoints.https=true'
+      - '--entrypoints.https.address=:443'
+      - '--log=true'
+      - '--log.level=DEBUG'
+      - '--log.filepath=/var/log/traefik.log'
+
+  secure:
+    image: containous/whoami
+    container_name: secure
+    networks:
+      - net
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.secure.rule=Host(`secure.example.com`)'
+      - 'traefik.http.routers.secure.entrypoints=https'
+      - 'traefik.http.routers.secure.tls=true'
+      - 'traefik.http.routers.secure.tls.options=default'
+      - 'traefik.http.routers.secure.middlewares=authelia@docker'
+    expose:
+      - 80
+    restart: unless-stopped
+
+  public:
+      image: containous/whoami
+      container_name: public
+      networks:
+        - net
+      labels:
+        - 'traefik.enable=true'
+        - 'traefik.http.routers.public.rule=Host(`public.example.com`)'
+        - 'traefik.http.routers.public.entrypoints=https'
+        - 'traefik.http.routers.public.tls=true'
+        - 'traefik.http.routers.public.tls.options=default'
+        - 'traefik.http.routers.public.middlewares=authelia@docker'
+      expose:
+        - 80
+      restart: unless-stopped

--- a/compose/local/docker-compose.yml
+++ b/compose/local/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - TZ=Australia/Melbourne
 
   traefik:
-    image: traefik:v2.1.3
+    image: traefik:v2.2
     container_name: traefik
     volumes:
       - ./traefik:/etc/traefik
@@ -58,6 +58,8 @@ services:
       - '--providers.file.filename=/etc/traefik/certificates.yml'
       - '--entrypoints.http=true'
       - '--entrypoints.http.address=:80'
+      - '--entrypoints.http.http.redirections.entrypoint.to=https'
+      - '--entrypoints.http.http.redirections.entrypoint.scheme=https'
       - '--entrypoints.https=true'
       - '--entrypoints.https.address=:443'
       - '--log=true'

--- a/compose/local/docker-compose.yml
+++ b/compose/local/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.3'
 
 networks:
   net:

--- a/compose/local/docker-compose.yml
+++ b/compose/local/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./authelia:/var/lib/authelia
       - ./configuration.yml:/etc/authelia/configuration.yml:ro
-      - ./users_database.yml:/etc/authelia/users_database.yml:ro
+      - ./users_database.yml:/etc/authelia/users_database.yml
     networks:
       - net
     labels:

--- a/compose/local/docker-compose.yml
+++ b/compose/local/docker-compose.yml
@@ -3,9 +3,6 @@ version: '3.7'
 networks:
   net:
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.31.255.0/24
 
 services:
   authelia:
@@ -38,8 +35,7 @@ services:
       - ./traefik:/etc/traefik
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
-      net:
-        ipv4_address: 172.31.255.100
+      - net
     labels:
       - 'traefik.enable=true'
       - 'traefik.http.routers.api.rule=Host(`traefik.example.com`)'

--- a/compose/local/setup.sh
+++ b/compose/local/setup.sh
@@ -87,6 +87,7 @@ You can now visit the following locations:
 - https://traefik.$DOMAIN - Secured with Authelia one-factor authentication
 - https://secure.$DOMAIN - Secured with Authelia two-factor authentication (see note below)
 
+You will need to authorize the self-signed certificate upon visiting each domain.
 To visit https://secure.$DOMAIN you will need to register a device for second factor authentication and confirm by clicking on a link sent by email. Since this is a demo with a fake email address, the content of the email will be stored in './authelia/notification.txt'.
 Upon registering, you can grab this link easily by running the following command: 'grep -Eo '"https://.*" ' ./authelia/notification.txt'.
 EOF

--- a/compose/local/setup.sh
+++ b/compose/local/setup.sh
@@ -33,10 +33,10 @@ MODIFIED=$(cat /etc/hosts | grep $DOMAIN && echo true || echo false)
 
 if [[ $MODIFIED == "false" ]]; then
 echo "\
-172.31.255.100  authelia.$DOMAIN
-172.31.255.100  public.$DOMAIN
-172.31.255.100  traefik.$DOMAIN
-172.31.255.100  secure.$DOMAIN" >> /etc/hosts
+127.0.0.1  authelia.$DOMAIN
+127.0.0.1  public.$DOMAIN
+127.0.0.1  traefik.$DOMAIN
+127.0.0.1  secure.$DOMAIN" >> /etc/hosts
 fi
 
 echo "Generating SSL certificate for *.$DOMAIN"

--- a/compose/local/setup.sh
+++ b/compose/local/setup.sh
@@ -66,11 +66,10 @@ fi
 password
 
 if [[ $PASSWORD != "" ]]; then
+  PASSWORD=$(docker run authelia/authelia authelia hash-password $PASSWORD | sed 's/Password hash: //g')
   if [[ $(uname) == "Darwin" ]]; then
-    PASSWORD=$(docker run authelia/authelia authelia hash-password $PASSWORD | sed 's/Password hash: //g')
     sed -i '' "s/<PASSWORD>/$(echo $PASSWORD | sed -e 's/[\/&]/\\&/g')/g" users_database.yml
   else
-    PASSWORD=$(docker run authelia/authelia authelia hash-password $PASSWORD | sed 's/Password hash: //g')
     sed -i "s/<PASSWORD>/$(echo $PASSWORD | sed -e 's/[\/&]/\\&/g')/g" users_database.yml
   fi
 else

--- a/compose/local/setup.sh
+++ b/compose/local/setup.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+username(){
+  read -ep "Enter your username for Authelia: " USERNAME
+}
+
+password(){
+  read -esp "Enter a password for $USERNAME: " PASSWORD
+}
+
+echo "Checking for pre-requisites"
+
+if [[ ! -x "$(command -v docker)" ]]; then
+  echo "You must install Docker on your machine";
+  return
+fi
+
+if [[ ! -x "$(command -v docker-compose)" ]]; then
+  echo "You must install Docker Compose on your machine";
+  return
+fi
+
+echo "Pulling Authelia docker image for setup"
+docker pull authelia/authelia > /dev/null
+
+read -ep "What root domain would you like to protect? (default/no selection is example.com): " DOMAIN
+
+if [[ $DOMAIN == "" ]]; then
+  DOMAIN="example.com"
+fi
+
+MODIFIED=$(cat /etc/hosts | grep $DOMAIN && echo true || echo false)
+
+if [[ $MODIFIED == "false" ]]; then
+echo "\
+172.31.255.100  authelia.$DOMAIN
+172.31.255.100  public.$DOMAIN
+172.31.255.100  traefik.$DOMAIN
+172.31.255.100  secure.$DOMAIN" >> /etc/hosts
+fi
+
+echo "Generating SSL certificate for *.$DOMAIN"
+docker run -a stdout -v $PWD/traefik/certs:/tmp/certs authelia/authelia authelia certificates generate --host *.$DOMAIN --dir /tmp/certs/ > /dev/null
+
+if [[ $DOMAIN != "example.com" ]]; then
+  sed -i "s/example.com/$DOMAIN/g" {docker-compose.yml,configuration.yml}
+fi
+
+username
+
+if [[ $USERNAME != "" ]]; then
+  sed -i "s/<USERNAME>/$USERNAME/g" users_database.yml
+else
+  echo "Username cannot be empty"
+  username
+fi
+
+password
+
+if [[ $PASSWORD != "" ]]; then
+  PASSWORD=$(docker run authelia/authelia authelia hash-password $PASSWORD | sed 's/Password hash: //g')
+  sed -i "s/<PASSWORD>/$(echo $PASSWORD | sed -e 's/[\/&]/\\&/g')/g" users_database.yml
+else
+  echo "Password cannot be empty"
+  password
+fi
+
+cat << EOF
+Setup completed successfully, please start up containers with 'docker-compose up -d'.
+
+Once containers have been started you can now visit the following locations:
+- https://public.$DOMAIN - Bypasses Authelia
+- https://traefik.$DOMAIN - Secured with Authelia one-factor authentication
+- https://secure.$DOMAIN - Secured with Authelia two-factor authentication
+
+Once you have registered an OTP device, the link to generate your QR code will be in 'compose/local/authelia/notifications.txt'.
+'grep "<a href=" compose/local/authelia/notifications.txt'
+EOF
+

--- a/compose/local/setup.sh
+++ b/compose/local/setup.sh
@@ -77,15 +77,17 @@ else
   password
 fi
 
-cat << EOF
-Setup completed successfully, please start up containers with 'docker-compose up -d'.
+docker-compose up -d
 
-Once containers have been started you can now visit the following locations:
+cat << EOF
+Setup completed successfully.
+
+You can now visit the following locations:
 - https://public.$DOMAIN - Bypasses Authelia
 - https://traefik.$DOMAIN - Secured with Authelia one-factor authentication
 - https://secure.$DOMAIN - Secured with Authelia two-factor authentication (see note below)
 
-To visit https://secure.$DOMAIN you will need to register an OTP device, the email/link to generate your QR code will be in stored in: './authelia/notification.txt'.
+To visit https://secure.$DOMAIN you will need to register a device for second factor authentication and confirm by clicking on a link sent by email. Since this is a demo with a fake email address, the content of the email will be stored in './authelia/notification.txt'.
 Upon registering, you can grab this link easily by running the following command: 'grep -Eo '"https://.*" ' ./authelia/notification.txt'.
 EOF
 

--- a/compose/local/traefik/certificates.yml
+++ b/compose/local/traefik/certificates.yml
@@ -1,0 +1,4 @@
+tls:
+  certificates:
+    - certFile: /etc/traefik/certs/cert.pem
+      keyFile: /etc/traefik/certs/key.pem

--- a/compose/local/users_database.yml
+++ b/compose/local/users_database.yml
@@ -1,0 +1,14 @@
+###############################################################
+#                         Users Database                      #
+###############################################################
+
+# This file can be used if you do not have an LDAP set up.
+
+# List of users
+users:
+  <USERNAME>:
+    password: "<PASSWORD>"
+    email: <USERNAME>@example.com
+    groups:
+      - admins
+      - dev

--- a/docs/configuration/storage/mysql.md
+++ b/docs/configuration/storage/mysql.md
@@ -3,7 +3,7 @@ layout: default
 title: MySQL
 parent: Storage backends
 grand_parent: Configuration
-nav_order: 3
+nav_order: 2
 ---
 
 # MySQL

--- a/docs/configuration/storage/postgres.md
+++ b/docs/configuration/storage/postgres.md
@@ -3,7 +3,7 @@ layout: default
 title: PostgreSQL
 parent: Storage backends
 grand_parent: Configuration
-nav_order: 2
+nav_order: 3
 ---
 
 # PostgreSQL

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -6,3 +6,50 @@ has_children: true
 ---
 
 # Contributing
+
+## Development workflow
+
+**Authelia** and its development workflow can be tested with Docker and docker-compose on Linux.
+
+In order to deploy the current version of Authelia locally, run the following command and
+follow the instructions of bootstrap.sh:
+
+    $ source bootstrap.sh
+
+Then, start the *Standalone* [suite].
+
+    $ authelia-scripts suites setup Standalone
+
+A [suite] is kind of a virtual environment for running Authelia in a complete ecosystem.
+If you want more details please read the related [documentation](./contributing/suites.md).
+
+## FAQ
+
+### What version of Docker and docker-compose should I use?
+
+Here are the versions used for testing in Buildkite:
+
+    $ docker --version
+    Docker version 19.03.5, build 633a0ea838
+
+    $ docker-compose --version
+    docker-compose version 1.24.1, build unknown
+
+### How can I serve my application under example.com?
+
+Don't worry, you don't need to own the domain *example.com* to test Authelia.
+Copy the following lines in your /etc/hosts.
+
+    192.168.240.100 home.example.com
+    192.168.240.100 login.example.com
+    192.168.240.100 singlefactor.example.com
+    192.168.240.100 public.example.com
+    192.168.240.100 secure.example.com
+    192.168.240.100 mail.example.com
+    192.168.240.100 mx1.mail.example.com
+
+`192.168.240.100` is the IP attributed by Docker to the reverse proxy. Once done
+you can access the listed sub-domains from your browser and they will target
+the reverse proxy.
+
+[suite]: ./contributing/suites.md

--- a/docs/deployment/deployment-ha.md
+++ b/docs/deployment/deployment-ha.md
@@ -27,9 +27,6 @@ persist user configurations and one or more nginx reverse proxies configured to
 be used with Authelia. With such a setup **Authelia** can easily be scaled to
 multiple instances to evenly handle the traffic.
 
-**NOTE**: If you don't have all those components, don't worry, there is a way to
-deploy **Authelia** with only nginx. This is described in [Deployment - Lite](./deployment-lite.md).
-
 Here are the available steps to deploy **Authelia** given 
 the configuration file is **/path/to/your/configuration.yml**. Note that you can
 create your own configuration file from [config.template.yml] located at

--- a/docs/deployment/deployment-lite.md
+++ b/docs/deployment/deployment-lite.md
@@ -6,68 +6,41 @@ parent: Deployment
 
 # Lite Deployment
 
-**Authelia** can be deployed as a lite setup not requiring any SQL server,
-Redis cluster or LDAP server. In some cases, like protecting personal projects/websites,
-it can be fine to use that setup but beware that this setup is non-resilient to failures
-so it should be used at your own risk.
+**Authelia** can be deployed as a lite setup with minimal external dependencies.
+The setup is called lite because it reduces the number of components in the architecture
+to a reverse proxy such as Nginx, Traefik or HAProxy, Authelia and Redis.
 
-The setup is called lite since it reduces the number of components in the architecture to
-only two: a reverse proxy such as Nginx, Traefik or HAProxy and Authelia.
+This setup assumes you have basic knowledge and understanding of IP addresses, DNS and port
+forwarding. You should setup the domain you intend to protect with Authelia to point to your
+external IP address and port forward ports `80` and `443` to the host you plan to host the
+`docker-compose.yml` bundle.
+
+Port 80 is utilised by LetsEncrypt for certificate challenges, this will [automatically
+provision](https://docs.traefik.io/https/acme/) up-to-date certificates for your domain(s).
+
+Traefik publishes the respective services with LetsEncrypt provided certificates on port `443`.
+The provided examples protect the Traefik dashboard with Authelia's one-factor auth
+(traefik.example.com) and two instances of the
+[whoami container](https://hub.docker.com/r/containous/whoami) with Authelia being
+bypassed (public.example.com) and another with it's two-factor auth (secure.example.com). 
+
+If you happen to already have an external SQL instance (MariaDB, MySQL or Postgres) this 
+setup can easily be adapted to utilise said [service](../configuration/storage/index.md).
+
+## Steps
+
+- `git clone https://github.com/authelia/authelia.git`
+- `cd authelia/compose/lite`
+- Modify the `users_database.yml` the default username and password is `authelia`
+- Modify the `configuration.yml` and `docker-compose.yml` with your respective domains and secrets
+- `docker-compose up -d`
 
 ## Reverse Proxy
 
-Documentation for deploying a reverse proxy collaborating with Authelia is available
-[here](./supported-proxies/index.md).
-
-Please note that Authelia only works for websites served over HTTPS because the session cookie
-can only be transmitted over secure connections. Therefore, if you need to generate a
-self-signed certificate for your setup, you can use the dedicated helper function provided
-by the authelia binary.
-
-    # Generate a certificate covering "example.com" for one year in the /tmp/certs/ directory.
-    $ docker run authelia/authelia authelia certificates generate --host example.com --dir /tmp/certs/
-
-You can see all available options with the following command:
-
-    $ docker run authelia/authelia authelia certificates generate --help
-
-## Discard components
-
-### Discard SQL server
-
-It's possible to use a SQLite file instead of a SQL server as documented
-[here](../configuration/storage/sqlite.md).
-
-### Discard Redis
-
-Connection details to Redis are optional. If not provided, sessions will
-be stored in memory instead. This has the inconvenient of logging out users
-every time Authelia restarts.
-
-The documentation about session management is available
-[here](../configuration/session.md).
-
-
-### Discard LDAP
-
-**Authelia** can use a file backend in order to store users instead of a
-LDAP server or an Active Directory.
-
-To use a file backend instead of a LDAP server, please follow the related
-documentation [here](../configuration/authentication/file.md).
+The [Lite bundle](https://github.com/authelia/authelia/blob/master/compose/lite/docker-compose.yml)
+provides pre-made examples with [Traefik2.x](./supported-proxies/traefik2.x.md), you can swap this
+out for any of the [supported proxies](./supported-proxies/index.md).
 
 ## FAQ
 
-### Can you give more details on why this is not suitable for production environments?
-
-This documentation gives instructions that will make **Authelia** non
-resilient to failures and non scalable by preventing you from running multiple
-instances of the application. This means that **Authelia** won't be able to distribute
-the load across multiple servers and it will prevent failover in case of a
-crash or an hardware issue. Moreover, users will be logged out every time
-Authelia restarts.
-
-### Why aren't all those steps automated?
-
-We would really be more than happy to review any contribution with an Ansible playbook,
-a Chef cookbook or whatever else to automate the process.
+Under construction.

--- a/docs/deployment/deployment-lite.md
+++ b/docs/deployment/deployment-lite.md
@@ -43,4 +43,10 @@ out for any of the [supported proxies](./supported-proxies/index.md).
 
 ## FAQ
 
-Under construction.
+### Can you give more details on why this is not suitable for production environments?
+
+This documentation gives instructions that will make **Authelia** non
+resilient to failures and non scalable by preventing you from running multiple
+instances of the application. This means that **Authelia** won't be able to distribute
+the load across multiple servers and it will prevent failover in case of a
+crash or an hardware issue.

--- a/docs/deployment/supported-proxies/traefik1.x.md
+++ b/docs/deployment/supported-proxies/traefik1.x.md
@@ -36,7 +36,7 @@ services:
     image: traefik:v1.7.20-alpine
     container_name: traefik
     volumes:
-      - '/var/run/docker.sock:/var/run/docker.sock'
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - net
     labels:

--- a/docs/deployment/supported-proxies/traefik2.x.md
+++ b/docs/deployment/supported-proxies/traefik2.x.md
@@ -40,6 +40,7 @@ services:
     networks:
       - net
     labels:
+      - 'traefik.enable=true'
       - 'traefik.http.routers.api.rule=Host(`traefik.example.com`)'
       - 'traefik.http.routers.api.entrypoints=https'
       - 'traefik.http.routers.api.service=api@internal'
@@ -50,6 +51,7 @@ services:
     command:
       - '--api'
       - '--providers.docker=true'
+      - '--providers.docker.exposedByDefault=false'
       - '--entrypoints.http=true'
       - '--entrypoints.http.address=:80'
       - '--entrypoints.https=true'
@@ -67,9 +69,12 @@ services:
     networks:
       - net
     labels:
+      - 'traefik.enable=true'
       - 'traefik.http.routers.authelia.rule=Host(`login.example.com`)'
       - 'traefik.http.routers.authelia.entrypoints=https'
       - 'traefik.http.routers.authelia.tls=true'
+      - 'traefik.http.middlewares.authelia.forwardAuth.address=http://authelia:9091/api/verify?rd=https://login.example.com/'
+      - 'traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true'
     expose:
       - 9091
     restart: unless-stopped
@@ -85,11 +90,11 @@ services:
     networks:
       - net
     labels:
+      - 'traefik.enable=true'
       - 'traefik.http.routers.nextcloud.rule=Host(`nextcloud.example.com`)'
       - 'traefik.http.routers.nextcloud.entrypoints=https'
       - 'traefik.http.routers.nextcloud.tls=true'
-      - 'traefik.http.routers.nextcloud.middlewares=authelia'
-      - 'traefik.http.middlewares.authelia.forwardAuth.address=http://authelia:9091/api/verify?rd=https://login.example.com/'
+      - 'traefik.http.routers.nextcloud.middlewares=authelia@docker'
     expose:
       - 443
     restart: unless-stopped

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,130 +8,26 @@ nav_order: 2
 
 ## Docker Compose
 
-**Authelia** can be deployed as a local setup not requiring SQL server, Redis cluster
-or an LDAP server. In some cases, like protecting personal projects/websites, it can be
-fine to use this setup but beware that this setup is non-resilient to failures so it should
-be used at your own risk.
-
-The setup is called local since it reduces the number of components in the architecture to
-only two: a reverse proxy such as Nginx, Traefik or HAProxy and Authelia.
-
-Connection details to Redis are optional. If not provided, sessions will be stored in
-memory instead. This has the inconvenience of logging out users every time Authelia restarts.
-
-## Steps
+### Steps
 
 These commands are intended to be run sequentially:
 
 - `git clone https://github.com/authelia/authelia.git`
 - `cd authelia/compose/local`
-- `sudo ./setup.sh`
-- `docker-compose up -d`
+- `sudo ./setup.sh` *sudo is required to modify the `/etc/hosts` file*
 
 You can now visit the following locations; replace example.com with the domain you specified in the setup script:
 - https://public.example.com - Bypasses Authelia
 - https://traefik.example.com - Secured with Authelia one-factor authentication
 - https://secure.example.com - Secured with Authelia two-factor authentication (see note below)
 
-To visit https://secure.example.com you will need to register an OTP device, the email/link to generate your QR code will be in stored in: `./authelia/notification.txt`.
+To visit https://secure.example.com you will need to register a device for second factor authentication and confirm by clicking on a link sent by email.
+Since this is a demo with a fake email address, the content of the email will be stored in './authelia/notification.txt'.
 Upon registering, you can grab this link easily by running the following command: `grep -Eo '"https://.*" ' ./authelia/notification.txt`.
 
-## Reverse Proxy
+## Deployment
 
-Documentation for deploying a reverse proxy collaborating with Authelia is available
-[here](./supported-proxies/index.md).
-
-## FAQ
-
-### Can you give more details on why this is not suitable for production environments?
-
-This documentation gives instructions that will make **Authelia** non
-resilient to failures and non scalable by preventing you from running multiple
-instances of the application. This means that **Authelia** won't be able to distribute
-the load across multiple servers and it will prevent failover in case of a
-crash or an hardware issue. Moreover, users will be logged out every time
-Authelia restarts.
-
-## Development workflow
-
-**Authelia** and its development workflow can be tested with Docker and docker-compose on Linux.
-
-In order to deploy the current version of Authelia locally, run the following command and
-follow the instructions of bootstrap.sh:
-
-    $ source bootstrap.sh
-
-Then, start the *Standalone* [suite].
-
-    $ authelia-scripts suites setup Standalone
-
-A [suite] is kind of a virtual environment for running Authelia in a complete ecosystem.
-If you want more details please read the related [documentation](./contributing/suites.md).
-
-### Test it!
-
-After few seconds the services should be running and you should be able to
-visit [https://home.example.com:8080/](https://home.example.com:8080/).
-
-When accessing the login page, since this is a test environment a
-self-signed certificate exception should appear, it has to be trusted
-before you can get to the home page.
-The certificate must also be trusted for each subdomain, therefore it is
-normal to see this exception several times.
-
-Below is what the login page looks like after you accepted all exceptions:
-
-<p align="center">
-  <img src="./images/1FA.png" width="400">
-</p>
-
-You can use one of the users listed in
-[https://home.example.com:8080/](https://home.example.com:8080/).
-The rights granted to each user and group is also provided in the page as
-a list of rules.
-
-At some point, you'll be required to register your second factor device.
-Since your security is **Authelia**'s priority, it will send 
-an email to the email address of the user to confirm the user identity.
-Since you are running a test environment, a fake webmail called
-*MailCatcher* has been deployed for you to check out the email and
-confirm your identity.
-The webmail is accessible at
-[http://mail.example.com:8080](http://mail.example.com:8080).
-
-Enjoy!
-
-## FAQ
-
-### What version of Docker and docker-compose should I use?
-
-Here are the versions used for testing in Buildkite:
-
-    $ docker --version
-    Docker version 19.03.5, build 633a0ea838
-
-    $ docker-compose --version
-    docker-compose version 1.24.1, build unknown
-
-### How can I serve my application under example.com?
-
-Don't worry, you don't need to own the domain *example.com* to test Authelia.
-Copy the following lines in your /etc/hosts.
-
-    192.168.240.100 home.example.com
-    192.168.240.100 login.example.com
-    192.168.240.100 singlefactor.example.com
-    192.168.240.100 public.example.com
-    192.168.240.100 secure.example.com
-    192.168.240.100 mail.example.com
-    192.168.240.100 mx1.mail.example.com
-
-`192.168.240.100` is the IP attributed by Docker to the reverse proxy. Once done
-you can access the listed sub-domains from your browser and they will target
-the reverse proxy.
-
-### What should I do if I want to contribute?
-
-You can refer to the dedicated documentation [here](./contributing/index.md).
-
-[suite]: ./contributing/suites.md
+So you're convinced that Authelia is what you need. You can head to the deployment documentation [here](./deployment/index.md).
+Some recipes have been crafted for helping with the bootstrap of your environment.
+You can choose between a [lite](./deployment/deployment-lite.md) deployment which is deployment advised for a single server setup.
+However, this setup just does not scale. If you want a full environment that can scale out, use the [HA](./deployment/deployment-ha.md) or [Kubernetes](./deployment/deployment-kubernetes.md) deployment documentation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,9 @@ be used at your own risk.
 The setup is called local since it reduces the number of components in the architecture to
 only two: a reverse proxy such as Nginx, Traefik or HAProxy and Authelia.
 
+Connection details to Redis are optional. If not provided, sessions will be stored in
+memory instead. This has the inconvenience of logging out users every time Authelia restarts.
+
 ## Steps
 
 - `git clone https://github.com/authelia/authelia.git`
@@ -36,30 +39,6 @@ Once you have registered an OTP device, the link to generate your QR code will b
 Documentation for deploying a reverse proxy collaborating with Authelia is available
 [here](./supported-proxies/index.md).
 
-## Discarded components
-
-### Discard SQL server
-
-It's possible to use a SQLite file instead of a SQL server as documented
-[here](../configuration/storage/sqlite.md).
-
-### Discard Redis
-
-Connection details to Redis are optional. If not provided, sessions will
-be stored in memory instead. This has the inconvenience of logging out users
-every time Authelia restarts.
-
-The documentation about session management is available
-[here](../configuration/session.md).
-
-### Discard LDAP
-
-**Authelia** can use a file backend in order to store users instead of a
-LDAP server or Active Directory.
-
-To use a file backend instead of a LDAP server, please follow the related
-documentation [here](../configuration/authentication/file.md).
-
 ## FAQ
 
 ### Can you give more details on why this is not suitable for production environments?
@@ -71,15 +50,9 @@ the load across multiple servers and it will prevent failover in case of a
 crash or an hardware issue. Moreover, users will be logged out every time
 Authelia restarts.
 
-### Why aren't all those steps automated?
-
-We would really be more than happy to review any contribution with an Ansible playbook,
-a Chef cookbook or whatever else to automate the process.
-
 ## Development workflow
 
-**Authelia** and its development workflow can be tested in a matter of seconds with Docker and
-docker-compose on Linux.
+**Authelia** and its development workflow can be tested with Docker and docker-compose on Linux.
 
 In order to deploy the current version of Authelia locally, run the following command and
 follow the instructions of bootstrap.sh:
@@ -93,7 +66,7 @@ Then, start the *Standalone* [suite].
 A [suite] is kind of a virtual environment for running Authelia in a complete ecosystem.
 If you want more details please read the related [documentation](./contributing/suites.md).
 
-## Test it!
+### Test it!
 
 After few seconds the services should be running and you should be able to
 visit [https://home.example.com:8080/](https://home.example.com:8080/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,10 +6,83 @@ nav_order: 2
 
 # Getting Started
 
-**Authelia** can be tested in a matter of seconds with Docker and docker-compose.
+## Docker Compose
 
-In order to deploy the current version of Authelia locally, run the following
-command and follow the instructions of bootstrap.sh:
+**Authelia** can be deployed as a local setup not requiring SQL server, Redis cluster
+or an LDAP server. In some cases, like protecting personal projects/websites, it can be
+fine to use this setup but beware that this setup is non-resilient to failures so it should
+be used at your own risk.
+
+The setup is called local since it reduces the number of components in the architecture to
+only two: a reverse proxy such as Nginx, Traefik or HAProxy and Authelia.
+
+## Steps
+
+- `git clone https://github.com/authelia/authelia.git`
+- `cd authelia/compose/local`
+- `sudo ./setup.sh`
+- `docker-compose up -d`
+
+You can now visit the following locations; replace example.com with the domain you specified in the setup script:
+- https://public.example.com - Bypasses Authelia
+- https://traefik.example.com - Secured with Authelia one-factor authentication
+- https://secure.example.com - Secured with Authelia two-factor authentication
+
+Once you have registered an OTP device, the link to generate your QR code will be in `compose/local/authelia/notifications.txt`.
+`grep "<a href=" compose/local/authelia/notifications.txt` 
+
+## Reverse Proxy
+
+Documentation for deploying a reverse proxy collaborating with Authelia is available
+[here](./supported-proxies/index.md).
+
+## Discarded components
+
+### Discard SQL server
+
+It's possible to use a SQLite file instead of a SQL server as documented
+[here](../configuration/storage/sqlite.md).
+
+### Discard Redis
+
+Connection details to Redis are optional. If not provided, sessions will
+be stored in memory instead. This has the inconvenience of logging out users
+every time Authelia restarts.
+
+The documentation about session management is available
+[here](../configuration/session.md).
+
+### Discard LDAP
+
+**Authelia** can use a file backend in order to store users instead of a
+LDAP server or Active Directory.
+
+To use a file backend instead of a LDAP server, please follow the related
+documentation [here](../configuration/authentication/file.md).
+
+## FAQ
+
+### Can you give more details on why this is not suitable for production environments?
+
+This documentation gives instructions that will make **Authelia** non
+resilient to failures and non scalable by preventing you from running multiple
+instances of the application. This means that **Authelia** won't be able to distribute
+the load across multiple servers and it will prevent failover in case of a
+crash or an hardware issue. Moreover, users will be logged out every time
+Authelia restarts.
+
+### Why aren't all those steps automated?
+
+We would really be more than happy to review any contribution with an Ansible playbook,
+a Chef cookbook or whatever else to automate the process.
+
+## Development workflow
+
+**Authelia** and its development workflow can be tested in a matter of seconds with Docker and
+docker-compose on Linux.
+
+In order to deploy the current version of Authelia locally, run the following command and
+follow the instructions of bootstrap.sh:
 
     $ source bootstrap.sh
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,6 +21,7 @@ You can now visit the following locations; replace example.com with the domain y
 - https://traefik.example.com - Secured with Authelia one-factor authentication
 - https://secure.example.com - Secured with Authelia two-factor authentication (see note below)
 
+You will need to authorize the self-signed certificate upon visiting each domain.
 To visit https://secure.example.com you will need to register a device for second factor authentication and confirm by clicking on a link sent by email.
 Since this is a demo with a fake email address, the content of the email will be stored in './authelia/notification.txt'.
 Upon registering, you can grab this link easily by running the following command: `grep -Eo '"https://.*" ' ./authelia/notification.txt`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,6 +21,8 @@ memory instead. This has the inconvenience of logging out users every time Authe
 
 ## Steps
 
+These commands are intended to be run sequentially:
+
 - `git clone https://github.com/authelia/authelia.git`
 - `cd authelia/compose/local`
 - `sudo ./setup.sh`
@@ -29,10 +31,10 @@ memory instead. This has the inconvenience of logging out users every time Authe
 You can now visit the following locations; replace example.com with the domain you specified in the setup script:
 - https://public.example.com - Bypasses Authelia
 - https://traefik.example.com - Secured with Authelia one-factor authentication
-- https://secure.example.com - Secured with Authelia two-factor authentication
+- https://secure.example.com - Secured with Authelia two-factor authentication (see note below)
 
-Once you have registered an OTP device, the link to generate your QR code will be in `compose/local/authelia/notifications.txt`.
-`grep "<a href=" compose/local/authelia/notifications.txt` 
+To visit https://secure.example.com you will need to register an OTP device, the email/link to generate your QR code will be in stored in: `./authelia/notification.txt`.
+Upon registering, you can grab this link easily by running the following command: `grep -Eo '"https://.*" ' ./authelia/notification.txt`.
 
 ## Reverse Proxy
 


### PR DESCRIPTION
This provides two flavours of compose bundles for users to test Authelia.

- Local
This bundle is intended for scenarios where the server will not be exposed to the internet, domains will be defined in the local hosts file and self-signed certificates will be utilised.
This bundle includes a script to generate all the required configuration and is intended as the quickest method to demo Authelia.

- Lite
This bundle is intended for scenarios where the server will be exposed to the internet, domains and DNS will need to be setup accordingly and certificates will be generated through LetsEncrypt.
The Lite element refers to minimal external dependencies; File based user storage, SQLite based configuration storage. In this configuration, the service will not scale well.

A future PR will also include the Full bundle which is intended to be a fully scalable and highly-available setup.

Closes #480.
Closes #610.
Closes #681.
Closes #783.