### PR TITLE
[BUGFIX] LDAP group retrieval of users with parenthesis in their name

### DIFF
--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -169,7 +169,7 @@ func (p *LDAPUserProvider) createGroupsFilter(conn LDAPConnection, username stri
 		if err != nil {
 			return "", err
 		}
-		return strings.Replace(p.configuration.GroupsFilter, "{dn}", profile.DN, -1), nil
+		return strings.Replace(p.configuration.GroupsFilter, "{dn}", ldap.EscapeFilter(profile.DN), -1), nil
 	} else if strings.Contains(p.configuration.GroupsFilter, "{1}") {
 		profile, err := p.getUserProfile(conn, username)
 		if err != nil {

--- a/internal/suites/example/compose/ldap/ldif/base.ldif
+++ b/internal/suites/example/compose/ldap/ldif/base.ldif
@@ -10,58 +10,63 @@ ou: users
 
 dn: cn=dev,ou=groups,dc=example,dc=com
 cn: dev
-member: uid=john,ou=users,dc=example,dc=com
-member: uid=bob,ou=users,dc=example,dc=com
+member: cn=John Doe (external),ou=users,dc=example,dc=com
+member: cn=Bob Dylan,ou=users,dc=example,dc=com
 objectclass: groupOfNames
 objectclass: top
 
 dn: cn=admins,ou=groups,dc=example,dc=com
 cn: admins
-member: uid=john,ou=users,dc=example,dc=com
+member: cn=John Doe (external),ou=users,dc=example,dc=com
 objectclass: groupOfNames
 objectclass: top
 
-dn: uid=john,ou=users,dc=example,dc=com
-uid: john
-cn: john
+dn: cn=John Doe (external),ou=users,dc=example,dc=com
+cn: John Doe (external)
+givenName: John
 objectclass: inetOrgPerson
 objectclass: top
 mail: john.doe@authelia.com
-sn: John Doe
+sn: Doe
+uid: john
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: uid=harry,ou=users,dc=example,dc=com
-uid: harry
-cn: harry
+dn: cn=Harry Potter,ou=users,dc=example,dc=com
+cn: Harry Potter
+givenName: Harry
 objectclass: inetOrgPerson
 objectclass: top
 mail: harry.potter@authelia.com
-sn: Harry Potter
+sn: Potter
+uid: harry
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: uid=bob,ou=users,dc=example,dc=com
-uid: bob
-cn: bob
+dn: cn=Bob Dylan,ou=users,dc=example,dc=com
+cn: Bob Dylan
+givenName: Bob
 objectclass: inetOrgPerson
 objectclass: top
 mail: bob.dylan@authelia.com
-sn: Bob Dylan
+sn: Dylan
+uid: bob
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: uid=james,ou=users,dc=example,dc=com
-uid: james
-cn: james
+dn: cn=James Dean,ou=users,dc=example,dc=com
+cn: James Dean
+givenName: James
 objectclass: inetOrgPerson
 objectclass: top
 mail: james.dean@authelia.com
-sn: James Dean
+sn: Dean
+uid: james
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
-dn: uid=blackhat,ou=users,dc=example,dc=com
-uid: blackhat
-cn: blackhat
+dn: cn=Billy Blackhat,ou=users,dc=example,dc=com
+cn: Billy Blackhat
+givenName: Billy
 objectclass: inetOrgPerson
 objectclass: top
 mail: billy.blackhat@authelia.com
-sn: Billy BlackHat
+sn: BlackHat
+uid: blackhat
 userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/


### PR DESCRIPTION
This aligns the search filter escaping to [RFC4515](https://tools.ietf.org/search/rfc4515).
I've also updated our `base.ldif` to be a closer match to RFC 2307.

Fixes #702.