### PR TITLE
[BUGFIX] Fix Docker healthcheck script

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,17 +1,22 @@
 #!/bin/sh
 
-AUTHELIA_CONFIG=$(ps | grep authelia | awk '{print $6}' | head -1)
-AUTHELIA_SCHEME=$(cat "${AUTHELIA_CONFIG}" | grep ^tls)
-AUTHELIA_PORT=$(cat "${AUTHELIA_CONFIG}" | grep ^port | sed -e 's/port: //')
+AUTHELIA_CONFIG=$(pgrep -af authelia | awk '{print $4}')
+AUTHELIA_SCHEME=$(grep ^tls "${AUTHELIA_CONFIG}")
+AUTHELIA_HOST=$(grep ^host "${AUTHELIA_CONFIG}" | sed -e 's/host: //')
+AUTHELIA_PORT=$(grep ^port "${AUTHELIA_CONFIG}" | sed -e 's/port: //')
 
-if [[ -z ${AUTHELIA_PORT} ]]; then
-  AUTHELIA_PORT=9091
-fi
-
-if [[ -z ${AUTHELIA_SCHEME} ]]; then
+if [ -z "${AUTHELIA_SCHEME}" ]; then
   AUTHELIA_SCHEME=http
 else
   AUTHELIA_SCHEME=https
 fi
 
-wget --quiet --tries=1 --spider ${AUTHELIA_SCHEME}://localhost:${AUTHELIA_PORT}/api/state || exit 1
+if [ -z "${AUTHELIA_HOST}" ] || [ "${AUTHELIA_HOST}" = "0.0.0.0" ]; then
+  AUTHELIA_HOST=localhost
+fi
+
+if [ -z "${AUTHELIA_PORT}" ]; then
+  AUTHELIA_PORT=9091
+fi
+
+wget --quiet --tries=1 --spider "${AUTHELIA_SCHEME}://${AUTHELIA_HOST}:${AUTHELIA_PORT}/api/state" || exit 1

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -2,8 +2,8 @@
 
 AUTHELIA_CONFIG=$(pgrep -af authelia | awk '{print $4}')
 AUTHELIA_SCHEME=$(grep ^tls "${AUTHELIA_CONFIG}")
-AUTHELIA_HOST=$(grep ^host "${AUTHELIA_CONFIG}" | sed -e 's/host: //')
-AUTHELIA_PORT=$(grep ^port "${AUTHELIA_CONFIG}" | sed -e 's/port: //')
+AUTHELIA_HOST=$(grep ^host "${AUTHELIA_CONFIG}" | sed -e 's/host: //' -e 's/\r//')
+AUTHELIA_PORT=$(grep ^port "${AUTHELIA_CONFIG}" | sed -e 's/port: //' -e 's/\r//')
 
 if [ -z "${AUTHELIA_SCHEME}" ]; then
   AUTHELIA_SCHEME=http


### PR DESCRIPTION
The configuration.yml might contain CRLF characters. If that's the case, they are included in the results of sed, which breaks the healthcheck, so remove any CR characters in the host/port variables (#1483).

This script also now determines the host for Docker healthcheck from the `configuration.yml` that Authelia is started with.

Fixes #1461.