### PR TITLE
[MISC] Introduce CryptAlgo type.

### DIFF
--- a/internal/authentication/const.go
+++ b/internal/authentication/const.go
@@ -24,7 +24,7 @@ const (
 // PossibleMethods is the set of all possible 2FA methods.
 var PossibleMethods = []string{TOTP, U2F, Push}
 
-// CryptAlgo
+// CryptAlgo the crypt representation of an algorithm used in the prefix of the hash.
 type CryptAlgo string
 
 const (

--- a/internal/authentication/const.go
+++ b/internal/authentication/const.go
@@ -24,11 +24,14 @@ const (
 // PossibleMethods is the set of all possible 2FA methods.
 var PossibleMethods = []string{TOTP, U2F, Push}
 
+// CryptAlgo
+type CryptAlgo string
+
 const (
 	// HashingAlgorithmArgon2id Argon2id hash identifier.
-	HashingAlgorithmArgon2id = "argon2id"
+	HashingAlgorithmArgon2id CryptAlgo = "argon2id"
 	// HashingAlgorithmSHA512 SHA512 hash identifier.
-	HashingAlgorithmSHA512 = "6"
+	HashingAlgorithmSHA512 CryptAlgo = "6"
 )
 
 // These are the default values from the upstream crypt module we use them to for GetInt

--- a/internal/authentication/file_user_provider.go
+++ b/internal/authentication/file_user_provider.go
@@ -54,7 +54,7 @@ func NewFileUserProvider(configuration *schema.FileAuthenticationBackendConfigur
 	var cryptAlgo CryptAlgo = HashingAlgorithmArgon2id
 	// TODO: Remove this. This is only here to temporarily fix the username enumeration security flaw in #949.
 	// This generates a hash that should be usable to do a fake CheckUserPassword
-	if configuration.Password.Algorithm == "sha512" {
+	if configuration.Password.Algorithm == sha512 {
 		cryptAlgo = HashingAlgorithmSHA512
 	}
 	settings := getCryptSettings(utils.RandomString(configuration.Password.SaltLength, HashingPossibleSaltCharacters),

--- a/internal/authentication/file_user_provider.go
+++ b/internal/authentication/file_user_provider.go
@@ -51,14 +51,14 @@ func NewFileUserProvider(configuration *schema.FileAuthenticationBackendConfigur
 		panic(err.Error())
 	}
 
+	var cryptAlgo CryptAlgo = HashingAlgorithmArgon2id
 	// TODO: Remove this. This is only here to temporarily fix the username enumeration security flaw in #949.
 	// This generates a hash that should be usable to do a fake CheckUserPassword
-	algorithm := configuration.Password.Algorithm
 	if configuration.Password.Algorithm == "sha512" {
-		algorithm = HashingAlgorithmSHA512
+		cryptAlgo = HashingAlgorithmSHA512
 	}
 	settings := getCryptSettings(utils.RandomString(configuration.Password.SaltLength, HashingPossibleSaltCharacters),
-		algorithm, configuration.Password.Iterations, configuration.Password.Memory*1024, configuration.Password.Parallelism,
+		cryptAlgo, configuration.Password.Iterations, configuration.Password.Memory*1024, configuration.Password.Parallelism,
 		configuration.Password.KeyLength)
 	data := crypt.Base64Encoding.EncodeToString([]byte(utils.RandomString(configuration.Password.KeyLength, HashingPossibleSaltCharacters)))
 	fakeHash := fmt.Sprintf("%s$%s", settings, data)
@@ -140,7 +140,7 @@ func (p *FileUserProvider) UpdatePassword(username string, newPassword string) e
 		return fmt.Errorf("User '%s' does not exist in database", username)
 	}
 
-	var algorithm string
+	var algorithm CryptAlgo
 	if p.configuration.Password.Algorithm == "argon2id" {
 		algorithm = HashingAlgorithmArgon2id
 	} else if p.configuration.Password.Algorithm == "sha512" {

--- a/internal/commands/hash.go
+++ b/internal/commands/hash.go
@@ -34,7 +34,7 @@ var HashPasswordCmd = &cobra.Command{
 
 		var err error
 		var hash string
-		var algorithm string
+		var algorithm authentication.CryptAlgo
 
 		if sha512 {
 			if iterations == schema.DefaultPasswordConfiguration.Iterations {


### PR DESCRIPTION
It helps distinguish between the configuration representation of an algorithm
and the crypt representation (6 and argon2id vs sha512 vs argon2id).