### PR TITLE
[BUGFIX] Disable colored logging outputs when file is specified

### DIFF
--- a/internal/logging/const.go
+++ b/internal/logging/const.go
@@ -1,0 +1,3 @@
+package logging
+
+const logFormatJSON = "json"

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -23,7 +23,7 @@ func InitializeLogger(format, filename string) error {
 	stackLevels := []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel}
 	logrus.AddHook(logrus_stack.NewHook(callerLevels, stackLevels))
 
-	if format == "json" {
+	if format == logFormatJSON {
 		logrus.SetFormatter(&logrus.JSONFormatter{})
 	} else {
 		logrus.SetFormatter(&logrus.TextFormatter{})
@@ -34,6 +34,13 @@ func InitializeLogger(format, filename string) error {
 
 		if err != nil {
 			return err
+		}
+
+		if format != logFormatJSON {
+			logrus.SetFormatter(&logrus.TextFormatter{
+				DisableColors: true,
+				FullTimestamp: true,
+			})
 		}
 
 		logrus.SetOutput(f)


### PR DESCRIPTION
In some scenarios if a user has a `log_file_path` specified and a TTY seems to be detected this causes terminal coloring outputs to be written to the file. This in turn will cause issues when attempting to utilise the log with the provided fail2ban regexes.

We now override any TTY detection/logging treatments and disable coloring/removal of the timestamp when a user is utilising the text based logger to a file.

Fixes #1480.