### PR TITLE
docs: Add a page listing supported proxies.

### DIFF
--- a/docs/home/supported-proxies.md
+++ b/docs/home/supported-proxies.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Supported Proxies
+parent: Home
+nav_order: 2
+---
+
+The following reverse proxies are currently supported:
+
+* NGINX
+* Traefik
+* HAProxy
+
+Those proxies are also supported on Kubernetes using their related ingress controller.
+
+For more details on the deployment on Kubernetes, please refer
+to [this documentation](../deployment/deployment-kubernetes.md).


### PR DESCRIPTION
I'm adding this page because after doing a quick review of the doc, it was not easy to find out this basic information.