### PR TITLE
[MISC] Refactor and address most errcheck linter ignores

### DIFF
--- a/cmd/authelia-scripts/cmd_suites.go
+++ b/cmd/authelia-scripts/cmd_suites.go
@@ -195,10 +195,16 @@ func setupSuite(suiteName string) error {
 
 	if errSetup := runSuiteSetupTeardown("setup", suiteName); errSetup != nil || interrupted {
 		if errSetup == utils.ErrTimeoutReached {
-			runOnSetupTimeout(suiteName) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+			err := runOnSetupTimeout(suiteName)
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 
-		teardownSuite(suiteName) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+		err := teardownSuite(suiteName)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		return errSetup
 	}

--- a/internal/handlers/handler_configuration.go
+++ b/internal/handlers/handler_configuration.go
@@ -26,5 +26,9 @@ func ConfigurationGet(ctx *middlewares.AutheliaCtx) {
 	ctx.Logger.Tracef("Second factor enabled: %v", body.SecondFactorEnabled)
 
 	ctx.Logger.Tracef("Available methods are %s", body.AvailableMethods)
-	ctx.SetJSONBody(body) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+
+	err := ctx.SetJSONBody(body)
+	if err != nil {
+		ctx.Logger.Errorf("Unable to set configuration response in body: %s", err)
+	}
 }

--- a/internal/handlers/handler_firstfactor.go
+++ b/internal/handlers/handler_firstfactor.go
@@ -95,7 +95,8 @@ func FirstFactorPost(msInitialDelay time.Duration, delayEnabled bool) middleware
 
 		if err != nil {
 			ctx.Logger.Debugf("Mark authentication attempt made by user %s", bodyJSON.Username)
-			ctx.Providers.Regulator.Mark(bodyJSON.Username, false) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+
+			_ = ctx.Providers.Regulator.Mark(bodyJSON.Username, false)
 
 			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Error while checking password for user %s: %s", bodyJSON.Username, err.Error()), authenticationFailedMessage)
 
@@ -104,7 +105,8 @@ func FirstFactorPost(msInitialDelay time.Duration, delayEnabled bool) middleware
 
 		if !userPasswordOk {
 			ctx.Logger.Debugf("Mark authentication attempt made by user %s", bodyJSON.Username)
-			ctx.Providers.Regulator.Mark(bodyJSON.Username, false) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+
+			_ = ctx.Providers.Regulator.Mark(bodyJSON.Username, false)
 
 			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Credentials are wrong for user %s", bodyJSON.Username), authenticationFailedMessage)
 

--- a/internal/handlers/handler_firstfactor.go
+++ b/internal/handlers/handler_firstfactor.go
@@ -96,7 +96,9 @@ func FirstFactorPost(msInitialDelay time.Duration, delayEnabled bool) middleware
 		if err != nil {
 			ctx.Logger.Debugf("Mark authentication attempt made by user %s", bodyJSON.Username)
 
-			_ = ctx.Providers.Regulator.Mark(bodyJSON.Username, false)
+			if err := ctx.Providers.Regulator.Mark(bodyJSON.Username, false); err != nil {
+				ctx.Logger.Errorf("Unable to mark authentication: %s", err.Error())
+			}
 
 			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Error while checking password for user %s: %s", bodyJSON.Username, err.Error()), authenticationFailedMessage)
 
@@ -106,16 +108,14 @@ func FirstFactorPost(msInitialDelay time.Duration, delayEnabled bool) middleware
 		if !userPasswordOk {
 			ctx.Logger.Debugf("Mark authentication attempt made by user %s", bodyJSON.Username)
 
-			_ = ctx.Providers.Regulator.Mark(bodyJSON.Username, false)
+			if err := ctx.Providers.Regulator.Mark(bodyJSON.Username, false); err != nil {
+				ctx.Logger.Errorf("Unable to mark authentication: %s", err.Error())
+			}
 
 			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Credentials are wrong for user %s", bodyJSON.Username), authenticationFailedMessage)
 
-			ctx.ReplyError(fmt.Errorf("Credentials are wrong for user %s", bodyJSON.Username), authenticationFailedMessage)
-
 			return
 		}
-
-		ctx.Logger.Debugf("Credentials validation of user %s is ok", bodyJSON.Username)
 
 		ctx.Logger.Debugf("Mark authentication attempt made by user %s", bodyJSON.Username)
 		err = ctx.Providers.Regulator.Mark(bodyJSON.Username, true)
@@ -124,6 +124,8 @@ func FirstFactorPost(msInitialDelay time.Duration, delayEnabled bool) middleware
 			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to mark authentication: %s", err.Error()), authenticationFailedMessage)
 			return
 		}
+
+		ctx.Logger.Debugf("Credentials validation of user %s is ok", bodyJSON.Username)
 
 		// Reset all values from previous session before regenerating the cookie.
 		err = ctx.SaveSession(session.NewDefaultUserSession())

--- a/internal/handlers/handler_logout_test.go
+++ b/internal/handlers/handler_logout_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/authelia/authelia/internal/mocks"
@@ -20,7 +21,8 @@ func (s *LogoutSuite) SetupTest() {
 	s.mock = mocks.NewMockAutheliaCtx(s.T())
 	userSession := s.mock.Ctx.GetSession()
 	userSession.Username = testUsername
-	s.mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.mock.Ctx.SaveSession(userSession)
+	require.NoError(s.T(), err)
 }
 
 func (s *LogoutSuite) TearDownTest() {

--- a/internal/handlers/handler_register_totp.go
+++ b/internal/handlers/handler_register_totp.go
@@ -60,7 +60,10 @@ func secondFactorTOTPIdentityFinish(ctx *middlewares.AutheliaCtx, username strin
 		Base32Secret: key.Secret(),
 	}
 
-	ctx.SetJSONBody(response) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err = ctx.SetJSONBody(response)
+	if err != nil {
+		ctx.Logger.Errorf("Unable to set TOTP key response in body: %s", err)
+	}
 }
 
 // SecondFactorTOTPIdentityFinish the handler for finishing the identity validation.

--- a/internal/handlers/handler_register_u2f_step1.go
+++ b/internal/handlers/handler_register_u2f_step1.go
@@ -56,7 +56,10 @@ func secondFactorU2FIdentityFinish(ctx *middlewares.AutheliaCtx, username string
 		return
 	}
 
-	ctx.SetJSONBody(u2f.NewWebRegisterRequest(challenge, []u2f.Registration{})) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err = ctx.SetJSONBody(u2f.NewWebRegisterRequest(challenge, []u2f.Registration{}))
+	if err != nil {
+		ctx.Logger.Errorf("Unable to create request to enrol new token: %s", err)
+	}
 }
 
 // SecondFactorU2FIdentityFinish the handler for finishing the identity validation.

--- a/internal/handlers/handler_register_u2f_step1_test.go
+++ b/internal/handlers/handler_register_u2f_step1_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/authelia/authelia/internal/middlewares"
@@ -25,7 +26,8 @@ func (s *HandlerRegisterU2FStep1Suite) SetupTest() {
 
 	userSession := s.mock.Ctx.GetSession()
 	userSession.Username = testUsername
-	s.mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.mock.Ctx.SaveSession(userSession)
+	require.NoError(s.T(), err)
 }
 
 func (s *HandlerRegisterU2FStep1Suite) TearDownTest() {

--- a/internal/handlers/handler_register_u2f_step2.go
+++ b/internal/handlers/handler_register_u2f_step2.go
@@ -28,7 +28,11 @@ func SecondFactorU2FRegister(ctx *middlewares.AutheliaCtx) {
 	// Ensure the challenge is cleared if anything goes wrong.
 	defer func() {
 		userSession.U2FChallenge = nil
-		ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+
+		err := ctx.SaveSession(userSession)
+		if err != nil {
+			ctx.Logger.Errorf("Unable to clear U2F challenge in session for user %s: %s", userSession.Username, err)
+		}
 	}()
 
 	registration, err := u2f.Register(responseBody, *userSession.U2FChallenge, u2fConfig)

--- a/internal/handlers/handler_reset_password_step1.go
+++ b/internal/handlers/handler_reset_password_step1.go
@@ -46,7 +46,11 @@ func resetPasswordIdentityFinish(ctx *middlewares.AutheliaCtx, username string) 
 	userSession := ctx.GetSession()
 	// TODO(c.michaud): use JWT tokens to expire the request in only few seconds for better security.
 	userSession.PasswordResetUsername = &username
-	ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+
+	err := ctx.SaveSession(userSession)
+	if err != nil {
+		ctx.Logger.Errorf("Unable to clear password reset flag in session for user %s: %s", userSession.Username, err)
+	}
 
 	ctx.ReplyOK()
 }

--- a/internal/handlers/handler_sign_duo_test.go
+++ b/internal/handlers/handler_sign_duo_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/authelia/authelia/internal/duo"
@@ -25,7 +26,8 @@ func (s *SecondFactorDuoPostSuite) SetupTest() {
 	s.mock = mocks.NewMockAutheliaCtx(s.T())
 	userSession := s.mock.Ctx.GetSession()
 	userSession.Username = testUsername
-	s.mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.mock.Ctx.SaveSession(userSession)
+	require.NoError(s.T(), err)
 }
 
 func (s *SecondFactorDuoPostSuite) TearDownTest() {

--- a/internal/handlers/handler_sign_totp_test.go
+++ b/internal/handlers/handler_sign_totp_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tstranex/u2f"
 
@@ -25,7 +26,8 @@ func (s *HandlerSignTOTPSuite) SetupTest() {
 	userSession.Username = testUsername
 	userSession.U2FChallenge = &u2f.Challenge{}
 	userSession.U2FRegistration = &session.U2FRegistration{}
-	s.mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.mock.Ctx.SaveSession(userSession)
+	require.NoError(s.T(), err)
 }
 
 func (s *HandlerSignTOTPSuite) TearDownTest() {

--- a/internal/handlers/handler_sign_u2f_step2_test.go
+++ b/internal/handlers/handler_sign_u2f_step2_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tstranex/u2f"
 
@@ -25,7 +26,8 @@ func (s *HandlerSignU2FStep2Suite) SetupTest() {
 	userSession.Username = testUsername
 	userSession.U2FChallenge = &u2f.Challenge{}
 	userSession.U2FRegistration = &session.U2FRegistration{}
-	s.mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.mock.Ctx.SaveSession(userSession)
+	require.NoError(s.T(), err)
 }
 
 func (s *HandlerSignU2FStep2Suite) TearDownTest() {

--- a/internal/handlers/handler_state.go
+++ b/internal/handlers/handler_state.go
@@ -12,5 +12,9 @@ func StateGet(ctx *middlewares.AutheliaCtx) {
 		AuthenticationLevel:   userSession.AuthenticationLevel,
 		DefaultRedirectionURL: ctx.Configuration.DefaultRedirectionURL,
 	}
-	ctx.SetJSONBody(stateResponse) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+
+	err := ctx.SetJSONBody(stateResponse)
+	if err != nil {
+		ctx.Logger.Errorf("Unable to set state response in body: %s", err)
+	}
 }

--- a/internal/handlers/handler_state_test.go
+++ b/internal/handlers/handler_state_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/authelia/authelia/internal/authentication"
@@ -28,7 +29,8 @@ func (s *StateGetSuite) TearDownTest() {
 func (s *StateGetSuite) TestShouldReturnUsernameFromSession() {
 	userSession := s.mock.Ctx.GetSession()
 	userSession.Username = "username"
-	s.mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.mock.Ctx.SaveSession(userSession)
+	require.NoError(s.T(), err)
 
 	StateGet(s.mock.Ctx)
 
@@ -47,7 +49,8 @@ func (s *StateGetSuite) TestShouldReturnUsernameFromSession() {
 	}
 	actualBody := Response{}
 
-	json.Unmarshal(s.mock.Ctx.Response.Body(), &actualBody) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err = json.Unmarshal(s.mock.Ctx.Response.Body(), &actualBody)
+	require.NoError(s.T(), err)
 	assert.Equal(s.T(), 200, s.mock.Ctx.Response.StatusCode())
 	assert.Equal(s.T(), []byte("application/json"), s.mock.Ctx.Response.Header.ContentType())
 	assert.Equal(s.T(), expectedBody, actualBody)
@@ -56,7 +59,8 @@ func (s *StateGetSuite) TestShouldReturnUsernameFromSession() {
 func (s *StateGetSuite) TestShouldReturnAuthenticationLevelFromSession() {
 	userSession := s.mock.Ctx.GetSession()
 	userSession.AuthenticationLevel = authentication.OneFactor
-	s.mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.mock.Ctx.SaveSession(userSession)
+	require.NoError(s.T(), err)
 
 	StateGet(s.mock.Ctx)
 
@@ -75,7 +79,8 @@ func (s *StateGetSuite) TestShouldReturnAuthenticationLevelFromSession() {
 	}
 	actualBody := Response{}
 
-	json.Unmarshal(s.mock.Ctx.Response.Body(), &actualBody) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err = json.Unmarshal(s.mock.Ctx.Response.Body(), &actualBody)
+	require.NoError(s.T(), err)
 	assert.Equal(s.T(), 200, s.mock.Ctx.Response.StatusCode())
 	assert.Equal(s.T(), []byte("application/json"), s.mock.Ctx.Response.Header.ContentType())
 	assert.Equal(s.T(), expectedBody, actualBody)

--- a/internal/handlers/handler_user_info.go
+++ b/internal/handlers/handler_user_info.go
@@ -93,7 +93,10 @@ func UserInfoGet(ctx *middlewares.AutheliaCtx) {
 
 	userInfo.DisplayName = userSession.DisplayName
 
-	ctx.SetJSONBody(userInfo) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := ctx.SetJSONBody(userInfo)
+	if err != nil {
+		ctx.Logger.Errorf("Unable to set user info response in body: %s", err)
+	}
 }
 
 // MethodBody the selected 2FA method.

--- a/internal/handlers/handler_user_info_test.go
+++ b/internal/handlers/handler_user_info_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/authelia/authelia/internal/mocks"
@@ -24,7 +25,8 @@ func (s *FetchSuite) SetupTest() {
 	userSession := s.mock.Ctx.GetSession()
 	userSession.Username = testUsername
 	userSession.AuthenticationLevel = 1
-	s.mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.mock.Ctx.SaveSession(userSession)
+	require.NoError(s.T(), err)
 }
 
 func (s *FetchSuite) TearDownTest() {
@@ -92,7 +94,8 @@ func TestMethodSetToU2F(t *testing.T) {
 		userSession := mock.Ctx.GetSession()
 		userSession.Username = testUsername
 		userSession.AuthenticationLevel = 1
-		mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+		err := mock.Ctx.SaveSession(userSession)
+		require.NoError(t, err)
 
 		setPreferencesExpectations(expectedPreferences, mock.StorageProviderMock)
 		UserInfoGet(mock.Ctx)
@@ -170,7 +173,8 @@ func (s *SaveSuite) SetupTest() {
 	userSession := s.mock.Ctx.GetSession()
 	userSession.Username = testUsername
 	userSession.AuthenticationLevel = 1
-	s.mock.Ctx.SaveSession(userSession) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.mock.Ctx.SaveSession(userSession)
+	require.NoError(s.T(), err)
 }
 
 func (s *SaveSuite) TearDownTest() {

--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -15,7 +15,10 @@ import (
 func Handle1FAResponse(ctx *middlewares.AutheliaCtx, targetURI string, username string, groups []string) {
 	if targetURI == "" {
 		if !ctx.Providers.Authorizer.IsSecondFactorEnabled() && ctx.Configuration.DefaultRedirectionURL != "" {
-			ctx.SetJSONBody(redirectResponse{Redirect: ctx.Configuration.DefaultRedirectionURL}) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+			err := ctx.SetJSONBody(redirectResponse{Redirect: ctx.Configuration.DefaultRedirectionURL})
+			if err != nil {
+				ctx.Logger.Errorf("Unable to set default redirection URL in body: %s", err)
+			}
 		} else {
 			ctx.ReplyOK()
 		}
@@ -48,7 +51,10 @@ func Handle1FAResponse(ctx *middlewares.AutheliaCtx, targetURI string, username 
 
 	if !safeRedirection {
 		if !ctx.Providers.Authorizer.IsSecondFactorEnabled() && ctx.Configuration.DefaultRedirectionURL != "" {
-			ctx.SetJSONBody(redirectResponse{Redirect: ctx.Configuration.DefaultRedirectionURL}) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+			err := ctx.SetJSONBody(redirectResponse{Redirect: ctx.Configuration.DefaultRedirectionURL})
+			if err != nil {
+				ctx.Logger.Errorf("Unable to set default redirection URL in body: %s", err)
+			}
 		} else {
 			ctx.ReplyOK()
 		}
@@ -59,14 +65,21 @@ func Handle1FAResponse(ctx *middlewares.AutheliaCtx, targetURI string, username 
 	ctx.Logger.Debugf("Redirection URL %s is safe", targetURI)
 
 	response := redirectResponse{Redirect: targetURI}
-	ctx.SetJSONBody(response) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+
+	err = ctx.SetJSONBody(response)
+	if err != nil {
+		ctx.Logger.Errorf("Unable to set redirection URL in body: %s", err)
+	}
 }
 
 // Handle2FAResponse handle the redirection upon 2FA authentication.
 func Handle2FAResponse(ctx *middlewares.AutheliaCtx, targetURI string) {
 	if targetURI == "" {
 		if ctx.Configuration.DefaultRedirectionURL != "" {
-			ctx.SetJSONBody(redirectResponse{Redirect: ctx.Configuration.DefaultRedirectionURL}) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+			err := ctx.SetJSONBody(redirectResponse{Redirect: ctx.Configuration.DefaultRedirectionURL})
+			if err != nil {
+				ctx.Logger.Errorf("Unable to set default redirection URL in body: %s", err)
+			}
 		} else {
 			ctx.ReplyOK()
 		}
@@ -82,7 +95,10 @@ func Handle2FAResponse(ctx *middlewares.AutheliaCtx, targetURI string) {
 	}
 
 	if targetURL != nil && utils.IsRedirectionSafe(*targetURL, ctx.Configuration.Session.Domain) {
-		ctx.SetJSONBody(redirectResponse{Redirect: targetURI}) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+		err := ctx.SetJSONBody(redirectResponse{Redirect: targetURI})
+		if err != nil {
+			ctx.Logger.Errorf("Unable to set redirection URL in body: %s", err)
+		}
 	} else {
 		ctx.ReplyOK()
 	}

--- a/internal/suites/action_2fa_methods.go
+++ b/internal/suites/action_2fa_methods.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func (wds *WebDriverSession) doChangeMethod(ctx context.Context, t *testing.T, method string) {
-	wds.WaitElementLocatedByID(ctx, t, "methods-button").Click() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := wds.WaitElementLocatedByID(ctx, t, "methods-button").Click()
+	require.NoError(t, err)
 	wds.WaitElementLocatedByID(ctx, t, "methods-dialog")
-	wds.WaitElementLocatedByID(ctx, t, fmt.Sprintf("%s-option", method)).Click() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err = wds.WaitElementLocatedByID(ctx, t, fmt.Sprintf("%s-option", method)).Click()
+	require.NoError(t, err)
 }

--- a/internal/suites/action_reset_password.go
+++ b/internal/suites/action_reset_password.go
@@ -3,23 +3,31 @@ package suites
 import (
 	"context"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func (wds *WebDriverSession) doInitiatePasswordReset(ctx context.Context, t *testing.T, username string) {
-	wds.WaitElementLocatedByID(ctx, t, "reset-password-button").Click() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := wds.WaitElementLocatedByID(ctx, t, "reset-password-button").Click()
+	require.NoError(t, err)
 	// Fill in username
-	wds.WaitElementLocatedByID(ctx, t, "username-textfield").SendKeys(username) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err = wds.WaitElementLocatedByID(ctx, t, "username-textfield").SendKeys(username)
+	require.NoError(t, err)
 	// And click on the reset button
-	wds.WaitElementLocatedByID(ctx, t, "reset-button").Click() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err = wds.WaitElementLocatedByID(ctx, t, "reset-button").Click()
+	require.NoError(t, err)
 }
 
 func (wds *WebDriverSession) doCompletePasswordReset(ctx context.Context, t *testing.T, newPassword1, newPassword2 string) {
 	link := doGetLinkFromLastMail(t)
 	wds.doVisit(t, link)
 
-	wds.WaitElementLocatedByID(ctx, t, "password1-textfield").SendKeys(newPassword1) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
-	wds.WaitElementLocatedByID(ctx, t, "password2-textfield").SendKeys(newPassword2) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
-	wds.WaitElementLocatedByID(ctx, t, "reset-button").Click()                       //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := wds.WaitElementLocatedByID(ctx, t, "password1-textfield").SendKeys(newPassword1)
+	require.NoError(t, err)
+	err = wds.WaitElementLocatedByID(ctx, t, "password2-textfield").SendKeys(newPassword2)
+	require.NoError(t, err)
+	err = wds.WaitElementLocatedByID(ctx, t, "reset-button").Click()
+	require.NoError(t, err)
 }
 
 func (wds *WebDriverSession) doSuccessfullyCompletePasswordReset(ctx context.Context, t *testing.T, newPassword1, newPassword2 string) {

--- a/internal/suites/action_totp.go
+++ b/internal/suites/action_totp.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (wds *WebDriverSession) doRegisterTOTP(ctx context.Context, t *testing.T) string {
-	wds.WaitElementLocatedByID(ctx, t, "register-link").Click() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := wds.WaitElementLocatedByID(ctx, t, "register-link").Click()
+	require.NoError(t, err)
 	wds.verifyMailNotificationDisplayed(ctx, t)
 	link := doGetLinkFromLastMail(t)
 	wds.doVisit(t, link)
@@ -26,7 +28,8 @@ func (wds *WebDriverSession) doEnterOTP(ctx context.Context, t *testing.T, code 
 	inputs := wds.WaitElementsLocatedByCSSSelector(ctx, t, "#otp-input input")
 
 	for i := 0; i < 6; i++ {
-		inputs[i].SendKeys(string(code[i])) //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+		err := inputs[i].SendKeys(string(code[i]))
+		require.NoError(t, err)
 	}
 }
 

--- a/internal/suites/scenario_regulation_test.go
+++ b/internal/suites/scenario_regulation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -55,14 +56,18 @@ func (s *RegulationScenario) TestShouldBanUserAfterTooManyAttempt() {
 	s.verifyNotificationDisplayed(ctx, s.T(), "Incorrect username or password.")
 
 	for i := 0; i < 3; i++ {
-		s.WaitElementLocatedByID(ctx, s.T(), "password-textfield").SendKeys("bad-password") //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
-		s.WaitElementLocatedByID(ctx, s.T(), "sign-in-button").Click()                      //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+		err := s.WaitElementLocatedByID(ctx, s.T(), "password-textfield").SendKeys("bad-password")
+		require.NoError(s.T(), err)
+		err = s.WaitElementLocatedByID(ctx, s.T(), "sign-in-button").Click()
+		require.NoError(s.T(), err)
 		time.Sleep(1 * time.Second)
 	}
 
 	// Enter the correct password and test the regulation lock out
-	s.WaitElementLocatedByID(ctx, s.T(), "password-textfield").SendKeys("password") //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
-	s.WaitElementLocatedByID(ctx, s.T(), "sign-in-button").Click()                  //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err := s.WaitElementLocatedByID(ctx, s.T(), "password-textfield").SendKeys("password")
+	require.NoError(s.T(), err)
+	err = s.WaitElementLocatedByID(ctx, s.T(), "sign-in-button").Click()
+	require.NoError(s.T(), err)
 	s.verifyNotificationDisplayed(ctx, s.T(), "Incorrect username or password.")
 
 	time.Sleep(1 * time.Second)
@@ -70,8 +75,10 @@ func (s *RegulationScenario) TestShouldBanUserAfterTooManyAttempt() {
 	time.Sleep(9 * time.Second)
 
 	// Enter the correct password and test a successful login
-	s.WaitElementLocatedByID(ctx, s.T(), "password-textfield").SendKeys("password") //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
-	s.WaitElementLocatedByID(ctx, s.T(), "sign-in-button").Click()                  //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+	err = s.WaitElementLocatedByID(ctx, s.T(), "password-textfield").SendKeys("password")
+	require.NoError(s.T(), err)
+	err = s.WaitElementLocatedByID(ctx, s.T(), "sign-in-button").Click()
+	require.NoError(s.T(), err)
 	s.verifyIsSecondFactorPage(ctx, s.T())
 }
 

--- a/internal/suites/suite_kubernetes.go
+++ b/internal/suites/suite_kubernetes.go
@@ -12,6 +12,7 @@ import (
 
 var kubernetesSuiteName = "Kubernetes"
 
+//nolint:gocyclo // TODO: Consider refactoring/simplifying, time permitting.
 func init() {
 	kind := Kind{}
 	kubectl := Kubectl{}
@@ -92,8 +93,15 @@ func init() {
 	}
 
 	teardown := func(suitePath string) error {
-		kubectl.StopDashboard() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
-		kubectl.StopProxy()     //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
+		err := kubectl.StopDashboard()
+		if err != nil {
+			log.Errorf("Unable to stop Kubernetes dashboard: %s", err)
+		}
+
+		err = kubectl.StopProxy()
+		if err != nil {
+			log.Errorf("Unable to stop Kind proxy: %s", err)
+		}
 
 		return kind.DeleteCluster()
 	}

--- a/internal/suites/webdriver.go
+++ b/internal/suites/webdriver.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/tebeka/selenium"
 	"github.com/tebeka/selenium/chrome"
@@ -60,8 +61,9 @@ func StartWebDriverWithProxy(proxy string, port int) (*WebDriverSession, error) 
 
 	wd, err := selenium.NewRemote(caps, fmt.Sprintf("http://localhost:%d/wd/hub", port))
 	if err != nil {
-		service.Stop() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
-		panic(err)
+		_ = service.Stop()
+
+		log.Fatal(err)
 	}
 
 	return &WebDriverSession{

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -17,7 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true
   },
   "include": [


### PR DESCRIPTION
This is mostly a quality of life change.
When we first implemented the errcheck linter we ignored a number of items in our legacy codebase with intent to revisit down the track.

There's a only a few leftover TODO's, these have been left for the team to discuss on Matrix and agree on the way forward.