### PR TITLE
[CI] Add Dockerfile monitoring to dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,3 +12,33 @@ update_configs:
     commit_message:
       prefix: "[MISC] "
       include_scope: true
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[MISC] "
+      include_scope: true
+  - package_manager: "docker"
+    directory: "/internal/suites/example/compose/authelia"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[MISC] "
+      include_scope: true
+  - package_manager: "docker"
+    directory: "/internal/suites/example/compose/haproxy"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[MISC] "
+      include_scope: true
+  - package_manager: "docker"
+    directory: "/internal/suites/example/compose/duo-api"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[MISC] "
+      include_scope: true
+  - package_manager: "docker"
+    directory: "/internal/suites/example/compose/kind"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[MISC] "
+      include_scope: true


### PR DESCRIPTION
This will allow dependabot to inform us when there are newer version of the base packages for our Dockerfiles.