### PR TITLE
ci(buildkite): update buildkite deployment steps

### DIFF
--- a/.buildkite/deployment.sh
+++ b/.buildkite/deployment.sh
@@ -6,9 +6,9 @@ DIVERGED=$(git merge-base --fork-point origin/master > /dev/null; echo $?)
 if [[ $DIVERGED == 0 ]]; then
   if [[ $BUILDKITE_TAG == "" ]]; then
     if [[ $BUILDKITE_BRANCH == "master" ]]; then
-      CI_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^(BREAKING.md|CONTRIBUTING.md|README.md|docs\/.*)/!{q1}' && echo true || echo false)
+      CI_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^(BREAKING.md|CONTRIBUTING.md|README.md|SECURITY.md|docs\/.*)/!{q1}' && echo true || echo false)
     else
-      CI_BYPASS=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^(BREAKING.md|CONTRIBUTING.md|README.md|docs\/.*)/!{q1}' && echo true || echo false)
+      CI_BYPASS=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^(BREAKING.md|CONTRIBUTING.md|README.md|SECURITY.md|docs\/.*)/!{q1}' && echo true || echo false)
     fi
   else
     CI_BYPASS="false"
@@ -33,6 +33,8 @@ steps:
     command: "authelia-scripts docker push-manifest"
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
+    agents:
+      upload: "fast"
     if: build.env("CI_BYPASS") != "true"
 
   - label: ":github: Deploy Artifacts"

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -6,9 +6,9 @@ DIVERGED=$(git merge-base --fork-point origin/master > /dev/null; echo $?)
 if [[ $DIVERGED == 0 ]]; then
   if [[ $BUILDKITE_TAG == "" ]]; then
     if [[ $BUILDKITE_BRANCH == "master" ]]; then
-      CI_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^(BREAKING.md|CONTRIBUTING.md|README.md|docs\/.*)/!{q1}' && echo true || echo false)
+      CI_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^(BREAKING.md|CONTRIBUTING.md|README.md|SECURITY.md|docs\/.*)/!{q1}' && echo true || echo false)
     else
-      CI_BYPASS=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^(BREAKING.md|CONTRIBUTING.md|README.md|docs\/.*)/!{q1}' && echo true || echo false)
+      CI_BYPASS=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^(BREAKING.md|CONTRIBUTING.md|README.md|SECURITY.md|docs\/.*)/!{q1}' && echo true || echo false)
     fi
 
     if [[ $CI_BYPASS == "true" ]]; then

--- a/.buildkite/steps/buildimages.sh
+++ b/.buildkite/steps/buildimages.sh
@@ -31,6 +31,10 @@ if [[ "${BUILD_ARCH}" == "coverage" ]]; then
 cat << EOF
     if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/
 EOF
+else
+cat << EOF
+    if: build.branch !~ /^(dependabot|renovate)\/.*/
+EOF
 fi
   done
 done


### PR DESCRIPTION
This PR modifies the Buildkite CI pipeline with the following changes:

* Add `SECURITY.md` to CI_BYPASS
* Skip Docker {amd64,arm32v7,arm64v8} builds for renovate PRs
* Ensure Deploy Manifest step only is assigned to deployment nodes