### PR TITLE
[Buildkite] Fix pipeline to work alongside dependabot

### DIFF
--- a/.buildkite/deployment.sh
+++ b/.buildkite/deployment.sh
@@ -20,10 +20,10 @@ steps:
 
   - label: ":docker: Image Deployments"
     command: ".buildkite/steps/deployimages.sh | buildkite-agent pipeline upload"
-    if: build.branch != "master" && build.env("CI_DOCS_BYPASS") != "true"
+    if: build.branch != "master" && build.branch !~ /^dependabot\/.*/ && build.env("CI_DOCS_BYPASS") != "true"
 
   - wait:
-    if: build.env("CI_DOCS_BYPASS") != "true"
+    if: build.branch !~ /^dependabot\/.*/ && build.env("CI_DOCS_BYPASS") != "true"
 
   - label: ":docker: Deploy Manifests"
     command: "authelia-scripts docker push-manifest"
@@ -37,7 +37,7 @@ steps:
     command: "authelia-scripts docker push-manifest"
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
-    if: build.branch != "master" && build.env("CI_DOCS_BYPASS") != "true"
+    if: build.branch != "master" && build.branch !~ /^dependabot\/.*/ && build.env("CI_DOCS_BYPASS") != "true"
 
   - label: ":github: Deploy Artifacts"
     command: "ghartifacts.sh"

--- a/.github/probot.js
+++ b/.github/probot.js
@@ -4,6 +4,10 @@ on('pull_request.opened')
         context =>
             context.payload.pull_request.head.label.slice(0, 9) === 'authelia:'
     )
+    .filter(
+        context =>
+            context.payload.pull_request.head.ref.slice(0, 11) !== 'dependabot/'
+    )
     .comment(`# Docker Container
 These changes are published for testing at the following location:
 * \`docker pull authelia/authelia:{{ pull_request.head.ref }}\``)


### PR DESCRIPTION
This change will continue to perform unit and integration testing, however, disables deployment steps in association with dependabot PRs.
Deployment comments on the PR with autheliabot are also disabled.