### PR TITLE
[FEATURE] Display TOTP secret on device registration

### DIFF
--- a/internal/suites/action_totp.go
+++ b/internal/suites/action_totp.go
@@ -2,6 +2,7 @@ package suites
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,8 +17,10 @@ func (wds *WebDriverSession) doRegisterTOTP(ctx context.Context, t *testing.T) s
 	wds.verifyMailNotificationDisplayed(ctx, t)
 	link := doGetLinkFromLastMail(t)
 	wds.doVisit(t, link)
-	secret, err := wds.WaitElementLocatedByID(ctx, t, "base32-secret").GetAttribute("value")
+	secretURL, err := wds.WaitElementLocatedByID(ctx, t, "secret-url").GetAttribute("value")
 	assert.NoError(t, err)
+
+	secret := secretURL[strings.LastIndex(secretURL, "=")+1:]
 	assert.NotEqual(t, "", secret)
 	assert.NotNil(t, secret)
 

--- a/web/src/views/DeviceRegistration/RegisterOneTimePassword.tsx
+++ b/web/src/views/DeviceRegistration/RegisterOneTimePassword.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback, useState } from "react";
 import LoginLayout from "../../layouts/LoginLayout";
 import classnames from "classnames";
-import { makeStyles, Typography, Button, Link, CircularProgress } from "@material-ui/core";
+import { makeStyles, Typography, Button, IconButton, Link, CircularProgress, TextField } from "@material-ui/core";
 import QRCode from 'qrcode.react';
 import AppStoreBadges from "../../components/AppStoreBadges";
 import { GoogleAuthenticator } from "../../constants";
@@ -9,7 +9,7 @@ import { useHistory, useLocation } from "react-router";
 import { completeTOTPRegistrationProcess } from "../../services/RegisterDevice";
 import { useNotifications } from "../../hooks/NotificationsContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
+import { faCopy, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { red } from "@material-ui/core/colors";
 import { extractIdentityToken } from "../../utils/IdentityToken";
 import { FirstFactorRoute } from "../../Routes";
@@ -53,6 +53,14 @@ const RegisterOneTimePassword = function () {
     }, [processToken, createErrorNotification]);
 
     useEffect(() => { completeRegistrationProcess() }, [completeRegistrationProcess]);
+    const CopyButton = () => (
+      <IconButton
+        color="primary"
+        onClick={() =>  navigator.clipboard.writeText(`${secretBase32}`)}
+      >
+          <FontAwesomeIcon icon={faCopy} />
+      </IconButton>
+    )
     const qrcodeFuzzyStyle = (isLoading || hasErrored) ? style.fuzzy : undefined
 
     return (
@@ -77,16 +85,25 @@ const RegisterOneTimePassword = function () {
                         {hasErrored ? <FontAwesomeIcon className={style.failureIcon} icon={faTimesCircle} /> : null}
                     </Link>
                 </div>
-                {secretBase32
-                    ? <input id="base32-secret"
-                        style={{ display: "none" }}
-                        value={secretBase32} /> : null}
+                <div>
+                    <TextField
+                      id="base32-secret"
+                      label="Secret"
+                      className={style.secret}
+                      value={secretBase32}
+                      InputProps={{
+                          autoFocus: true,
+                          endAdornment: <CopyButton />,
+                          readOnly: true
+                      }}
+                    />
+                </div>
                 <Button
-                    variant="contained"
-                    color="primary"
-                    className={style.doneButton}
-                    onClick={handleDoneClick}
-                    disabled={isLoading}>
+                  variant="contained"
+                  color="primary"
+                  className={style.doneButton}
+                  onClick={handleDoneClick}
+                  disabled={isLoading}>
                     Done
                 </Button>
             </div>
@@ -109,8 +126,8 @@ const useStyles = makeStyles(theme => ({
         filter: "blur(10px)"
     },
     secret: {
-        display: "inline-block",
-        fontSize: theme.typography.fontSize * 0.9,
+        marginTop: theme.spacing(1),
+        marginBottom: theme.spacing(1),
     },
     googleAuthenticator: {},
     googleAuthenticatorText: {

--- a/web/src/views/DeviceRegistration/RegisterOneTimePassword.tsx
+++ b/web/src/views/DeviceRegistration/RegisterOneTimePassword.tsx
@@ -55,8 +55,8 @@ const RegisterOneTimePassword = function () {
     useEffect(() => { completeRegistrationProcess() }, [completeRegistrationProcess]);
     const CopyButton = () => (
       <IconButton
-        color="primary"
-        onClick={() =>  navigator.clipboard.writeText(`${secretBase32}`)}
+          color="primary"
+          onClick={() =>  navigator.clipboard.writeText(`${secretBase32}`)}
       >
           <FontAwesomeIcon icon={faCopy} />
       </IconButton>
@@ -85,25 +85,23 @@ const RegisterOneTimePassword = function () {
                         {hasErrored ? <FontAwesomeIcon className={style.failureIcon} icon={faTimesCircle} /> : null}
                     </Link>
                 </div>
-                <div>
-                    <TextField
-                      id="base32-secret"
-                      label="Secret"
-                      className={style.secret}
-                      value={secretBase32}
-                      InputProps={{
-                          autoFocus: true,
-                          endAdornment: <CopyButton />,
-                          readOnly: true
-                      }}
-                    />
-                </div>
+                {secretBase32
+                    ? <TextField
+                        id="base32-secret"
+                        label="Secret"
+                        className={style.secret}
+                        value={secretBase32}
+                        InputProps={{
+                            autoFocus: true,
+                            endAdornment: <CopyButton />,
+                            readOnly: true
+                        }} /> : null}
                 <Button
-                  variant="contained"
-                  color="primary"
-                  className={style.doneButton}
-                  onClick={handleDoneClick}
-                  disabled={isLoading}>
+                    variant="contained"
+                    color="primary"
+                    className={style.doneButton}
+                    onClick={handleDoneClick}
+                    disabled={isLoading}>
                     Done
                 </Button>
             </div>

--- a/web/src/views/DeviceRegistration/RegisterOneTimePassword.tsx
+++ b/web/src/views/DeviceRegistration/RegisterOneTimePassword.tsx
@@ -9,7 +9,7 @@ import { useHistory, useLocation } from "react-router";
 import { completeTOTPRegistrationProcess } from "../../services/RegisterDevice";
 import { useNotifications } from "../../hooks/NotificationsContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCopy, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
+import { IconDefinition, faCopy, faKey, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { red } from "@material-ui/core/colors";
 import { extractIdentityToken } from "../../utils/IdentityToken";
 import { FirstFactorRoute } from "../../Routes";
@@ -53,14 +53,17 @@ const RegisterOneTimePassword = function () {
     }, [processToken, createErrorNotification]);
 
     useEffect(() => { completeRegistrationProcess() }, [completeRegistrationProcess]);
-    const CopyButton = () => (
-      <IconButton
-          color="primary"
-          onClick={() =>  navigator.clipboard.writeText(`${secretBase32}`)}
-      >
-          <FontAwesomeIcon icon={faCopy} />
-      </IconButton>
-    )
+    function SecretButton(text: string | undefined, icon: IconDefinition) {
+        return (
+          <IconButton
+            className={style.secretButtons}
+            color="primary"
+            onClick={() =>  navigator.clipboard.writeText(`${text}`)}
+          >
+              <FontAwesomeIcon icon={icon} />
+          </IconButton>
+        )
+    }
     const qrcodeFuzzyStyle = (isLoading || hasErrored) ? style.fuzzy : undefined
 
     return (
@@ -85,17 +88,20 @@ const RegisterOneTimePassword = function () {
                         {hasErrored ? <FontAwesomeIcon className={style.failureIcon} icon={faTimesCircle} /> : null}
                     </Link>
                 </div>
-                {secretBase32
-                    ? <TextField
-                        id="base32-secret"
-                        label="Secret"
-                        className={style.secret}
-                        value={secretBase32}
-                        InputProps={{
-                            autoFocus: true,
-                            endAdornment: <CopyButton />,
-                            readOnly: true
-                        }} /> : null}
+                <div>
+                    {secretURL !== "empty"
+                        ? <TextField
+                            id="secret-url"
+                            label="Secret"
+                            className={style.secret}
+                            value={secretURL}
+                            InputProps={{
+                                autoFocus: true,
+                                readOnly: true
+                            }} /> : null}
+                    {secretBase32 ? SecretButton(secretBase32, faKey) : null}
+                    {secretURL !== "empty" ? SecretButton(secretURL, faCopy) : null}
+                </div>
                 <Button
                     variant="contained"
                     color="primary"
@@ -126,12 +132,16 @@ const useStyles = makeStyles(theme => ({
     secret: {
         marginTop: theme.spacing(1),
         marginBottom: theme.spacing(1),
+        width: "256px",
     },
     googleAuthenticator: {},
     googleAuthenticatorText: {
         fontSize: theme.typography.fontSize * 0.8,
     },
     googleAuthenticatorBadges: {},
+    secretButtons: {
+        width: "128px",
+    },
     doneButton: {
         width: "256px",
     },

--- a/web/src/views/DeviceRegistration/RegisterOneTimePassword.tsx
+++ b/web/src/views/DeviceRegistration/RegisterOneTimePassword.tsx
@@ -22,7 +22,7 @@ const RegisterOneTimePassword = function () {
     // The secret retrieved from the API is all is ok.
     const [secretURL, setSecretURL] = useState("empty");
     const [secretBase32, setSecretBase32] = useState(undefined as string | undefined);
-    const { createErrorNotification } = useNotifications();
+    const { createSuccessNotification, createErrorNotification } = useNotifications();
     const [hasErrored, setHasErrored] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
 
@@ -53,12 +53,15 @@ const RegisterOneTimePassword = function () {
     }, [processToken, createErrorNotification]);
 
     useEffect(() => { completeRegistrationProcess() }, [completeRegistrationProcess]);
-    function SecretButton(text: string | undefined, icon: IconDefinition) {
+    function SecretButton(text: string | undefined, action: string, icon: IconDefinition) {
         return (
           <IconButton
             className={style.secretButtons}
             color="primary"
-            onClick={() =>  navigator.clipboard.writeText(`${text}`)}
+            onClick={() => {
+                navigator.clipboard.writeText(`${text}`);
+                createSuccessNotification(`${action}`);
+            }}
           >
               <FontAwesomeIcon icon={icon} />
           </IconButton>
@@ -67,51 +70,50 @@ const RegisterOneTimePassword = function () {
     const qrcodeFuzzyStyle = (isLoading || hasErrored) ? style.fuzzy : undefined
 
     return (
-        <LoginLayout title="Scan QRCode">
-            <div className={style.root}>
-                <div className={style.googleAuthenticator}>
-                    <Typography className={style.googleAuthenticatorText}>Need Google Authenticator?</Typography>
-                    <AppStoreBadges
-                        iconSize={128}
-                        targetBlank
-                        className={style.googleAuthenticatorBadges}
-                        googlePlayLink={GoogleAuthenticator.googlePlay}
-                        appleStoreLink={GoogleAuthenticator.appleStore} />
-                </div>
-                <div className={style.qrcodeContainer}>
-                    <Link href={secretURL}>
-                        <QRCode
-                            value={secretURL}
-                            className={classnames(qrcodeFuzzyStyle, style.qrcode)}
-                            size={256} />
-                        {!hasErrored && isLoading ? <CircularProgress className={style.loader} size={128} /> : null}
-                        {hasErrored ? <FontAwesomeIcon className={style.failureIcon} icon={faTimesCircle} /> : null}
-                    </Link>
-                </div>
-                <div>
-                    {secretURL !== "empty"
-                        ? <TextField
-                            id="secret-url"
-                            label="Secret"
-                            className={style.secret}
-                            value={secretURL}
-                            InputProps={{
-                                autoFocus: true,
-                                readOnly: true
-                            }} /> : null}
-                    {secretBase32 ? SecretButton(secretBase32, faKey) : null}
-                    {secretURL !== "empty" ? SecretButton(secretURL, faCopy) : null}
-                </div>
-                <Button
-                    variant="contained"
-                    color="primary"
-                    className={style.doneButton}
-                    onClick={handleDoneClick}
-                    disabled={isLoading}>
-                    Done
-                </Button>
-            </div>
-        </LoginLayout>
+      <LoginLayout title="Scan QRCode">
+          <div className={style.root}>
+              <div className={style.googleAuthenticator}>
+                  <Typography className={style.googleAuthenticatorText}>Need Google Authenticator?</Typography>
+                  <AppStoreBadges
+                    iconSize={128}
+                    targetBlank
+                    className={style.googleAuthenticatorBadges}
+                    googlePlayLink={GoogleAuthenticator.googlePlay}
+                    appleStoreLink={GoogleAuthenticator.appleStore} />
+              </div>
+              <div className={style.qrcodeContainer}>
+                  <Link href={secretURL}>
+                      <QRCode
+                        value={secretURL}
+                        className={classnames(qrcodeFuzzyStyle, style.qrcode)}
+                        size={256} />
+                      {!hasErrored && isLoading ? <CircularProgress className={style.loader} size={128} /> : null}
+                      {hasErrored ? <FontAwesomeIcon className={style.failureIcon} icon={faTimesCircle} /> : null}
+                  </Link>
+              </div>
+              <div>
+                  {secretURL !== "empty"
+                    ? <TextField
+                      id="secret-url"
+                      label="Secret"
+                      className={style.secret}
+                      value={secretURL}
+                      InputProps={{
+                          readOnly: true
+                      }} /> : null}
+                  {secretBase32 ? SecretButton(secretBase32, "OTP Secret copied to clipboard.", faKey) : null}
+                  {secretURL !== "empty" ? SecretButton(secretURL, "OTP URL copied to clipboard.", faCopy) : null}
+              </div>
+              <Button
+                variant="contained"
+                color="primary"
+                className={style.doneButton}
+                onClick={handleDoneClick}
+                disabled={isLoading}>
+                  Done
+              </Button>
+          </div>
+      </LoginLayout>
     )
 }
 


### PR DESCRIPTION
This change provides the TOTP secret which allows users to copy and utilise for password managers and other applications.

![Screenshot_2020-12-20-03-21-51](https://user-images.githubusercontent.com/3339418/102705443-21aa9d80-42dc-11eb-9acd-220d876d40c3.png)

**EDIT:** I've made a slight modification to the view, refer to my [comment below](https://github.com/authelia/authelia/pull/1551#issuecomment-750701251).

Closes #1509.