### PR TITLE
fix(oidc): implement required subject types supported meta

### DIFF
--- a/internal/handlers/handler_oidc_wellknown.go
+++ b/internal/handlers/handler_oidc_wellknown.go
@@ -50,6 +50,9 @@ func oidcWellKnown(ctx *middlewares.AutheliaCtx) {
 		"groups",
 		"name",
 	}
+	configuration.SubjectTypesSupported = []string{
+		"plain",
+	}
 	configuration.ResponseTypesSupported = []string{
 		"code",
 		"token",

--- a/internal/handlers/types_oidc.go
+++ b/internal/handlers/types_oidc.go
@@ -52,6 +52,7 @@ type WellKnownConfigurationJSON struct {
 	RevocationEndpoint                 string   `json:"revocation_endpoint"`
 	JWKSURL                            string   `json:"jwks_uri"`
 	Algorithms                         []string `json:"id_token_signing_alg_values_supported"`
+	SubjectTypesSupported              []string `json:"subject_types_supported"`
 	ResponseTypesSupported             []string `json:"response_types_supported"`
 	ScopesSupported                    []string `json:"scopes_supported"`
 	ClaimsSupported                    []string `json:"claims_supported"`


### PR DESCRIPTION
The well known openid-configuration should have the subject_types_supported meta values.