### PR TITLE
[MISC] Validate domain set in session is not a wildcard domain.

### DIFF
--- a/internal/configuration/validator/session.go
+++ b/internal/configuration/validator/session.go
@@ -46,4 +46,8 @@ func ValidateSession(configuration *schema.SessionConfiguration, validator *sche
 	if configuration.Domain == "" {
 		validator.Push(errors.New("Set domain of the session object"))
 	}
+
+	if strings.Contains(configuration.Domain, "*") {
+		validator.Push(errors.New("The domain of the session must be the root domain you're protecting instead of a wildcard domain"))
+	}
 }

--- a/internal/configuration/validator/session_test.go
+++ b/internal/configuration/validator/session_test.go
@@ -121,6 +121,17 @@ func TestShouldRaiseErrorWhenDomainNotSet(t *testing.T) {
 	assert.EqualError(t, validator.Errors()[0], "Set domain of the session object")
 }
 
+func TestShouldRaiseErrorWhenDomainIsWildcard(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+	config.Domain = "*.example.com"
+
+	ValidateSession(&config, validator)
+
+	assert.Len(t, validator.Errors(), 1)
+	assert.EqualError(t, validator.Errors()[0], "The domain of the session must be the root domain you're protecting instead of a wildcard domain")
+}
+
 func TestShouldRaiseErrorWhenBadInactivityAndExpirationSet(t *testing.T) {
 	validator := schema.NewStructValidator()
 	config := newDefaultSessionConfig()


### PR DESCRIPTION
Some users spend several hours figuring out the domain must be plain root domain instead of a wildcard. Here we try to let them know as fast as possible with a configuration check.