### PR TITLE
[MISC] Use /usr/bin/env bash for scripts

### DIFF
--- a/.buildkite/deployment.sh
+++ b/.buildkite/deployment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -u
 
 DIVERGED=$(git merge-base --fork-point origin/master > /dev/null; echo $?)

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set +u
 

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set +u
 

--- a/.buildkite/hooks/pre-artifact
+++ b/.buildkite/hooks/pre-artifact
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set +u
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set +u
 

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set +u
 

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -u
 
 DIVERGED=$(git merge-base --fork-point origin/master > /dev/null; echo $?)

--- a/.buildkite/steps/aurhelper.sh
+++ b/.buildkite/steps/aurhelper.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 GITTAG=$(git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g')
 

--- a/.buildkite/steps/aurpackages.sh
+++ b/.buildkite/steps/aurpackages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 for AUR_PACKAGE in authelia authelia-bin authelia-git; do

--- a/.buildkite/steps/buildimages.sh
+++ b/.buildkite/steps/buildimages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 declare -A BUILDS=(["linux"]="amd64 arm32v7 arm64v8 coverage")

--- a/.buildkite/steps/deployimages.sh
+++ b/.buildkite/steps/deployimages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 for BUILD_ARCH in amd64 arm32v7 arm64v8; do

--- a/.buildkite/steps/e2etests.sh
+++ b/.buildkite/steps/e2etests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 for SUITE_NAME in $(authelia-scripts suites list); do

--- a/.buildkite/steps/ghartifacts.sh
+++ b/.buildkite/steps/ghartifacts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 
 artifacts=()

--- a/.buildkite/steps/syncdoc.sh
+++ b/.buildkite/steps/syncdoc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export PATH=$PATH:./cmd/authelia-scripts/:./.buildkite/steps/:$GOPATH/bin:./web/node_modules/.bin:/tmp
 

--- a/cmd/authelia-scripts/authelia-scripts
+++ b/cmd/authelia-scripts/authelia-scripts
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 go run cmd/authelia-scripts/*.go $*

--- a/compose/local/setup.sh
+++ b/compose/local/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 username(){
   read -ep "Enter your username for Authelia: " USERNAME

--- a/internal/suites/example/compose/kind/entrypoint-dashboard.sh
+++ b/internal/suites/example/compose/kind/entrypoint-dashboard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Retries a command on failure.
 # $1 - the max number of attempts

--- a/internal/suites/example/kube/bootstrap-dashboard.sh
+++ b/internal/suites/example/kube/bootstrap-dashboard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 start_dashboard() {
   kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta8/aio/deploy/recommended.yaml


### PR DESCRIPTION
Hardcoding /bin/bash prevents some users (e.g. NixOS users) from running the scripts.

I got Standalone running and have not done further testing.