### PR TITLE
test(suites): short mode skip suites testing

### DIFF
--- a/internal/suites/scenario_backend_protection_test.go
+++ b/internal/suites/scenario_backend_protection_test.go
@@ -66,5 +66,9 @@ func (s *BackendProtectionScenario) TestInvalidEndpointsReturn404() {
 }
 
 func TestRunBackendProtection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewBackendProtectionScenario())
 }

--- a/internal/suites/scenario_bypass_policy_test.go
+++ b/internal/suites/scenario_bypass_policy_test.go
@@ -59,5 +59,9 @@ func (s *BypassPolicyScenario) TestShouldAccessPublicResource() {
 }
 
 func TestBypassPolicyScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewBypassPolicyScenario())
 }

--- a/internal/suites/scenario_custom_headers_test.go
+++ b/internal/suites/scenario_custom_headers_test.go
@@ -125,5 +125,9 @@ func (s *CustomHeadersScenario) TestShouldForwardCustomHeaderForAuthenticatedUse
 }
 
 func TestCustomHeadersScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewCustomHeadersScenario())
 }

--- a/internal/suites/scenario_default_redirection_url_test.go
+++ b/internal/suites/scenario_default_redirection_url_test.go
@@ -65,5 +65,9 @@ func (drus *DefaultRedirectionURLScenario) TestUserIsRedirectedToDefaultURL() {
 }
 
 func TestShouldRunDefaultRedirectionURLScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewDefaultRedirectionURLScenario())
 }

--- a/internal/suites/scenario_inactivity_test.go
+++ b/internal/suites/scenario_inactivity_test.go
@@ -115,5 +115,9 @@ func (s *InactivityScenario) TestShouldDisableCookieExpirationAndInactivity() {
 }
 
 func TestInactivityScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewInactivityScenario())
 }

--- a/internal/suites/scenario_one_factor_test.go
+++ b/internal/suites/scenario_one_factor_test.go
@@ -76,5 +76,9 @@ func (s *OneFactorSuite) TestShouldDenyAccessOnBadPassword() {
 }
 
 func TestRunOneFactor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewOneFactorScenario())
 }

--- a/internal/suites/scenario_password_complexity_test.go
+++ b/internal/suites/scenario_password_complexity_test.go
@@ -57,5 +57,9 @@ func (s *PasswordComplexityScenario) TestShouldRejectPasswordReset() {
 }
 
 func TestRunPasswordComplexityScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewPasswordComplexityScenario())
 }

--- a/internal/suites/scenario_redirection_check_test.go
+++ b/internal/suites/scenario_redirection_check_test.go
@@ -78,5 +78,9 @@ func (s *RedirectionCheckScenario) TestShouldRedirectOnlyWhenDomainIsHandledByAu
 }
 
 func TestRedirectionCheckScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewRedirectionCheckScenario())
 }

--- a/internal/suites/scenario_redirection_url_test.go
+++ b/internal/suites/scenario_redirection_url_test.go
@@ -58,5 +58,9 @@ func (rus *RedirectionURLScenario) TestShouldVerifyCustomURLParametersArePropaga
 }
 
 func TestRedirectionURLScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewRedirectionURLScenario())
 }

--- a/internal/suites/scenario_regulation_test.go
+++ b/internal/suites/scenario_regulation_test.go
@@ -83,5 +83,9 @@ func (s *RegulationScenario) TestShouldBanUserAfterTooManyAttempt() {
 }
 
 func TestBlacklistingScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewRegulationScenario())
 }

--- a/internal/suites/scenario_reset_password_test.go
+++ b/internal/suites/scenario_reset_password_test.go
@@ -97,5 +97,9 @@ func (s *ResetPasswordScenario) TestShouldLetUserNoticeThereIsAPasswordMismatch(
 }
 
 func TestRunResetPasswordScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewResetPasswordScenario())
 }

--- a/internal/suites/scenario_signin_email_test.go
+++ b/internal/suites/scenario_signin_email_test.go
@@ -59,5 +59,9 @@ func (s *SigninEmailScenario) TestShouldSignInWithUserEmail() {
 }
 
 func TestSigninEmailScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewSigninEmailScenario())
 }

--- a/internal/suites/scenario_two_factor_test.go
+++ b/internal/suites/scenario_two_factor_test.go
@@ -98,5 +98,9 @@ func (s *TwoFactorSuite) TestShouldFailTwoFactor() {
 }
 
 func TestRunTwoFactor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewTwoFactorScenario())
 }

--- a/internal/suites/scenario_user_preferences_test.go
+++ b/internal/suites/scenario_user_preferences_test.go
@@ -94,5 +94,9 @@ func (s *UserPreferencesScenario) TestShouldRememberLastUsed2FAMethod() {
 }
 
 func TestUserPreferencesScenario(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewUserPreferencesScenario())
 }

--- a/internal/suites/suite_activedirectory_test.go
+++ b/internal/suites/suite_activedirectory_test.go
@@ -35,5 +35,9 @@ func (s *ActiveDirectorySuite) TestSigninEmailScenario() {
 }
 
 func TestActiveDirectorySuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewActiveDirectorySuite())
 }

--- a/internal/suites/suite_bypass_all_test.go
+++ b/internal/suites/suite_bypass_all_test.go
@@ -64,5 +64,9 @@ func (s *BypassAllSuite) TestCustomHeadersScenario() {
 }
 
 func TestBypassAllSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewBypassAllSuite())
 }

--- a/internal/suites/suite_cli_test.go
+++ b/internal/suites/suite_cli_test.go
@@ -143,5 +143,9 @@ func (s *CLISuite) TestShouldGenerateCertificateECDSAP521() {
 }
 
 func TestCLISuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewCLISuite())
 }

--- a/internal/suites/suite_docker_test.go
+++ b/internal/suites/suite_docker_test.go
@@ -23,5 +23,9 @@ func (s *DockerSuite) TestTwoFactorScenario() {
 }
 
 func TestDockerSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewDockerSuite())
 }

--- a/internal/suites/suite_duo_push_test.go
+++ b/internal/suites/suite_duo_push_test.go
@@ -145,5 +145,9 @@ func (s *DuoPushSuite) TestUserPreferencesScenario() {
 }
 
 func TestDuoPushSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewDuoPushSuite())
 }

--- a/internal/suites/suite_haproxy_test.go
+++ b/internal/suites/suite_haproxy_test.go
@@ -27,5 +27,9 @@ func (s *HAProxySuite) TestCustomHeaders() {
 }
 
 func TestHAProxySuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewHAProxySuite())
 }

--- a/internal/suites/suite_high_availability_test.go
+++ b/internal/suites/suite_high_availability_test.go
@@ -183,38 +183,38 @@ var UserHarry = "harry"
 var Users = []string{UserJohn, UserBob, UserHarry}
 
 var expectedAuthorizations = map[string](map[string]bool){
-	fmt.Sprintf("%s/secret.html", PublicBaseURL): map[string]bool{
+	fmt.Sprintf("%s/secret.html", PublicBaseURL): {
 		UserJohn: true, UserBob: true, UserHarry: true,
 	},
-	fmt.Sprintf("%s/secret.html", SecureBaseURL): map[string]bool{
+	fmt.Sprintf("%s/secret.html", SecureBaseURL): {
 		UserJohn: true, UserBob: true, UserHarry: true,
 	},
-	fmt.Sprintf("%s/secret.html", AdminBaseURL): map[string]bool{
+	fmt.Sprintf("%s/secret.html", AdminBaseURL): {
 		UserJohn: true, UserBob: false, UserHarry: false,
 	},
-	fmt.Sprintf("%s/secret.html", SingleFactorBaseURL): map[string]bool{
+	fmt.Sprintf("%s/secret.html", SingleFactorBaseURL): {
 		UserJohn: true, UserBob: true, UserHarry: true,
 	},
-	fmt.Sprintf("%s/secret.html", MX1MailBaseURL): map[string]bool{
+	fmt.Sprintf("%s/secret.html", MX1MailBaseURL): {
 		UserJohn: true, UserBob: true, UserHarry: false,
 	},
-	fmt.Sprintf("%s/secret.html", MX2MailBaseURL): map[string]bool{
+	fmt.Sprintf("%s/secret.html", MX2MailBaseURL): {
 		UserJohn: false, UserBob: true, UserHarry: false,
 	},
 
-	fmt.Sprintf("%s/groups/admin/secret.html", DevBaseURL): map[string]bool{
+	fmt.Sprintf("%s/groups/admin/secret.html", DevBaseURL): {
 		UserJohn: true, UserBob: false, UserHarry: false,
 	},
-	fmt.Sprintf("%s/groups/dev/secret.html", DevBaseURL): map[string]bool{
+	fmt.Sprintf("%s/groups/dev/secret.html", DevBaseURL): {
 		UserJohn: true, UserBob: true, UserHarry: false,
 	},
-	fmt.Sprintf("%s/users/john/secret.html", DevBaseURL): map[string]bool{
+	fmt.Sprintf("%s/users/john/secret.html", DevBaseURL): {
 		UserJohn: true, UserBob: false, UserHarry: false,
 	},
-	fmt.Sprintf("%s/users/harry/secret.html", DevBaseURL): map[string]bool{
+	fmt.Sprintf("%s/users/harry/secret.html", DevBaseURL): {
 		UserJohn: true, UserBob: false, UserHarry: true,
 	},
-	fmt.Sprintf("%s/users/bob/secret.html", DevBaseURL): map[string]bool{
+	fmt.Sprintf("%s/users/bob/secret.html", DevBaseURL): {
 		UserJohn: true, UserBob: true, UserHarry: false,
 	},
 }
@@ -264,8 +264,8 @@ func NewHighAvailabilitySuite() *HighAvailabilitySuite {
 func DoGetWithAuth(t *testing.T, username, password string) int {
 	client := NewHTTPClient()
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/secret.html", SingleFactorBaseURL), nil)
-	req.SetBasicAuth(username, password)
 	assert.NoError(t, err)
+	req.SetBasicAuth(username, password)
 
 	res, err := client.Do(req)
 	assert.NoError(t, err)
@@ -304,9 +304,17 @@ func (s *HighAvailabilitySuite) TestHighAvailabilityWebDriverSuite() {
 }
 
 func TestHighAvailabilityWebDriverSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewHighAvailabilityWebDriverSuite())
 }
 
 func TestHighAvailabilitySuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewHighAvailabilitySuite())
 }

--- a/internal/suites/suite_kubernetes_test.go
+++ b/internal/suites/suite_kubernetes_test.go
@@ -27,5 +27,9 @@ func (s *KubernetesSuite) TestRedirectionURLScenario() {
 }
 
 func TestKubernetesSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewKubernetesSuite())
 }

--- a/internal/suites/suite_ldap_test.go
+++ b/internal/suites/suite_ldap_test.go
@@ -35,5 +35,9 @@ func (s *LDAPSuite) TestSigninEmailScenario() {
 }
 
 func TestLDAPSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewLDAPSuite())
 }

--- a/internal/suites/suite_mariadb_test.go
+++ b/internal/suites/suite_mariadb_test.go
@@ -23,5 +23,9 @@ func (s *MariadbSuite) TestTwoFactorScenario() {
 }
 
 func TestMariadbSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewMariadbSuite())
 }

--- a/internal/suites/suite_mysql_test.go
+++ b/internal/suites/suite_mysql_test.go
@@ -23,5 +23,9 @@ func (s *MySQLSuite) TestTwoFactorScenario() {
 }
 
 func TestMySQLSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewMySQLSuite())
 }

--- a/internal/suites/suite_network_acl_test.go
+++ b/internal/suites/suite_network_acl_test.go
@@ -77,5 +77,9 @@ func (s *NetworkACLSuite) TestShouldAccessSecretUpon0FA() {
 }
 
 func TestNetworkACLSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewNetworkACLSuite())
 }

--- a/internal/suites/suite_one_factor_only_test.go
+++ b/internal/suites/suite_one_factor_only_test.go
@@ -80,5 +80,9 @@ func (s *OneFactorOnlySuite) TestWeb() {
 }
 
 func TestOneFactorOnlySuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, new(OneFactorOnlySuite))
 }

--- a/internal/suites/suite_pathprefix_test.go
+++ b/internal/suites/suite_pathprefix_test.go
@@ -31,5 +31,9 @@ func (s *PathPrefixSuite) TestResetPasswordScenario() {
 }
 
 func TestPathPrefixSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewPathPrefixSuite())
 }

--- a/internal/suites/suite_postgres_test.go
+++ b/internal/suites/suite_postgres_test.go
@@ -23,5 +23,9 @@ func (s *PostgresSuite) TestTwoFactorScenario() {
 }
 
 func TestPostgresSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewPostgresSuite())
 }

--- a/internal/suites/suite_short_timeouts_test.go
+++ b/internal/suites/suite_short_timeouts_test.go
@@ -27,5 +27,9 @@ func (s *ShortTimeoutsSuite) TestRegulationScenario() {
 }
 
 func TestShortTimeoutsSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewShortTimeoutsSuite())
 }

--- a/internal/suites/suite_standalone_test.go
+++ b/internal/suites/suite_standalone_test.go
@@ -213,5 +213,9 @@ func (s *StandaloneSuite) TestRedirectionURLScenario() {
 }
 
 func TestStandaloneSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewStandaloneSuite())
 }

--- a/internal/suites/suite_traefik2_test.go
+++ b/internal/suites/suite_traefik2_test.go
@@ -58,5 +58,9 @@ func (s *Traefik2Suite) TestShouldKeepSessionAfterRedisRestart() {
 }
 
 func TestTraefik2Suite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewTraefik2Suite())
 }

--- a/internal/suites/suite_traefik_test.go
+++ b/internal/suites/suite_traefik_test.go
@@ -31,5 +31,9 @@ func (s *TraefikSuite) TestCustomHeaders() {
 }
 
 func TestTraefikSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping suite test in short mode")
+	}
+
 	suite.Run(t, NewTraefikSuite())
 }


### PR DESCRIPTION
This PR changes the suites tests so if go test -short is used, they are skipped per go standards and a message is displayed. Additionally removed some redundant types from suite_high_availability_test.go and adjusted a warning about a nil req var.