### PR TITLE
[BUGFIX] 2FA after 1FA only when necessary for access to target

### DIFF
--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -34,8 +34,8 @@ func Handle1FAResponse(ctx *middlewares.AutheliaCtx, targetURI string, username 
 
 	ctx.Logger.Debugf("Required level for the URL %s is %d", targetURI, requiredLevel)
 
-	if requiredLevel > authorization.OneFactor {
-		ctx.Logger.Warnf("%s requires more than 1FA, cannot be redirected to", targetURI)
+	if requiredLevel == authorization.TwoFactor {
+		ctx.Logger.Warnf("%s requires 2FA, cannot be redirected yet", targetURI)
 		ctx.ReplyOK()
 		return
 	}


### PR DESCRIPTION
* prevents requirement to always 2FA if the user doesn't have permission to access a target URL

Fixes #816