### PR TITLE
[FEATURE] Add health checks to containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,11 @@ EXPOSE 9091
 
 VOLUME /config
 
-ENV PATH="/app:${PATH}"
-ENV PUID=0
-ENV PGID=0
+# Set environment variables
+ENV PATH="/app:${PATH}" \
+PUID=0 \
+PGID=0
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["--config", "/config/configuration.yml"]
+HEALTHCHECK --interval=30s --timeout=3s CMD wget --quiet --tries=1 --spider http://localhost:9091/api/state || exit 1

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -68,9 +68,11 @@ EXPOSE 9091
 
 VOLUME /config
 
-ENV PATH="/app:${PATH}"
-ENV PUID=0
-ENV PGID=0
+# Set environment variables
+ENV PATH="/app:${PATH}" \
+PUID=0 \
+PGID=0
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["--config", "/config/configuration.yml"]
+HEALTHCHECK --interval=30s --timeout=3s CMD wget --quiet --tries=1 --spider http://localhost:9091/api/state || exit 1

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -68,9 +68,11 @@ EXPOSE 9091
 
 VOLUME /config
 
-ENV PATH="/app:${PATH}"
-ENV PUID=0
-ENV PGID=0
+# Set environment variables
+ENV PATH="/app:${PATH}" \
+PUID=0 \
+PGID=0
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["--config", "/config/configuration.yml"]
+HEALTHCHECK --interval=30s --timeout=3s CMD wget --quiet --tries=1 --spider http://localhost:9091/api/state || exit 1


### PR DESCRIPTION
One thing to consider would be if the user is running Authelia with TLS enabled, perhaps an option would be to set a runtime variable that specifies TLS/Non-TLS and that can be utilised to determine the switch for http/https in the health check?

EDIT: Because we can't set the shell's environment variable inside Go's context I think we just stick to adding the healthcheck for the default deployment option (non-TLS) and perhaps add some docs regarding adjusting the healthcheck if the user deploys with TLS, thoughts?

Closes #1423.