### PR TITLE
test(handlers): add health check to coverage build

### DIFF
--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -57,6 +57,7 @@ RUN apk --no-cache add ca-certificates tzdata
 WORKDIR /app
 
 COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
+COPY healthcheck.sh /usr/local/bin/
 
 EXPOSE 9091
 
@@ -65,3 +66,4 @@ VOLUME /config
 ENV PATH="/app:${PATH}"
 
 CMD ["authelia", "-test.coverprofile=/authelia/coverage.txt", "COVERAGE", "--config", "/config/configuration.yml"]
+HEALTHCHECK --interval=30s --timeout=3s --start-period=1m CMD /usr/local/bin/healthcheck.sh

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -66,4 +66,4 @@ VOLUME /config
 ENV PATH="/app:${PATH}"
 
 CMD ["authelia", "-test.coverprofile=/authelia/coverage.txt", "COVERAGE", "--config", "/config/configuration.yml"]
-HEALTHCHECK --interval=30s --timeout=3s --start-period=1m CMD /usr/local/bin/healthcheck.sh
+HEALTHCHECK --interval=30s --timeout=3s CMD /usr/local/bin/healthcheck.sh

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -20,4 +20,4 @@ if [ -z "${AUTHELIA_PORT}" ]; then
   AUTHELIA_PORT=9091
 fi
 
-wget --quiet --tries=1 --spider "${AUTHELIA_SCHEME}://${AUTHELIA_HOST}:${AUTHELIA_PORT}${AUTHELIA_PATH}/api/health" || exit 1
+wget --quiet --no-check-certificate --tries=1 --spider "${AUTHELIA_SCHEME}://${AUTHELIA_HOST}:${AUTHELIA_PORT}${AUTHELIA_PATH}/api/health" || exit 1

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-AUTHELIA_CONFIG=$(pgrep -af authelia | awk '{print $4}')
+AUTHELIA_CONFIG=$(pgrep -af authelia | awk '{print $NF}')
 AUTHELIA_SCHEME=$(grep ^tls "${AUTHELIA_CONFIG}")
 AUTHELIA_HOST=$(grep ^host "${AUTHELIA_CONFIG}" | sed -e 's/host: //' -e 's/\r//')
 AUTHELIA_PORT=$(grep ^port "${AUTHELIA_CONFIG}" | sed -e 's/port: //' -e 's/\r//')


### PR DESCRIPTION
This change ensures that the integration test container also utilises the health check script to ensure coverage for this area of code.