### PR TITLE
Fix healthcheck failing because of CRLF in configuration.yml

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -2,8 +2,8 @@
 
 AUTHELIA_CONFIG=$(pgrep -af authelia | awk '{print $4}')
 AUTHELIA_SCHEME=$(grep ^tls "${AUTHELIA_CONFIG}")
-AUTHELIA_HOST=$(grep ^host "${AUTHELIA_CONFIG}" | sed -e 's/host: //')
-AUTHELIA_PORT=$(grep ^port "${AUTHELIA_CONFIG}" | sed -e 's/port: //')
+AUTHELIA_HOST=$(grep ^host "${AUTHELIA_CONFIG}" | sed -e 's/host: //' -e 's/\r//')
+AUTHELIA_PORT=$(grep ^port "${AUTHELIA_CONFIG}" | sed -e 's/port: //' -e 's/\r//')
 
 if [ -z "${AUTHELIA_SCHEME}" ]; then
   AUTHELIA_SCHEME=http


### PR DESCRIPTION
When merged to `master` #1461 can be closed.
The configuration.yml might contain CRLF characters. If that's the case, they are included in the results of sed, which breaks the healthcheck, so remove any CR characters in the host/port variables.