### PR TITLE
ci(golangci-lint): replace golint with revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,11 +22,11 @@ linters:
     - godot
     - gofmt
     - goimports
-    - golint
     - gosec
     - misspell
     - nolintlint
     - prealloc
+    - revive
     - unconvert
     - unparam
     - whitespace

--- a/cmd/authelia-scripts/cmd_suites.go
+++ b/cmd/authelia-scripts/cmd_suites.go
@@ -182,7 +182,7 @@ func runOnError(suite string) error {
 func setupSuite(suiteName string) error {
 	log.Infof("Setup environment for suite %s...", suiteName)
 
-	signalChannel := make(chan os.Signal)
+	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
 
 	interrupted := false

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -234,7 +234,8 @@ func (c *AutheliaCtx) GetOriginalURL() (*url.URL, error) {
 
 	var requestURI string
 
-	scheme := append(forwardedProto, protoHostSeparator...)
+	scheme := forwardedProto
+	scheme = append(scheme, protoHostSeparator...)
 	requestURI = string(append(scheme,
 		append(forwardedHost, forwardedURI...)...))
 

--- a/internal/suites/kubernetes.go
+++ b/internal/suites/kubernetes.go
@@ -36,11 +36,9 @@ func (k Kind) CreateCluster() error {
 	// In that case /etc/resolv.conf use 127.0.0.11 as DNS and CoreDNS thinks it is talking to itself which is wrong.
 	// This IP is the docker internal DNS so it is safe to disable the loop check.
 	cmd = kindCommand("sh -c 'kubectl -n kube-system get configmap/coredns -o yaml | grep -v loop | kubectl replace -f -'")
-	if err := cmd.Run(); err != nil {
-		return err
-	}
+	err := cmd.Run()
 
-	return nil
+	return err
 }
 
 // DeleteCluster delete a Kubernetes cluster.
@@ -90,11 +88,9 @@ func (k Kubectl) StartDashboard() error {
 		return err
 	}
 
-	if err := utils.Shell("docker-compose -p authelia -f internal/suites/docker-compose.yml -f internal/suites/example/compose/kind/docker-compose.yml up -d kube-dashboard").Run(); err != nil {
-		return err
-	}
+	err := utils.Shell("docker-compose -p authelia -f internal/suites/docker-compose.yml -f internal/suites/example/compose/kind/docker-compose.yml up -d kube-dashboard").Run()
 
-	return nil
+	return err
 }
 
 // StopDashboard stop kube dashboard.

--- a/internal/suites/suite_kubernetes.go
+++ b/internal/suites/suite_kubernetes.go
@@ -12,7 +12,6 @@ import (
 
 var kubernetesSuiteName = "Kubernetes"
 
-//nolint:gocyclo // TODO: Consider refactoring/simplifying, time permitting.
 func init() {
 	kind := Kind{}
 	kubectl := Kubectl{}
@@ -85,11 +84,9 @@ func init() {
 
 		log.Debug("Starting proxy...")
 
-		if err := kubectl.StartProxy(); err != nil {
-			return err
-		}
+		err = kubectl.StartProxy()
 
-		return nil
+		return err
 	}
 
 	teardown := func(suitePath string) error {

--- a/internal/utils/exec.go
+++ b/internal/utils/exec.go
@@ -48,7 +48,7 @@ func Shell(command string) *exec.Cmd {
 func RunCommandUntilCtrlC(cmd *exec.Cmd) {
 	mutex := sync.Mutex{}
 	cond := sync.NewCond(&mutex)
-	signalChannel := make(chan os.Signal)
+	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
 
 	mutex.Lock()
@@ -84,7 +84,7 @@ func RunFuncUntilCtrlC(fn func() error) error {
 	mutex := sync.Mutex{}
 	cond := sync.NewCond(&mutex)
 	errorChannel := make(chan error)
-	signalChannel := make(chan os.Signal)
+	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
 
 	mutex.Lock()


### PR DESCRIPTION
Remove deprecated `golint` linter and replace with `revive` linter.

Also fix outstanding issues due to upgraded linters.