### PR TITLE
[BUGFIX] Add ability to specify SMTP HELO/EHLO identifier

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -400,6 +400,8 @@ notifier:
     host: 127.0.0.1
     port: 1025
     sender: admin@example.com
+    # HELO/EHLO Identifier. Some SMTP Servers may reject the default of localhost.
+    identifier: localhost
     # Subject configuration of the emails sent.
     # {title} is replaced by the text from the notifier
     subject: "[Authelia] {title}"

--- a/docs/configuration/notifier/smtp.md
+++ b/docs/configuration/notifier/smtp.md
@@ -43,6 +43,8 @@ notifier:
     host: 127.0.0.1
     port: 1025
     sender: admin@example.com
+    # HELO/EHLO Identifier. Some SMTP Servers may reject the default of localhost.
+    identifier: localhost
     # Subject configuration of the emails sent.
     # {title} is replaced by the text from the notifier
     subject: "[Authelia] {title}"
@@ -58,6 +60,10 @@ notifier:
 
 Most configuration options are self-explanatory, however here is an explanation of the ones that may not
 be as obvious.
+
+### identifier
+The name to send to the SMTP server as the identifier with the HELO/EHLO command. Some SMTP providers like Google Mail
+reject the message if it's localhost.
 
 ### subject
 This is the subject Authelia will use in the email, it has a single placeholder at present `{title}` which should

--- a/internal/configuration/schema/notifier.go
+++ b/internal/configuration/schema/notifier.go
@@ -11,6 +11,7 @@ type SMTPNotifierConfiguration struct {
 	Port                int    `mapstructure:"port"`
 	Username            string `mapstructure:"username"`
 	Password            string `mapstructure:"password"`
+	Identifier          string `mapstructure:"identifier"`
 	Sender              string `mapstructure:"sender"`
 	Subject             string `mapstructure:"subject"`
 	TrustedCert         string `mapstructure:"trusted_cert"`
@@ -29,5 +30,6 @@ type NotifierConfiguration struct {
 
 // DefaultSMTPNotifierConfiguration represents default configuration parameters for the SMTP notifier.
 var DefaultSMTPNotifierConfiguration = SMTPNotifierConfiguration{
-	Subject: "[Authelia] {title}",
+	Subject:    "[Authelia] {title}",
+	Identifier: "localhost",
 }

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -66,6 +66,7 @@ var validKeys = []string{
 	"notifier.smtp.password",
 	"notifier.smtp.host",
 	"notifier.smtp.port",
+	"notifier.smtp.identifier",
 	"notifier.smtp.sender",
 	"notifier.smtp.subject",
 	"notifier.smtp.startup_check_address",

--- a/internal/configuration/validator/notifier.go
+++ b/internal/configuration/validator/notifier.go
@@ -47,6 +47,10 @@ func ValidateNotifier(configuration *schema.NotifierConfiguration, validator *sc
 			configuration.SMTP.Subject = schema.DefaultSMTPNotifierConfiguration.Subject
 		}
 
+		if configuration.SMTP.Identifier == "" {
+			configuration.SMTP.Identifier = schema.DefaultSMTPNotifierConfiguration.Identifier
+		}
+
 		return
 	}
 }

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -21,6 +21,7 @@ type SMTPNotifier struct {
 	username            string
 	password            string
 	sender              string
+	identifier          string
 	host                string
 	port                int
 	trustedCert         string
@@ -39,6 +40,7 @@ func NewSMTPNotifier(configuration schema.SMTPNotifierConfiguration) *SMTPNotifi
 		username:            configuration.Username,
 		password:            configuration.Password,
 		sender:              configuration.Sender,
+		identifier:          configuration.Identifier,
 		host:                configuration.Host,
 		port:                configuration.Port,
 		trustedCert:         configuration.TrustedCert,
@@ -277,6 +279,10 @@ func (n *SMTPNotifier) StartupCheck() (bool, error) {
 
 	defer n.cleanup()
 
+	if err := n.client.Hello(n.identifier); err != nil {
+		return false, err
+	}
+
 	if err := n.startTLS(); err != nil {
 		return false, err
 	}
@@ -310,6 +316,10 @@ func (n *SMTPNotifier) Send(recipient, title, body, htmlBody string) error {
 
 	// Always execute QUIT at the end once we're connected.
 	defer n.cleanup()
+
+	if err := n.client.Hello(n.identifier); err != nil {
+		return err
+	}
 
 	// Start TLS and then Authenticate.
 	if err := n.startTLS(); err != nil {


### PR DESCRIPTION
* add docs
* add configuration option for SMTP called `identifier`
* default should act the same as before

Closes #1146 if merged.