### PR TITLE
[BUGFIX] Fix Dockerfile WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,12 +51,12 @@ GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags netgo -ldflags '-s -w -link
 # ===================================
 FROM alpine:3.12.0
 
-COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
-COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
+WORKDIR /app
 
 RUN apk --no-cache add ca-certificates su-exec tzdata
 
-WORKDIR /app
+COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
+COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 
 EXPOSE 9091
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -54,14 +54,15 @@ GOOS=linux GOARCH=arm CGO_ENABLED=1 CC=arm-linux-musleabihf-gcc go build -tags n
 # ===================================
 FROM arm32v7/alpine:3.12.0
 
+WORKDIR /app
+
 COPY ./qemu-arm-static /usr/bin/qemu-arm-static
-COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
-COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 
 RUN apk --no-cache add ca-certificates su-exec tzdata && \
     rm /usr/bin/qemu-arm-static
 
-WORKDIR /app
+COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
+COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 
 EXPOSE 9091
 

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -54,14 +54,15 @@ GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-musl-gcc go build -tags n
 # ===================================
 FROM arm64v8/alpine:3.12.0
 
+WORKDIR /app
+
 COPY ./qemu-aarch64-static /usr/bin/qemu-aarch64-static
-COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
-COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 
 RUN apk --no-cache add ca-certificates su-exec tzdata && \
     rm /usr/bin/qemu-aarch64-static
 
-WORKDIR /app
+COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
+COPY ./entrypoint.sh /usr/local/bin/entrypoint.sh
 
 EXPOSE 9091
 


### PR DESCRIPTION
The `WORKDIR` needs to be set early to ensure that the files are copied into the appropriate directory.
This is a minor regression that was introduced in af2ae328e7cb810d2282ae615791cc10b840b9a9.