### PR TITLE
[BUGFIX] Fix CSP not propagated in default handler.

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"fmt"
 	"os"
-	"path"
 
 	duoapi "github.com/duosecurity/duo_api_golang"
 	"github.com/fasthttp/router"
@@ -112,9 +111,7 @@ func StartServer(configuration schema.Configuration, providers middlewares.Provi
 		router.GET("/debug/vars", expvarhandler.ExpvarHandler)
 	}
 
-	router.NotFound = func(ctx *fasthttp.RequestCtx) {
-		ctx.SendFile(path.Join(publicDir, "index.html"))
-	}
+	router.NotFound = ServeIndex(publicDir)
 
 	server := &fasthttp.Server{
 		Handler: middlewares.LogRequestMiddleware(router.Handler),

--- a/internal/suites/example/compose/authelia/resources/nginx.conf
+++ b/internal/suites/example/compose/authelia/resources/nginx.conf
@@ -13,10 +13,6 @@ http {
         set $backend_endpoint https://authelia-backend:9091;
 
         location / {
-            # We don't want to apply CSP in dev mode because the frontend is served by CRA
-            # and thus cannot have the nonce injected.
-            proxy_hide_header Content-Security-Policy;
-
             proxy_set_header  Host $http_host;
             proxy_pass        $backend_endpoint;
         }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,6 +20,10 @@ import SignOut from './views/LoginPortal/SignOut/SignOut';
 import { useConfiguration } from './hooks/Configuration';
 import Tracker from "./components/Tracker";
 import { useTracking } from "./hooks/Tracking";
+import '@fortawesome/fontawesome-svg-core/styles.css'
+import {config as faConfig} from '@fortawesome/fontawesome-svg-core';
+
+faConfig.autoAddCss = false;
 
 const App: React.FC = () => {
     const [notification, setNotification] = useState(null as Notification | null);


### PR DESCRIPTION
Also:
- not hide the CSP header in the dist version of suites.
- Fix CSP errors due to FontAwesome loading stylesheets dynamically.