### PR TITLE
refactor: use fatal log message on oidc init error

### DIFF
--- a/cmd/authelia/main.go
+++ b/cmd/authelia/main.go
@@ -121,7 +121,7 @@ func startServer() {
 	oidcProvider, err := oidc.NewOpenIDConnectProvider(config.IdentityProviders.OIDC)
 
 	if err != nil {
-		panic(err)
+		logger.Fatalf("Error initializing OpenID Connect Provider: %+v", err)
 	}
 
 	providers := middlewares.Providers{


### PR DESCRIPTION
Instead of using panic() when an unknown error was detected on OP initialization, use logger.Fatalf. This provides a more useful output to the user.