### PR TITLE
build: optimize docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,23 @@
+# CI/Git Directories
 .git
 .cache
+.buildkite
+.github
+coverage.txt
+Dockerfile*
+
+# Node Modules Directories
 **/node_modules
+
+# Documentation
+docs
+examples
+
+# Dot Files and Markdown
+.*
+*.md
+
+# Other
+internal/server/public_html
+authelia.service
+bootstrap.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ WORKDIR /app
 
 RUN apk --no-cache add ca-certificates su-exec tzdata
 
-COPY --from=builder-backend /go/src/app/authelia ./
-COPY entrypoint.sh healthcheck.sh /usr/local/bin/
+COPY --from=builder-backend /go/src/app/authelia /go/src/app/LICENSE /go/src/app/entrypoint.sh /go/src/app/healthcheck.sh ./
 
 EXPOSE 9091
 
@@ -38,9 +37,9 @@ VOLUME /config
 
 # Set environment variables
 ENV PATH="/app:${PATH}" \
-PUID=0 \
-PGID=0
+    PUID=0 \
+    PGID=0
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["--config", "/config/configuration.yml"]
-HEALTHCHECK --interval=30s --timeout=3s --start-period=1m CMD /usr/local/bin/healthcheck.sh
+HEALTHCHECK --interval=30s --timeout=3s --start-period=1m CMD /app/healthcheck.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,30 +6,19 @@ FROM golang:1.16.4-alpine AS builder-backend
 ARG BUILD_TAG
 ARG BUILD_COMMIT
 
-# gcc and musl-dev are required for building go-sqlite3
-RUN apk --no-cache add gcc musl-dev
-
 WORKDIR /go/src/app
 
-COPY go.mod go.sum config.template.yml ./
+COPY / ./
 
-RUN go mod download
-
-COPY cmd cmd
-COPY internal internal
-
-# Prepare static files to be embedded in Go binary
-RUN rm -rf internal/server/public_html
-COPY public_html internal/server/public_html
-
-# Set the build version and time
-RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
-    sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
-    sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go
-
-# CGO_ENABLED=1 is mandatory for building go-sqlite3
-RUN cd cmd/authelia && \
-GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags netgo -ldflags '-s -w -linkmode external -extldflags -static' -trimpath -o authelia
+# CGO_ENABLED=1 is required for building go-sqlite3
+RUN \
+apk --no-cache add gcc musl-dev && \
+go mod download && \
+mv public_html internal/server/public_html && \
+echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
+sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
+sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go && \
+GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags netgo -ldflags '-s -w -linkmode external -extldflags -static' -trimpath -o authelia ./cmd/authelia
 
 # ===================================
 # ===== Authelia official image =====
@@ -40,7 +29,7 @@ WORKDIR /app
 
 RUN apk --no-cache add ca-certificates su-exec tzdata
 
-COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
+COPY --from=builder-backend /go/src/app/authelia ./
 COPY entrypoint.sh healthcheck.sh /usr/local/bin/
 
 EXPOSE 9091

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -7,32 +7,21 @@ ARG BUILD_TAG
 ARG BUILD_COMMIT
 ARG CC_VERSION="v15"
 
-# gcc cross-compiler is required for building go-sqlite3
-RUN apk --no-cache add curl && \
-    curl -Lfs -o /tmp/gcc-9.2.0-arm-linux-musleabihf.tar.xz "https://github.com/just-containers/musl-cross-make/releases/download/${CC_VERSION}/gcc-9.2.0-arm-linux-musleabihf.tar.xz" && \
-    tar xf /tmp/gcc-9.2.0-arm-linux-musleabihf.tar.xz -C /
-
 WORKDIR /go/src/app
 
-COPY go.mod go.sum config.template.yml ./
+COPY / ./
 
-RUN go mod download
-
-COPY cmd cmd
-COPY internal internal
-
-# Prepare static files to be embedded in Go binary
-RUN rm -rf internal/server/public_html
-COPY public_html internal/server/public_html
-
-# Set the build version and time
-RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
-    sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
-    sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go
-
-# CGO_ENABLED=1 is mandatory for building go-sqlite3
-RUN cd cmd/authelia && \
-GOOS=linux GOARCH=arm CGO_ENABLED=1 CC=arm-linux-musleabihf-gcc go build -tags netgo -ldflags '-s -w -linkmode external -extldflags -static' -trimpath -o authelia
+# CGO_ENABLED=1 and gcc cross-compiler is required for building go-sqlite3
+RUN \
+apk --no-cache add curl && \
+curl -Lfs -o /tmp/gcc-9.2.0-arm-linux-musleabihf.tar.xz "https://github.com/just-containers/musl-cross-make/releases/download/${CC_VERSION}/gcc-9.2.0-arm-linux-musleabihf.tar.xz" && \
+tar xf /tmp/gcc-9.2.0-arm-linux-musleabihf.tar.xz -C / && \
+go mod download && \
+mv public_html internal/server/public_html && \
+echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
+sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
+sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go && \
+GOOS=linux GOARCH=arm CGO_ENABLED=1 CC=arm-linux-musleabihf-gcc CGO_LDFLAGS=-fuse-ld=bfd go build -tags netgo -ldflags '-s -w -linkmode external -extldflags -static' -trimpath -o authelia ./cmd/authelia
 
 # ===================================
 # ===== Authelia official image =====
@@ -46,7 +35,7 @@ COPY ./qemu-arm-static /usr/bin/qemu-arm-static
 RUN apk --no-cache add ca-certificates su-exec tzdata && \
     rm /usr/bin/qemu-arm-static
 
-COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
+COPY --from=builder-backend /go/src/app/authelia ./
 COPY entrypoint.sh healthcheck.sh /usr/local/bin/
 
 EXPOSE 9091

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -35,8 +35,7 @@ COPY ./qemu-arm-static /usr/bin/qemu-arm-static
 RUN apk --no-cache add ca-certificates su-exec tzdata && \
     rm /usr/bin/qemu-arm-static
 
-COPY --from=builder-backend /go/src/app/authelia ./
-COPY entrypoint.sh healthcheck.sh /usr/local/bin/
+COPY --from=builder-backend /go/src/app/authelia /go/src/app/LICENSE /go/src/app/entrypoint.sh /go/src/app/healthcheck.sh ./
 
 EXPOSE 9091
 
@@ -44,9 +43,9 @@ VOLUME /config
 
 # Set environment variables
 ENV PATH="/app:${PATH}" \
-PUID=0 \
-PGID=0
+    PUID=0 \
+    PGID=0
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["--config", "/config/configuration.yml"]
-HEALTHCHECK --interval=30s --timeout=3s --start-period=1m CMD /usr/local/bin/healthcheck.sh
+HEALTHCHECK --interval=30s --timeout=3s --start-period=1m CMD /app/healthcheck.sh

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -35,8 +35,7 @@ COPY ./qemu-aarch64-static /usr/bin/qemu-aarch64-static
 RUN apk --no-cache add ca-certificates su-exec tzdata && \
     rm /usr/bin/qemu-aarch64-static
 
-COPY --from=builder-backend /go/src/app/authelia ./
-COPY entrypoint.sh healthcheck.sh /usr/local/bin/
+COPY --from=builder-backend /go/src/app/authelia /go/src/app/LICENSE /go/src/app/entrypoint.sh /go/src/app/healthcheck.sh ./
 
 EXPOSE 9091
 
@@ -44,9 +43,9 @@ VOLUME /config
 
 # Set environment variables
 ENV PATH="/app:${PATH}" \
-PUID=0 \
-PGID=0
+    PUID=0 \
+    PGID=0
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["--config", "/config/configuration.yml"]
-HEALTHCHECK --interval=30s --timeout=3s --start-period=1m CMD /usr/local/bin/healthcheck.sh
+HEALTHCHECK --interval=30s --timeout=3s --start-period=1m CMD /app/healthcheck.sh

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -7,32 +7,21 @@ ARG BUILD_TAG
 ARG BUILD_COMMIT
 ARG CC_VERSION="v15"
 
-# gcc cross-compiler is required for building go-sqlite3
-RUN apk --no-cache add curl && \
-    curl -Lfs -o /tmp/gcc-9.2.0-aarch64-linux-musl.tar.xz "https://github.com/just-containers/musl-cross-make/releases/download/${CC_VERSION}/gcc-9.2.0-aarch64-linux-musl.tar.xz" && \
-    tar xf /tmp/gcc-9.2.0-aarch64-linux-musl.tar.xz -C /
-
 WORKDIR /go/src/app
 
-COPY go.mod go.sum config.template.yml ./
+COPY / ./
 
-RUN go mod download
-
-COPY cmd cmd
-COPY internal internal
-
-# Prepare static files to be embedded in Go binary
-RUN rm -rf internal/server/public_html
-COPY public_html internal/server/public_html
-
-# Set the build version and time
-RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
-    sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
-    sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go
-
-# CGO_ENABLED=1 is mandatory for building go-sqlite3
-RUN cd cmd/authelia && \
-GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-musl-gcc go build -tags netgo -ldflags '-s -w -linkmode external -extldflags -static' -trimpath -o authelia
+# CGO_ENABLED=1 and gcc cross-compiler is required for building go-sqlite3
+RUN \
+apk --no-cache add curl && \
+curl -Lfs -o /tmp/gcc-9.2.0-aarch64-linux-musl.tar.xz "https://github.com/just-containers/musl-cross-make/releases/download/${CC_VERSION}/gcc-9.2.0-aarch64-linux-musl.tar.xz" && \
+tar xf /tmp/gcc-9.2.0-aarch64-linux-musl.tar.xz -C / && \
+go mod download && \
+mv public_html internal/server/public_html && \
+echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
+sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
+sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go && \
+GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-musl-gcc CGO_LDFLAGS=-fuse-ld=bfd go build -tags netgo -ldflags '-s -w -linkmode external -extldflags -static' -trimpath -o authelia ./cmd/authelia
 
 # ===================================
 # ===== Authelia official image =====
@@ -46,7 +35,7 @@ COPY ./qemu-aarch64-static /usr/bin/qemu-aarch64-static
 RUN apk --no-cache add ca-certificates su-exec tzdata && \
     rm /usr/bin/qemu-aarch64-static
 
-COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
+COPY --from=builder-backend /go/src/app/authelia ./
 COPY entrypoint.sh healthcheck.sh /usr/local/bin/
 
 EXPOSE 9091

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -17,30 +17,22 @@ FROM golang:1.16.4-alpine AS builder-backend
 ARG BUILD_TAG
 ARG BUILD_COMMIT
 
-# gcc and musl-dev are required for building go-sqlite3
-RUN apk --no-cache add gcc musl-dev
-
 WORKDIR /go/src/app
 
-COPY go.mod go.sum config.template.yml ./
-
-RUN go mod download
-
-COPY cmd cmd
-COPY internal internal
+COPY / ./
 
 # Prepare static files to be embedded in Go binary
-RUN rm -rf internal/server/public_html
 COPY --from=builder-frontend /node/src/app/build internal/server/public_html
-COPY api internal/server/public_html/api
 
-# Set the build version and time
-RUN echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
-    sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
-    sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go
-
-# Build binary for collecting integration test coverage
-RUN cd cmd/authelia && \
+# gcc and musl-dev are required for building go-sqlite3
+RUN \
+apk --no-cache add gcc musl-dev && \
+go mod download && \
+mv api internal/server/public_html/api && \
+echo "Write tag ${BUILD_TAG} and commit ${BUILD_COMMIT} in binary." && \
+sed -i "s/__BUILD_TAG__/${BUILD_TAG}/" cmd/authelia/constants.go && \
+sed -i "s/__BUILD_COMMIT__/${BUILD_COMMIT}/" cmd/authelia/constants.go && \
+cd cmd/authelia && \
 go test -c --tags coverage -covermode=atomic -o authelia -coverpkg github.com/authelia/authelia/...
 
 # ===================================

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -44,8 +44,7 @@ RUN apk --no-cache add ca-certificates tzdata
 
 WORKDIR /app
 
-COPY --from=builder-backend /go/src/app/cmd/authelia/authelia ./
-COPY healthcheck.sh /usr/local/bin/
+COPY --from=builder-backend /go/src/app/cmd/authelia/authelia /go/src/app/LICENSE /go/src/app/healthcheck.sh ./
 
 EXPOSE 9091
 
@@ -54,4 +53,4 @@ VOLUME /config
 ENV PATH="/app:${PATH}"
 
 CMD ["authelia", "-test.coverprofile=/authelia/coverage.txt", "COVERAGE", "--config", "/config/configuration.yml"]
-HEALTHCHECK --interval=30s --timeout=3s CMD /usr/local/bin/healthcheck.sh
+HEALTHCHECK --interval=30s --timeout=3s CMD /app/healthcheck.sh


### PR DESCRIPTION
This change is so that each of the COPY/RUN steps occurs in a single layer which should theoretically decrease build times.