### PR TITLE
[MISC] Consistently utilise correct logging interface

### DIFF
--- a/cmd/authelia-scripts/cmd_bootstrap.go
+++ b/cmd/authelia-scripts/cmd_bootstrap.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/authelia/authelia/internal/utils"

--- a/cmd/authelia/main.go
+++ b/cmd/authelia/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -37,7 +36,7 @@ func startServer() {
 	}
 
 	if err := logging.InitializeLogger(config.LogFilePath); err != nil {
-		log.Fatalf("Cannot initialize logger: %v", err)
+		logging.Logger().Fatalf("Cannot initialize logger: %v", err)
 	}
 
 	switch config.LogLevel {
@@ -64,7 +63,7 @@ func startServer() {
 	case config.AuthenticationBackend.Ldap != nil:
 		userProvider = authentication.NewLDAPUserProvider(*config.AuthenticationBackend.Ldap)
 	default:
-		log.Fatalf("Unrecognized authentication backend")
+		logging.Logger().Fatalf("Unrecognized authentication backend")
 	}
 
 	var storageProvider storage.Provider
@@ -77,7 +76,7 @@ func startServer() {
 	case config.Storage.Local != nil:
 		storageProvider = storage.NewSQLiteProvider(config.Storage.Local.Path)
 	default:
-		log.Fatalf("Unrecognized storage backend")
+		logging.Logger().Fatalf("Unrecognized storage backend")
 	}
 
 	var notifier notification.Notifier
@@ -88,13 +87,13 @@ func startServer() {
 	case config.Notifier.FileSystem != nil:
 		notifier = notification.NewFileNotifier(*config.Notifier.FileSystem)
 	default:
-		log.Fatalf("Unrecognized notifier")
+		logging.Logger().Fatalf("Unrecognized notifier")
 	}
 
 	if !config.Notifier.DisableStartupCheck {
 		_, err := notifier.StartupCheck()
 		if err != nil {
-			log.Fatalf("Error during notifier startup check: %s", err)
+			logging.Logger().Fatalf("Error during notifier startup check: %s", err)
 		}
 	}
 
@@ -136,6 +135,6 @@ func main() {
 		commands.ValidateConfigCmd, commands.CertificatesCmd)
 
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err)
+		logging.Logger().Fatal(err)
 	}
 }

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/authelia/authelia/internal/configuration/schema"
+	"github.com/authelia/authelia/internal/logging"
 	"github.com/authelia/authelia/internal/utils"
 )
 
@@ -58,7 +57,7 @@ func NewSMTPNotifier(configuration schema.SMTPNotifierConfiguration) *SMTPNotifi
 func (n *SMTPNotifier) initializeTLSConfig() {
 	// Do not allow users to disable verification of certs if they have also set a trusted cert that was loaded
 	// The second part of this check happens in the Configure Cert Pool code block
-	log.Debug("Notifier SMTP client initializing TLS configuration")
+	logging.Logger().Debug("Notifier SMTP client initializing TLS configuration")
 
 	// Configure Cert Pool
 	certPool, err := x509.SystemCertPool()
@@ -67,25 +66,25 @@ func (n *SMTPNotifier) initializeTLSConfig() {
 	}
 
 	if n.trustedCert != "" {
-		log.Debugf("Notifier SMTP client attempting to load certificate from %s", n.trustedCert)
+		logging.Logger().Debugf("Notifier SMTP client attempting to load certificate from %s", n.trustedCert)
 
 		if exists, err := utils.FileExists(n.trustedCert); exists {
 			pem, err := ioutil.ReadFile(n.trustedCert)
 			if err != nil {
-				log.Warnf("Notifier SMTP failed to load cert from file with error: %s", err)
+				logging.Logger().Warnf("Notifier SMTP failed to load cert from file with error: %s", err)
 			} else {
 				if ok := certPool.AppendCertsFromPEM(pem); !ok {
-					log.Warn("Notifier SMTP failed to import cert loaded from file")
+					logging.Logger().Warn("Notifier SMTP failed to import cert loaded from file")
 				} else {
-					log.Debug("Notifier SMTP successfully loaded certificate")
+					logging.Logger().Debug("Notifier SMTP successfully loaded certificate")
 					if n.disableVerifyCert {
-						log.Warn("Notifier SMTP when trusted_cert is specified we force disable_verify_cert to false, if you want to disable certificate validation please comment/delete trusted_cert from your config")
+						logging.Logger().Warn("Notifier SMTP when trusted_cert is specified we force disable_verify_cert to false, if you want to disable certificate validation please comment/delete trusted_cert from your config")
 						n.disableVerifyCert = false
 					}
 				}
 			}
 		} else {
-			log.Warnf("Notifier SMTP failed to load cert from file (file does not exist) with error: %s", err)
+			logging.Logger().Warnf("Notifier SMTP failed to load cert from file (file does not exist) with error: %s", err)
 		}
 	}
 
@@ -100,23 +99,23 @@ func (n *SMTPNotifier) initializeTLSConfig() {
 func (n *SMTPNotifier) startTLS() error {
 	// Only start if not already encrypted
 	if _, ok := n.client.TLSConnectionState(); ok {
-		log.Debugf("Notifier SMTP connection is already encrypted, skipping STARTTLS")
+		logging.Logger().Debugf("Notifier SMTP connection is already encrypted, skipping STARTTLS")
 		return nil
 	}
 
 	switch ok, _ := n.client.Extension("STARTTLS"); ok {
 	case true:
-		log.Debugf("Notifier SMTP server supports STARTTLS (disableVerifyCert: %t, ServerName: %s), attempting", n.tlsConfig.InsecureSkipVerify, n.tlsConfig.ServerName)
+		logging.Logger().Debugf("Notifier SMTP server supports STARTTLS (disableVerifyCert: %t, ServerName: %s), attempting", n.tlsConfig.InsecureSkipVerify, n.tlsConfig.ServerName)
 
 		if err := n.client.StartTLS(n.tlsConfig); err != nil {
 			return err
 		}
 
-		log.Debug("Notifier SMTP STARTTLS completed without error")
+		logging.Logger().Debug("Notifier SMTP STARTTLS completed without error")
 	default:
 		switch n.disableRequireTLS {
 		case true:
-			log.Warn("Notifier SMTP server does not support STARTTLS and SMTP configuration is set to disable the TLS requirement (only useful for unauthenticated emails over plain text)")
+			logging.Logger().Warn("Notifier SMTP server does not support STARTTLS and SMTP configuration is set to disable the TLS requirement (only useful for unauthenticated emails over plain text)")
 		default:
 			return errors.New("Notifier SMTP server does not support TLS and it is required by default (see documentation if you want to disable this highly recommended requirement)")
 		}
@@ -139,18 +138,18 @@ func (n *SMTPNotifier) auth() error {
 		if ok {
 			var auth smtp.Auth
 
-			log.Debugf("Notifier SMTP server supports authentication with the following mechanisms: %s", m)
+			logging.Logger().Debugf("Notifier SMTP server supports authentication with the following mechanisms: %s", m)
 			mechanisms := strings.Split(m, " ")
 
 			// Adaptively select the AUTH mechanism to use based on what the server advertised.
 			if utils.IsStringInSlice("PLAIN", mechanisms) {
 				auth = smtp.PlainAuth("", n.username, n.password, n.host)
 
-				log.Debug("Notifier SMTP client attempting AUTH PLAIN with server")
+				logging.Logger().Debug("Notifier SMTP client attempting AUTH PLAIN with server")
 			} else if utils.IsStringInSlice("LOGIN", mechanisms) {
 				auth = newLoginAuth(n.username, n.password, n.host)
 
-				log.Debug("Notifier SMTP client attempting AUTH LOGIN with server")
+				logging.Logger().Debug("Notifier SMTP client attempting AUTH LOGIN with server")
 			}
 
 			// Throw error since AUTH extension is not supported.
@@ -163,7 +162,7 @@ func (n *SMTPNotifier) auth() error {
 				return err
 			}
 
-			log.Debug("Notifier SMTP client authenticated successfully with the server")
+			logging.Logger().Debug("Notifier SMTP client authenticated successfully with the server")
 
 			return nil
 		}
@@ -171,13 +170,13 @@ func (n *SMTPNotifier) auth() error {
 		return errors.New("Notifier SMTP server does not advertise the AUTH extension but config requires AUTH (password specified), either disable AUTH, or use an SMTP host that supports AUTH PLAIN or AUTH LOGIN")
 	}
 
-	log.Debug("Notifier SMTP config has no password specified so authentication is being skipped")
+	logging.Logger().Debug("Notifier SMTP config has no password specified so authentication is being skipped")
 
 	return nil
 }
 
 func (n *SMTPNotifier) compose(recipient, subject, body, htmlBody string) error {
-	log.Debugf("Notifier SMTP client attempting to send email body to %s", recipient)
+	logging.Logger().Debugf("Notifier SMTP client attempting to send email body to %s", recipient)
 
 	if !n.disableRequireTLS {
 		_, ok := n.client.TLSConnectionState()
@@ -188,7 +187,7 @@ func (n *SMTPNotifier) compose(recipient, subject, body, htmlBody string) error 
 
 	wc, err := n.client.Data()
 	if err != nil {
-		log.Debugf("Notifier SMTP client error while obtaining WriteCloser: %s", err)
+		logging.Logger().Debugf("Notifier SMTP client error while obtaining WriteCloser: %s", err)
 		return err
 	}
 
@@ -218,13 +217,13 @@ func (n *SMTPNotifier) compose(recipient, subject, body, htmlBody string) error 
 
 	_, err = fmt.Fprint(wc, msg)
 	if err != nil {
-		log.Debugf("Notifier SMTP client error while sending email body over WriteCloser: %s", err)
+		logging.Logger().Debugf("Notifier SMTP client error while sending email body over WriteCloser: %s", err)
 		return err
 	}
 
 	err = wc.Close()
 	if err != nil {
-		log.Debugf("Notifier SMTP client error while closing the WriteCloser: %s", err)
+		logging.Logger().Debugf("Notifier SMTP client error while closing the WriteCloser: %s", err)
 		return err
 	}
 
@@ -233,10 +232,10 @@ func (n *SMTPNotifier) compose(recipient, subject, body, htmlBody string) error 
 
 // Dial the SMTP server with the SMTPNotifier config.
 func (n *SMTPNotifier) dial() error {
-	log.Debugf("Notifier SMTP client attempting connection to %s", n.address)
+	logging.Logger().Debugf("Notifier SMTP client attempting connection to %s", n.address)
 
 	if n.port == 465 {
-		log.Warnf("Notifier SMTP client configured to connect to a SMTPS server. It's highly recommended you use a non SMTPS port and STARTTLS instead of SMTPS, as the protocol is long deprecated.")
+		logging.Logger().Warnf("Notifier SMTP client configured to connect to a SMTPS server. It's highly recommended you use a non SMTPS port and STARTTLS instead of SMTPS, as the protocol is long deprecated.")
 
 		conn, err := tls.Dial("tcp", n.address, n.tlsConfig)
 		if err != nil {
@@ -258,7 +257,7 @@ func (n *SMTPNotifier) dial() error {
 		n.client = client
 	}
 
-	log.Debug("Notifier SMTP client connected successfully")
+	logging.Logger().Debug("Notifier SMTP client connected successfully")
 
 	return nil
 }
@@ -267,7 +266,7 @@ func (n *SMTPNotifier) dial() error {
 func (n *SMTPNotifier) cleanup() {
 	err := n.client.Quit()
 	if err != nil {
-		log.Warnf("Notifier SMTP client encountered error during cleanup: %s", err)
+		logging.Logger().Warnf("Notifier SMTP client encountered error during cleanup: %s", err)
 	}
 }
 
@@ -332,12 +331,12 @@ func (n *SMTPNotifier) Send(recipient, title, body, htmlBody string) error {
 
 	// Set the sender and recipient first.
 	if err := n.client.Mail(n.sender); err != nil {
-		log.Debugf("Notifier SMTP failed while sending MAIL FROM (using sender) with error: %s", err)
+		logging.Logger().Debugf("Notifier SMTP failed while sending MAIL FROM (using sender) with error: %s", err)
 		return err
 	}
 
 	if err := n.client.Rcpt(recipient); err != nil {
-		log.Debugf("Notifier SMTP failed while sending RCPT TO (using recipient) with error: %s", err)
+		logging.Logger().Debugf("Notifier SMTP failed while sending RCPT TO (using recipient) with error: %s", err)
 		return err
 	}
 
@@ -346,7 +345,7 @@ func (n *SMTPNotifier) Send(recipient, title, body, htmlBody string) error {
 		return err
 	}
 
-	log.Debug("Notifier SMTP client successfully sent email")
+	logging.Logger().Debug("Notifier SMTP client successfully sent email")
 
 	return nil
 }


### PR DESCRIPTION
This change aims to utilise the correct logging interface consistently.

The only instances where stdlib log is utilised is for tests and when commands that Authelia supports; for example certificate generation, password hashing and config validation.