### PR TITLE
[CI] Update reviewdog level to error

### DIFF
--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -5,4 +5,4 @@ runner:
       - '%E%f:%l:%c: %m'
       - '%E%f:%l: %m'
       - '%C%.%#'
-    level: warning
+    level: error


### PR DESCRIPTION
This will ensure that GitHub checks are identified as failures as opposed to neutral warnings.