### PR TITLE
[CI] Fix race condition on Docker tag clean up

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -30,14 +30,15 @@ if [[ $BUILDKITE_LABEL == ":docker: Deploy Manifests" ]] && [[ $BUILDKITE_BRANCH
   anontoken=$(curl -fsL --retry 3 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:authelia/authelia:pull' | jq -r .token)
   authtoken=$(curl -fs --retry 3 -H "Content-Type: application/json" -X "POST" -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
   for BRANCH_TAG in $(dockerbranchtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/authelia/tags/list | jq -r '.tags[] | select(startswith("PR") | not)' | \
-  sed -r '/^(latest|master|develop|v.*|([[:digit:]]+)\.?([[:digit:]]+)?\.?([[:digit:]]+)?)/d' | sort) && \
+  sed -r '/^(latest|master|develop|v.*|([[:digit:]]+)\.?([[:digit:]]+)?\.?([[:digit:]]+)?)|(amd64|arm32v7|arm64v8)$/d' | sort) && \
   githubbranches=$(curl -fs --retry 3 https://api.github.com/repos/authelia/authelia/branches | jq -r '.[].name' | sort) && \
   comm -23 <(echo "${dockerbranchtags}") <(echo "${githubbranches}")); do
     echo "Removing tag ${BRANCH_TAG}"
     curl -fsL --retry 3 -o /dev/null -X "DELETE" -H "Authorization: JWT ${authtoken}" https://hub.docker.com/v2/repositories/authelia/authelia/tags/${BRANCH_TAG}/
   done
   echo "--- :docker: Removing tags for merged or closed pull requests"
-  for PR_TAG in $(dockerprtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/authelia/tags/list | jq -r '.tags[] | select(startswith("PR"))' | sort) && \
+  for PR_TAG in $(dockerprtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/authelia/tags/list | jq -r '.tags[] | select(startswith("PR"))' | \
+  sed -r '/(amd64|arm32v7|arm64v8)$/d' | sort) && \
   githubprs=$(curl -fs --retry 3 https://api.github.com/repos/authelia/authelia/pulls | jq -r '.[].number' | sed -e 's/^/PR/' | sort) && \
   comm -23 <(echo "${dockerprtags}") <(echo "${githubprs}")); do
     echo "Removing tag ${PR_TAG}"


### PR DESCRIPTION
Prior to this change if there was a branch/PR build which had not yet published manifests and a master build running simultaneously, assuming the master build finished publishing manifests before the former it would clean up the architecture tagged containers (-{amd64,arm32v7,arm64v8}) which would result in the manifest step failing for the branch or PR build.

The aforementioned architecture containers should not be considered in either of the clean up steps because they're removed as part of a successful manifest being published.