### PR TITLE
[DOCS] Update session docs to clarify encryption

### DIFF
--- a/docs/configuration/session.md
+++ b/docs/configuration/session.md
@@ -22,7 +22,7 @@ session:
   # The name of the session cookie. (default: authelia_session).
   name: authelia_session
 
-  # The secret to encrypt the session cookie.
+  # The secret to encrypt the session data. This is only used with Redis.
   # Secret can also be set using a secret: https://docs.authelia.com/configuration/secrets.html
   secret: unsecure_session_secret
 


### PR DESCRIPTION
This looks like it just fell out of sync with what actually already exists within the [`config.template.yml`](https://github.com/authelia/authelia/blob/695cd5bf8f5d964ffff715c1ea14c240299c6899/config.template.yml#L291).

Fixes #1411.