### PR TITLE
[MISC] Fix authelia-frontend dev server startup.

### DIFF
--- a/internal/suites/example/compose/authelia/docker-compose.frontend.dev.yml
+++ b/internal/suites/example/compose/authelia/docker-compose.frontend.dev.yml
@@ -9,6 +9,7 @@ services:
         GROUP_ID: ${GROUP_ID}
     command: '/resources/entrypoint-frontend.sh'
     working_dir: /app
+    tty: true
     volumes:
       - './example/compose/authelia/resources/:/resources'
       - '../../web:/app'


### PR DESCRIPTION
The latest react-scripts bumps broke the startup of the authelia-frontend
container because the new version of react-scripts behaves differently when
the container is spawned with a pseudo-tty and when there is not.