### PR TITLE
[FEATURE] Create dedicated health endpoint

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -4,6 +4,7 @@ AUTHELIA_CONFIG=$(pgrep -af authelia | awk '{print $4}')
 AUTHELIA_SCHEME=$(grep ^tls "${AUTHELIA_CONFIG}")
 AUTHELIA_HOST=$(grep ^host "${AUTHELIA_CONFIG}" | sed -e 's/host: //' -e 's/\r//')
 AUTHELIA_PORT=$(grep ^port "${AUTHELIA_CONFIG}" | sed -e 's/port: //' -e 's/\r//')
+AUTHELIA_PATH=$(grep ^\ \ path "${AUTHELIA_CONFIG}" | sed -e 's/  path: //' -e 's/\r//' -e 's/^/\//')
 
 if [ -z "${AUTHELIA_SCHEME}" ]; then
   AUTHELIA_SCHEME=http
@@ -19,4 +20,4 @@ if [ -z "${AUTHELIA_PORT}" ]; then
   AUTHELIA_PORT=9091
 fi
 
-wget --quiet --tries=1 --spider "${AUTHELIA_SCHEME}://${AUTHELIA_HOST}:${AUTHELIA_PORT}/api/state" || exit 1
+wget --quiet --tries=1 --spider "${AUTHELIA_SCHEME}://${AUTHELIA_HOST}:${AUTHELIA_PORT}${AUTHELIA_PATH}/api/health" || exit 1

--- a/internal/handlers/handler_health.go
+++ b/internal/handlers/handler_health.go
@@ -1,0 +1,10 @@
+package handlers
+
+import (
+	"github.com/authelia/authelia/internal/middlewares"
+)
+
+// HealthGet can be used by health checks.
+func HealthGet(ctx *middlewares.AutheliaCtx) {
+	ctx.ReplyOK()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,6 +42,7 @@ func StartServer(configuration schema.Configuration, providers middlewares.Provi
 
 	r.GET("/static/{filepath:*}", fasthttpadaptor.NewFastHTTPHandler(br.Serve(embeddedAssets)))
 
+	r.GET("/api/health", autheliaMiddleware(handlers.HealthGet))
 	r.GET("/api/state", autheliaMiddleware(handlers.StateGet))
 
 	r.GET("/api/configuration", autheliaMiddleware(

--- a/internal/utils/aes.go
+++ b/internal/utils/aes.go
@@ -8,8 +8,8 @@ import (
 	"io"
 )
 
-// The implementation of Encrypt and Decrypt methods comes from
-// https://github.com/gtank/cryptopasta
+// The implementation of Encrypt and Decrypt methods comes from:
+// https://github.com/gtank/cryptopasta.
 
 // Encrypt encrypts data using 256-bit AES-GCM.  This both hides the content of
 // the data and provides a check that it hasn't been altered. Output takes the


### PR DESCRIPTION
This change points the Docker containers healthcheck to the dedicated `/api/health` endpoint and also includes support for Authelia running with a path prefix.