### PR TITLE
[MISC] Append log file instead of overwriting

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -5,7 +5,7 @@
 # The host and port to listen on
 host: 0.0.0.0
 port: 9091
-# tls_key: /config/ssl/key.pem
+# tls_key: /config/ssl/key.pem
 # tls_cert: /config/ssl/cert.pem
 
 # Configuration options specific to the internal http server
@@ -22,7 +22,7 @@ server:
 # Level of verbosity for logs: info, debug, trace
 log_level: debug
 ## File path where the logs will be written. If not set logs are written to stdout.
-# log_file_path: /config/authelia.log
+# log_file_path: /config/authelia.log
 
 # The secret used to generate JWT tokens when validating user identity by
 # email confirmation.

--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -39,9 +39,9 @@ tls_cert: /config/ssl/cert.pem
 `optional: true`
 
 Defines the level of logs used by Authelia. This level can be set to
-`trace`, `debug` or `info`. When setting log_level to trace, you will
-generate a large amount of log entries and expose the /debug/vars and
-/debug/pprof/ endpoints which should not be enabled in production.
+`trace`, `debug` or `info`. When setting log_level to `trace`, you will
+generate a large amount of log entries and expose the `/debug/vars` and
+`/debug/pprof/` endpoints which should not be enabled in production.
 
 ```yaml
 log_level: debug
@@ -52,7 +52,10 @@ log_level: debug
 `optional: true`
 
 Logs can be stored in a file when file path is provided. Otherwise logs
-are written to standard output.
+are written to standard output. When setting the log_level to `debug` or
+`trace` this will generate large amount of log entries.
+Administrators will need to ensure that they rotate and/or truncate the
+logs over time to prevent significant long-term disk usage.
 
 ```yaml
 log_file_path: /config/authelia.log

--- a/docs/security/measures.md
+++ b/docs/security/measures.md
@@ -146,7 +146,7 @@ applying them blindly.
 
 ```
 # We don't want any credentials / TOTP secret key / QR code to be cached by
-# the client
+# the client
 add_header Cache-Control "no-store";
 add_header Pragma "no-cache";
 

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -24,7 +24,8 @@ func InitializeLogger(filename string) error {
 	logrus.AddHook(logrus_stack.NewHook(callerLevels, stackLevels))
 
 	if filename != "" {
-		f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, 0600)
+		f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+
 		if err != nil {
 			return err
 		}

--- a/internal/suites/example/compose/nginx/portal/nginx.conf
+++ b/internal/suites/example/compose/nginx/portal/nginx.conf
@@ -78,7 +78,7 @@ http {
         }
     }
 
-    # Example configuration of domains protected by Authelia.
+    # Example configuration of domains protected by Authelia.
     server {
         listen 8080 ssl; 
         server_name     public.example.com
@@ -235,7 +235,7 @@ http {
         }
     }
 
-    # Matches all domains. It redirects to the home page.
+    # Matches all domains. It redirects to the home page.
     server {
 	    listen 8080 ssl;
 	    server_name _;

--- a/internal/suites/example/compose/squid/squid.conf
+++ b/internal/suites/example/compose/squid/squid.conf
@@ -1195,7 +1195,7 @@ http_access allow all
 # http_access allow localhost
 
 # And finally deny all other access to this proxy
-# http_access deny all
+# http_access deny all
 
 #  TAG: adapted_http_access
 #	Allowing or Denying access based on defined access lists


### PR DESCRIPTION
If Authelia is restarted when a `log_file_path` is defined, upon restart the log file is overwritten.

This change ensures that the log file will be appended to. Users will need to ensure that they rotate/truncate this over time especially if running in `debug` or `trace`.

Fixes #1294.