### PR TITLE
[BUGFIX] Fix indenting on lite compose bundle

### DIFF
--- a/compose/lite/docker-compose.yml
+++ b/compose/lite/docker-compose.yml
@@ -93,18 +93,18 @@ services:
       - 80
     restart: unless-stopped
 
-    public:
-      image: containous/whoami
-      container_name: public
-      networks:
-        - net
-      labels:
-        - 'traefik.enable=true'
-        - 'traefik.http.routers.public.rule=Host(`public.example.com`)'
-        - 'traefik.http.routers.public.entrypoints=https'
-        - 'traefik.http.routers.public.tls=true'
-        - 'traefik.http.routers.public.tls.certresolver=letsencrypt'
-        - 'traefik.http.routers.public.middlewares=authelia@docker'
-      expose:
-        - 80
-      restart: unless-stopped
+  public:
+    image: containous/whoami
+    container_name: public
+    networks:
+      - net
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.public.rule=Host(`public.example.com`)'
+      - 'traefik.http.routers.public.entrypoints=https'
+      - 'traefik.http.routers.public.tls=true'
+      - 'traefik.http.routers.public.tls.certresolver=letsencrypt'
+      - 'traefik.http.routers.public.middlewares=authelia@docker'
+    expose:
+      - 80
+    restart: unless-stopped


### PR DESCRIPTION
docker-compose up -d no longer complains about the public service because of wrong indentation