### PR TITLE
[BUGFIX] Make username_attribute a mandatory placeholder in users_filter

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -133,7 +133,7 @@ authentication_backend:
     # The users filter used in search queries to find the user profile based on input filled in login form.
     # Various placeholders are available to represent the user input and back reference other options of the configuration:
     # - {input} is a placeholder replaced by what the user inputs in the login form. 
-    # - {username_attribute} is a placeholder replaced by what is configured in `username_attribute`.
+    # - {username_attribute} is a mandatory placeholder replaced by what is configured in `username_attribute`.
     # - {mail_attribute} is a placeholder replaced by what is configured in `mail_attribute`.
     # - DON'T USE - {0} is an alias for {input} supported for backward compatibility but it will be deprecated in later versions, so please don't use it.
     #

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -185,9 +185,9 @@ In order to avoid such problems, we highly recommended you follow https://www.ie
 `sAMAccountName` for Active Directory and `uid` for other implementations as the attribute holding the
 unique identifier for your users.
 
-As of versions > `4.23.1` the `users_filter` must include the `username_attribute` placeholder, not including this will
+As of versions > `4.24.0` the `users_filter` must include the `username_attribute` placeholder, not including this will
 result in Authelia throwing an error.
-In versions <= `4.23.1` not including the `username_attribute` placeholder will cause issues with the session refresh
+In versions <= `4.24.0` not including the `username_attribute` placeholder will cause issues with the session refresh
 and will result in session resets when the refresh interval has expired, default of 5 minutes. 
 
 ## Loading a password from a secret instead of inside the configuration

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -78,7 +78,7 @@ authentication_backend:
     # The users filter used in search queries to find the user profile based on input filled in login form.
     # Various placeholders are available to represent the user input and back reference other options of the configuration:
     # - {input} is a placeholder replaced by what the user inputs in the login form. 
-    # - {username_attribute} is a placeholder replaced by what is configured in `username_attribute`.
+    # - {username_attribute} is a mandatory placeholder replaced by what is configured in `username_attribute`.
     # - {mail_attribute} is a placeholder replaced by what is configured in `mail_attribute`.
     # - DON'T USE - {0} is an alias for {input} supported for backward compatibility but it will be deprecated in later versions, so please don't use it.
     #
@@ -184,6 +184,11 @@ fail authenticating the user and display an error message in the logs.
 In order to avoid such problems, we highly recommended you follow https://www.ietf.org/rfc/rfc2307.txt by using
 `sAMAccountName` for Active Directory and `uid` for other implementations as the attribute holding the
 unique identifier for your users.
+
+As of versions > `4.23.1` the `users_filter` must include the `username_attribute` placeholder, not including this will
+result in Authelia throwing an error.
+In versions <= `4.23.1` not including the `username_attribute` placeholder will cause issues with the session refresh
+and will result in session resets when the refresh interval has expired, default of 5 minutes. 
 
 ## Loading a password from a secret instead of inside the configuration
 

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -137,7 +137,12 @@ func validateLdapAuthenticationBackend(configuration *schema.LDAPAuthenticationB
 		validator.Push(errors.New("Please provide a users filter with `users_filter` attribute"))
 	} else {
 		if !strings.HasPrefix(configuration.UsersFilter, "(") || !strings.HasSuffix(configuration.UsersFilter, ")") {
-			validator.Push(errors.New("The users filter should contain enclosing parenthesis. For instance uid={input} should be (uid={input})"))
+			validator.Push(errors.New("The users filter should contain enclosing parenthesis. For instance {username_attribute}={input} should be ({username_attribute}={input})"))
+		}
+
+		if !strings.Contains(configuration.UsersFilter, "{username_attribute}") {
+			validator.Push(errors.New("Unable to detect {username_attribute} placeholder in users_filter, your configuration is broken. " +
+				"Please review configuration options listed at https://docs.authelia.com/configuration/authentication/ldap.html"))
 		}
 
 		// This test helps the user know that users_filter is broken after the breaking change induced by this commit.


### PR DESCRIPTION
Not including the `username_attribute` in the `users_filter` will cause issues with the LDAP session refresh and will result in session resets when the refresh interval has expired.

This change makes said attribute mandatory for the `users_filter`.

Fixes #1357.