### PR TITLE
[MISC] Allow HEAD method on /api/verify

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,7 @@ func StartServer(configuration schema.Configuration, providers middlewares.Provi
 		middlewares.RequireFirstFactor(handlers.ExtendedConfigurationGet)))
 
 	router.GET("/api/verify", autheliaMiddleware(handlers.VerifyGet))
+	router.HEAD("/api/verify", autheliaMiddleware(handlers.VerifyGet))
 
 	router.POST("/api/firstfactor", autheliaMiddleware(handlers.FirstFactorPost))
 	router.POST("/api/logout", autheliaMiddleware(handlers.LogoutPost))

--- a/internal/suites/example/compose/haproxy/Dockerfile
+++ b/internal/suites/example/compose/haproxy/Dockerfile
@@ -6,6 +6,5 @@ apk add --no-cache \
   lua5.3-socket \
   openssl && \
 curl -Lfs -o /usr/local/etc/haproxy/auth-request.lua "https://raw.githubusercontent.com/TimWolla/haproxy-auth-request/master/auth-request.lua" && \
-sed -i 's/HEAD/GET/g' /usr/local/etc/haproxy/auth-request.lua && \
 openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=AU/ST=Victoria/L=Melbourne/O=Authelia/CN=*.example.com" -keyout haproxy.key -out haproxy.crt && \
 cat haproxy.key haproxy.crt > /usr/local/etc/haproxy/haproxy.pem


### PR DESCRIPTION
This is to natively support the upstream HAProxy module haproxy-auth-request without patching.