### PR TITLE
[CI] Exclude non-coverage files from codecov upload

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -16,7 +16,10 @@ if [[ ! $BUILDKITE_BRANCH =~ ^(v.*) ]] && [[ $BUILDKITE_COMMAND_EXIT_STATUS == 0
       BUILDKITE_AGENT_META_DATA_CODECOV="-v"
     fi
     bash <(curl -s --connect-timeout 10 --retry 10 --retry-max-time 0 https://codecov.io/bash) -Z -c -f "coverage.txt" -F backend ${BUILDKITE_AGENT_META_DATA_CODECOV}
-    bash <(curl -s --connect-timeout 10 --retry 10 --retry-max-time 0 https://codecov.io/bash) -Z -c -F frontend ${BUILDKITE_AGENT_META_DATA_CODECOV}
+    if [[ $BUILDKITE_LABEL =~ ":selenium:" ]]; then
+      cd web && yarn report
+    fi
+    bash <(curl -s --connect-timeout 10 --retry 10 --retry-max-time 0 https://codecov.io/bash) -Z -c -f '!*.go' -f '!*.zst' -F frontend ${BUILDKITE_AGENT_META_DATA_CODECOV}
   fi
 fi
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -32,6 +32,9 @@ flags:
     paths:
       - "web/"
 
+ignore:
+  - "web/src/serviceWorker.ts"
+
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
This change ensure that files are not incorrectly identified and uploaded to codecov as reports.

Also as we do not utilise service workers in React, ignoring `serviceWorker.ts` gives more accurate coverage percentages.