### PR TITLE
refactor(authentication): use crypto constant time compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
   [![AUR development version](https://img.shields.io/aur/version/authelia-git?logo=arch-linux&label=authelia-git&style=flat-square&color=blue)](https://aur.archlinux.org/packages/authelia-git/)
   [![License](https://img.shields.io/github/license/authelia/authelia?logo=apache&style=flat-square&color=blue)][Apache 2.0]
   [![Sponsor](https://img.shields.io/opencollective/all/authelia-sponsors?logo=Open%20Collective&label=financial%20contributors&style=flat-square&color=blue)](https://opencollective.com/authelia-sponsors)
-  [![Discord](https://img.shields.io/discord/707844280412012608?logo=discord&style=flat-square&color=blue)](https://discord.authelia.com)
-  [![Matrix](https://img.shields.io/matrix/authelia:matrix.org?logo=matrix&style=flat-square&color=blue)](https://riot.im/app/#/room/#authelia:matrix.org)
+  [![Discord](https://img.shields.io/discord/707844280412012608?label=discord&logo=discord&style=flat-square&color=blue)](https://discord.authelia.com)
+  [![Matrix](https://img.shields.io/matrix/authelia:matrix.org?label=matrix&logo=matrix&style=flat-square&color=blue)](https://riot.im/app/#/room/#authelia:matrix.org)
 
 **Authelia** is an open-source authentication and authorization server
 providing 2-factor authentication and single sign-on (SSO) for your

--- a/internal/authentication/password_hash.go
+++ b/internal/authentication/password_hash.go
@@ -1,6 +1,7 @@
 package authentication
 
 import (
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"strconv"
@@ -151,7 +152,7 @@ func CheckPassword(password, hash string) (ok bool, err error) {
 		return false, err
 	}
 
-	return passwordHash.Key == expectedHash.Key, nil
+	return subtle.ConstantTimeCompare([]byte(passwordHash.Key), []byte(expectedHash.Key)) == 1, nil
 }
 
 func getCryptSettings(salt string, algorithm CryptAlgo, iterations, memory, parallelism, keyLength int) (settings string) {


### PR DESCRIPTION
Improve security with usage of the crypto/subtle ConstantTimeCompare() method for hash comparison.

Fixes #1799