### PR TITLE
feat(handlers): authorization header switch via query param to /api/verify

### DIFF
--- a/docs/deployment/supported-proxies/nginx.md
+++ b/docs/deployment/supported-proxies/nginx.md
@@ -30,7 +30,7 @@ With the below configuration you can add `authelia.conf` to virtual hosts to sup
 set $upstream_authelia http://authelia:9091/api/verify;
 
 # Virtual endpoint created by nginx to forward auth requests.
-location = /authelia {
+location /authelia {
     internal;
     proxy_pass_request_body off;
     proxy_pass $upstream_authelia;
@@ -190,14 +190,71 @@ Here's an example for using HTTP basic auth on a specific endpoint. It is based 
 # Notice we added the auth=basic query arg here
 set $upstream_authelia http://authelia:9091/api/verify?auth=basic;
 
-location = /authelia {
-    # Exactly the same as above
+location /authelia {
+    internal;
+    proxy_pass_request_body off;
+    proxy_pass $upstream_authelia;
+    proxy_set_header Content-Length "";
+
+    # Timeout if the real server is dead
+    proxy_next_upstream error timeout invalid_header http_500 http_502 http_503;
+
+    # [REQUIRED] Needed by Authelia to check authorizations of the resource.
+    # Provide either X-Original-URL and X-Forwarded-Proto or
+    # X-Forwarded-Proto, X-Forwarded-Host and X-Forwarded-Uri or both.
+    # Those headers will be used by Authelia to deduce the target url of the user.
+    # Basic Proxy Config
+    client_body_buffer_size 128k;
+    proxy_set_header Host $host;
+    proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $http_host;
+    proxy_set_header X-Forwarded-Uri $request_uri;
+    proxy_set_header X-Forwarded-Ssl on;
+    proxy_redirect  http://  $scheme://;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    proxy_cache_bypass $cookie_session;
+    proxy_no_cache $cookie_session;
+    proxy_buffers 4 32k;
+
+    # Advanced Proxy Config
+    send_timeout 5m;
+    proxy_read_timeout 240;
+    proxy_send_timeout 240;
+    proxy_connect_timeout 240;
 }
 ```
 
 ##### auth-basic.conf
 
 Same as `auth.conf` but without the `error_page` directive. We want nginx to proxy the 401 back to the client, not to return a 301.
+
+```nginx
+# Basic Authelia Config
+# Send a subsequent request to Authelia to verify if the user is authenticated
+# and has the right permissions to access the resource.
+auth_request /authelia;
+# Set the `target_url` variable based on the request. It will be used to build the portal
+# URL with the correct redirection parameter.
+auth_request_set $target_url $scheme://$http_host$request_uri;
+# Set the X-Forwarded-User and X-Forwarded-Groups with the headers
+# returned by Authelia for the backends which can consume them.
+# This is not safe, as the backend must make sure that they come from the
+# proxy. In the future, it's gonna be safe to just use OAuth.
+auth_request_set $user $upstream_http_remote_user;
+auth_request_set $groups $upstream_http_remote_groups;
+auth_request_set $name $upstream_http_remote_name;
+auth_request_set $email $upstream_http_remote_email;
+proxy_set_header Remote-User $user;
+proxy_set_header Remote-Groups $groups;
+proxy_set_header Remote-Name $name;
+proxy_set_header Remote-Email $email;
+# If Authelia returns 401, then nginx passes it to the user.
+# If it returns 200, then the request pass through to the backend.
+```
 
 #### Protected Endpoint
 
@@ -264,9 +321,30 @@ location = /authelia-redirect {
 
 ##### auth.conf
 
-Same as above, but replace error_page with the following:
+Here we replace `error_page` directive to determine if basic auth should be utilised or not.
 
 ```nginx
+# Basic Authelia Config
+# Send a subsequent request to Authelia to verify if the user is authenticated
+# and has the right permissions to access the resource.
+auth_request /authelia;
+# Set the `target_url` variable based on the request. It will be used to build the portal
+# URL with the correct redirection parameter.
+auth_request_set $target_url $scheme://$http_host$request_uri;
+# Set the X-Forwarded-User and X-Forwarded-Groups with the headers
+# returned by Authelia for the backends which can consume them.
+# This is not safe, as the backend must make sure that they come from the
+# proxy. In the future, it's gonna be safe to just use OAuth.
+auth_request_set $user $upstream_http_remote_user;
+auth_request_set $groups $upstream_http_remote_groups;
+auth_request_set $name $upstream_http_remote_name;
+auth_request_set $email $upstream_http_remote_email;
+proxy_set_header Remote-User $user;
+proxy_set_header Remote-Groups $groups;
+proxy_set_header Remote-Name $name;
+proxy_set_header Remote-Email $email;
+# If Authelia returns 401, then nginx passes it to the user.
+# If it returns 200, then the request pass through to the backend.
 error_page 401 /authelia-redirect?rd=$target_url;
 ```
 

--- a/docs/deployment/supported-proxies/traefik1.x.md
+++ b/docs/deployment/supported-proxies/traefik1.x.md
@@ -17,10 +17,16 @@ Below you will find commented examples of the following configuration:
 * Traefik 1.x
 * Authelia portal
 * Protected endpoint (Nextcloud)
+* Protected endpoint with `Authorization` header for basic authentication (Heimdall)
 
 The below configuration looks to provide examples of running Traefik 1.x with labels to protect your endpoint (Nextcloud in this case).
 
 Please ensure that you also setup the respective [ACME configuration](https://docs.traefik.io/v1.7/configuration/acme/) for your Traefik setup as this is not covered in the example below.
+
+### Basic Authentication
+
+Authelia provides the means to be able to authenticate your first factor via the `Proxy-Authorization` header.
+Given that this is not compatible with Traefik 1.x you can call Authelia's `/api/verify` endpoint with the `auth=basic` query parameter to force a switch to the `Authentication` header.
 
 ##### docker-compose.yml
 ```yml
@@ -85,6 +91,26 @@ services:
     labels:
       - 'traefik.frontend.rule=Host:nextcloud.example.com'
       - 'traefik.frontend.auth.forward.address=http://authelia:9091/api/verify?rd=https://login.example.com/'
+      - 'traefik.frontend.auth.forward.trustForwardHeader=true'
+      - 'traefik.frontend.auth.forward.authResponseHeaders=Remote-User,Remote-Groups,Remote-Name,Remote-Email'
+    expose:
+      - 443
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Australia/Melbourne
+      
+  heimdall:
+    image: linuxserver/heimdall
+    container_name: heimdall
+    volumes:
+      - /path/to/heimdall/config:/config
+    networks:
+      - net
+    labels:
+      - 'traefik.frontend.rule=Host:heimdall.example.com'
+      - 'traefik.frontend.auth.forward.address=http://authelia:9091/api/verify?auth=basic
       - 'traefik.frontend.auth.forward.trustForwardHeader=true'
       - 'traefik.frontend.auth.forward.authResponseHeaders=Remote-User,Remote-Groups,Remote-Name,Remote-Email'
     expose:

--- a/docs/features/single-factor.md
+++ b/docs/features/single-factor.md
@@ -21,12 +21,25 @@ To know more about the configuration of the feature, please visit the
 documentation about the [configuration](../configuration/access-control.md).
 
 
-## Proxy-Authorization header
+## HTTP Basic Auth
+
+Authelia supports two different methods for basic auth.
+
+### Proxy-Authorization header
 
 Authelia reads credentials from the header `Proxy-Authorization` instead of
 the usual `Authorization` header. This is because in some circumstances both Authelia
 and the application could require authentication in order to provide specific
 authorizations at the level of the application.
+
+### API argument
+
+If instead of the `Proxy-Authorization` header you want, or need, to use the more
+conventional `Authorization` header, you should then configure your reverse-proxy
+to use `/api/verify?auth=basic`.  
+When authentication fails and `auth=basic` was set, Authelia's response will include
+the `WWW-Authenticate` header. This will cause browsers to prompt for authentication,
+and users will not land on the HTML login page.
 
 
 ## Session-Username header
@@ -34,7 +47,7 @@ authorizations at the level of the application.
 Authelia by default only verifies the cookie and the associated user with that cookie can
 access a protected resource. The client browser does not know the username and does not send
 this to Authelia, it's stored by Authelia for security reasons.
- 
+
 The Session-Username header has been implemented as a means
 to use Authelia with non-web services such as PAM. Basically how it works is if the
 Session-Username header is sent in the request to the /api/verify endpoint it will

--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -11,8 +11,11 @@ const ResetPasswordAction = "ResetPassword"
 
 const authPrefix = "Basic "
 
-// AuthorizationHeader is the basic-auth HTTP header Authelia utilises.
-const AuthorizationHeader = "Proxy-Authorization"
+// ProxyAuthorizationHeader is the basic-auth HTTP header Authelia utilises.
+const ProxyAuthorizationHeader = "Proxy-Authorization"
+
+// AuthorizationHeader is the basic-auth HTTP header Authelia utilises with "auth=basic" query param.
+const AuthorizationHeader = "Authorization"
 
 // SessionUsernameHeader is used as additional protection to validate a user for things like pam_exec.
 const SessionUsernameHeader = "Session-Username"

--- a/internal/handlers/handler_verify_test.go
+++ b/internal/handlers/handler_verify_test.go
@@ -120,27 +120,27 @@ func TestShouldRaiseWhenXForwardedURIIsNotParsable(t *testing.T) {
 
 // Test parseBasicAuth.
 func TestShouldRaiseWhenHeaderDoesNotContainBasicPrefix(t *testing.T) {
-	_, _, err := parseBasicAuth("alzefzlfzemjfej==")
+	_, _, err := parseBasicAuth(ProxyAuthorizationHeader, "alzefzlfzemjfej==")
 	assert.Error(t, err)
 	assert.Equal(t, "Basic prefix not found in Proxy-Authorization header", err.Error())
 }
 
 func TestShouldRaiseWhenCredentialsAreNotInBase64(t *testing.T) {
-	_, _, err := parseBasicAuth("Basic alzefzlfzemjfej==")
+	_, _, err := parseBasicAuth(ProxyAuthorizationHeader, "Basic alzefzlfzemjfej==")
 	assert.Error(t, err)
 	assert.Equal(t, "illegal base64 data at input byte 16", err.Error())
 }
 
 func TestShouldRaiseWhenCredentialsAreNotInCorrectForm(t *testing.T) {
 	// The decoded format should be user:password.
-	_, _, err := parseBasicAuth("Basic am9obiBwYXNzd29yZA==")
+	_, _, err := parseBasicAuth(ProxyAuthorizationHeader, "Basic am9obiBwYXNzd29yZA==")
 	assert.Error(t, err)
 	assert.Equal(t, "Format of Proxy-Authorization header must be user:password", err.Error())
 }
 
 func TestShouldReturnUsernameAndPassword(t *testing.T) {
 	// the decoded format should be user:password.
-	user, password, err := parseBasicAuth("Basic am9objpwYXNzd29yZA==")
+	user, password, err := parseBasicAuth(ProxyAuthorizationHeader, "Basic am9objpwYXNzd29yZA==")
 	assert.NoError(t, err)
 	assert.Equal(t, "john", user)
 	assert.Equal(t, "password", password)
@@ -204,7 +204,7 @@ func TestShouldVerifyWrongCredentials(t *testing.T) {
 		Return(false, nil)
 
 	url, _ := url.ParseRequestURI("https://test.example.com")
-	_, _, _, _, _, err := verifyBasicAuth([]byte("Basic am9objpwYXNzd29yZA=="), *url, mock.Ctx)
+	_, _, _, _, _, err := verifyBasicAuth(ProxyAuthorizationHeader, []byte("Basic am9objpwYXNzd29yZA=="), *url, mock.Ctx)
 
 	assert.Error(t, err)
 }


### PR DESCRIPTION
When `/api/verify` is called with `?auth=basic`, use the standard `Authorization` header instead of `Proxy-Authorization`.

Fixes #1353.