### PR TITLE
fix: exit setup.sh if missing pre-requisites

### DIFF
--- a/compose/local/setup.sh
+++ b/compose/local/setup.sh
@@ -16,12 +16,12 @@ echo "Checking for pre-requisites"
 
 if [[ ! -x "$(command -v docker)" ]]; then
   echo "You must install Docker on your machine";
-  exit
+  exit 1
 fi
 
 if [[ ! -x "$(command -v docker-compose)" ]]; then
   echo "You must install Docker Compose on your machine";
-  exit
+  exit 1
 fi
 
 echo "Pulling Authelia docker image for setup"
@@ -108,4 +108,3 @@ You will need to authorize the self-signed certificate upon visiting each domain
 To visit https://secure.$DOMAIN you will need to register a device for second factor authentication and confirm by clicking on a link sent by email. Since this is a demo with a fake email address, the content of the email will be stored in './authelia/notification.txt'.
 Upon registering, you can grab this link easily by running the following command: 'grep -Eo '"https://.*" ' ./authelia/notification.txt'.
 EOF
-

--- a/compose/local/setup.sh
+++ b/compose/local/setup.sh
@@ -16,12 +16,12 @@ echo "Checking for pre-requisites"
 
 if [[ ! -x "$(command -v docker)" ]]; then
   echo "You must install Docker on your machine";
-  return
+  exit
 fi
 
 if [[ ! -x "$(command -v docker-compose)" ]]; then
   echo "You must install Docker Compose on your machine";
-  return
+  exit
 fi
 
 echo "Pulling Authelia docker image for setup"


### PR DESCRIPTION
Running the script with missing prerequisites
doesn't fail, but instead warns the user
that return statements aren't allowed here.

---

I didn't have ``docker-compose`` installed, but the script continued to run instead of stopping immediately. Seems like an oversight?