### PR TITLE
[CI] Fix development workflow

### DIFF
--- a/web/.env.development
+++ b/web/.env.development
@@ -1,2 +1,4 @@
 HOST=authelia-frontend
 PUBLIC_URL=""
+REACT_APP_REMEMBER_ME=true
+REACT_APP_RESET_PASSWORD=true

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,1 +1,3 @@
 PUBLIC_URL={{.Base}}
+REACT_APP_REMEMBER_ME={{.RememberMe}}
+REACT_APP_RESET_PASSWORD={{.ResetPassword}}

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -25,7 +25,7 @@
   <title>Login - Authelia</title>
 </head>
 
-<body data-basepath="%PUBLIC_URL%" data-rememberme="{{.RememberMe}}" data-disable-resetpassword="{{.ResetPassword}}">
+<body data-basepath="%PUBLIC_URL%" data-rememberme="%REACT_APP_REMEMBER_ME%" data-resetpassword="%REACT_APP_RESET_PASSWORD%">
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <!--

--- a/web/src/setupTests.js
+++ b/web/src/setupTests.js
@@ -1,6 +1,6 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 document.body.setAttribute("data-basepath", "");
-document.body.setAttribute("data-rememberme", "false");
-document.body.setAttribute("data-disable-resetpassword", "false");
+document.body.setAttribute("data-rememberme", "true");
+document.body.setAttribute("data-resetpassword", "true");
 configure({ adapter: new Adapter() });

--- a/web/src/utils/Configuration.ts
+++ b/web/src/utils/Configuration.ts
@@ -12,5 +12,5 @@ export function getRememberMe() {
 }
 
 export function getResetPassword() {
-  return getEmbeddedVariable("disable-resetpassword") === "true";
+  return getEmbeddedVariable("resetpassword") === "true";
 }


### PR DESCRIPTION
Since merging #1135 and utilising Go templating to enable/disable the rememeber me and password reset features these have stopped working in the development workflow.

During frontend development if someone wants to enable/disable these features they should modify the `.env.development` file accordingly.