### PR TITLE
Docs Improvement of Traefik2 Example - Add X-ORIGINAL-URL Example

### DIFF
--- a/docs/deployment/supported-proxies/traefik2.x.md
+++ b/docs/deployment/supported-proxies/traefik2.x.md
@@ -105,7 +105,6 @@ services:
       - 'traefik.http.routers.nextcloud.middlewares=nextcloud-redirect@docker,authelia@docker'
       - 'traefik.http.middlewares.nextcloud-redirect.headers.customrequestheaders.X-ORIGINAL-URL=https://nextcloud.example.com"
 
-
     expose:
       - 443
     restart: unless-stopped

--- a/docs/deployment/supported-proxies/traefik2.x.md
+++ b/docs/deployment/supported-proxies/traefik2.x.md
@@ -96,7 +96,16 @@ services:
       - 'traefik.http.routers.nextcloud.rule=Host(`nextcloud.example.com`)'
       - 'traefik.http.routers.nextcloud.entrypoints=https'
       - 'traefik.http.routers.nextcloud.tls=true'
+
+      # Option 1: Middleware with auth but no redirect
       - 'traefik.http.routers.nextcloud.middlewares=authelia@docker'
+
+      # Option 2: Middleware with auth with custom redirect after successful login
+      # note: redirect only used on logins, does not affect already-active sessions
+      - 'traefik.http.routers.nextcloud.middlewares=nextcloud-redirect@docker,authelia@docker'
+      - 'traefik.http.middlewares.nextcloud-redirect.headers.customrequestheaders.X-ORIGINAL-URL=https://nextcloud.example.com"
+
+
     expose:
       - 443
     restart: unless-stopped


### PR DESCRIPTION
Title says it all! I was able to get this working for my own use, and thought this might be a good thing to have in the traefik example yaml, as I assume most users would like to be redirected back to their app after logging in.

This does have the traefik imposed limitation that it can't detect the original access URL and store that, but at the very least, it seems better to get back to a well known static route in the app instead of going to the authelia "authenticated!" page.