### PR TITLE
[Buildkite] Fix AUR version tagging

### DIFF
--- a/.buildkite/steps/aurhelper.sh
+++ b/.buildkite/steps/aurhelper.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 
+git fetch && \
 GITTAG=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
 
 echo "--- :linux: Deploy AUR package: ${PACKAGE}"


### PR DESCRIPTION
Need to fetch all tags prior to extracting the correct version.