### PR TITLE
[BUGFIX] Set username retrieved from authentication backend in session.

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -9,13 +9,12 @@ breaking changes and about what you should do to overcome those changes.
 ## Breaking in v4.7.0
 
 * `logs_level` configuration key has been renamed to `log_level`.
-* `users_filter` was a pattern of research for a given user with {0} matcher replaced by
+* `users_filter` was a search pattern for a given user with the `{0}` matcher replaced with the
 actual username. In v4.7.0, `username_attribute` has been introduced. Consequently, the computed
-user filter used by the LDAP search finding the user is a conjonction of a filter based
-on the username attribute and the filter provided in `users_filter`. Concretely, `users_filter` now
-reduces the scope of users targeted by the LDAP search query. For instance if
-`username_attribute` is set to `uid` and `users_filter` is set to `(objectClass=user)` then
-the computed filter is `(&(uid=john)(objectClass=user))`.
+user filter utilised by the LDAP search query is a combination of filters based on the
+`username_attribute` and `users_filter`. `users_filter` now reduces the scope of users targeted by
+the LDAP search query. For instance if `username_attribute` is set to `uid` and `users_filter` is
+set to `(objectClass=person)` then the computed filter is `(&(uid=john)(objectClass=person))`.
 
 ## Breaking in v4.0.0
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -8,7 +8,14 @@ breaking changes and about what you should do to overcome those changes.
 
 ## Breaking in v4.7.0
 
-`logs_level` configuration key has been renamed to `log_level`.
+* `logs_level` configuration key has been renamed to `log_level`.
+* `users_filter` was a pattern of research for a given user with {0} matcher replaced by
+actual username. In v4.7.0, `username_attribute` has been introduced. Consequently, the computed
+user filter used by the LDAP search finding the user is a conjonction of a filter based
+on the username attribute and the filter provided in `users_filter`. Concretely, `users_filter` now
+reduces the scope of users targeted by the LDAP search query. For instance if
+`username_attribute` is set to `uid` and `users_filter` is set to `(objectClass=user)` then
+the computed filter is `(&(uid=john)(objectClass=user))`.
 
 ## Breaking in v4.0.0
 

--- a/config.template.yml
+++ b/config.template.yml
@@ -74,7 +74,7 @@ authentication_backend:
     # case insensitive search queries: #561).
     # Microsoft Active Directory usually uses 'sAMAccountName'
     # OpenLDAP usually uses 'uid'
-    username_attribute: cn
+    username_attribute: uid
     # An additional dn to define the scope to all users
     additional_users_dn: ou=users
     # The users filter used to find the user DN

--- a/config.template.yml
+++ b/config.template.yml
@@ -56,7 +56,7 @@ duo_api:
 # and retrieve information such as email address and groups
 # users belong to.
 #
-# There are two supported backends: `ldap` and `file`.
+# There are two supported backends: 'ldap' and 'file'.
 authentication_backend:
   # LDAP backend configuration.
   #
@@ -82,12 +82,14 @@ authentication_backend:
     # An additional dn to define the scope to all users
     additional_users_dn: ou=users
 
-    # This attribute is optional. The user filter used in the LDAP search query
-    # is a conjonction of this filter and a filter based on the username attribute.
-    # Concretely, this filter is used to reduce the scope of users targeted by the LDAP
-    # search query.
-    # For instance, if the username attribute is set to uid, the computed filter is
+    # This attribute is optional. The user filter used in the LDAP search queries
+    # is a combination of this filter and the username attribute.
+    # This filter is used to reduce the scope of users targeted by the LDAP search query.
+    # For instance, if the username attribute is set to 'uid', the computed filter is
     # (&(uid=<username>)(&(objectCategory=person)(objectClass=user)))
+    # Recommended settings are as follows:
+    # Microsoft Active Directory '(&(objectCategory=person)(objectClass=user))'
+    # OpenLDAP '(objectClass=person)' or '(objectClass=inetOrgPerson)'
     users_filter: (&(objectCategory=person)(objectClass=user))
 
     # An additional dn to define the scope of groups
@@ -137,7 +139,7 @@ authentication_backend:
 # Access control is a list of rules defining the authorizations applied for one
 # resource to users or group of users.
 #
-# If 'access_control' is not defined, ACL rules are disabled and the `bypass`
+# If 'access_control' is not defined, ACL rules are disabled and the 'bypass'
 # rule is applied, i.e., access is allowed to anyone. Otherwise restrictions follow
 # the rules defined.
 #
@@ -147,27 +149,27 @@ authentication_backend:
 # Note: You must put patterns containing wildcards between simple quotes for the YAML
 # to be syntactically correct.
 #
-# Definition: A `rule` is an object with the following keys: `domain`, `subject`,
-# `policy` and `resources`.
+# Definition: A 'rule' is an object with the following keys: 'domain', 'subject',
+# 'policy' and 'resources'.
 #
-# - `domain` defines which domain or set of domains the rule applies to.
+# - 'domain' defines which domain or set of domains the rule applies to.
 #
-# - `subject` defines the subject to apply authorizations to. This parameter is
+# - 'subject' defines the subject to apply authorizations to. This parameter is
 #    optional and matching any user if not provided. If provided, the parameter
 #    represents either a user or a group. It should be of the form 'user:<username>'
 #    or 'group:<groupname>'.
 #
-# - `policy` is the policy to apply to resources. It must be either `bypass`,
-#   `one_factor`, `two_factor` or `deny`.
+# - 'policy' is the policy to apply to resources. It must be either 'bypass',
+#   'one_factor', 'two_factor' or 'deny'.
 #
-# - `resources` is a list of regular expressions that matches a set of resources to
+# - 'resources' is a list of regular expressions that matches a set of resources to
 #    apply the policy to. This parameter is optional and matches any resource if not
 #    provided.
 #
 # Note: the order of the rules is important. The first policy matching
 # (domain, resource, subject) applies.
 access_control:
-  # Default policy can either be `bypass`, `one_factor`, `two_factor` or `deny`.
+  # Default policy can either be 'bypass', 'one_factor', 'two_factor' or 'deny'.
   # It is the policy applied to any resource if there is no policy to be applied
   # to the user.
   default_policy: deny
@@ -269,7 +271,7 @@ regulation:
   max_retries: 3
 
   # The time range during which the user can attempt login before being banned.
-  # The user is banned if the authentication failed `max_retries` times in a `find_time` seconds window.
+  # The user is banned if the authentication failed 'max_retries' times in a 'find_time' seconds window.
   find_time: 120
 
   # The length of time before a banned user can login again.

--- a/config.template.yml
+++ b/config.template.yml
@@ -83,9 +83,9 @@ authentication_backend:
     # An additional dn to define the scope of groups
     additional_groups_dn: ou=groups
     # The groups filter used for retrieving groups of a given user.
-    # {0} is a matcher replaced by username.
+    # {0} is a matcher replaced by username (as provided in login portal).
+    # {1} is a matcher replaced by username (as stored in LDAP).
     # {dn} is a matcher replaced by user DN.
-    # {uid} is a matcher replaced by user uid.
     # 'member={dn}' by default.
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     # The attribute holding the name of the group

--- a/config.template.yml
+++ b/config.template.yml
@@ -79,8 +79,7 @@ authentication_backend:
     additional_users_dn: ou=users
     # The users filter used to find the user DN
     # {0} is a matcher replaced by username.
-    # 'cn={0}' by default.
-    users_filter: (cn={0})
+    users_filter: (uid={0})
     # An additional dn to define the scope of groups
     additional_groups_dn: ou=groups
     # The groups filter used for retrieving groups of a given user.

--- a/config.template.yml
+++ b/config.template.yml
@@ -86,11 +86,11 @@ authentication_backend:
     # is a combination of this filter and the username attribute.
     # This filter is used to reduce the scope of users targeted by the LDAP search query.
     # For instance, if the username attribute is set to 'uid', the computed filter is
-    # (&(uid=<username>)(&(objectCategory=person)(objectClass=user)))
+    # (&(uid=<username>)(objectClass=person))
     # Recommended settings are as follows:
     # Microsoft Active Directory '(&(objectCategory=person)(objectClass=user))'
     # OpenLDAP '(objectClass=person)' or '(objectClass=inetOrgPerson)'
-    users_filter: (&(objectCategory=person)(objectClass=user))
+    users_filter: (objectClass=person)
 
     # An additional dn to define the scope of groups
     additional_groups_dn: ou=groups

--- a/config.template.yml
+++ b/config.template.yml
@@ -66,32 +66,46 @@ authentication_backend:
   ldap:
     # The url to the ldap server. Scheme can be ldap:// or ldaps://
     url: ldap://127.0.0.1
+    
     # Skip verifying the server certificate (to allow self-signed certificate).
     skip_verify: false
+    
     # The base dn for every entries
     base_dn: dc=example,dc=com
+    
     # The attribute holding the username of the user (introduced to handle
     # case insensitive search queries: #561).
     # Microsoft Active Directory usually uses 'sAMAccountName'
     # OpenLDAP usually uses 'uid'
     username_attribute: uid
+    
     # An additional dn to define the scope to all users
     additional_users_dn: ou=users
-    # The users filter used to find the user DN
-    # {0} is a matcher replaced by username.
-    users_filter: (uid={0})
+
+    # This attribute is optional. The user filter used in the LDAP search query
+    # is a conjonction of this filter and a filter based on the username attribute.
+    # Concretely, this filter is used to reduce the scope of users targeted by the LDAP
+    # search query.
+    # For instance, if the username attribute is set to uid, the computed filter is
+    # (&(uid=<username>)(&(objectCategory=person)(objectClass=user)))
+    users_filter: (&(objectCategory=person)(objectClass=user))
+
     # An additional dn to define the scope of groups
     additional_groups_dn: ou=groups
+    
     # The groups filter used for retrieving groups of a given user.
     # {0} is a matcher replaced by username (as provided in login portal).
     # {1} is a matcher replaced by username (as stored in LDAP).
     # {dn} is a matcher replaced by user DN.
     # 'member={dn}' by default.
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    
     # The attribute holding the name of the group
     group_name_attribute: cn
+    
     # The attribute holding the mail address of the user
     mail_attribute: mail
+    
     # The username and password of the admin user.
     user: cn=admin,dc=example,dc=com
     # This secret can also be set using the env variables AUTHELIA_AUTHENTICATION_BACKEND_LDAP_PASSWORD

--- a/config.template.yml
+++ b/config.template.yml
@@ -70,6 +70,11 @@ authentication_backend:
     skip_verify: false
     # The base dn for every entries
     base_dn: dc=example,dc=com
+    # The attribute holding the username of the user (introduced to handle
+    # case insensitive search queries: #561).
+    # Microsoft Active Directory usually uses 'sAMAccountName'
+    # OpenLDAP usually uses 'uid'
+    username_attribute: cn
     # An additional dn to define the scope to all users
     additional_users_dn: ou=users
     # The users filter used to find the user DN

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -35,12 +35,14 @@ authentication_backend:
         # An additional dn to define the scope to all users
         additional_users_dn: ou=users
         
-        # This attribute is optional. The user filter used in the LDAP search query
-        # is a conjonction of this filter and a filter based on the username attribute.
-        # Concretely, this filter is used to reduce the scope of users targeted by the LDAP
-        # search query.
-        # For instance, if the username attribute is set to uid, the computed filter is
+        # This attribute is optional. The user filter used in the LDAP search queries
+        # is a combination of this filter and the username attribute.
+        # This filter is used to reduce the scope of users targeted by the LDAP search query.
+        # For instance, if the username attribute is set to 'uid', the computed filter is
         # (&(uid=<username>)(&(objectCategory=person)(objectClass=user)))
+        # Recommended settings are as follows:
+        # Microsoft Active Directory '(&(objectCategory=person)(objectClass=user))'
+        # OpenLDAP '(objectClass=person)' or '(objectClass=inetOrgPerson)'
         users_filter: (&(objectCategory=person)(objectClass=user))
         
         # An additional dn to define the scope of groups

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -37,8 +37,7 @@ authentication_backend:
         
         # The users filter used to find the user DN
         # {0} is a matcher replaced by username.
-        # 'cn={0}' by default.
-        users_filter: (cn={0})
+        users_filter: (uid={0})
         
         # An additional dn to define the scope of groups
         additional_groups_dn: ou=groups
@@ -47,7 +46,6 @@ authentication_backend:
         # {0} is a matcher replaced by username.
         # {dn} is a matcher replaced by user DN.
         # {uid} is a matcher replaced by user uid.
-        # 'member={dn}' by default.
         groups_filter: (&(member={dn})(objectclass=groupOfNames))
         
         # The attribute holding the name of the group

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -43,9 +43,10 @@ authentication_backend:
         additional_groups_dn: ou=groups
         
         # The groups filter used for retrieving groups of a given user.
-        # {0} is a matcher replaced by username.
+        # {0} is a matcher replaced by username (as provided in login portal).
+        # {1} is a matcher replaced by username (as stored in LDAP).
         # {dn} is a matcher replaced by user DN.
-        # {uid} is a matcher replaced by user uid.
+        # 'member={dn}' by default.
         groups_filter: (&(member={dn})(objectclass=groupOfNames))
         
         # The attribute holding the name of the group

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -35,9 +35,13 @@ authentication_backend:
         # An additional dn to define the scope to all users
         additional_users_dn: ou=users
         
-        # The users filter used to find the user DN
-        # {0} is a matcher replaced by username.
-        users_filter: (uid={0})
+        # This attribute is optional. The user filter used in the LDAP search query
+        # is a conjonction of this filter and a filter based on the username attribute.
+        # Concretely, this filter is used to reduce the scope of users targeted by the LDAP
+        # search query.
+        # For instance, if the username attribute is set to uid, the computed filter is
+        # (&(uid=<username>)(&(objectCategory=person)(objectClass=user)))
+        users_filter: (&(objectCategory=person)(objectClass=user))
         
         # An additional dn to define the scope of groups
         additional_groups_dn: ou=groups

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -25,6 +25,12 @@ authentication_backend:
 
         # The base dn for every entries
         base_dn: dc=example,dc=com
+
+        # The attribute holding the username of the user (introduced to handle
+        # case insensitive search queries: #561).
+        # Microsoft Active Directory usually uses 'sAMAccountName'
+        # OpenLDAP usually uses 'uid'
+        username_attribute: uid
         
         # An additional dn to define the scope to all users
         additional_users_dn: ou=users

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -39,11 +39,11 @@ authentication_backend:
         # is a combination of this filter and the username attribute.
         # This filter is used to reduce the scope of users targeted by the LDAP search query.
         # For instance, if the username attribute is set to 'uid', the computed filter is
-        # (&(uid=<username>)(&(objectCategory=person)(objectClass=user)))
+        # (&(uid=<username>)(objectClass=person))
         # Recommended settings are as follows:
         # Microsoft Active Directory '(&(objectCategory=person)(objectClass=user))'
         # OpenLDAP '(objectClass=person)' or '(objectClass=inetOrgPerson)'
-        users_filter: (&(objectCategory=person)(objectClass=user))
+        users_filter: (objectClass=person)
         
         # An additional dn to define the scope of groups
         additional_groups_dn: ou=groups

--- a/internal/authentication/file_user_provider.go
+++ b/internal/authentication/file_user_provider.go
@@ -101,8 +101,9 @@ func (p *FileUserProvider) CheckUserPassword(username string, password string) (
 func (p *FileUserProvider) GetDetails(username string) (*UserDetails, error) {
 	if details, ok := p.database.Users[username]; ok {
 		return &UserDetails{
-			Groups: details.Groups,
-			Emails: []string{details.Email},
+			Username: username,
+			Groups:   details.Groups,
+			Emails:   []string{details.Email},
 		}, nil
 	}
 	return nil, fmt.Errorf("User '%s' does not exist in database", username)

--- a/internal/authentication/file_user_provider_test.go
+++ b/internal/authentication/file_user_provider_test.go
@@ -85,6 +85,7 @@ func TestShouldRetrieveUserDetails(t *testing.T) {
 		provider := NewFileUserProvider(&config)
 		details, err := provider.GetDetails("john")
 		assert.NoError(t, err)
+		assert.Equal(t, details.Username, "john")
 		assert.Equal(t, details.Emails, []string{"john.doe@authelia.com"})
 		assert.Equal(t, details.Groups, []string{"admins", "dev"})
 	})

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -249,7 +249,7 @@ func (p *LDAPUserProvider) GetDetails(username string) (*UserDetails, error) {
 
 	searchEmailRequest := ldap.NewSearchRequest(
 		userDN, ldap.ScopeBaseObject, ldap.NeverDerefAliases,
-		0, 0, false, "(cn=*)", []string{p.configuration.MailAttribute}, nil,
+		0, 0, false, "", []string{p.configuration.MailAttribute}, nil,
 	)
 
 	sr, err = conn.Search(searchEmailRequest)

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -108,7 +108,10 @@ type ldapUserProfile struct {
 
 func (p *LDAPUserProvider) getUserProfile(conn LDAPConnection, username string) (*ldapUserProfile, error) {
 	username = p.ldapEscape(username)
-	userFilter := strings.Replace(p.configuration.UsersFilter, "{0}", username, -1)
+	userFilter := fmt.Sprintf("(%s=%s)", p.configuration.UsernameAttribute, username)
+	if p.configuration.UsersFilter != "" {
+		userFilter = fmt.Sprintf("(&%s%s)", userFilter, p.configuration.UsersFilter)
+	}
 	baseDN := p.configuration.BaseDN
 	if p.configuration.AdditionalUsersDN != "" {
 		baseDN = p.configuration.AdditionalUsersDN + "," + baseDN

--- a/internal/authentication/types.go
+++ b/internal/authentication/types.go
@@ -2,6 +2,7 @@ package authentication
 
 // UserDetails represent the details retrieved for a given user.
 type UserDetails struct {
-	Emails []string
-	Groups []string
+	Username string
+	Emails   []string
+	Groups   []string
 }

--- a/internal/configuration/schema/authentication.go
+++ b/internal/configuration/schema/authentication.go
@@ -10,6 +10,7 @@ type LDAPAuthenticationBackendConfiguration struct {
 	AdditionalGroupsDN string `mapstructure:"additional_groups_dn"`
 	GroupsFilter       string `mapstructure:"groups_filter"`
 	GroupNameAttribute string `mapstructure:"group_name_attribute"`
+	UsernameAttribute  string `mapstructure:"username_attribute"`
 	MailAttribute      string `mapstructure:"mail_attribute"`
 	User               string `mapstructure:"user"`
 	Password           string `mapstructure:"password"`

--- a/internal/configuration/test_resources/config.yml
+++ b/internal/configuration/test_resources/config.yml
@@ -21,7 +21,7 @@ authentication_backend:
     base_dn: dc=example,dc=com
     username_attribute: uid
     additional_users_dn: ou=users
-    users_filter: (uid={0})
+    users_filter: (&(objectCategory=person)(objectClass=user))
     additional_groups_dn: ou=groups
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn

--- a/internal/configuration/test_resources/config.yml
+++ b/internal/configuration/test_resources/config.yml
@@ -19,8 +19,9 @@ authentication_backend:
   ldap:
     url: ldap://127.0.0.1
     base_dn: dc=example,dc=com
+    username_attribute: uid
     additional_users_dn: ou=users
-    users_filter: (cn={0})
+    users_filter: (uid={0})
     additional_groups_dn: ou=groups
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -121,7 +121,7 @@ func validateLdapAuthenticationBackend(configuration *schema.LDAPAuthenticationB
 	}
 
 	if configuration.UsersFilter == "" {
-		validator.Push(errors.New("Provide a users filter with `users_filter` attribute"))
+		validator.Push(errors.New("Please provide a users filter with `users_filter` attribute"))
 	} else {
 		if !strings.HasPrefix(configuration.UsersFilter, "(") || !strings.HasSuffix(configuration.UsersFilter, ")") {
 			validator.Push(errors.New("The users filter should contain enclosing parenthesis. For instance uid={0} should be (uid={0})"))
@@ -129,11 +129,15 @@ func validateLdapAuthenticationBackend(configuration *schema.LDAPAuthenticationB
 	}
 
 	if configuration.GroupsFilter == "" {
-		validator.Push(errors.New("Provide a groups filter with `groups_filter` attribute"))
+		validator.Push(errors.New("Please provide a groups filter with `groups_filter` attribute"))
 	} else {
 		if !strings.HasPrefix(configuration.GroupsFilter, "(") || !strings.HasSuffix(configuration.GroupsFilter, ")") {
 			validator.Push(errors.New("The groups filter should contain enclosing parenthesis. For instance cn={0} should be (cn={0})"))
 		}
+	}
+
+	if configuration.UsernameAttribute == "" {
+		validator.Push(errors.New("Please provide a username attribute with `username_attribute`"))
 	}
 
 	if configuration.GroupNameAttribute == "" {

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -121,19 +121,19 @@ func validateLdapAuthenticationBackend(configuration *schema.LDAPAuthenticationB
 	}
 
 	if configuration.UsersFilter == "" {
-		configuration.UsersFilter = "(cn={0})"
-	}
-
-	if !strings.HasPrefix(configuration.UsersFilter, "(") || !strings.HasSuffix(configuration.UsersFilter, ")") {
-		validator.Push(errors.New("The users filter should contain enclosing parenthesis. For instance cn={0} should be (cn={0})"))
+		validator.Push(errors.New("Provide a users filter with `users_filter` attribute"))
+	} else {
+		if !strings.HasPrefix(configuration.UsersFilter, "(") || !strings.HasSuffix(configuration.UsersFilter, ")") {
+			validator.Push(errors.New("The users filter should contain enclosing parenthesis. For instance uid={0} should be (uid={0})"))
+		}
 	}
 
 	if configuration.GroupsFilter == "" {
-		configuration.GroupsFilter = "(member={dn})"
-	}
-
-	if !strings.HasPrefix(configuration.GroupsFilter, "(") || !strings.HasSuffix(configuration.GroupsFilter, ")") {
-		validator.Push(errors.New("The groups filter should contain enclosing parenthesis. For instance cn={0} should be (cn={0})"))
+		validator.Push(errors.New("Provide a groups filter with `groups_filter` attribute"))
+	} else {
+		if !strings.HasPrefix(configuration.GroupsFilter, "(") || !strings.HasSuffix(configuration.GroupsFilter, ")") {
+			validator.Push(errors.New("The groups filter should contain enclosing parenthesis. For instance cn={0} should be (cn={0})"))
+		}
 	}
 
 	if configuration.GroupNameAttribute == "" {

--- a/internal/configuration/validator/authentication_test.go
+++ b/internal/configuration/validator/authentication_test.go
@@ -169,6 +169,7 @@ func (suite *LdapAuthenticationBackendSuite) SetupTest() {
 	suite.configuration.Ldap.User = "user"
 	suite.configuration.Ldap.Password = "password"
 	suite.configuration.Ldap.BaseDN = "base_dn"
+	suite.configuration.Ldap.UsernameAttribute = "uid"
 	suite.configuration.Ldap.UsersFilter = "(uid={0})"
 	suite.configuration.Ldap.GroupsFilter = "(cn={0})"
 }
@@ -206,13 +207,20 @@ func (suite *LdapAuthenticationBackendSuite) TestShouldRaiseErrorWhenBaseDNNotPr
 	assert.EqualError(suite.T(), suite.validator.Errors()[0], "Please provide a base DN to connect to the LDAP server")
 }
 
-func (suite *LdapAuthenticationBackendSuite) TestShouldSetUsersFilterAndGroupsFilter() {
+func (suite *LdapAuthenticationBackendSuite) TestShouldRaiseOnEmptyFilterAndGroupsFilter() {
 	suite.configuration.Ldap.UsersFilter = ""
 	suite.configuration.Ldap.GroupsFilter = ""
 	ValidateAuthenticationBackend(&suite.configuration, suite.validator)
 	require.Len(suite.T(), suite.validator.Errors(), 2)
-	assert.EqualError(suite.T(), suite.validator.Errors()[0], "Provide a users filter with `users_filter` attribute")
-	assert.EqualError(suite.T(), suite.validator.Errors()[1], "Provide a groups filter with `groups_filter` attribute")
+	assert.EqualError(suite.T(), suite.validator.Errors()[0], "Please provide a users filter with `users_filter` attribute")
+	assert.EqualError(suite.T(), suite.validator.Errors()[1], "Please provide a groups filter with `groups_filter` attribute")
+}
+
+func (suite *LdapAuthenticationBackendSuite) TestShouldRaiseOnEmptyUsernameAttribute() {
+	suite.configuration.Ldap.UsernameAttribute = ""
+	ValidateAuthenticationBackend(&suite.configuration, suite.validator)
+	require.Len(suite.T(), suite.validator.Errors(), 1)
+	assert.EqualError(suite.T(), suite.validator.Errors()[0], "Please provide a username attribute with `username_attribute`")
 }
 
 func (suite *LdapAuthenticationBackendSuite) TestShouldSetDefaultGroupNameAttribute() {

--- a/internal/handlers/handler_firstfactor.go
+++ b/internal/handlers/handler_firstfactor.go
@@ -95,7 +95,7 @@ func FirstFactorPost(ctx *middlewares.AutheliaCtx) {
 
 	// And set those information in the new session.
 	userSession := ctx.GetSession()
-	userSession.Username = bodyJSON.Username
+	userSession.Username = userDetails.Username
 	userSession.Groups = userDetails.Groups
 	userSession.Emails = userDetails.Emails
 	userSession.AuthenticationLevel = authentication.OneFactor

--- a/internal/suites/HighAvailability/configuration.yml
+++ b/internal/suites/HighAvailability/configuration.yml
@@ -17,7 +17,7 @@ authentication_backend:
     base_dn: dc=example,dc=com
     username_attribute: uid
     additional_users_dn: ou=users
-    users_filter: (uid={0})
+    users_filter: (&(objectCategory=person)(objectClass=user))
     additional_groups_dn: ou=groups
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn

--- a/internal/suites/HighAvailability/configuration.yml
+++ b/internal/suites/HighAvailability/configuration.yml
@@ -17,7 +17,7 @@ authentication_backend:
     base_dn: dc=example,dc=com
     username_attribute: uid
     additional_users_dn: ou=users
-    users_filter: (&(objectCategory=person)(objectClass=user))
+    users_filter: (objectClass=person)
     additional_groups_dn: ou=groups
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn

--- a/internal/suites/HighAvailability/configuration.yml
+++ b/internal/suites/HighAvailability/configuration.yml
@@ -2,116 +2,30 @@
 #                   Authelia configuration                    #
 ###############################################################
 
-# The port to listen on
 port: 9091
 
-# Log level
-#
-# Level of verbosity for logs
 log_level: debug
 
 jwt_secret: unsecure_secret
 
-# TOTP Issuer Name
-#
-# This will be the issuer name displayed in Google Authenticator
-# See: https://github.com/google/google-authenticator/wiki/Key-Uri-Format for more info on issuer names
 totp:
   issuer: authelia.com
 
-# The authentication backend to use for verifying user passwords
-# and retrieve information such as email address and groups
-# users belong to.
-#
-# There are two supported backends: `ldap` and `file`.
 authentication_backend:
-  # LDAP backend configuration.
-  #
-  # This backend allows Authelia to be scaled to more
-  # than one instance and therefore is recommended for
-  # production.
   ldap:
-    # The url of the ldap server
     url: ldap://openldap
-
-    # The base dn for every entries
     base_dn: dc=example,dc=com
-
-    # An additional dn to define the scope to all users
+    username_attribute: uid
     additional_users_dn: ou=users
-
-    # The users filter used to find the user DN
-    # {0} is a matcher replaced by username.
     users_filter: (uid={0})
-
-    # An additional dn to define the scope of groups
     additional_groups_dn: ou=groups
-
-    # The groups filter used for retrieving groups of a given user.
-    # {0} is a matcher replaced by username.
-    # {dn} is a matcher replaced by user DN.
-    # 'member={dn}' by default.
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
-
-    # The attribute holding the name of the group
     group_name_attribute: cn
-
-    # The attribute holding the mail address of the user
     mail_attribute: mail
-
-    # The username and password of the admin user.
     user: cn=admin,dc=example,dc=com
     password: password
 
-  # File backend configuration.
-  #
-  # With this backend, the users database is stored in a file
-  # which is updated when users reset their passwords.
-  # Therefore, this backend is meant to be used in a dev environment
-  # and not in production since it prevents Authelia to be scaled to
-  # more than one instance.
-  #
-  ## file:
-  ##   path: ./users_database.yml
-
-# Access Control
-#
-# Access control is a list of rules defining the authorizations applied for one
-# resource to users or group of users.
-#
-# If 'access_control' is not defined, ACL rules are disabled and the `bypass`
-# rule is applied, i.e., access is allowed to anyone. Otherwise restrictions follow
-# the rules defined.
-#
-# Note: One can use the wildcard * to match any subdomain.
-# It must stand at the beginning of the pattern. (example: *.mydomain.com)
-#
-# Note: You must put patterns containing wildcards between simple quotes for the YAML
-# to be syntaxically correct.
-#
-# Definition: A `rule` is an object with the following keys: `domain`, `subject`,
-# `policy` and `resources`.
-#
-# - `domain` defines which domain or set of domains the rule applies to.
-#
-# - `subject` defines the subject to apply authorizations to. This parameter is
-#    optional and matching any user if not provided. If provided, the parameter
-#    represents either a user or a group. It should be of the form 'user:<username>'
-#    or 'group:<groupname>'.
-#
-# - `policy` is the policy to apply to resources. It must be either `bypass`,
-#   `one_factor`, `two_factor` or `deny`.
-#
-# - `resources` is a list of regular expressions that matches a set of resources to
-#    apply the policy to. This parameter is optional and matches any resource if not
-#    provided.
-#
-# Note: the order of the rules is important. The first policy matching
-# (domain, resource, subject) applies.
 access_control:
-  # Default policy can either be `bypass`, `one_factor`, `two_factor` or `deny`.
-  # It is the policy applied to any resource if there is no policy to be applied
-  # to the user.
   default_policy: deny
 
   rules:
@@ -161,55 +75,23 @@ access_control:
       subject: "user:bob"
       policy: two_factor
 
-# Configuration of session cookies
-#
-# The session cookies identify the user once logged in.
 session:
-  # The name of the session cookie. (default: authelia_session).
   name: authelia_session
-
-  # The secret to encrypt the session cookie.
   secret: unsecure_session_secret
-
-  # The time in ms before the cookie expires and session is reset.
   expiration: 3600 # 1 hour
-
-  # The inactivity time in ms before the session is reset.
   inactivity: 300 # 5 minutes
-
-  # The domain to protect.
-  # Note: the authenticator must also be in that domain. If empty, the cookie
-  # is restricted to the subdomain of the issuer.
   domain: example.com
-
-  # The redis connection details
   redis:
     host: redis
     port: 6379
     password: authelia
 
-# Configuration of the authentication regulation mechanism.
-#
-# This mechanism prevents attackers from brute forcing the first factor.
-# It bans the user if too many attempts are done in a short period of
-# time.
 regulation:
-  # The number of failed login attempts before user is banned.
-  # Set it to 0 to disable regulation.
   max_retries: 3
-
-  # The time range during which the user can attempt login before being banned.
-  # The user is banned if the authentication failed `max_retries` times in a `find_time` seconds window.
   find_time: 8
-
-  # The length of time before a banned user can login again.
   ban_time: 10
 
-# Configuration of the storage backend used to store data and secrets.
-#
-# You must use only an available configuration: local, sql
 storage:
-  # Settings to connect to mariadb server
   mysql:
     host: mariadb
     port: 3306
@@ -217,13 +99,7 @@ storage:
     username: admin
     password: password
 
-# Configuration of the notification system.
-#
-# Notifications are sent to users when they require a password reset, a u2f
-# registration or a TOTP registration.
-# Use only an available configuration: filesystem, gmail
 notifier:
-  # Use a SMTP server for sending notifications
   smtp:
     host: smtp
     port: 1025

--- a/internal/suites/HighAvailability/configuration.yml
+++ b/internal/suites/HighAvailability/configuration.yml
@@ -42,8 +42,7 @@ authentication_backend:
 
     # The users filter used to find the user DN
     # {0} is a matcher replaced by username.
-    # 'cn={0}' by default.
-    users_filter: (cn={0})
+    users_filter: (uid={0})
 
     # An additional dn to define the scope of groups
     additional_groups_dn: ou=groups

--- a/internal/suites/LDAP/configuration.yml
+++ b/internal/suites/LDAP/configuration.yml
@@ -12,38 +12,16 @@ jwt_secret: very_important_secret
 
 authentication_backend:
   ldap:
-    # The url of the ldap server
     url: ldaps://openldap
-
-    # Skip certificate verification (for self-signed certificates)
     skip_verify: true
-
-    # The base dn for every entries
     base_dn: dc=example,dc=com
-
-    # An additional dn to define the scope to all users
+    username_attribute: uid
     additional_users_dn: ou=users
-
-    # The users filter used to find the user DN
-    # {0} is a matcher replaced by username.
     users_filter: (uid={0})
-
-    # An additional dn to define the scope of groups
     additional_groups_dn: ou=groups
-
-    # The groups filter used for retrieving groups of a given user.
-    # {0} is a matcher replaced by username.
-    # {dn} is a matcher replaced by user DN.
-    # 'member={dn}' by default.
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
-
-    # The attribute holding the name of the group
     group_name_attribute: cn
-
-    # The attribute holding the mail address of the user
     mail_attribute: mail
-
-    # The username and password of the admin user.
     user: cn=admin,dc=example,dc=com
     password: password
 
@@ -53,15 +31,10 @@ session:
   expiration: 3600 # 1 hour
   inactivity: 300 # 5 minutes
 
-# Configuration of the storage backend used to store data and secrets. i.e. totp data
 storage:
   local:
     path: /var/lib/authelia/db.sqlite3
 
-# TOTP Issuer Name
-#
-# This will be the issuer name displayed in Google Authenticator
-# See: https://github.com/google/google-authenticator/wiki/Key-Uri-Format for more info on issuer names
 totp:
   issuer: example.com
 
@@ -77,19 +50,12 @@ access_control:
     - domain: "singlefactor.example.com"
       policy: one_factor
 
-# Configuration of the authentication regulation mechanism.
 regulation:
-  # Set it to 0 to disable max_retries.
   max_retries: 3
-
-  # The user is banned if the authentication failed `max_retries` times in a `find_time` seconds window.
   find_time: 300
-
-  # The length of time before a banned user can login again.
   ban_time: 900
 
 notifier:
-  # Use a SMTP server for sending notifications
   smtp:
     host: smtp
     port: 1025

--- a/internal/suites/LDAP/configuration.yml
+++ b/internal/suites/LDAP/configuration.yml
@@ -17,7 +17,7 @@ authentication_backend:
     base_dn: dc=example,dc=com
     username_attribute: uid
     additional_users_dn: ou=users
-    users_filter: (uid={0})
+    users_filter: (&(objectCategory=person)(objectClass=user))
     additional_groups_dn: ou=groups
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn

--- a/internal/suites/LDAP/configuration.yml
+++ b/internal/suites/LDAP/configuration.yml
@@ -26,8 +26,7 @@ authentication_backend:
 
     # The users filter used to find the user DN
     # {0} is a matcher replaced by username.
-    # 'cn={0}' by default.
-    users_filter: (cn={0})
+    users_filter: (uid={0})
 
     # An additional dn to define the scope of groups
     additional_groups_dn: ou=groups

--- a/internal/suites/LDAP/configuration.yml
+++ b/internal/suites/LDAP/configuration.yml
@@ -17,7 +17,7 @@ authentication_backend:
     base_dn: dc=example,dc=com
     username_attribute: uid
     additional_users_dn: ou=users
-    users_filter: (&(objectCategory=person)(objectClass=user))
+    users_filter: (objectClass=person)
     additional_groups_dn: ou=groups
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn

--- a/internal/suites/example/compose/ldap/docker-compose.yml
+++ b/internal/suites/example/compose/ldap/docker-compose.yml
@@ -16,5 +16,7 @@ services:
       - './example/compose/ldap/ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom'
     command:
       - '--copy-service'
+      - '--loglevel'
+      - 'debug'
     networks:
       - authelianet

--- a/internal/suites/example/compose/ldap/ldif/base.ldif
+++ b/internal/suites/example/compose/ldap/ldif/base.ldif
@@ -10,18 +10,19 @@ ou: users
 
 dn: cn=dev,ou=groups,dc=example,dc=com
 cn: dev
-member: cn=john,ou=users,dc=example,dc=com
-member: cn=bob,ou=users,dc=example,dc=com
+member: uid=john,ou=users,dc=example,dc=com
+member: uid=bob,ou=users,dc=example,dc=com
 objectclass: groupOfNames
 objectclass: top
 
 dn: cn=admins,ou=groups,dc=example,dc=com
 cn: admins
-member: cn=john,ou=users,dc=example,dc=com
+member: uid=john,ou=users,dc=example,dc=com
 objectclass: groupOfNames
 objectclass: top
 
-dn: cn=john,ou=users,dc=example,dc=com
+dn: uid=john,ou=users,dc=example,dc=com
+uid: john
 cn: john
 objectclass: inetOrgPerson
 objectclass: top
@@ -29,7 +30,8 @@ mail: john.doe@authelia.com
 sn: John Doe
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: cn=harry,ou=users,dc=example,dc=com
+dn: uid=harry,ou=users,dc=example,dc=com
+uid: harry
 cn: harry
 objectclass: inetOrgPerson
 objectclass: top
@@ -37,7 +39,8 @@ mail: harry.potter@authelia.com
 sn: Harry Potter
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: cn=bob,ou=users,dc=example,dc=com
+dn: uid=bob,ou=users,dc=example,dc=com
+uid: bob
 cn: bob
 objectclass: inetOrgPerson
 objectclass: top
@@ -45,7 +48,8 @@ mail: bob.dylan@authelia.com
 sn: Bob Dylan
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: cn=james,ou=users,dc=example,dc=com
+dn: uid=james,ou=users,dc=example,dc=com
+uid: james
 cn: james
 objectclass: inetOrgPerson
 objectclass: top
@@ -53,7 +57,8 @@ mail: james.dean@authelia.com
 sn: James Dean
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: cn=blackhat,ou=users,dc=example,dc=com
+dn: uid=blackhat,ou=users,dc=example,dc=com
+uid: blackhat
 cn: blackhat
 objectclass: inetOrgPerson
 objectclass: top

--- a/internal/suites/example/kube/authelia/configs/configuration.yml
+++ b/internal/suites/example/kube/authelia/configs/configuration.yml
@@ -12,6 +12,7 @@ authentication_backend:
     url: ldaps://ldap-service
     skip_verify: true
     base_dn: dc=example,dc=com
+    username_attribute: uid
     additional_users_dn: ou=users
     users_filter: (uid={0})
     additional_groups_dn: ou=groups

--- a/internal/suites/example/kube/authelia/configs/configuration.yml
+++ b/internal/suites/example/kube/authelia/configs/configuration.yml
@@ -14,7 +14,7 @@ authentication_backend:
     base_dn: dc=example,dc=com
     username_attribute: uid
     additional_users_dn: ou=users
-    users_filter: (uid={0})
+    users_filter: (&(objectCategory=person)(objectClass=user))
     additional_groups_dn: ou=groups
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn

--- a/internal/suites/example/kube/authelia/configs/configuration.yml
+++ b/internal/suites/example/kube/authelia/configs/configuration.yml
@@ -14,7 +14,7 @@ authentication_backend:
     base_dn: dc=example,dc=com
     username_attribute: uid
     additional_users_dn: ou=users
-    users_filter: (&(objectCategory=person)(objectClass=user))
+    users_filter: (objectClass=person)
     additional_groups_dn: ou=groups
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn

--- a/internal/suites/example/kube/authelia/configs/configuration.yml
+++ b/internal/suites/example/kube/authelia/configs/configuration.yml
@@ -13,7 +13,7 @@ authentication_backend:
     skip_verify: true
     base_dn: dc=example,dc=com
     additional_users_dn: ou=users
-    users_filter: (cn={0})
+    users_filter: (uid={0})
     additional_groups_dn: ou=groups
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn

--- a/internal/suites/example/kube/ldap/base.ldif
+++ b/internal/suites/example/kube/ldap/base.ldif
@@ -10,18 +10,19 @@ ou: users
 
 dn: cn=dev,ou=groups,dc=example,dc=com
 cn: dev
-member: cn=john,ou=users,dc=example,dc=com
-member: cn=bob,ou=users,dc=example,dc=com
+member: uid=john,ou=users,dc=example,dc=com
+member: uid=bob,ou=users,dc=example,dc=com
 objectclass: groupOfNames
 objectclass: top
 
 dn: cn=admins,ou=groups,dc=example,dc=com
 cn: admins
-member: cn=john,ou=users,dc=example,dc=com
+member: uid=john,ou=users,dc=example,dc=com
 objectclass: groupOfNames
 objectclass: top
 
-dn: cn=john,ou=users,dc=example,dc=com
+dn: uid=john,ou=users,dc=example,dc=com
+uid: john
 cn: john
 objectclass: inetOrgPerson
 objectclass: top
@@ -29,7 +30,8 @@ mail: john.doe@authelia.com
 sn: John Doe
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: cn=harry,ou=users,dc=example,dc=com
+dn: uid=harry,ou=users,dc=example,dc=com
+uid: harry
 cn: harry
 objectclass: inetOrgPerson
 objectclass: top
@@ -37,7 +39,8 @@ mail: harry.potter@authelia.com
 sn: Harry Potter
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: cn=bob,ou=users,dc=example,dc=com
+dn: uid=bob,ou=users,dc=example,dc=com
+uid: bob
 cn: bob
 objectclass: inetOrgPerson
 objectclass: top
@@ -45,7 +48,8 @@ mail: bob.dylan@authelia.com
 sn: Bob Dylan
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: cn=james,ou=users,dc=example,dc=com
+dn: uid=james,ou=users,dc=example,dc=com
+uid: james
 cn: james
 objectclass: inetOrgPerson
 objectclass: top
@@ -53,7 +57,8 @@ mail: james.dean@authelia.com
 sn: James Dean
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: cn=blackhat,ou=users,dc=example,dc=com
+dn: uid=blackhat,ou=users,dc=example,dc=com
+uid: blackhat
 cn: blackhat
 objectclass: inetOrgPerson
 objectclass: top

--- a/internal/suites/suite_high_availability.go
+++ b/internal/suites/suite_high_availability.go
@@ -31,7 +31,7 @@ func init() {
 		return waitUntilAutheliaBackendIsReady(haDockerEnvironment)
 	}
 
-	onSetupTimeout := func() error {
+	displayAutheliaLogs := func() error {
 		backendLogs, err := haDockerEnvironment.Logs("authelia-backend", nil)
 		if err != nil {
 			return err
@@ -53,10 +53,11 @@ func init() {
 	GlobalRegistry.Register(highAvailabilitySuiteName, Suite{
 		SetUp:           setup,
 		SetUpTimeout:    5 * time.Minute,
-		OnSetupTimeout:  onSetupTimeout,
+		OnSetupTimeout:  displayAutheliaLogs,
 		TestTimeout:     5 * time.Minute,
 		TearDown:        teardown,
 		TearDownTimeout: 2 * time.Minute,
+		OnError:         displayAutheliaLogs,
 		Description: `This suite is made to test Authelia in a *complete*
 environment, that is, with all components making Authelia highly available.`,
 	})

--- a/internal/suites/suite_ldap.go
+++ b/internal/suites/suite_ldap.go
@@ -30,7 +30,7 @@ func init() {
 		return waitUntilAutheliaBackendIsReady(dockerEnvironment)
 	}
 
-	onSetupTimeout := func() error {
+	displayAutheliaLogs := func() error {
 		backendLogs, err := dockerEnvironment.Logs("authelia-backend", nil)
 		if err != nil {
 			return err
@@ -53,9 +53,10 @@ func init() {
 	GlobalRegistry.Register(ldapSuiteName, Suite{
 		SetUp:           setup,
 		SetUpTimeout:    5 * time.Minute,
-		OnSetupTimeout:  onSetupTimeout,
+		OnSetupTimeout:  displayAutheliaLogs,
 		TestTimeout:     1 * time.Minute,
 		TearDown:        teardown,
 		TearDownTimeout: 2 * time.Minute,
+		OnError:         displayAutheliaLogs,
 	})
 }


### PR DESCRIPTION
In some setups, binding is case insensitive but Authelia is case
sensitive and therefore need the actual username as stored in the
authentication backend in order for Authelia to work correctly.