### PR TITLE
Add config example for LDAP groupOfUniqueNames group structure

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -161,6 +161,7 @@ authentication_backend:
     # - {mail_attribute} is a placeholder replaced by what is configured in `mail_attribute`.
     # - DON'T USE - {0} is an alias for {input} supported for backward compatibility but it will be deprecated in later versions, so please don't use it.
     # - DON'T USE - {1} is an alias for {username} supported for backward compatibility but it will be deprecated in later version, so please don't use it.
+    # If your groups use the `groupOfUniqueNames` structure use this instead: (&(uniquemember={dn})(objectclass=groupOfUniqueNames))
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
 
     # The attribute holding the name of the group

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -107,6 +107,7 @@ authentication_backend:
     # - {mail_attribute} is a placeholder replaced by what is configured in `mail_attribute`.
     # - DON'T USE - {0} is an alias for {input} supported for backward compatibility but it will be deprecated in later versions, so please don't use it.
     # - DON'T USE - {1} is an alias for {username} supported for backward compatibility but it will be deprecated in later version, so please don't use it.
+    # If your groups use the `groupOfUniqueNames` structure use this instead: (&(uniquemember={dn})(objectclass=groupOfUniqueNames))
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
 
     # The attribute holding the name of the group


### PR DESCRIPTION
Based on #1517 

Adding a comment to the LDAP group section of the config file to tell users they need to use a different group_filter if their LDAP groups use the `groupOfUniqueNames` structure instead of the expected `groupOfNames` structure.

Not doing so result in Authelia not finding the groups for the user and not authorizing group-based access.