### PR TITLE
[CI] Add ability to customise the chromedriver port

### DIFF
--- a/internal/suites/const.go
+++ b/internal/suites/const.go
@@ -48,6 +48,7 @@ var DuoBaseURL = "https://duo.example.com"
 var AutheliaBaseURL = "https://authelia.example.com:9091"
 
 const stringTrue = "true"
+const defaultChromeDriverPort = "4444"
 
 const testUsername = "john"
 const testPassword = "password"

--- a/internal/suites/suite_network_acl_test.go
+++ b/internal/suites/suite_network_acl_test.go
@@ -3,6 +3,8 @@ package suites
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -39,7 +41,13 @@ func (s *NetworkACLSuite) TestShouldAccessSecretUpon1FA() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	wds, err := StartWebDriverWithProxy("http://proxy-client1.example.com:3128", 4444)
+	driverPort := os.Getenv("CHROMEDRIVER_PORT")
+	if driverPort == "" {
+		driverPort = defaultChromeDriverPort
+	}
+
+	p, _ := strconv.Atoi(driverPort)
+	wds, err := StartWebDriverWithProxy("http://proxy-client1.example.com:3128", p)
 	s.Require().NoError(err)
 
 	defer wds.Stop() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
@@ -58,7 +66,13 @@ func (s *NetworkACLSuite) TestShouldAccessSecretUpon0FA() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	wds, err := StartWebDriverWithProxy("http://proxy-client2.example.com:3128", 4444)
+	driverPort := os.Getenv("CHROMEDRIVER_PORT")
+	if driverPort == "" {
+		driverPort = defaultChromeDriverPort
+	}
+
+	p, _ := strconv.Atoi(driverPort)
+	wds, err := StartWebDriverWithProxy("http://proxy-client2.example.com:3128", p)
 	s.Require().NoError(err)
 
 	defer wds.Stop() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.

--- a/internal/suites/webdriver.go
+++ b/internal/suites/webdriver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -69,7 +70,14 @@ func StartWebDriverWithProxy(proxy string, port int) (*WebDriverSession, error) 
 
 // StartWebDriver create a selenium session.
 func StartWebDriver() (*WebDriverSession, error) {
-	return StartWebDriverWithProxy("", 4444)
+	driverPort := os.Getenv("CHROMEDRIVER_PORT")
+	if driverPort == "" {
+		driverPort = defaultChromeDriverPort
+	}
+
+	p, _ := strconv.Atoi(driverPort)
+
+	return StartWebDriverWithProxy("", p)
 }
 
 // Stop stop the selenium session.


### PR DESCRIPTION
The development workflow expects chromedriver to be run on the host on port `4444`.
There is currently no mechanism to modify this behaviour at runtime, so if another service is running on `4444` tests will just fail silently.

This change introduces the `CHROMEDRIVER_PORT` environment variable which can be utilised to set a custom port.