### PR TITLE
fix(web): fix compilation and running in development mode

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -63,6 +63,9 @@
       "not op_mini all"
     ],
     "development": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all",
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version"


### PR DESCRIPTION
During a `yarn start` the react frontend would throw the following errors during compilation:

```
Starting the development server...

Compiled with warnings.

./src/index.css (./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-4-1!./node_modules/postcss-loader/src??postcss!./src/index.css)
Warning

Greetings, time traveller. We are in the golden age of prefix-less CSS, where Autoprefixer is no longer needed for your stylesheet.

./node_modules/@fortawesome/fontawesome-svg-core/styles.css (./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-4-1!./node_modules/postcss-loader/src??postcss!./node_modules/@fortawesome/fontawesome-svg-core/styles.css)
Warning

Greetings, time traveller. We are in the golden age of prefix-less CSS, where Autoprefixer is no longer needed for your stylesheet.

./src/components/FingerTouchIcon.module.css (./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-5-1!./node_modules/postcss-loader/src??postcss!./src/components/FingerTouchIcon.module.css)
Warning

Greetings, time traveller. We are in the golden age of prefix-less CSS, where Autoprefixer is no longer needed for your stylesheet.

./src/components/PushNotificationIcon.module.css (./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-5-1!./node_modules/postcss-loader/src??postcss!./src/components/PushNotificationIcon.module.css)
Warning

Greetings, time traveller. We are in the golden age of prefix-less CSS, where Autoprefixer is no longer needed for your stylesheet.

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.
```

This in turn would mean that the server would never finish loading.
This change will allow the code to compile and run appropriately both in production and development modes.