### PR TITLE
Fix basic authentication using "Authorization" header

### DIFF
--- a/docs/features/single-factor.md
+++ b/docs/features/single-factor.md
@@ -20,10 +20,18 @@ resources matching `app1.example.com/admin` with two factors.
 To know more about the configuration of the feature, please visit the
 documentation about the [configuration](../configuration/access-control.md).
 
+Authelia also supports machine to machine authentication. The authentication
+backed stay the same as UI driven authentication. But since there is not 
+user to input the credentials, those credentials will try to be extracted 
+from either the `Proxy-Authorization` header or the `Authorization` header.
 
 ## Proxy-Authorization header
 
-Authelia reads credentials from the header `Proxy-Authorization` instead of
-the usual `Authorization` header. This is because in some circumstances both Authelia
-and the application could require authentication in order to provide specific
-authorizations at the level of the application.
+By default, Authelia reads credentials from the header `Proxy-Authorization` 
+instead of the usual `Authorization` header. This header is considered a 
+[Hop header](https://tools.ietf.org/html/rfc7235#section-4.4) and many proxies 
+will remove the header before sending the authentication request to Authelia. 
+
+## Authorization header
+
+If the Proxy-Authorization header is not found, but the Authorization header is present, Authelia will try to use that header to extract username and password for authentication. This could cause issues when the `Authentication` header is not directed to Authelia. Still, to the destination application, in that case, the proxy in front of Authelia should be instructed to explicitly remove the headers before sending an authentication request to Authelia. 

--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -11,8 +11,10 @@ const ResetPasswordAction = "ResetPassword"
 
 const authPrefix = "Basic "
 
-// AuthorizationHeader is the basic-auth HTTP header Authelia utilises.
-const AuthorizationHeader = "Proxy-Authorization"
+// AuthorizationHeaderName and ProxyAuthorizationHeaderName are the headers Authelia utilises for basic-auth.
+const AuthorizationHeaderName = "Authorization"
+const ProxyAuthorizationHeaderName = "Proxy-Authorization"
+
 const remoteUserHeader = "Remote-User"
 const remoteGroupsHeader = "Remote-Groups"
 

--- a/internal/handlers/handler_verify.go
+++ b/internal/handlers/handler_verify.go
@@ -67,7 +67,7 @@ func getOriginalURL(ctx *middlewares.AutheliaCtx) (*url.URL, error) {
 
 // parseBasicAuth parses an HTTP Basic Authentication string
 // "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" returns ("Aladdin", "open sesame", true)
-func parseBasicAuth(authorizationHeaderName string, auth string) (username, password string, err error) {
+func parseBasicAuth(authorizationHeaderName, auth string) (username, password string, err error) {
 	if !strings.HasPrefix(auth, authPrefix) {
 		return "", "", fmt.Errorf("%s prefix not found in %s header", strings.Trim(authPrefix, " "), authorizationHeaderName)
 	}

--- a/internal/handlers/handler_verify_test.go
+++ b/internal/handlers/handler_verify_test.go
@@ -113,27 +113,27 @@ func TestShouldRaiseWhenXForwardedURIIsNotParseable(t *testing.T) {
 
 // Test parseBasicAuth
 func TestShouldRaiseWhenHeaderDoesNotContainBasicPrefix(t *testing.T) {
-	_, _, err := parseBasicAuth("alzefzlfzemjfej==")
+	_, _, err := parseBasicAuth(ProxyAuthorizationHeaderName, "alzefzlfzemjfej==")
 	assert.Error(t, err)
 	assert.Equal(t, "Basic prefix not found in Proxy-Authorization header", err.Error())
 }
 
 func TestShouldRaiseWhenCredentialsAreNotInBase64(t *testing.T) {
-	_, _, err := parseBasicAuth("Basic alzefzlfzemjfej==")
+	_, _, err := parseBasicAuth("", "Basic alzefzlfzemjfej==")
 	assert.Error(t, err)
 	assert.Equal(t, "illegal base64 data at input byte 16", err.Error())
 }
 
 func TestShouldRaiseWhenCredentialsAreNotInCorrectForm(t *testing.T) {
 	// the decoded format should be user:password.
-	_, _, err := parseBasicAuth("Basic am9obiBwYXNzd29yZA==")
+	_, _, err := parseBasicAuth(ProxyAuthorizationHeaderName, "Basic am9obiBwYXNzd29yZA==")
 	assert.Error(t, err)
 	assert.Equal(t, "Format of Proxy-Authorization header must be user:password", err.Error())
 }
 
 func TestShouldReturnUsernameAndPassword(t *testing.T) {
 	// the decoded format should be user:password.
-	user, password, err := parseBasicAuth("Basic am9objpwYXNzd29yZA==")
+	user, password, err := parseBasicAuth("", "Basic am9objpwYXNzd29yZA==")
 	assert.NoError(t, err)
 	assert.Equal(t, "john", user)
 	assert.Equal(t, "password", password)
@@ -196,7 +196,7 @@ func TestShouldVerifyWrongCredentials(t *testing.T) {
 		Return(false, nil)
 
 	url, _ := url.ParseRequestURI("https://test.example.com")
-	_, _, _, err := verifyBasicAuth([]byte("Basic am9objpwYXNzd29yZA=="), *url, mock.Ctx)
+	_, _, _, err := verifyBasicAuth(AuthorizationHeaderName, []byte("Basic am9objpwYXNzd29yZA=="), *url, mock.Ctx)
 
 	assert.Error(t, err)
 }


### PR DESCRIPTION
There are some cases when the same service is accessed by humans and machines (like Prometheus). Currently, authelia allows the use of basic auth, but it is restricted to basic auth passed through the header Proxy-Authorization.

The problem is that load load balancers consider that header as a hop by hop header and is not passed to the authentication service when set by the originator of the request.

In my opinion, authelia should allow basic auth using the Authorization header. I know this could expose authelia to a brute-force attack but reverse proxies like Treafic can be configured to strip that header off before passing it to the auth service if basic auth is not expected.

Fixes issue [841](https://github.com/authelia/authelia/issues/841)


