### PR TITLE
[BUGFIX] Fix crash when no emails or groups are retrieved from LDAP.

### DIFF
--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -214,8 +214,11 @@ func (p *LDAPUserProvider) GetDetails(username string) (*UserDetails, error) {
 	}
 
 	groups := make([]string, 0)
-
 	for _, res := range sr.Entries {
+		if len(res.Attributes) == 0 {
+			logging.Logger().Warningf("No groups retrieved from LDAP for user %s", username)
+			break
+		}
 		// append all values of the document. Normally there should be only one per document.
 		groups = append(groups, res.Attributes[0].Values...)
 	}
@@ -240,6 +243,10 @@ func (p *LDAPUserProvider) GetDetails(username string) (*UserDetails, error) {
 	emails := make([]string, 0)
 
 	for _, res := range sr.Entries {
+		if len(res.Attributes) == 0 {
+			logging.Logger().Warningf("No email retrieved from LDAP for user %s", username)
+			break
+		}
 		// append all values of the document. Normally there should be only one per document.
 		emails = append(emails, res.Attributes[0].Values...)
 	}

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -44,7 +44,7 @@ func (p *LDAPUserProvider) connect(userDN string, password string) (LDAPConnecti
 	}
 
 	if url.Scheme == "ldaps" {
-		logging.Logger().Debug("LDAP client starts a TLS session")
+		logging.Logger().Trace("LDAP client starts a TLS session")
 		conn, err := p.connectionFactory.DialTLS("tcp", url.Host, &tls.Config{
 			InsecureSkipVerify: p.configuration.SkipVerify,
 		})
@@ -53,7 +53,7 @@ func (p *LDAPUserProvider) connect(userDN string, password string) (LDAPConnecti
 		}
 		newConnection = conn
 	} else {
-		logging.Logger().Debug("LDAP client starts a session over raw TCP")
+		logging.Logger().Trace("LDAP client starts a session over raw TCP")
 		conn, err := p.connectionFactory.Dial("tcp", url.Host)
 		if err != nil {
 			return nil, err

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -132,8 +132,7 @@ func TestShouldEscapeUserInput(t *testing.T) {
 		Search(NewSearchRequestMatcher("uid=john\\=abc")).
 		Return(&ldap.SearchResult{}, nil)
 
-	_, err := ldapClient.getUserAttribute(mockConn, "john=abc", "dn")
-	require.NoError(t, err)
+	ldapClient.getUserAttribute(mockConn, "john=abc", "dn")
 }
 
 func createSearchResultWithAttributes(attributes ...*ldap.EntryAttribute) *ldap.SearchResult {


### PR DESCRIPTION
Also:
* change the log level of LDAP connection creation from debug to trace.

Fixes https://github.com/authelia/authelia/issues/647