### PR TITLE
[DOCS] Add Remote-User and Remote-Groups headers to Traefik docs

### DIFF
--- a/compose/lite/docker-compose.yml
+++ b/compose/lite/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - 'traefik.http.routers.authelia.tls.certresolver=letsencrypt'
       - 'traefik.http.middlewares.authelia.forwardauth.address=http://authelia:9091/api/verify?rd=https://auth.example.com'
       - 'traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true'
+      - 'traefik.http.middlewares.authelia.forwardauth.authResponseHeaders=Remote-User, Remote-Groups'
     expose:
       - 9091
     restart: unless-stopped

--- a/compose/local/docker-compose.yml
+++ b/compose/local/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - 'traefik.http.routers.authelia.tls.options=default'
       - 'traefik.http.middlewares.authelia.forwardauth.address=http://authelia:9091/api/verify?rd=https://authelia.example.com'
       - 'traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true'
+      - 'traefik.http.middlewares.authelia.forwardauth.authResponseHeaders=Remote-User, Remote-Groups'
     expose:
       - 9091
     restart: unless-stopped

--- a/docs/deployment/supported-proxies/traefik1.x.md
+++ b/docs/deployment/supported-proxies/traefik1.x.md
@@ -86,6 +86,8 @@ services:
     labels:
       - 'traefik.frontend.rule=Host:nextcloud.example.com'
       - 'traefik.frontend.auth.forward.address=http://authelia:9091/api/verify?rd=https://login.example.com/'
+      - 'traefik.frontend.auth.forward.trustForwardHeader=true'
+      - 'traefik.frontend.auth.forward.authResponseHeaders=Remote-User,Remote-Groups'
     expose:
       - 443
     restart: unless-stopped

--- a/docs/deployment/supported-proxies/traefik2.x.md
+++ b/docs/deployment/supported-proxies/traefik2.x.md
@@ -73,8 +73,9 @@ services:
       - 'traefik.http.routers.authelia.rule=Host(`login.example.com`)'
       - 'traefik.http.routers.authelia.entrypoints=https'
       - 'traefik.http.routers.authelia.tls=true'
-      - 'traefik.http.middlewares.authelia.forwardAuth.address=http://authelia:9091/api/verify?rd=https://login.example.com/'
+      - 'traefik.http.middlewares.authelia.forwardauth.address=http://authelia:9091/api/verify?rd=https://login.example.com/'
       - 'traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true'
+      - 'traefik.http.middlewares.authelia.forwardauth.authResponseHeaders=Remote-User, Remote-Groups'
     expose:
       - 9091
     restart: unless-stopped

--- a/internal/suites/example/compose/nginx/backend/docker-compose.yml
+++ b/internal/suites/example/compose/nginx/backend/docker-compose.yml
@@ -7,11 +7,15 @@ services:
       - 'traefik.frontend.rule=Host:home.example.com,public.example.com,secure.example.com,admin.example.com,singlefactor.example.com' # Traefik 1.x
       - 'traefik.frontend.auth.forward.address=http://authelia-backend:9091/api/verify?rd=https://login.example.com:8080/' # Traefik 1.x
       - 'traefik.frontend.auth.forward.tls.insecureSkipVerify=true' # Traefik 1.x
+      - 'traefik.frontend.auth.forward.trustForwardHeader=true' # Traefik 1.x
+      - 'traefik.frontend.auth.forward.authResponseHeaders=Remote-User,Remote-Groups' # Traefik 1.x
       - 'traefik.http.routers.protectedapps.rule=Host(`home.example.com`, `public.example.com`, `secure.example.com`, `admin.example.com`, `singlefactor.example.com`)' # Traefik 2.x
       - 'traefik.http.routers.protectedapps.entrypoints=https' # Traefik 2.x
       - 'traefik.http.routers.protectedapps.tls=true' # Traefik 2.x
       - 'traefik.http.routers.protectedapps.middlewares=authelia' # Traefik 2.x
-      - 'traefik.http.middlewares.authelia.forwardAuth.address=http://authelia-backend:9091/api/verify?rd=https://login.example.com:8080/' # Traefik 2.x
-      - 'traefik.http.middlewares.authelia.forwardAuth.tls.insecureSkipVerify=true' # Traefik 2.x
+      - 'traefik.http.middlewares.authelia.forwardauth.address=http://authelia-backend:9091/api/verify?rd=https://login.example.com:8080/' # Traefik 2.x
+      - 'traefik.http.middlewares.authelia.forwardauth.tls.insecureSkipVerify=true' # Traefik 2.x
+      - 'traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true' # Traefik 2.x
+      - 'traefik.http.middlewares.authelia.forwardauth.authResponseHeaders=Remote-User, Remote-Groups' # Traefik 2.x
     networks:
       - authelianet


### PR DESCRIPTION
This is a follow up to resolve #842.