### PR TITLE
fix(notification): don't remove file based notifier on start up

### DIFF
--- a/internal/notification/file_notifier.go
+++ b/internal/notification/file_notifier.go
@@ -37,10 +37,6 @@ func (n *FileNotifier) StartupCheck() (bool, error) {
 		if !os.IsNotExist(err) {
 			return false, err
 		}
-	} else {
-		if err = os.Remove(n.path); err != nil {
-			return false, err
-		}
 	}
 
 	if err := ioutil.WriteFile(n.path, []byte(""), fileNotifierMode); err != nil {


### PR DESCRIPTION
Attempting to run Authelia with least privilege principle as the `nobody` user and a file based notifier will cause issues during start up as the user cannot remove the notification file.

Given that `ioutil.WriteFile` truncates the file before writing the removal is not necessary.

Fixes #1846.