### PR TITLE
Fixed minor typo of "Fowarded" to "Forwarded"

### DIFF
--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -9,5 +9,5 @@ const InternalError = "Internal error."
 // UnauthorizedError is the error message sent when the user is not authorized.
 const UnauthorizedError = "You're not authorized."
 
-var errMissingXForwardedHost = errors.New("Missing header X-Fowarded-Host")
-var errMissingXForwardedProto = errors.New("Missing header X-Fowarded-Proto")
+var errMissingXForwardedHost = errors.New("Missing header X-Forwarded-Host")
+var errMissingXForwardedProto = errors.New("Missing header X-Forwarded-Proto")

--- a/internal/handlers/handler_register_u2f_step1_test.go
+++ b/internal/handlers/handler_register_u2f_step1_test.go
@@ -63,7 +63,7 @@ func (s *HandlerRegisterU2FStep1Suite) TestShouldRaiseWhenXForwardedProtoIsMissi
 	SecondFactorU2FIdentityFinish(s.mock.Ctx)
 
 	assert.Equal(s.T(), 200, s.mock.Ctx.Response.StatusCode())
-	assert.Equal(s.T(), "Missing header X-Fowarded-Proto", s.mock.Hook.LastEntry().Message)
+	assert.Equal(s.T(), "Missing header X-Forwarded-Proto", s.mock.Hook.LastEntry().Message)
 }
 
 func (s *HandlerRegisterU2FStep1Suite) TestShouldRaiseWhenXForwardedHostIsMissing() {
@@ -83,7 +83,7 @@ func (s *HandlerRegisterU2FStep1Suite) TestShouldRaiseWhenXForwardedHostIsMissin
 	SecondFactorU2FIdentityFinish(s.mock.Ctx)
 
 	assert.Equal(s.T(), 200, s.mock.Ctx.Response.StatusCode())
-	assert.Equal(s.T(), "Missing header X-Fowarded-Host", s.mock.Hook.LastEntry().Message)
+	assert.Equal(s.T(), "Missing header X-Forwarded-Host", s.mock.Hook.LastEntry().Message)
 }
 
 func TestShouldRunHandlerRegisterU2FStep1Suite(t *testing.T) {

--- a/internal/handlers/handler_sign_u2f_step1_test.go
+++ b/internal/handlers/handler_sign_u2f_step1_test.go
@@ -27,7 +27,7 @@ func (s *HandlerSignU2FStep1Suite) TestShouldRaiseWhenXForwardedProtoIsMissing()
 	SecondFactorU2FSignGet(s.mock.Ctx)
 
 	assert.Equal(s.T(), 200, s.mock.Ctx.Response.StatusCode())
-	assert.Equal(s.T(), "Missing header X-Fowarded-Proto", s.mock.Hook.LastEntry().Message)
+	assert.Equal(s.T(), "Missing header X-Forwarded-Proto", s.mock.Hook.LastEntry().Message)
 }
 
 func (s *HandlerSignU2FStep1Suite) TestShouldRaiseWhenXForwardedHostIsMissing() {
@@ -35,7 +35,7 @@ func (s *HandlerSignU2FStep1Suite) TestShouldRaiseWhenXForwardedHostIsMissing() 
 	SecondFactorU2FSignGet(s.mock.Ctx)
 
 	assert.Equal(s.T(), 200, s.mock.Ctx.Response.StatusCode())
-	assert.Equal(s.T(), "Missing header X-Fowarded-Host", s.mock.Hook.LastEntry().Message)
+	assert.Equal(s.T(), "Missing header X-Forwarded-Host", s.mock.Hook.LastEntry().Message)
 }
 
 func TestShouldRunHandlerSignU2FStep1Suite(t *testing.T) {

--- a/internal/handlers/handler_verify.go
+++ b/internal/handlers/handler_verify.go
@@ -67,7 +67,7 @@ func getOriginalURL(ctx *middlewares.AutheliaCtx) (*url.URL, error) {
 		return nil, fmt.Errorf("Unable to parse URL %s: %v", requestURI, err)
 	}
 
-	ctx.Logger.Tracef("Using X-Fowarded-Proto, X-Forwarded-Host and X-Forwarded-URI headers " +
+	ctx.Logger.Tracef("Using X-Forwarded-Proto, X-Forwarded-Host and X-Forwarded-URI headers " +
 		"to construct targeted site URL")
 
 	return url, nil
@@ -228,7 +228,7 @@ func verifySessionCookie(ctx *middlewares.AutheliaCtx, targetURL *url.URL, userS
 func handleUnauthorized(ctx *middlewares.AutheliaCtx, targetURL fmt.Stringer, username string) {
 	// Kubernetes ingress controller and Traefik use the rd parameter of the verify
 	// endpoint to provide the URL of the login portal. The target URL of the user
-	// is computed from X-Fowarded-* headers or X-Original-URL.
+	// is computed from X-Forwarded-* headers or X-Original-URL.
 	rd := string(ctx.QueryArgs().Peek("rd"))
 	if rd != "" {
 		redirectionURL := fmt.Sprintf("%s?rd=%s", rd, url.QueryEscape(targetURL.String()))

--- a/internal/handlers/handler_verify_test.go
+++ b/internal/handlers/handler_verify_test.go
@@ -80,7 +80,7 @@ func TestShouldRaiseWhenNoHeaderProvidedToDetectTargetURL(t *testing.T) {
 	defer mock.Close()
 	_, err := getOriginalURL(mock.Ctx)
 	assert.Error(t, err)
-	assert.Equal(t, "Missing header X-Fowarded-Proto", err.Error())
+	assert.Equal(t, "Missing header X-Forwarded-Proto", err.Error())
 }
 
 func TestShouldRaiseWhenNoXForwardedHostHeaderProvidedToDetectTargetURL(t *testing.T) {
@@ -90,7 +90,7 @@ func TestShouldRaiseWhenNoXForwardedHostHeaderProvidedToDetectTargetURL(t *testi
 	mock.Ctx.Request.Header.Set("X-Forwarded-Proto", "https")
 	_, err := getOriginalURL(mock.Ctx)
 	assert.Error(t, err)
-	assert.Equal(t, "Missing header X-Fowarded-Host", err.Error())
+	assert.Equal(t, "Missing header X-Forwarded-Host", err.Error())
 }
 
 func TestShouldRaiseWhenXForwardedProtoIsNotParsable(t *testing.T) {

--- a/internal/middlewares/errors.go
+++ b/internal/middlewares/errors.go
@@ -9,5 +9,5 @@ const InternalError = "Internal error."
 // UnauthorizedError is the error message sent when the user is not authorized.
 const UnauthorizedError = "You're not authorized."
 
-var errMissingXForwardedHost = errors.New("Missing header X-Fowarded-Host")
-var errMissingXForwardedProto = errors.New("Missing header X-Fowarded-Proto")
+var errMissingXForwardedHost = errors.New("Missing header X-Forwarded-Host")
+var errMissingXForwardedProto = errors.New("Missing header X-Forwarded-Proto")

--- a/internal/middlewares/identity_verification_test.go
+++ b/internal/middlewares/identity_verification_test.go
@@ -103,7 +103,7 @@ func TestShouldFailWhenXForwardedProtoHeaderIsMissing(t *testing.T) {
 	middlewares.IdentityVerificationStart(args)(mock.Ctx)
 
 	assert.Equal(t, 200, mock.Ctx.Response.StatusCode())
-	assert.Equal(t, "Missing header X-Fowarded-Proto", mock.Hook.LastEntry().Message)
+	assert.Equal(t, "Missing header X-Forwarded-Proto", mock.Hook.LastEntry().Message)
 }
 
 func TestShouldFailWhenXForwardedHostHeaderIsMissing(t *testing.T) {
@@ -121,7 +121,7 @@ func TestShouldFailWhenXForwardedHostHeaderIsMissing(t *testing.T) {
 	middlewares.IdentityVerificationStart(args)(mock.Ctx)
 
 	assert.Equal(t, 200, mock.Ctx.Response.StatusCode())
-	assert.Equal(t, "Missing header X-Fowarded-Host", mock.Hook.LastEntry().Message)
+	assert.Equal(t, "Missing header X-Forwarded-Host", mock.Hook.LastEntry().Message)
 }
 
 func TestShouldSucceedIdentityVerificationStartProcess(t *testing.T) {


### PR DESCRIPTION
While troubleshooting some issues, I ran into this small typo. I decided I should create a PR for it.