### PR TITLE
[CI] Update PR commentary

### DIFF
--- a/.github/probot.js
+++ b/.github/probot.js
@@ -24,7 +24,7 @@ on('pull_request.opened')
         context =>
             !context.payload.pull_request.head.label.includes(':master')
     )
-    .comment(`Thanks for choosing to contribute @{{ pull_request.user.login }}. We lint all PR's with golangci-lint, I may add a review to your PR with some suggestions.
+    .comment(`Thanks for choosing to contribute @{{ pull_request.user.login }}. We lint all PR's with golangci-lint and eslint, I may add a review to your PR with some suggestions.
     
 You are free to apply the changes if you're comfortable, alternatively you are welcome to ask a team member for advice.
 
@@ -33,18 +33,3 @@ These changes once approved by a team member will be published for testing on Bu
 
 ### Docker Container
 * \`docker pull authelia/authelia:PR{{ pull_request.number }}\``)
-
-// PR commentary for forked master branches
-on('pull_request.opened')
-    .filter(
-        context =>
-            context.payload.pull_request.head.label.slice(0, 9) !== 'authelia:'
-    )
-    .filter(
-        context =>
-            context.payload.pull_request.head.label.includes(':master')
-    )
-    .comment(`Thanks for choosing to contribute @{{ pull_request.user.login }}.
-    
-Unfortunately it appears that you're submitting a PR from a forked master branch and this is known to causes issues with codecov. Please re-submit your PR from a branch other than master.`)
-    .close()


### PR DESCRIPTION
This change updates the PR commentary specifically around linting.

We now also allow users to submit PRs to Authelia from forked `master` branches, this was previously disabled as it caused issues with codecov.