### PR TITLE
[MISC] Fix authelia-{backend,frontend} dev server logging and startup

### DIFF
--- a/internal/suites/example/compose/authelia/docker-compose.frontend.dev.yml
+++ b/internal/suites/example/compose/authelia/docker-compose.frontend.dev.yml
@@ -9,7 +9,7 @@ services:
         GROUP_ID: ${GROUP_ID}
     command: '/resources/entrypoint-frontend.sh'
     working_dir: /app
-    tty: true
+    stdin_open: true
     volumes:
       - './example/compose/authelia/resources/:/resources'
       - '../../web:/app'

--- a/internal/suites/example/compose/authelia/resources/reflex.conf
+++ b/internal/suites/example/compose/authelia/resources/reflex.conf
@@ -1,1 +1,1 @@
--r '(\.go$|go\.mod|\.sh|\.yml)' -s /resources/run-backend-dev.sh
+-R '^web/' -r '(\.go$|go\.mod|\.sh|\.yml)' -s /resources/run-backend-dev.sh


### PR DESCRIPTION
#767 added an interactive tty to the authelia-frontend server due toe a bump in react-scripts, this in turn consumes all logging and pages on a failure and made it difficult to interact with within the dev workflow.
The tty has been replaced with an open stdin as this also satisfies the react-scripts requirement.

This change also ignores the web directory in the reflex script to avoid errors and long start-ups in the authelia-frontend container.