### PR TITLE
[CI] Prevent race conditions with appropriate deployment steps

### DIFF
--- a/.buildkite/deployment.sh
+++ b/.buildkite/deployment.sh
@@ -61,11 +61,15 @@ steps:
 
   - label: ":linux: Deploy AUR"
     command: ".buildkite/steps/aurpackages.sh | buildkite-agent pipeline upload"
+    concurrency: 1
+    concurrency_group: "aur"
     depends_on: ~
     if: build.tag != null || build.branch == "master" && build.env("CI_BYPASS") != "true"
 
   - label: ":book: Deploy Documentation"
     command: "syncdoc.sh"
+    concurrency: 1
+    concurrency_group: "documentation"
     depends_on: ~
     agents:
       upload: "fast"


### PR DESCRIPTION
If we have multiple builds to master that intend to deploy AUR packages or documentation, we must ensure that the jobs are locked and executed sequentially, not simultaneously. If they were to run simultaneously this has the ability to cause a race condition when attempting to commit the respective steps.