### PR TITLE
[MISC] Automatically redirect from http to https in suites.

### DIFF
--- a/internal/suites/example/compose/nginx/portal/nginx.conf
+++ b/internal/suites/example/compose/nginx/portal/nginx.conf
@@ -22,6 +22,8 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
 
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
+
         # Serve the backend API for the portal.
         location /api {
             proxy_set_header  X-Real-IP $remote_addr;
@@ -68,6 +70,8 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
 
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
+
         location / {
             proxy_set_header  Host $http_host;
             proxy_pass        $upstream_endpoint;
@@ -94,6 +98,8 @@ http {
 
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
+
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
 
         # Reverse proxy to the backend. It is protected by Authelia by forwarding authorization checks
         # to the virtual endpoint introduced by nginx and declared in the next block.
@@ -187,6 +193,8 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
 
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
+
         location / {
             proxy_set_header  Host $http_host;
             proxy_pass        $upstream_endpoint;
@@ -206,6 +214,8 @@ http {
 
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
+
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
 
         location / {
             proxy_set_header  Host $http_host;

--- a/internal/suites/example/compose/nginx/portal/nginx.https.conf
+++ b/internal/suites/example/compose/nginx/portal/nginx.https.conf
@@ -22,6 +22,8 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
 
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
+
         # Serve the backend API for the portal.
         location /api {
             proxy_set_header  X-Real-IP $remote_addr;
@@ -68,6 +70,8 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
 
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
+
         location / {
             proxy_set_header  Host $http_host;
             proxy_pass        $upstream_endpoint;
@@ -94,6 +98,8 @@ http {
 
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
+
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
 
         # Reverse proxy to the backend. It is protected by Authelia by forwarding authorization checks
         # to the virtual endpoint introduced by nginx and declared in the next block.
@@ -187,6 +193,8 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
 
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
+
         location / {
             proxy_set_header  Host $http_host;
             proxy_pass        $upstream_endpoint;
@@ -206,6 +214,8 @@ http {
 
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN";
+
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
 
         location / {
             proxy_set_header  Host $http_host;


### PR DESCRIPTION
While working with suites in development, when home.example.com was visited for instance, the browser sometimes ended up displaying an error while the developer was expected to see the home page served over https.

This change configures an automatic redirection from http to https.