### PR TITLE
[CI] Add Gemfile.lock monitoring to dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,6 +12,12 @@ update_configs:
     commit_message:
       prefix: "[MISC] "
       include_scope: true
+  - package_manager: "ruby:bundler"
+    directory: "/docs"
+    update_schedule: "live"
+    commit_message:
+      prefix: "[MISC] "
+      include_scope: true
   - package_manager: "docker"
     directory: "/"
     update_schedule: "daily"


### PR DESCRIPTION
This will allow dependabot to inform us when there are newer ruby bundles available.