### PR TITLE
fix(server): send 404 on missing api endpoints instead of 200

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,7 +53,7 @@ func StartServer(configuration schema.Configuration, providers middlewares.Provi
 	}
 
 	r.GET("/static/{filepath:*}", embeddedFS)
-	r.GET("/api/{filepath:*}", embeddedFS)
+	r.ANY("/api/{filepath:*}", embeddedFS)
 
 	r.GET("/api/health", autheliaMiddleware(handlers.HealthGet))
 	r.GET("/api/state", autheliaMiddleware(handlers.StateGet))

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"github.com/valyala/fasthttp"
@@ -38,11 +37,6 @@ func ServeTemplatedFile(publicDir, file, base, rememberMe, resetPassword, sessio
 	}
 
 	return func(ctx *fasthttp.RequestCtx) {
-		if publicDir == embeddedAssets && strings.HasPrefix(string(ctx.Path()), "/api/") {
-			ctx.Error(fasthttp.StatusMessage(fasthttp.StatusNotFound), fasthttp.StatusNotFound)
-			return
-		}
-
 		nonce := utils.RandomString(32, alphaNumericRunes)
 
 		switch extension := filepath.Ext(file); extension {

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -39,7 +39,7 @@ func ServeTemplatedFile(publicDir, file, base, rememberMe, resetPassword, sessio
 
 	return func(ctx *fasthttp.RequestCtx) {
 		if publicDir == embeddedAssets && strings.HasPrefix(string(ctx.Path()), "/api/") {
-			ctx.SetStatusCode(404)
+			ctx.Error(fasthttp.StatusMessage(fasthttp.StatusNotFound), fasthttp.StatusNotFound)
 			return
 		}
 

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/valyala/fasthttp"
@@ -37,6 +38,11 @@ func ServeTemplatedFile(publicDir, file, base, rememberMe, resetPassword, sessio
 	}
 
 	return func(ctx *fasthttp.RequestCtx) {
+		if publicDir == embeddedAssets && strings.HasPrefix(string(ctx.Path()), "/api/") {
+			ctx.SetStatusCode(404)
+			return
+		}
+
 		nonce := utils.RandomString(32, alphaNumericRunes)
 
 		switch extension := filepath.Ext(file); extension {

--- a/internal/suites/scenario_backend_protection_test.go
+++ b/internal/suites/scenario_backend_protection_test.go
@@ -35,7 +35,7 @@ func (s *BackendProtectionScenario) AssertRequestStatusCode(method, url string, 
 		}
 		res, err := client.Do(req)
 		s.Assert().NoError(err)
-		s.Assert().Equal(res.StatusCode, expectedStatusCode)
+		s.Assert().Equal(expectedStatusCode, res.StatusCode)
 	})
 }
 
@@ -57,12 +57,12 @@ func (s *BackendProtectionScenario) TestProtectionOfBackendEndpoints() {
 
 func (s *BackendProtectionScenario) TestInvalidEndpointsReturn404() {
 	s.AssertRequestStatusCode("GET", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 404)
-	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 404)
-	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 404)
+	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 405)
+	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 405)
 
 	s.AssertRequestStatusCode("GET", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 404)
-	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 404)
-	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 404)
+	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 405)
+	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 405)
 }
 
 func TestRunBackendProtection(t *testing.T) {

--- a/internal/suites/scenario_backend_protection_test.go
+++ b/internal/suites/scenario_backend_protection_test.go
@@ -57,12 +57,12 @@ func (s *BackendProtectionScenario) TestProtectionOfBackendEndpoints() {
 
 func (s *BackendProtectionScenario) TestInvalidEndpointsReturn404() {
 	s.AssertRequestStatusCode("GET", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 404)
-	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 405)
-	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 405)
+	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 404)
+	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 404)
 
 	s.AssertRequestStatusCode("GET", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 404)
-	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 405)
-	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 405)
+	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 404)
+	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 404)
 }
 
 func TestRunBackendProtection(t *testing.T) {

--- a/internal/suites/scenario_backend_protection_test.go
+++ b/internal/suites/scenario_backend_protection_test.go
@@ -55,6 +55,16 @@ func (s *BackendProtectionScenario) TestProtectionOfBackendEndpoints() {
 	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/secondfactor/totp/identity/finish", AutheliaBaseURL), 403)
 }
 
+func (s *BackendProtectionScenario) TestInvalidEndpointsReturn404() {
+	s.AssertRequestStatusCode("GET", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 404)
+	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 404)
+	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing", AutheliaBaseURL), 404)
+
+	s.AssertRequestStatusCode("GET", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 404)
+	s.AssertRequestStatusCode("HEAD", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 404)
+	s.AssertRequestStatusCode("POST", fmt.Sprintf("%s/api/not_existing/second", AutheliaBaseURL), 404)
+}
+
 func TestRunBackendProtection(t *testing.T) {
 	suite.Run(t, NewBackendProtectionScenario())
 }


### PR DESCRIPTION
Returns a 404 instead of 200 on bad API endpoints.
Co-authored-by: Clément Michaud <clement.michaud34@gmail.com>

Fixes #1520
Closes #1534