### PR TITLE
[CI] Update QEMU to v5.1.0-2

### DIFF
--- a/cmd/authelia-scripts/cmd_docker.go
+++ b/cmd/authelia-scripts/cmd_docker.go
@@ -46,7 +46,7 @@ func dockerBuildOfficialImage(arch string) error {
 	// Set default Architecture Dockerfile to amd64.
 	dockerfile := "Dockerfile"
 	// Set version of QEMU.
-	qemuversion := "v5.0.0-2"
+	qemuversion := "v5.1.0-2"
 
 	// If not the default value.
 	if arch != defaultArch {

--- a/cmd/authelia-scripts/main.go
+++ b/cmd/authelia-scripts/main.go
@@ -1,5 +1,5 @@
 //usr/bin/env go run "$0" "$@"; exit
-//nolint:godot
+//nolint:gocritic,godot
 
 package main
 

--- a/internal/authentication/file_user_provider_test.go
+++ b/internal/authentication/file_user_provider_test.go
@@ -20,17 +20,17 @@ func WithDatabase(content []byte, f func(path string)) {
 		log.Fatal(err)
 	}
 
-	defer os.Remove(tmpfile.Name()) // clean up
+	defer os.Remove(tmpfile.Name()) // Clean up
 
 	if _, err := tmpfile.Write(content); err != nil {
 		tmpfile.Close()
-		log.Fatal(err)
+		log.Panic(err)
 	}
 
 	f(tmpfile.Name())
 
 	if err := tmpfile.Close(); err != nil {
-		log.Fatal(err)
+		log.Panic(err)
 	}
 }
 

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -39,7 +39,7 @@ func validateFileAuthenticationBackend(configuration *schema.FileAuthenticationB
 			validator.Push(fmt.Errorf("The number of iterations specified is invalid, must be 1 or more, you configured %d", configuration.Password.Iterations))
 		}
 
-		//Salt Length
+		// Salt Length
 		switch {
 		case configuration.Password.SaltLength == 0:
 			configuration.Password.SaltLength = schema.DefaultPasswordConfiguration.SaltLength

--- a/internal/configuration/validator/secrets.go
+++ b/internal/configuration/validator/secrets.go
@@ -55,7 +55,7 @@ func getSecretValue(name string, validator *schema.StructValidator, viper *viper
 		if err != nil {
 			validator.Push(fmt.Errorf("error loading secret file (%s): %s", name, err))
 		} else {
-			return strings.Replace(string(content), "\n", "", -1)
+			return strings.ReplaceAll(string(content), "\n", "")
 		}
 	}
 

--- a/internal/handlers/handler_verify_test.go
+++ b/internal/handlers/handler_verify_test.go
@@ -913,7 +913,6 @@ func TestShouldGetRemovedUserGroupsFromBackend(t *testing.T) {
 
 func TestShouldGetAddedUserGroupsFromBackend(t *testing.T) {
 	mock := mocks.NewMockAutheliaCtx(t)
-	//defer mock.Close()
 
 	// Setup pointer to john so we can adjust it during the test.
 	user := &authentication.UserDetails{

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -58,7 +58,7 @@ func (n *SMTPNotifier) initializeTLSConfig() {
 	// The second part of this check happens in the Configure Cert Pool code block
 	log.Debug("Notifier SMTP client initializing TLS configuration")
 
-	//Configure Cert Pool
+	// Configure Cert Pool
 	certPool, err := x509.SystemCertPool()
 	if err != nil || certPool == nil {
 		certPool = x509.NewCertPool()

--- a/internal/storage/sql_provider_test.go
+++ b/internal/storage/sql_provider_test.go
@@ -270,7 +270,7 @@ func TestSQLProviderMethodsTOTP(t *testing.T) {
 		WithArgs(args...).
 		WillReturnRows(sqlmock.NewRows([]string{"secret"}))
 
-	//Test Blank Rows
+	// Test Blank Rows
 	secret, err = provider.LoadTOTPSecret(unitTestUser)
 	assert.EqualError(t, err, "No TOTP secret registered")
 	assert.Equal(t, "", secret)


### PR DESCRIPTION
This also includes fixes for linter errors from a golangci-lint update.