### PR TITLE
fix(suites): ensure k8s suite utilises the registry cache

### DIFF
--- a/internal/suites/example/compose/kind/config.yml
+++ b/internal/suites/example/compose/kind/config.yml
@@ -4,6 +4,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
   # yamllint disable-line rule:indentation
   - |-
-    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registrycache.internal:5000"]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
       endpoint = ["http://registrycache.internal:5000"]
 ...


### PR DESCRIPTION
The annotation was previously pointing to the incorrect registry so the registrycache was not being utilised.