### PR TITLE
[DOC] Correct private IP range

### DIFF
--- a/docs/deployment/supported-proxies/nginx.md
+++ b/docs/deployment/supported-proxies/nginx.md
@@ -123,7 +123,7 @@ proxy_buffers 64 256k;
 
 # If behind reverse proxy, forwards the correct IP
 set_real_ip_from 10.0.0.0/8;
-set_real_ip_from 172.0.0.0/8;
+set_real_ip_from 172.16.0.0/12;
 set_real_ip_from 192.168.0.0/16;
 set_real_ip_from fc00::/7;
 real_ip_header X-Forwarded-For;


### PR DESCRIPTION
This PR updates the trusted IP range in the nginx example.

The example only trusts the correct IP from the Private Internets (as described here: https://tools.ietf.org/html/rfc1918) however one of the ranges was too large. 

The correct ranges are:
-  `10.0.0.0/8`
-  `172.16.0.0/12`
-  `192.168.0.0/16`

Source: https://tools.ietf.org/html/rfc1918#section-3

Happy New Year!