### PR TITLE
[BUGFIX] Prevent crash when email has not been set

### DIFF
--- a/internal/handlers/handler_verify.go
+++ b/internal/handlers/handler_verify.go
@@ -159,7 +159,12 @@ func setForwardedHeaders(headers *fasthttp.ResponseHeader, username, name string
 		headers.Set(remoteUserHeader, username)
 		headers.Set(remoteGroupsHeader, strings.Join(groups, ","))
 		headers.Set(remoteNameHeader, name)
-		headers.Set(remoteEmailHeader, emails[0])
+
+		if emails != nil {
+			headers.Set(remoteEmailHeader, emails[0])
+		} else {
+			headers.Set(remoteEmailHeader, "")
+		}
 	}
 }
 


### PR DESCRIPTION
https://github.com/authelia/authelia/commit/a83ccd71887cb843adce10fe14d630fbf3ac9bec introduced a regression where if a misconfigured deployment presented an empty emails array, setting the `Remote-*` headers would fail and in turn would result in Authelia crashing.

If the emails array is empty we now set the `Remote-Email` header to an empty string.

Fixes #1451.