### PR TITLE
ci(buildkite): add tag for highavailability suite

### DIFF
--- a/.buildkite/steps/e2etests.sh
+++ b/.buildkite/steps/e2etests.sh
@@ -13,6 +13,11 @@ cat << EOF
     agents:
       suite: "activedirectory"
 EOF
+elif [[ "${SUITE_NAME}" = "HighAvailability" ]]; then
+cat << EOF
+    agents:
+      suite: "highavailability"
+EOF
 elif [[ "${SUITE_NAME}" = "Kubernetes" ]]; then
 cat << EOF
     agents:


### PR DESCRIPTION
Allows granular control for node assignment on the high availability testing suite.