### PR TITLE
[CI] Fix pipeline dependencies

### DIFF
--- a/.buildkite/steps/deployimages.sh
+++ b/.buildkite/steps/deployimages.sh
@@ -5,6 +5,22 @@ for BUILD_ARCH in amd64 arm32v7 arm64v8; do
 cat << EOF
   - label: ":docker: Deploy Image [${BUILD_ARCH}]"
     command: "authelia-scripts docker push-image --arch=${BUILD_ARCH}"
+    depends_on:
+EOF
+if [[ "${BUILD_ARCH}" == "amd64" ]]; then
+cat << EOF
+      - "build-docker-linux-amd64"
+EOF
+elif [[ "${BUILD_ARCH}" == "arm32v7" ]]; then
+cat << EOF
+      - "build-docker-linux-arm32v7"
+EOF
+else
+cat << EOF
+      - "build-docker-linux-arm64v8"
+EOF
+fi
+cat << EOF
     agents:
       upload: "fast"
     env:

--- a/.buildkite/upstream.yml
+++ b/.buildkite/upstream.yml
@@ -1,0 +1,40 @@
+# This represents the hardcoded pipeline set in Buildkite interface which executes the repo provided dynamic pipeline.
+# It is used to ensure that insecure code from external PR cannot be executed before a maintainers approval, to avoid secret leaks.
+steps:
+  # Blocking pipeline for master branch deployments (concurrency_group).
+  - label: ":pipeline: Setup Pipeline"
+    command: ".buildkite/pipeline.sh | buildkite-agent pipeline upload"
+    concurrency: 1
+    concurrency_group: "deployments"
+    if: build.branch == "master"
+
+  # Non-blocking pipeline for all others (tagged commits/local branches/PRs).
+  - label: ":pipeline: Setup Pipeline"
+    command: ".buildkite/pipeline.sh | buildkite-agent pipeline upload"
+    if: build.branch != "master"
+
+  - wait:
+    if: build.pull_request.repository.fork != true && build.branch !~ /^dependabot\/.*/
+
+  # Manual intervention by team required to deploy for forked PRs (prevent secret leakage).
+  - block: "Public fork needs approval"
+    if: build.pull_request.repository.fork == true
+
+  # Blocking deployment for master branch deployments (concurrency_group).
+  - label: ":rocket: Setup Deployment"
+    command: ".buildkite/deployment.sh | buildkite-agent pipeline upload"
+    concurrency: 1
+    concurrency_group: "deployments"
+    depends_on: ~
+    if: build.branch == "master"
+
+  # Non-blocking deployment for all others (tagged commits/local branches).
+  - label: ":rocket: Setup Deployment"
+    command: ".buildkite/deployment.sh | buildkite-agent pipeline upload"
+    depends_on: ~
+    if: build.branch != "master" && build.branch !~ /^dependabot\/.*/ && build.pull_request.repository.fork != true
+
+  # Removed dependency optimisation for forked PRs to enforce block step.
+  - label: ":rocket: Setup Deployment"
+    command: ".buildkite/deployment.sh | buildkite-agent pipeline upload"
+    if: build.pull_request.repository.fork == true


### PR DESCRIPTION
This change ensures that CI_BYPASS works as intended and ensures that the hardcoded pipeline does not conflict with the repo provided dynamic pipeline.

The hardcoded pipeline has been changed to reflect the following:
```yaml
steps:
  # Blocking pipeline for master branch deployments (concurrency_group).
  - label: ":pipeline: Setup Pipeline"
    command: ".buildkite/pipeline.sh | buildkite-agent pipeline upload"
    concurrency: 1
    concurrency_group: "deployments"
    if: build.branch == "master"

  # Non-blocking pipeline for all others (tagged commits/local branches/PRs).
  - label: ":pipeline: Setup Pipeline"
    command: ".buildkite/pipeline.sh | buildkite-agent pipeline upload"
    if: build.branch != "master"

  - wait:
    if: build.pull_request.repository.fork != true && build.branch !~ /^dependabot\/.*/

  # Manual intervention by team required to deploy for forked PRs (prevent secret leakage).
  - block: "Public fork needs approval"
    if: build.pull_request.repository.fork == true

  # Blocking deployment for master branch deployments (concurrency_group).
  - label: ":rocket: Setup Deployment"
    command: ".buildkite/deployment.sh | buildkite-agent pipeline upload"
    concurrency: 1
    concurrency_group: "deployments"
    depends_on: ~
    if: build.branch == "master"

  # Non-blocking deployment for all others (tagged commits/local branches).
  - label: ":rocket: Setup Deployment"
    command: ".buildkite/deployment.sh | buildkite-agent pipeline upload"
    depends_on: ~
    if: build.branch != "master" && build.branch !~ /^dependabot\/.*/ && build.pull_request.repository.fork != true

  # Removed dependency optimisation for forked PRs to enforce block step.
  - label: ":rocket: Setup Deployment"
    command: ".buildkite/deployment.sh | buildkite-agent pipeline upload"
    if: build.pull_request.repository.fork == true
```