### PR TITLE
[Buildkite] Disable jest cache due to erratic unit test behaviour

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --no-cache",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
It seems that running unit tests can result in failures if the build is not run on a clean machine, examples of this can be found at:

- https://buildkite.com/authelia/authelia/builds/1083#8916f6fc-6a53-4619-8c2e-a762f78f1de2
- https://buildkite.com/authelia/authelia/builds/1095#2206e39c-55dd-4311-8348-09f4f7c90fa1

This seems to be a pretty common issue too, just google issues with jest cache:

- https://github.com/vuejs/vue-jest/issues/56