### PR TITLE
ci: restore dependabot rules

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
     if: build.branch != "master"
 
   - wait:
-    if: build.pull_request.repository.fork != true && build.branch !~ /^renovate\/.*/
+    if: build.pull_request.repository.fork != true && build.branch !~ /^(dependabot|renovate)\/.*/
 
   # Manual intervention by team required to deploy for forked PRs (prevent secret leakage).
   - block: "Public fork needs approval"
@@ -32,7 +32,7 @@ steps:
   - label: ":rocket: Setup Deployment"
     command: ".buildkite/deployment.sh | buildkite-agent pipeline upload"
     depends_on: ~
-    if: build.branch != "master" && build.branch !~ /^renovate\/.*/ && build.pull_request.repository.fork != true
+    if: build.branch != "master" && build.branch !~ /^(dependabot|renovate)\/.*/ && build.pull_request.repository.fork != true
 
   # Removed dependency optimisation for forked PRs to enforce block step.
   - label: ":rocket: Setup Deployment"

--- a/.buildkite/steps/buildimages.sh
+++ b/.buildkite/steps/buildimages.sh
@@ -33,7 +33,7 @@ cat << EOF
 EOF
 else
 cat << EOF
-    if: build.branch !~ /^renovate\/.*/
+    if: build.branch !~ /^(dependabot|renovate)\/.*/
 EOF
 fi
   done

--- a/.github/probot.js
+++ b/.github/probot.js
@@ -6,6 +6,10 @@ on('pull_request.opened')
     )
     .filter(
         context =>
+            context.payload.pull_request.head.ref.slice(0, 11) !== 'dependabot/'
+    )
+    .filter(
+        context =>
             context.payload.pull_request.head.ref.slice(0, 9) !== 'renovate/'
     )
     .comment(`## Artifacts


### PR DESCRIPTION
Restores the dependabot rules in buildkite for the purpose of security fixes which are still handled by dependabot.