### PR TITLE
fix: remove health checks on compose examples

### DIFF
--- a/compose/lite/docker-compose.yml
+++ b/compose/lite/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     expose:
       - 9091
     restart: unless-stopped
+    healthcheck:
+      disable: true
     environment:
       - TZ=Australia/Melbourne
 
@@ -74,7 +76,6 @@ services:
       - '--certificatesResolvers.letsencrypt.acme.httpChallenge.entryPoint=http'
       - '--log=true'
       - '--log.level=DEBUG'
-      - '--log.filepath=/var/log/traefik.log'
 
   secure:
     image: containous/whoami

--- a/compose/lite/docker-compose.yml
+++ b/compose/lite/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - '--log.level=DEBUG'
 
   secure:
-    image: containous/whoami
+    image: traefik/whoami
     container_name: secure
     networks:
       - net
@@ -94,7 +94,7 @@ services:
     restart: unless-stopped
 
   public:
-    image: containous/whoami
+    image: traefik/whoami
     container_name: public
     networks:
       - net

--- a/compose/local/docker-compose.yml
+++ b/compose/local/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     expose:
       - 9091
     restart: unless-stopped
+    healthcheck:
+      disable: true
     environment:
       - TZ=Australia/Melbourne
 
@@ -59,7 +61,6 @@ services:
       - '--entrypoints.https.address=:443'
       - '--log=true'
       - '--log.level=DEBUG'
-      - '--log.filepath=/var/log/traefik.log'
 
   secure:
     image: containous/whoami

--- a/compose/local/docker-compose.yml
+++ b/compose/local/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - '--log.level=DEBUG'
 
   secure:
-    image: containous/whoami
+    image: traefik/whoami
     container_name: secure
     networks:
       - net
@@ -79,7 +79,7 @@ services:
     restart: unless-stopped
 
   public:
-    image: containous/whoami
+    image: traefik/whoami
     container_name: public
     networks:
       - net

--- a/docs/deployment/deployment-lite.md
+++ b/docs/deployment/deployment-lite.md
@@ -22,7 +22,7 @@ provision](https://docs.traefik.io/https/acme/) up-to-date certificates for your
 Traefik publishes the respective services with LetsEncrypt provided certificates on port `443`.
 The provided examples protect the Traefik dashboard with Authelia's one-factor auth
 (traefik.example.com) and two instances of the
-[whoami container](https://hub.docker.com/r/containous/whoami) with Authelia being
+[whoami container](https://hub.docker.com/r/traefik/whoami) with Authelia being
 bypassed (public.example.com) and another with it's two-factor auth (secure.example.com). 
 
 If you happen to already have an external SQL instance (MariaDB, MySQL or Postgres) this 


### PR DESCRIPTION
Traefik does not add routes for containers via the Docker provider if the health check does not return healthy, this causes inadvertent user experience issues when attempting the pre-made compose examples.

This change removes the health checks for said examples and also ensures that Traefik logs are written to stdout so a user can view them within the Docker container logs.

Fixes #1864.