### PR TITLE
[FIX] Layout discrepancy with U2F

### DIFF
--- a/web/src/layouts/LoginLayout.tsx
+++ b/web/src/layouts/LoginLayout.tsx
@@ -21,7 +21,7 @@ export default function (props: Props) {
             spacing={0}
             alignItems="center"
             justify="center">
-            <Container maxWidth="xs">
+            <Container maxWidth="xs" className={style.rootContainer}>
                 <Grid container>
                     <Grid item xs={12}>
                         <UserSvg className={style.icon}></UserSvg>
@@ -55,6 +55,10 @@ const useStyles = makeStyles(theme => ({
         minHeight: '90vh',
         textAlign: "center",
         // marginTop: theme.spacing(10),
+    },
+    rootContainer: {
+        paddingLeft: 32,
+        paddingRight: 32,
     },
     title: {},
     icon: {


### PR DESCRIPTION
* 4.8.0 deps bump changed the root containers padding from 32px to 24px
* only affects the u2f screen, this fixes the padding on the root container for the Login Layout
* this makes u2f screen layout behave the same as all of the other ones