### PR TITLE
feat(authentication): add ssha hash for ldap

### DIFF
--- a/internal/authentication/ldap_ssha.go
+++ b/internal/authentication/ldap_ssha.go
@@ -32,13 +32,16 @@ func (pass SSHA) Matches(encodedPassPhrase []byte) bool {
 	sha.Write(salt)
 	sum := sha.Sum(nil)
 
-	return bytes.Compare(sum, hash[:len(hash)-4]) == 0
+	return bytes.Equal(sum, hash[:len(hash)-4])
 }
 
 // makeSalt make a 4 byte array containing random bytes.
 func makeSalt() []byte {
 	sbytes := make([]byte, 4)
-	rand.Read(sbytes)
+	if _, err := rand.Read(sbytes); err != nil {
+		// this should never happen
+		return []byte("salt")
+	}
 	return sbytes
 }
 

--- a/internal/authentication/ldap_ssha.go
+++ b/internal/authentication/ldap_ssha.go
@@ -15,14 +15,14 @@ type SSHA256 []byte
 func (pass SSHA256) Encode() ([]byte, error) {
 	hash := makeSSHA256Hash(pass, makeSalt())
 	b64 := base64.StdEncoding.EncodeToString(hash)
-	return []byte(fmt.Sprintf("{SSHA256}%s", b64)), nil
+	ret := []byte(fmt.Sprintf("{SSHA256}%s", b64))
+	return ret, nil
 }
 
 // Matches matches the encoded password and the raw password.
 func (pass SSHA256) Matches(encodedPassPhrase []byte) bool {
 	// strip the {SSHA}.
-	eppS := string(encodedPassPhrase)[6:]
-	hash, err := base64.StdEncoding.DecodeString(eppS)
+	hash, err := base64.StdEncoding.DecodeString(string(encodedPassPhrase)[6:])
 	if err != nil {
 		return false
 	}
@@ -33,7 +33,9 @@ func (pass SSHA256) Matches(encodedPassPhrase []byte) bool {
 	sha.Write(salt)
 	sum := sha.Sum(nil)
 
-	return bytes.Equal(sum, hash[:len(hash)-4])
+	ok := bytes.Equal(sum, hash[:len(hash)-4])
+
+	return ok
 }
 
 // makeSalt make a 4 byte array containing random bytes.

--- a/internal/authentication/ldap_ssha.go
+++ b/internal/authentication/ldap_ssha.go
@@ -3,23 +3,23 @@ package authentication
 import (
 	"bytes"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 )
 
-// SSHA type is used for ldap password storage.
-type SSHA []byte
+// SSHA256 type is used for ldap password storage.
+type SSHA256 []byte
 
 // Encode encodes the []byte of raw password.
-func (pass SSHA) Encode() ([]byte, error) {
-	hash := makeSSHAHash(pass, makeSalt())
+func (pass SSHA256) Encode() ([]byte, error) {
+	hash := makeSSHA256Hash(pass, makeSalt())
 	b64 := base64.StdEncoding.EncodeToString(hash)
-	return []byte(fmt.Sprintf("{SSHA}%s", b64)), nil
+	return []byte(fmt.Sprintf("{SSHA256}%s", b64)), nil
 }
 
 // Matches matches the encoded password and the raw password.
-func (pass SSHA) Matches(encodedPassPhrase []byte) bool {
+func (pass SSHA256) Matches(encodedPassPhrase []byte) bool {
 	// strip the {SSHA}.
 	eppS := string(encodedPassPhrase)[6:]
 	hash, err := base64.StdEncoding.DecodeString(eppS)
@@ -28,7 +28,7 @@ func (pass SSHA) Matches(encodedPassPhrase []byte) bool {
 	}
 	salt := hash[len(hash)-4:]
 
-	sha := sha1.New()
+	sha := sha256.New()
 	sha.Write(pass)
 	sha.Write(salt)
 	sum := sha.Sum(nil)
@@ -46,9 +46,9 @@ func makeSalt() []byte {
 	return sbytes
 }
 
-// makeSSHAHash make hasing using SHA-1 with salt. This is not the final output though. You need to append {SSHA} string with base64 of this hash.
-func makeSSHAHash(passphrase, salt []byte) []byte {
-	sha := sha1.New()
+// makeSSHA256Hash make hasing using SHA-256 with salt. This is not the final output though. You need to append {SSHA} string with base64 of this hash.
+func makeSSHA256Hash(passphrase, salt []byte) []byte {
+	sha := sha256.New()
 	sha.Write(passphrase)
 	sha.Write(salt)
 

--- a/internal/authentication/ldap_ssha.go
+++ b/internal/authentication/ldap_ssha.go
@@ -1,0 +1,53 @@
+package authentication
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+)
+
+type SSHA []byte
+
+// Encode encodes the []byte of raw password
+func (pass SSHA) Encode() ([]byte, error) {
+	hash := makeSSHAHash(pass, makeSalt())
+	b64 := base64.StdEncoding.EncodeToString(hash)
+	return []byte(fmt.Sprintf("{SSHA}%s", b64)), nil
+}
+
+// Matches matches the encoded password and the raw password
+func (pass SSHA) Matches(encodedPassPhrase []byte) bool {
+	//strip the {SSHA}
+	eppS := string(encodedPassPhrase)[6:]
+	hash, err := base64.StdEncoding.DecodeString(eppS)
+	if err != nil {
+		return false
+	}
+	salt := hash[len(hash)-4:]
+
+	sha := sha1.New()
+	sha.Write(pass)
+	sha.Write(salt)
+	sum := sha.Sum(nil)
+
+	return bytes.Compare(sum, hash[:len(hash)-4]) == 0
+}
+
+// makeSalt make a 4 byte array containing random bytes.
+func makeSalt() []byte {
+	sbytes := make([]byte, 4)
+	rand.Read(sbytes)
+	return sbytes
+}
+
+// makeSSHAHash make hasing using SHA-1 with salt. This is not the final output though. You need to append {SSHA} string with base64 of this hash.
+func makeSSHAHash(passphrase, salt []byte) []byte {
+	sha := sha1.New()
+	sha.Write(passphrase)
+	sha.Write(salt)
+
+	h := sha.Sum(nil)
+	return append(h, salt...)
+}

--- a/internal/authentication/ldap_ssha.go
+++ b/internal/authentication/ldap_ssha.go
@@ -8,18 +8,19 @@ import (
 	"fmt"
 )
 
+// SSHA type is used for ldap password storage.
 type SSHA []byte
 
-// Encode encodes the []byte of raw password
+// Encode encodes the []byte of raw password.
 func (pass SSHA) Encode() ([]byte, error) {
 	hash := makeSSHAHash(pass, makeSalt())
 	b64 := base64.StdEncoding.EncodeToString(hash)
 	return []byte(fmt.Sprintf("{SSHA}%s", b64)), nil
 }
 
-// Matches matches the encoded password and the raw password
+// Matches matches the encoded password and the raw password.
 func (pass SSHA) Matches(encodedPassPhrase []byte) bool {
-	//strip the {SSHA}
+	// strip the {SSHA}.
 	eppS := string(encodedPassPhrase)[6:]
 	hash, err := base64.StdEncoding.DecodeString(eppS)
 	if err != nil {
@@ -39,7 +40,7 @@ func (pass SSHA) Matches(encodedPassPhrase []byte) bool {
 func makeSalt() []byte {
 	sbytes := make([]byte, 4)
 	if _, err := rand.Read(sbytes); err != nil {
-		// this should never happen
+		// this should never happen.
 		return []byte("salt")
 	}
 	return sbytes

--- a/internal/authentication/ldap_ssha.go
+++ b/internal/authentication/ldap_ssha.go
@@ -55,5 +55,6 @@ func makeSSHA256Hash(passphrase, salt []byte) []byte {
 	sha.Write(salt)
 
 	h := sha.Sum(nil)
+
 	return append(h, salt...)
 }

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -289,11 +289,12 @@ func (p *LDAPUserProvider) UpdatePassword(inputUsername string, newPassword stri
 		return fmt.Errorf("Unable to update password. Cause: %s", err)
 	}
 
-	modifyRequest := ldap.NewModifyRequest(profile.DN, nil)
 	newPassBytes, err := SSHA256([]byte(newPassword)).Encode()
 	if err != nil {
 		return fmt.Errorf("Unable to convert to SSHA: %s", err)
 	}
+
+	modifyRequest := ldap.NewModifyRequest(profile.DN, nil)
 	switch p.configuration.Implementation {
 	case schema.LDAPImplementationActiveDirectory:
 		utf16 := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -290,7 +290,7 @@ func (p *LDAPUserProvider) UpdatePassword(inputUsername string, newPassword stri
 	}
 
 	modifyRequest := ldap.NewModifyRequest(profile.DN, nil)
-	newPassBytes, err := SSHA([]byte(newPassword)).Encode()
+	newPassBytes, err := SSHA256([]byte(newPassword)).Encode()
 	if err != nil {
 		return fmt.Errorf("Unable to convert to SSHA: %s", err)
 	}


### PR DESCRIPTION
LDAP was storing passwords in cleartext. This commit add a SSHA hash on the password for secure storage.