### PR TITLE
ci(renovate): disable automatic rebasing

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -53,5 +53,6 @@
         "ruby"
       ]
     }
-  ]
+  ],
+  "rebaseWhen": "never"
 }


### PR DESCRIPTION
This change is to ensure that our CI workers are not flooded with jobs that fail.
This setting will be removed when the initial backlog has been merged.