### PR TITLE
feat(handlers): synology password complexity err on reset

### DIFF
--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -44,8 +44,13 @@ const mfaValidationFailedMessage = "Authentication failed, please retry later."
 
 const ldapPasswordComplexityCode = "0000052D."
 
-var ldapPasswordComplexityCodes = []string{"0000052D"}
-var ldapPasswordComplexityErrors = []string{"LDAP Result Code 19 \"Constraint Violation\": Password fails quality checking policy"}
+var ldapPasswordComplexityCodes = []string{
+	"0000052D", "SynoNumber", "SynoMixedCase", "SynoExcludeNameDesc", "SynoSpecialChar",
+}
+var ldapPasswordComplexityErrors = []string{
+	"LDAP Result Code 19 \"Constraint Violation\": Password fails quality checking policy",
+	"LDAP Result Code 19 \"Constraint Violation\": Password is too young to change",
+}
 
 const testInactivity = "10"
 const testRedirectionURL = "http://redirection.local"

--- a/internal/handlers/handler_reset_password_step2.go
+++ b/internal/handlers/handler_reset_password_step2.go
@@ -31,9 +31,8 @@ func ResetPasswordPost(ctx *middlewares.AutheliaCtx) {
 
 	if err != nil {
 		switch {
-		case utils.IsStringInSliceContains(err.Error(), ldapPasswordComplexityCodes):
-			ctx.Error(fmt.Errorf("%s", err), ldapPasswordComplexityCode)
-		case utils.IsStringInSliceContains(err.Error(), ldapPasswordComplexityErrors):
+		case utils.IsStringInSliceContains(err.Error(), ldapPasswordComplexityCodes),
+			utils.IsStringInSliceContains(err.Error(), ldapPasswordComplexityErrors):
 			ctx.Error(fmt.Errorf("%s", err), ldapPasswordComplexityCode)
 		default:
 			ctx.Error(fmt.Errorf("%s", err), unableToResetPasswordMessage)


### PR DESCRIPTION
This responds to the client with the correct error when used with Synology LDAP servers.