### PR TITLE
fix(cmd): retry clean tag logic for dockerhub

### DIFF
--- a/internal/utils/exec.go
+++ b/internal/utils/exec.go
@@ -147,3 +147,23 @@ func RunCommandWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
 		return err
 	}
 }
+
+// RunFuncWithRetry run a function for n attempts with a sleep of n duration between each attempt.
+func RunFuncWithRetry(attempts int, sleep time.Duration, f func() error) (err error) {
+	for i := 0; ; i++ {
+		err = f()
+		if err == nil {
+			return
+		}
+
+		if i >= (attempts - 1) {
+			break
+		}
+
+		time.Sleep(sleep)
+
+		log.Printf("Retrying after error: %s", err)
+	}
+
+	return fmt.Errorf("Failed after %d attempts, last error: %s", attempts, err)
+}


### PR DESCRIPTION
This change will ensure that if the curl command for the cleaning of Docker tags on DockerHub fails it will be reattempted up to 2 more times (total of 3) with a 10 second sleep between each attempt.

The clean tag logic itself within curl attempts to execute the http request upto 3 times so this will ensure a maximum of 9 attempts.