### PR TITLE
[FEATURE] Redis DB Index Selection

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -223,6 +223,8 @@ session:
     port: 6379
     # This secret can also be set using the env variables AUTHELIA_SESSION_REDIS_PASSWORD
     password: authelia
+    # This is the Redis DB Index https://redis.io/commands/select
+    database: 0
 
 # Configuration of the authentication regulation mechanism.
 #

--- a/config.template.yml
+++ b/config.template.yml
@@ -223,8 +223,8 @@ session:
     port: 6379
     # This secret can also be set using the env variables AUTHELIA_SESSION_REDIS_PASSWORD
     password: authelia
-    # This is the Redis DB Index https://redis.io/commands/select
-    database: 0
+    # This is the Redis DB Index https://redis.io/commands/select (sometimes referred to as database number, DB, etc).
+    database_index: 0
 
 # Configuration of the authentication regulation mechanism.
 #

--- a/internal/configuration/schema/session.go
+++ b/internal/configuration/schema/session.go
@@ -2,10 +2,10 @@ package schema
 
 // RedisSessionConfiguration represents the configuration related to redis session store.
 type RedisSessionConfiguration struct {
-	Host     string `mapstructure:"host"`
-	Port     int64  `mapstructure:"port"`
-	Password string `mapstructure:"password"`
-	Database int    `mapstructure:"database"`
+	Host          string `mapstructure:"host"`
+	Port          int64  `mapstructure:"port"`
+	Password      string `mapstructure:"password"`
+	DatabaseIndex int    `mapstructure:"database_index"`
 }
 
 // SessionConfiguration represents the configuration related to user sessions.

--- a/internal/configuration/schema/session.go
+++ b/internal/configuration/schema/session.go
@@ -5,6 +5,7 @@ type RedisSessionConfiguration struct {
 	Host     string `mapstructure:"host"`
 	Port     int64  `mapstructure:"port"`
 	Password string `mapstructure:"password"`
+	Database int    `mapstructure:"database"`
 }
 
 // SessionConfiguration represents the configuration related to user sessions.

--- a/internal/session/provider_config.go
+++ b/internal/session/provider_config.go
@@ -43,10 +43,11 @@ func NewProviderConfig(configuration schema.SessionConfiguration) ProviderConfig
 	if configuration.Redis != nil {
 		providerName = "redis"
 		providerConfig = &redis.Config{
-			Host:        configuration.Redis.Host,
-			Port:        configuration.Redis.Port,
-			Password:    configuration.Redis.Password,
-			DbNumber:    configuration.Redis.Database,
+			Host:     configuration.Redis.Host,
+			Port:     configuration.Redis.Port,
+			Password: configuration.Redis.Password,
+			// DbNumber is the fasthttp/session property for the Redis DB Index
+			DbNumber:    configuration.Redis.DatabaseIndex,
 			PoolSize:    8,
 			IdleTimeout: 300,
 			KeyPrefix:   "authelia-session",

--- a/internal/session/provider_config.go
+++ b/internal/session/provider_config.go
@@ -1,8 +1,9 @@
 package session
 
 import (
-	"github.com/valyala/fasthttp"
 	"time"
+
+	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/internal/configuration/schema"
 	"github.com/fasthttp/session"

--- a/internal/session/provider_config.go
+++ b/internal/session/provider_config.go
@@ -1,9 +1,8 @@
 package session
 
 import (
-	"time"
-
 	"github.com/valyala/fasthttp"
+	"time"
 
 	"github.com/authelia/authelia/internal/configuration/schema"
 	"github.com/fasthttp/session"
@@ -46,6 +45,7 @@ func NewProviderConfig(configuration schema.SessionConfiguration) ProviderConfig
 			Host:        configuration.Redis.Host,
 			Port:        configuration.Redis.Port,
 			Password:    configuration.Redis.Password,
+			DbNumber:    configuration.Redis.Database,
 			PoolSize:    8,
 			IdleTimeout: 300,
 			KeyPrefix:   "authelia-session",

--- a/internal/session/provider_config_test.go
+++ b/internal/session/provider_config_test.go
@@ -54,6 +54,7 @@ func TestShouldCreateRedisSessionProvider(t *testing.T) {
 	assert.Equal(t, "redis.example.com", pConfig.Host)
 	assert.Equal(t, int64(6379), pConfig.Port)
 	assert.Equal(t, "pass", pConfig.Password)
+	// DbNumber is the fasthttp/session property for the Redis DB Index
 	assert.Equal(t, 0, pConfig.DbNumber)
 }
 
@@ -63,14 +64,15 @@ func TestShouldSetDbNumber(t *testing.T) {
 	configuration.Name = "my_session"
 	configuration.Expiration = 40
 	configuration.Redis = &schema.RedisSessionConfiguration{
-		Host:     "redis.example.com",
-		Port:     6379,
-		Password: "pass",
-		Database: 5,
+		Host:          "redis.example.com",
+		Port:          6379,
+		Password:      "pass",
+		DatabaseIndex: 5,
 	}
 	providerConfig := NewProviderConfig(configuration)
 	assert.Equal(t, "redis", providerConfig.providerName)
 	assert.IsType(t, &redis.Config{}, providerConfig.providerConfig)
 	pConfig := providerConfig.providerConfig.(*redis.Config)
+	// DbNumber is the fasthttp/session property for the Redis DB Index
 	assert.Equal(t, 5, pConfig.DbNumber)
 }

--- a/internal/session/provider_config_test.go
+++ b/internal/session/provider_config_test.go
@@ -54,4 +54,23 @@ func TestShouldCreateRedisSessionProvider(t *testing.T) {
 	assert.Equal(t, "redis.example.com", pConfig.Host)
 	assert.Equal(t, int64(6379), pConfig.Port)
 	assert.Equal(t, "pass", pConfig.Password)
+	assert.Equal(t, 0, pConfig.DbNumber)
+}
+
+func TestShouldSetDbNumber(t *testing.T) {
+	configuration := schema.SessionConfiguration{}
+	configuration.Domain = "example.com"
+	configuration.Name = "my_session"
+	configuration.Expiration = 40
+	configuration.Redis = &schema.RedisSessionConfiguration{
+		Host:     "redis.example.com",
+		Port:     6379,
+		Password: "pass",
+		Database: 5,
+	}
+	providerConfig := NewProviderConfig(configuration)
+	assert.Equal(t, "redis", providerConfig.providerName)
+	assert.IsType(t, &redis.Config{}, providerConfig.providerConfig)
+	pConfig := providerConfig.providerConfig.(*redis.Config)
+	assert.Equal(t, 5, pConfig.DbNumber)
 }


### PR DESCRIPTION
- Allow users to specify the DB number
- This is so users who use their redis for multiple purposes can have clear demarcation between their data

This is a simple change, works as expected. I haven't updated docs since we're moving to GitHub Pages but will look to make a commit there too. I added to unit tests as you'll see to verify the behavior of both no configuration and a value other than zero. 