### PR TITLE
[Buildkite] Fix docs bypass for origin/master divergences

### DIFF
--- a/.buildkite/deployment.sh
+++ b/.buildkite/deployment.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 set -u
 
-if [[ $BUILDKITE_TAG == "" ]]; then
-  if [[ $BUILDKITE_BRANCH == "master" ]]; then
-    CI_DOCS_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^docs\/.*/!{q1}' && echo true || echo false)
+DIVERGED=$(git merge-base --fork-point origin/master > /dev/null; echo $?)
+
+if [[ $DIVERGED -eq 0 ]]; then
+  if [[ $BUILDKITE_TAG == "" ]]; then
+    if [[ $BUILDKITE_BRANCH == "master" ]]; then
+      CI_DOCS_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^docs\/.*/!{q1}' && echo true || echo false)
+    else
+      CI_DOCS_BYPASS=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^docs\/.*/!{q1}' && echo true || echo false)
+    fi
   else
-    CI_DOCS_BYPASS=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^docs\/.*/!{q1}' && echo true || echo false)
+    CI_DOCS_BYPASS="false"
   fi
 else
   CI_DOCS_BYPASS="false"

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 set -u
 
-if [[ $BUILDKITE_TAG == "" ]]; then
-  if [[ $BUILDKITE_BRANCH == "master" ]]; then
-    CI_DOCS_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^docs\/.*/!{q1}' && echo true || echo false)
-  else
-    CI_DOCS_BYPASS=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^docs\/.*/!{q1}' && echo true || echo false)
-  fi
+DIVERGED=$(git merge-base --fork-point origin/master > /dev/null; echo $?)
 
-  if [[ $CI_DOCS_BYPASS == "true" ]]; then
-  cat .buildkite/annotations/documentation | buildkite-agent annotate --style "info" --context "ctx-info"
+if [[ $DIVERGED -eq 0 ]]; then
+  if [[ $BUILDKITE_TAG == "" ]]; then
+    if [[ $BUILDKITE_BRANCH == "master" ]]; then
+      CI_DOCS_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^docs\/.*/!{q1}' && echo true || echo false)
+    else
+      CI_DOCS_BYPASS=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^docs\/.*/!{q1}' && echo true || echo false)
+    fi
+
+    if [[ $CI_DOCS_BYPASS == "true" ]]; then
+      cat .buildkite/annotations/documentation | buildkite-agent annotate --style "info" --context "ctx-info"
+    fi
+  else
+    CI_DOCS_BYPASS="false"
   fi
 else
   CI_DOCS_BYPASS="false"


### PR DESCRIPTION
If origin/master diverges beyond the initial fork-point on branches or external forks, the `git merge-base` command exits unsuccessfully. This will cause commits to incorrectly be recognised as a docs bypass. This change will catch the unsuccessful exit and treat it as a normal CI/CD run.

Examples:
- https://buildkite.com/authelia/authelia/builds/932
- https://buildkite.com/authelia/authelia/builds/933
- https://buildkite.com/authelia/authelia/builds/941