### PR TITLE
fix(handlers): include the jwk key id in the jwt for validation

### DIFF
--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -100,7 +100,10 @@ func newDefaultOIDCSession(ctx *middlewares.AutheliaCtx) (session *openid.Defaul
 			Extra:       make(map[string]interface{}),
 		},
 		Headers: &jwt.Headers{
-			Extra: make(map[string]interface{}),
+			Extra: map[string]interface{}{
+				// TODO: Obtain this from the active keys when we implement key rotation.
+				"kid": "main-key",
+			},
 		},
 	}, err
 }


### PR DESCRIPTION
This is so the sig key used to sign the JWT can be verified using the JWKS endpoint.

Fixes #1979