### PR TITLE
ci: update renovate configuration

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -1,7 +1,6 @@
 {
   "extends": [
     "config:base",
-    ":prHourlyLimit4",
     ":semanticCommitTypeAll(chore)",
     ":separatePatchReleases"
   ],


### PR DESCRIPTION
This PR removes the hourly limit for the number of PRs that renovate will raise.