### PR TITLE
[MISC] Strip debug information from compiled binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
 RUN cd cmd/authelia && \
-GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags netgo -ldflags '-w -linkmode external -extldflags -static' -trimpath -o authelia
+GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags netgo -ldflags '-s -w -linkmode external -extldflags -static' -trimpath -o authelia
 
 # ===================================
 # ===== Authelia official image =====

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -47,7 +47,7 @@ RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
 RUN cd cmd/authelia && \
-GOOS=linux GOARCH=arm CGO_ENABLED=1 CC=arm-linux-musleabihf-gcc go build -tags netgo -ldflags '-w -linkmode external -extldflags -static' -trimpath -o authelia
+GOOS=linux GOARCH=arm CGO_ENABLED=1 CC=arm-linux-musleabihf-gcc go build -tags netgo -ldflags '-s -w -linkmode external -extldflags -static' -trimpath -o authelia
 
 # ===================================
 # ===== Authelia official image =====

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -47,7 +47,7 @@ RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
 
 # CGO_ENABLED=1 is mandatory for building go-sqlite3
 RUN cd cmd/authelia && \
-GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-musl-gcc go build -tags netgo -ldflags '-w -linkmode external -extldflags -static' -trimpath -o authelia
+GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-musl-gcc go build -tags netgo -ldflags '-s -w -linkmode external -extldflags -static' -trimpath -o authelia
 
 # ===================================
 # ===== Authelia official image =====


### PR DESCRIPTION
This change ensures that we strip debug information from the generated binaries in order to keep the files smaller.

Summary of the options for these are as follows, we have been running with `-w` for quite some time now:

```
-w    disable DWARF generation
-s    disable symbol table
