### PR TITLE
[FEATURE] Regenerate session IDs after 2FA authentication.

### DIFF
--- a/internal/handlers/handler_sign_duo.go
+++ b/internal/handlers/handler_sign_duo.go
@@ -43,6 +43,13 @@ func SecondFactorDuoPost(duoAPI duo.API) middlewares.RequestHandler {
 			return
 		}
 
+		err = ctx.Providers.SessionProvider.RegenerateSession(ctx.RequestCtx)
+
+		if err != nil {
+			ctx.Error(fmt.Errorf("Unable to regenerate session for user %s: %s", userSession.Username, err), authenticationFailedMessage)
+			return
+		}
+
 		userSession.AuthenticationLevel = authentication.TwoFactor
 		err = ctx.SaveSession(userSession)
 

--- a/internal/handlers/handler_sign_totp.go
+++ b/internal/handlers/handler_sign_totp.go
@@ -32,6 +32,13 @@ func SecondFactorTOTPPost(totpVerifier TOTPVerifier) middlewares.RequestHandler 
 			return
 		}
 
+		err = ctx.Providers.SessionProvider.RegenerateSession(ctx.RequestCtx)
+
+		if err != nil {
+			ctx.Error(fmt.Errorf("Unable to regenerate session for user %s: %s", userSession.Username, err), authenticationFailedMessage)
+			return
+		}
+
 		userSession.AuthenticationLevel = authentication.TwoFactor
 		err = ctx.SaveSession(userSession)
 

--- a/internal/handlers/handler_sign_u2f_step2.go
+++ b/internal/handlers/handler_sign_u2f_step2.go
@@ -40,6 +40,13 @@ func SecondFactorU2FSignPost(u2fVerifier U2FVerifier) middlewares.RequestHandler
 			return
 		}
 
+		err = ctx.Providers.SessionProvider.RegenerateSession(ctx.RequestCtx)
+
+		if err != nil {
+			ctx.Error(fmt.Errorf("Unable to regenerate session for user %s: %s", userSession.Username, err), authenticationFailedMessage)
+			return
+		}
+
 		userSession.AuthenticationLevel = authentication.TwoFactor
 		err = ctx.SaveSession(userSession)
 


### PR DESCRIPTION
Session fixation attacks were prevented because a session ID was
regenerated at each first factor authentication but this commit
generalize session regeneration from first to second factor too.

Fixes #180