### PR TITLE
[BUGFIX] Relax CSP for trusted-types

### DIFF
--- a/internal/server/index.go
+++ b/internal/server/index.go
@@ -36,7 +36,7 @@ func ServeIndex(publicDir, base string) fasthttp.RequestHandler {
 		nonce := utils.RandomString(32, alphaNumericRunes)
 
 		ctx.SetContentType("text/html; charset=utf-8")
-		ctx.Response.Header.Add("Content-Security-Policy", fmt.Sprintf("default-src 'self'; object-src 'none'; require-trusted-types-for 'script'; style-src 'self' 'nonce-%s'", nonce))
+		ctx.Response.Header.Add("Content-Security-Policy", fmt.Sprintf("default-src 'self'; object-src 'none'; style-src 'self' 'nonce-%s'", nonce))
 
 		err := tmpl.Execute(ctx.Response.BodyWriter(), struct{ CSPNonce, Base string }{CSPNonce: nonce, Base: base})
 		if err != nil {


### PR DESCRIPTION
This will need to be revisited to re-introduce trusted-types when we have a clear handle on all the libraries and their implementation to support this.