### PR TITLE
[MISC] Fix OTP countdown circle

### DIFF
--- a/web/src/views/LoginPortal/SecondFactor/MethodSelectionDialog.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/MethodSelectionDialog.tsx
@@ -12,8 +12,8 @@ import {
 } from "@material-ui/core";
 
 import FingerTouchIcon from "../../../components/FingerTouchIcon";
-import PieChartIcon from "../../../components/PieChartIcon";
 import PushNotificationIcon from "../../../components/PushNotificationIcon";
+import TimerIcon from "../../../components/TimerIcon";
 import { SecondFactorMethod } from "../../../models/Methods";
 
 export interface Props {
@@ -30,14 +30,7 @@ const MethodSelectionDialog = function (props: Props) {
     const theme = useTheme();
 
     const pieChartIcon = (
-        <PieChartIcon
-            width={24}
-            height={24}
-            maxProgress={1000}
-            progress={150}
-            color={theme.palette.primary.main}
-            backgroundColor={"white"}
-        />
+        <TimerIcon width={24} height={24} period={15} color={theme.palette.primary.main} backgroundColor={"white"} />
     );
 
     return (


### PR DESCRIPTION
On the method selection page previously the OTP option had a circle which gradually reduced in size and eventually reset, this was a intended as a visual indicator for a time based OTP.

Currently this is broken and in turn we see the following:
![Screenshot_2021-01-15-03-36-01](https://user-images.githubusercontent.com/3339418/104682060-f46cd600-5747-11eb-8466-802872c65b5b.png)

With this fixed implemented we see the following:
![Peek 2021-01-15 15-39](https://user-images.githubusercontent.com/3339418/104682110-0d758700-5748-11eb-8209-521b8f093b09.gif)