### PR TITLE
[MISC] Add http debug routes

### DIFF
--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -36,7 +36,9 @@ following configuration options:
 `optional: true`
 
 Defines the level of logs used by Authelia. This level can be set to
-`trace`, `debug` or `info`.
+`trace`, `debug` or `info`. When setting log_level to trace, you will
+generate a large amount of log entries and expose the /debug/vars and
+/debug/pprof/ endpoints which should not be enabled in production.
 
     log_level: debug
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/duosecurity/duo_api_golang v0.0.0-20190308151101-6c680f768e74
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
-	github.com/fasthttp/router v0.7.0
+	github.com/fasthttp/router v1.0.1
 	github.com/fasthttp/session v1.1.7
 	github.com/go-ldap/ldap/v3 v3.1.8
 	github.com/go-sql-driver/mysql v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/fasthttp/router v0.6.1 h1:cPfY4S9tZSh0J62O6h4n6Kxwg9eskQ2GPCNWvXDsa1s
 github.com/fasthttp/router v0.6.1/go.mod h1:00BQmm3xiThNypescxIQ+Gfgw2I/3QWKvuagFoENUb4=
 github.com/fasthttp/router v0.7.0 h1:k2ZhnUNPr7CLXSwDSNvkuOtH4vSijR1Kjjxh0gYzWVQ=
 github.com/fasthttp/router v0.7.0/go.mod h1:00BQmm3xiThNypescxIQ+Gfgw2I/3QWKvuagFoENUb4=
+github.com/fasthttp/router v1.0.1 h1:OEc/ITEJ7CQbQZ4UTPwQynBka/kmL/lrQsc2chKbHRo=
+github.com/fasthttp/router v1.0.1/go.mod h1:ZVa4I0mMb6i+hPjW90TE5DzFpIv03w8eAo6dlExRE7U=
 github.com/fasthttp/session v1.1.3 h1:2qjxNltI7iv0yh7frsIdhbsGmSoRnTajU8xtpC6Hd80=
 github.com/fasthttp/session v1.1.3/go.mod h1:DRxVb1PWFtAUTE4U+GgggsVkUaQyacoL8TN+3o4/yLw=
 github.com/fasthttp/session v1.1.7 h1:dTLeicJrpzb6pulR/c9X5RJWyYxI/WMwfJjcblt52Ic=
@@ -259,6 +261,8 @@ github.com/savsgio/gotils v0.0.0-20190925070755-524bc4f47500 h1:9Pi10H7E8E79/x2H
 github.com/savsgio/gotils v0.0.0-20190925070755-524bc4f47500/go.mod h1:lHhJedqxCoHN+zMtwGNTXWmF0u9Jt363FYRhV6g0CdY=
 github.com/savsgio/gotils v0.0.0-20200117113501-90175b0fbe3f h1:PgA+Olipyj258EIEYnpFFONrrCcAIWNUNoFhUfMqAGY=
 github.com/savsgio/gotils v0.0.0-20200117113501-90175b0fbe3f/go.mod h1:lHhJedqxCoHN+zMtwGNTXWmF0u9Jt363FYRhV6g0CdY=
+github.com/savsgio/gotils v0.0.0-20200319105752-a9cc718f6a3f h1:XfUnevLK4O22at3R77FlyQHKwlQs75LELdsH2wRX2KQ=
+github.com/savsgio/gotils v0.0.0-20200319105752-a9cc718f6a3f/go.mod h1:lHhJedqxCoHN+zMtwGNTXWmF0u9Jt363FYRhV6g0CdY=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/simia-tech/crypt v0.2.0 h1:cU8qdqUYNuEFKSMq15yaB2aI1aC5vrn6dFOonT6Kg6o=
 github.com/simia-tech/crypt v0.2.0/go.mod h1:DMwvjPTzsiHrjqHVW5HvIbF4vUUzMCYDKVLsPWmLdTo=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,7 +29,7 @@ func StartServer(configuration schema.Configuration, providers middlewares.Provi
 
 	router := router.New()
 	router.GET("/", fasthttp.FSHandler(publicDir, 0))
-	router.ServeFiles("/static/*filepath", publicDir+"/static")
+	router.ServeFiles("/static/{filepath:*}", publicDir+"/static")
 
 	router.GET("/api/state", autheliaMiddleware(handlers.StateGet))
 
@@ -106,7 +106,7 @@ func StartServer(configuration schema.Configuration, providers middlewares.Provi
 
 	// If trace is set, enable pprofhandler and expvarhandler
 	if configuration.LogLevel == "trace" {
-		router.GET("/debug/pprof/:name", pprofhandler.PprofHandler)
+		router.GET("/debug/pprof/{name?}", pprofhandler.PprofHandler)
 		router.GET("/debug/vars", expvarhandler.ExpvarHandler)
 	}
 
@@ -114,11 +114,10 @@ func StartServer(configuration schema.Configuration, providers middlewares.Provi
 		ctx.SendFile(path.Join(publicDir, "index.html"))
 	}
 
-	addrPattern := fmt.Sprintf("%s:%d", configuration.Host, configuration.Port)
-
 	server := &fasthttp.Server{
 		Handler: middlewares.LogRequestMiddleware(router.Handler),
 	}
+	addrPattern := fmt.Sprintf("%s:%d", configuration.Host, configuration.Port)
 
 	if configuration.TLSCert != "" && configuration.TLSKey != "" {
 		logging.Logger().Infof("Authelia is listening for TLS connections on %s", addrPattern)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,8 @@ import (
 	duoapi "github.com/duosecurity/duo_api_golang"
 	"github.com/fasthttp/router"
 	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/expvarhandler"
+	"github.com/valyala/fasthttp/pprofhandler"
 
 	"github.com/authelia/authelia/internal/configuration/schema"
 	"github.com/authelia/authelia/internal/duo"
@@ -18,16 +20,14 @@ import (
 
 // StartServer start Authelia server with the given configuration and providers.
 func StartServer(configuration schema.Configuration, providers middlewares.Providers) {
-	router := router.New()
-
 	autheliaMiddleware := middlewares.AutheliaMiddleware(configuration, providers)
-
 	publicDir := os.Getenv("PUBLIC_DIR")
 	if publicDir == "" {
 		publicDir = "./public_html"
 	}
 	logging.Logger().Infof("Selected public_html directory is %s", publicDir)
 
+	router := router.New()
 	router.GET("/", fasthttp.FSHandler(publicDir, 0))
 	router.ServeFiles("/static/*filepath", publicDir+"/static")
 
@@ -104,22 +104,27 @@ func StartServer(configuration schema.Configuration, providers middlewares.Provi
 			middlewares.RequireFirstFactor(handlers.SecondFactorDuoPost(duoAPI))))
 	}
 
+	// If trace is set, enable pprofhandler and expvarhandler
+	if configuration.LogLevel == "trace" {
+		router.GET("/debug/pprof/:name", pprofhandler.PprofHandler)
+		router.GET("/debug/vars", expvarhandler.ExpvarHandler)
+	}
+
 	router.NotFound = func(ctx *fasthttp.RequestCtx) {
 		ctx.SendFile(path.Join(publicDir, "index.html"))
 	}
 
 	addrPattern := fmt.Sprintf("%s:%d", configuration.Host, configuration.Port)
 
+	server := &fasthttp.Server{
+		Handler: middlewares.LogRequestMiddleware(router.Handler),
+	}
+
 	if configuration.TLSCert != "" && configuration.TLSKey != "" {
 		logging.Logger().Infof("Authelia is listening for TLS connections on %s", addrPattern)
-
-		logging.Logger().Fatal(fasthttp.ListenAndServeTLS(addrPattern,
-			configuration.TLSCert, configuration.TLSKey,
-			middlewares.LogRequestMiddleware(router.Handler)))
+		logging.Logger().Fatal(server.ListenAndServeTLS(addrPattern, configuration.TLSCert, configuration.TLSKey))
 	} else {
 		logging.Logger().Infof("Authelia is listening for non-TLS connections on %s", addrPattern)
-
-		logging.Logger().Fatal(fasthttp.ListenAndServe(addrPattern,
-			middlewares.LogRequestMiddleware(router.Handler)))
+		logging.Logger().Fatal(server.ListenAndServe(addrPattern))
 	}
 }


### PR DESCRIPTION
* enabled only with trace logging
* allows go tool pprof usage when enabled
* enables both the expvarhandler and pprofhandler from fasthttp
* simplify tls/non-tls listen and serve
* make it easy to define custom settings of the fasthttp server in the future