### PR TITLE
fix(authorization): configuration reports 2fa disabled with 2fa oidc clients

### DIFF
--- a/cmd/authelia/main.go
+++ b/cmd/authelia/main.go
@@ -121,7 +121,7 @@ func startServer() {
 	}
 
 	clock := utils.RealClock{}
-	authorizer := authorization.NewAuthorizer(config.AccessControl)
+	authorizer := authorization.NewAuthorizer(config)
 	sessionProvider := session.NewProvider(config.Session, autheliaCertPool)
 	regulator := regulation.NewRegulator(config.Regulation, storageProvider, clock)
 	oidcProvider, err := oidc.NewOpenIDConnectProvider(config.IdentityProviders.OIDC)

--- a/internal/authorization/authorizer.go
+++ b/internal/authorization/authorizer.go
@@ -44,11 +44,12 @@ func (p Authorizer) IsSecondFactorEnabled() bool {
 
 	if p.configuration.IdentityProviders.OIDC != nil {
 		for _, client := range p.configuration.IdentityProviders.OIDC.Clients {
-			if client.Policy == "two_factor" {
+			if client.Policy == twoFactor {
 				return true
 			}
 		}
 	}
+
 	return false
 }
 

--- a/internal/authorization/authorizer.go
+++ b/internal/authorization/authorizer.go
@@ -1,8 +1,6 @@
 package authorization
 
 import (
-	"github.com/sirupsen/logrus"
-
 	"github.com/authelia/authelia/internal/configuration/schema"
 	"github.com/authelia/authelia/internal/logging"
 )
@@ -16,13 +14,6 @@ type Authorizer struct {
 
 // NewAuthorizer create an instance of authorizer with a given access control configuration.
 func NewAuthorizer(configuration *schema.Configuration) *Authorizer {
-	if logging.Logger().IsLevelEnabled(logrus.TraceLevel) {
-		return &Authorizer{
-			defaultPolicy: PolicyToLevel(configuration.AccessControl.DefaultPolicy),
-			rules:         NewAccessControlRules(configuration.AccessControl),
-		}
-	}
-
 	return &Authorizer{
 		defaultPolicy: PolicyToLevel(configuration.AccessControl.DefaultPolicy),
 		rules:         NewAccessControlRules(configuration.AccessControl),

--- a/internal/authorization/authorizer_test.go
+++ b/internal/authorization/authorizer_test.go
@@ -107,7 +107,7 @@ var Sally = UserWithIPv6AddressAndGroups
 
 func (s *AuthorizerSuite) TestShouldCheckDefaultBypassConfig() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("bypass").Build()
+		WithDefaultPolicy(bypass).Build()
 
 	tester.CheckAuthorizations(s.T(), AnonymousUser, "https://public.example.com/", "GET", Bypass)
 	tester.CheckAuthorizations(s.T(), UserWithGroups, "https://public.example.com/", "GET", Bypass)
@@ -117,7 +117,7 @@ func (s *AuthorizerSuite) TestShouldCheckDefaultBypassConfig() {
 
 func (s *AuthorizerSuite) TestShouldCheckDefaultDeniedConfig() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").Build()
+		WithDefaultPolicy(deny).Build()
 
 	tester.CheckAuthorizations(s.T(), AnonymousUser, "https://public.example.com/", "GET", Denied)
 	tester.CheckAuthorizations(s.T(), UserWithGroups, "https://public.example.com/", "GET", Denied)
@@ -127,10 +127,10 @@ func (s *AuthorizerSuite) TestShouldCheckDefaultDeniedConfig() {
 
 func (s *AuthorizerSuite) TestShouldCheckMultiDomainRule() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains: []string{"*.example.com"},
-			Policy:  "bypass",
+			Policy:  bypass,
 		}).
 		Build()
 
@@ -144,14 +144,14 @@ func (s *AuthorizerSuite) TestShouldCheckMultiDomainRule() {
 
 func (s *AuthorizerSuite) TestShouldCheckDynamicDomainRules() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains: []string{"{user}.example.com"},
-			Policy:  "bypass",
+			Policy:  bypass,
 		}).
 		WithRule(schema.ACLRule{
 			Domains: []string{"{group}.example.com"},
-			Policy:  "bypass",
+			Policy:  bypass,
 		}).
 		Build()
 
@@ -163,10 +163,10 @@ func (s *AuthorizerSuite) TestShouldCheckDynamicDomainRules() {
 
 func (s *AuthorizerSuite) TestShouldCheckMultipleDomainRule() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains: []string{"*.example.com", "other.com"},
-			Policy:  "bypass",
+			Policy:  bypass,
 		}).
 		Build()
 
@@ -183,18 +183,18 @@ func (s *AuthorizerSuite) TestShouldCheckMultipleDomainRule() {
 
 func (s *AuthorizerSuite) TestShouldCheckFactorsPolicy() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains: []string{"single.example.com"},
-			Policy:  "one_factor",
+			Policy:  oneFactor,
 		}).
 		WithRule(schema.ACLRule{
 			Domains: []string{"protected.example.com"},
-			Policy:  "two_factor",
+			Policy:  twoFactor,
 		}).
 		WithRule(schema.ACLRule{
 			Domains: []string{"public.example.com"},
-			Policy:  "bypass",
+			Policy:  bypass,
 		}).
 		Build()
 
@@ -206,19 +206,19 @@ func (s *AuthorizerSuite) TestShouldCheckFactorsPolicy() {
 
 func (s *AuthorizerSuite) TestShouldCheckRulePrecedence() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"protected.example.com"},
-			Policy:   "bypass",
+			Policy:   bypass,
 			Subjects: [][]string{{"user:john"}},
 		}).
 		WithRule(schema.ACLRule{
 			Domains: []string{"protected.example.com"},
-			Policy:  "one_factor",
+			Policy:  oneFactor,
 		}).
 		WithRule(schema.ACLRule{
 			Domains: []string{"*.example.com"},
-			Policy:  "two_factor",
+			Policy:  twoFactor,
 		}).
 		Build()
 
@@ -229,10 +229,10 @@ func (s *AuthorizerSuite) TestShouldCheckRulePrecedence() {
 
 func (s *AuthorizerSuite) TestShouldCheckUserMatching() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"protected.example.com"},
-			Policy:   "one_factor",
+			Policy:   oneFactor,
 			Subjects: [][]string{{"user:john"}},
 		}).
 		Build()
@@ -243,10 +243,10 @@ func (s *AuthorizerSuite) TestShouldCheckUserMatching() {
 
 func (s *AuthorizerSuite) TestShouldCheckGroupMatching() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"protected.example.com"},
-			Policy:   "one_factor",
+			Policy:   oneFactor,
 			Subjects: [][]string{{"group:admins"}},
 		}).
 		Build()
@@ -257,10 +257,10 @@ func (s *AuthorizerSuite) TestShouldCheckGroupMatching() {
 
 func (s *AuthorizerSuite) TestShouldCheckSubjectsMatching() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"protected.example.com"},
-			Policy:   "one_factor",
+			Policy:   oneFactor,
 			Subjects: [][]string{{"group:admins"}, {"user:bob"}},
 		}).
 		Build()
@@ -273,10 +273,10 @@ func (s *AuthorizerSuite) TestShouldCheckSubjectsMatching() {
 
 func (s *AuthorizerSuite) TestShouldCheckMultipleSubjectsMatching() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"protected.example.com"},
-			Policy:   "one_factor",
+			Policy:   oneFactor,
 			Subjects: [][]string{{"group:admins", "user:bob"}, {"group:admins", "group:dev"}},
 		}).
 		Build()
@@ -288,30 +288,30 @@ func (s *AuthorizerSuite) TestShouldCheckMultipleSubjectsMatching() {
 
 func (s *AuthorizerSuite) TestShouldCheckIPMatching() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"protected.example.com"},
-			Policy:   "bypass",
+			Policy:   bypass,
 			Networks: []string{"192.168.1.8", "10.0.0.8"},
 		}).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"protected.example.com"},
-			Policy:   "one_factor",
+			Policy:   oneFactor,
 			Networks: []string{"10.0.0.7"},
 		}).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"net.example.com"},
-			Policy:   "two_factor",
+			Policy:   twoFactor,
 			Networks: []string{"10.0.0.0/8"},
 		}).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"ipv6.example.com"},
-			Policy:   "two_factor",
+			Policy:   twoFactor,
 			Networks: []string{"fec0::1/64"},
 		}).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"ipv6-alt.example.com"},
-			Policy:   "two_factor",
+			Policy:   twoFactor,
 			Networks: []string{"fec0::1"},
 		}).
 		Build()
@@ -332,20 +332,20 @@ func (s *AuthorizerSuite) TestShouldCheckIPMatching() {
 
 func (s *AuthorizerSuite) TestShouldCheckMethodMatching() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains: []string{"protected.example.com"},
-			Policy:  "bypass",
+			Policy:  bypass,
 			Methods: []string{"OPTIONS", "HEAD", "GET", "CONNECT", "TRACE"},
 		}).
 		WithRule(schema.ACLRule{
 			Domains: []string{"protected.example.com"},
-			Policy:  "one_factor",
+			Policy:  oneFactor,
 			Methods: []string{"PUT", "PATCH", "POST"},
 		}).
 		WithRule(schema.ACLRule{
 			Domains: []string{"protected.example.com"},
-			Policy:  "two_factor",
+			Policy:  twoFactor,
 			Methods: []string{"DELETE"},
 		}).
 		Build()
@@ -365,15 +365,15 @@ func (s *AuthorizerSuite) TestShouldCheckMethodMatching() {
 
 func (s *AuthorizerSuite) TestShouldCheckResourceMatching() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains:   []string{"resource.example.com"},
-			Policy:    "bypass",
+			Policy:    bypass,
 			Resources: []string{"^/bypass/[a-z]+$", "^/$", "embedded"},
 		}).
 		WithRule(schema.ACLRule{
 			Domains:   []string{"resource.example.com"},
-			Policy:    "one_factor",
+			Policy:    oneFactor,
 			Resources: []string{"^/one_factor/[a-z]+$"},
 		}).
 		Build()
@@ -390,15 +390,15 @@ func (s *AuthorizerSuite) TestShouldCheckResourceMatching() {
 func (s *AuthorizerSuite) TestShouldMatchAnyDomainIfBlank() {
 	tester := NewAuthorizerBuilder().
 		WithRule(schema.ACLRule{
-			Policy:  "bypass",
+			Policy:  bypass,
 			Methods: []string{"OPTIONS", "HEAD", "GET", "CONNECT", "TRACE"},
 		}).
 		WithRule(schema.ACLRule{
-			Policy:  "one_factor",
+			Policy:  oneFactor,
 			Methods: []string{"PUT", "PATCH"},
 		}).
 		WithRule(schema.ACLRule{
-			Policy:  "two_factor",
+			Policy:  twoFactor,
 			Methods: []string{"DELETE"},
 		}).
 		Build()
@@ -422,41 +422,41 @@ func (s *AuthorizerSuite) TestShouldMatchAnyDomainIfBlank() {
 
 func (s *AuthorizerSuite) TestShouldMatchResourceWithSubjectRules() {
 	tester := NewAuthorizerBuilder().
-		WithDefaultPolicy("deny").
+		WithDefaultPolicy(deny).
 		WithRule(schema.ACLRule{
 			Domains:   []string{"public.example.com"},
 			Resources: []string{"^/admin/.*$"},
 			Subjects:  [][]string{{"group:admins"}},
-			Policy:    "one_factor",
+			Policy:    oneFactor,
 		}).
 		WithRule(schema.ACLRule{
 			Domains:   []string{"public.example.com"},
 			Resources: []string{"^/admin/.*$"},
-			Policy:    "deny",
+			Policy:    deny,
 		}).
 		WithRule(schema.ACLRule{
 			Domains: []string{"public.example.com"},
-			Policy:  "bypass",
+			Policy:  bypass,
 		}).
 		WithRule(schema.ACLRule{
 			Domains:   []string{"public2.example.com"},
 			Resources: []string{"^/admin/.*$"},
 			Subjects:  [][]string{{"group:admins"}},
-			Policy:    "bypass",
+			Policy:    bypass,
 		}).
 		WithRule(schema.ACLRule{
 			Domains:   []string{"public2.example.com"},
 			Resources: []string{"^/admin/.*$"},
-			Policy:    "deny",
+			Policy:    deny,
 		}).
 		WithRule(schema.ACLRule{
 			Domains: []string{"public2.example.com"},
-			Policy:  "bypass",
+			Policy:  bypass,
 		}).
 		WithRule(schema.ACLRule{
 			Domains:  []string{"private.example.com"},
 			Subjects: [][]string{{"group:admins"}},
-			Policy:   "two_factor",
+			Policy:   twoFactor,
 		}).
 		Build()
 
@@ -484,10 +484,10 @@ func (s *AuthorizerSuite) TestShouldMatchResourceWithSubjectRules() {
 }
 
 func (s *AuthorizerSuite) TestPolicyToLevel() {
-	s.Assert().Equal(Bypass, PolicyToLevel("bypass"))
-	s.Assert().Equal(OneFactor, PolicyToLevel("one_factor"))
-	s.Assert().Equal(TwoFactor, PolicyToLevel("two_factor"))
-	s.Assert().Equal(Denied, PolicyToLevel("deny"))
+	s.Assert().Equal(Bypass, PolicyToLevel(bypass))
+	s.Assert().Equal(OneFactor, PolicyToLevel(oneFactor))
+	s.Assert().Equal(TwoFactor, PolicyToLevel(twoFactor))
+	s.Assert().Equal(Denied, PolicyToLevel(deny))
 
 	s.Assert().Equal(Denied, PolicyToLevel("whatever"))
 }

--- a/internal/authorization/authorizer_test.go
+++ b/internal/authorization/authorizer_test.go
@@ -20,8 +20,13 @@ type AuthorizerTester struct {
 }
 
 func NewAuthorizerTester(config schema.AccessControlConfiguration) *AuthorizerTester {
+
+	fullConfig := &schema.Configuration{
+		AccessControl: config,
+	}
+
 	return &AuthorizerTester{
-		NewAuthorizer(config),
+		NewAuthorizer(fullConfig),
 	}
 }
 

--- a/internal/authorization/authorizer_test.go
+++ b/internal/authorization/authorizer_test.go
@@ -20,7 +20,6 @@ type AuthorizerTester struct {
 }
 
 func NewAuthorizerTester(config schema.AccessControlConfiguration) *AuthorizerTester {
-
 	fullConfig := &schema.Configuration{
 		AccessControl: config,
 	}

--- a/internal/authorization/authorizer_test.go
+++ b/internal/authorization/authorizer_test.go
@@ -532,7 +532,7 @@ func TestNewAuthorizer(t *testing.T) {
 	assert.Equal(t, "admins", group.Name)
 }
 
-func TestAuthorizer_IsSecondFactorEnabled_RuleWithNoOIDC(t *testing.T) {
+func TestAuthorizerIsSecondFactorEnabledRuleWithNoOIDC(t *testing.T) {
 	config := &schema.Configuration{
 		AccessControl: schema.AccessControlConfiguration{
 			DefaultPolicy: deny,
@@ -552,7 +552,7 @@ func TestAuthorizer_IsSecondFactorEnabled_RuleWithNoOIDC(t *testing.T) {
 	assert.True(t, authorizer.IsSecondFactorEnabled())
 }
 
-func TestAuthorizer_IsSecondFactorEnabled_RuleWithOIDC(t *testing.T) {
+func TestAuthorizerIsSecondFactorEnabledRuleWithOIDC(t *testing.T) {
 	config := &schema.Configuration{
 		AccessControl: schema.AccessControlConfiguration{
 			DefaultPolicy: deny,

--- a/internal/authorization/const.go
+++ b/internal/authorization/const.go
@@ -17,4 +17,9 @@ const (
 const userPrefix = "user:"
 const groupPrefix = "group:"
 
+const bypass = "bypass"
+const oneFactor = "one_factor"
+const twoFactor = "two_factor"
+const deny = "deny"
+
 const traceFmtACLHitMiss = "ACL %s Position %d for subject %s and object %s (Method %s)"

--- a/internal/authorization/util.go
+++ b/internal/authorization/util.go
@@ -12,13 +12,13 @@ import (
 // PolicyToLevel converts a string policy to int authorization level.
 func PolicyToLevel(policy string) Level {
 	switch policy {
-	case "bypass":
+	case bypass:
 		return Bypass
-	case "one_factor":
+	case oneFactor:
 		return OneFactor
-	case "two_factor":
+	case twoFactor:
 		return TwoFactor
-	case "deny":
+	case deny:
 		return Denied
 	}
 	// By default the deny policy applies.

--- a/internal/handlers/handler_configuration.go
+++ b/internal/handlers/handler_configuration.go
@@ -23,6 +23,7 @@ func ConfigurationGet(ctx *middlewares.AutheliaCtx) {
 	}
 
 	body.SecondFactorEnabled = ctx.Providers.Authorizer.IsSecondFactorEnabled()
+
 	ctx.Logger.Tracef("Second factor enabled: %v", body.SecondFactorEnabled)
 
 	ctx.Logger.Tracef("Available methods are %s", body.AvailableMethods)

--- a/internal/handlers/handler_configuration_test.go
+++ b/internal/handlers/handler_configuration_test.go
@@ -17,10 +17,11 @@ type SecondFactorAvailableMethodsFixture struct {
 
 func (s *SecondFactorAvailableMethodsFixture) SetupTest() {
 	s.mock = mocks.NewMockAutheliaCtx(s.T())
-	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(schema.AccessControlConfiguration{
-		DefaultPolicy: "deny",
-		Rules:         []schema.ACLRule{},
-	})
+	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(&schema.Configuration{
+		AccessControl: schema.AccessControlConfiguration{
+			DefaultPolicy: "deny",
+			Rules:         []schema.ACLRule{},
+		}})
 }
 
 func (s *SecondFactorAvailableMethodsFixture) TearDownTest() {
@@ -66,23 +67,25 @@ func (s *SecondFactorAvailableMethodsFixture) TestShouldCheckSecondFactorIsDisab
 			Period: schema.DefaultTOTPConfiguration.Period,
 		},
 	}
-	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(schema.AccessControlConfiguration{
-		DefaultPolicy: "bypass",
-		Rules: []schema.ACLRule{
-			{
-				Domains: []string{"example.com"},
-				Policy:  "deny",
-			},
-			{
-				Domains: []string{"abc.example.com"},
-				Policy:  "single_factor",
-			},
-			{
-				Domains: []string{"def.example.com"},
-				Policy:  "bypass",
-			},
-		},
-	})
+	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(
+		&schema.Configuration{
+			AccessControl: schema.AccessControlConfiguration{
+				DefaultPolicy: "bypass",
+				Rules: []schema.ACLRule{
+					{
+						Domains: []string{"example.com"},
+						Policy:  "deny",
+					},
+					{
+						Domains: []string{"abc.example.com"},
+						Policy:  "single_factor",
+					},
+					{
+						Domains: []string{"def.example.com"},
+						Policy:  "bypass",
+					},
+				},
+			}})
 	ConfigurationGet(s.mock.Ctx)
 	s.mock.Assert200OK(s.T(), ConfigurationBody{
 		AvailableMethods:    []string{"totp", "u2f"},
@@ -97,23 +100,24 @@ func (s *SecondFactorAvailableMethodsFixture) TestShouldCheckSecondFactorIsEnabl
 			Period: schema.DefaultTOTPConfiguration.Period,
 		},
 	}
-	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(schema.AccessControlConfiguration{
-		DefaultPolicy: "two_factor",
-		Rules: []schema.ACLRule{
-			{
-				Domains: []string{"example.com"},
-				Policy:  "deny",
+	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(&schema.Configuration{
+		AccessControl: schema.AccessControlConfiguration{
+			DefaultPolicy: "two_factor",
+			Rules: []schema.ACLRule{
+				{
+					Domains: []string{"example.com"},
+					Policy:  "deny",
+				},
+				{
+					Domains: []string{"abc.example.com"},
+					Policy:  "single_factor",
+				},
+				{
+					Domains: []string{"def.example.com"},
+					Policy:  "bypass",
+				},
 			},
-			{
-				Domains: []string{"abc.example.com"},
-				Policy:  "single_factor",
-			},
-			{
-				Domains: []string{"def.example.com"},
-				Policy:  "bypass",
-			},
-		},
-	})
+		}})
 	ConfigurationGet(s.mock.Ctx)
 	s.mock.Assert200OK(s.T(), ConfigurationBody{
 		AvailableMethods:    []string{"totp", "u2f"},
@@ -128,23 +132,25 @@ func (s *SecondFactorAvailableMethodsFixture) TestShouldCheckSecondFactorIsEnabl
 			Period: schema.DefaultTOTPConfiguration.Period,
 		},
 	}
-	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(schema.AccessControlConfiguration{
-		DefaultPolicy: "bypass",
-		Rules: []schema.ACLRule{
-			{
-				Domains: []string{"example.com"},
-				Policy:  "deny",
-			},
-			{
-				Domains: []string{"abc.example.com"},
-				Policy:  "two_factor",
-			},
-			{
-				Domains: []string{"def.example.com"},
-				Policy:  "bypass",
-			},
-		},
-	})
+	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(
+		&schema.Configuration{
+			AccessControl: schema.AccessControlConfiguration{
+				DefaultPolicy: "bypass",
+				Rules: []schema.ACLRule{
+					{
+						Domains: []string{"example.com"},
+						Policy:  "deny",
+					},
+					{
+						Domains: []string{"abc.example.com"},
+						Policy:  "two_factor",
+					},
+					{
+						Domains: []string{"def.example.com"},
+						Policy:  "bypass",
+					},
+				},
+			}})
 	ConfigurationGet(s.mock.Ctx)
 	s.mock.Assert200OK(s.T(), ConfigurationBody{
 		AvailableMethods:    []string{"totp", "u2f"},

--- a/internal/handlers/handler_firstfactor_test.go
+++ b/internal/handlers/handler_firstfactor_test.go
@@ -288,8 +288,7 @@ func (s *FirstFactorRedirectionSuite) SetupTest() {
 			Policy:  "one_factor",
 		},
 	}
-	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(
-		s.mock.Ctx.Configuration.AccessControl)
+	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(&s.mock.Ctx.Configuration)
 
 	s.mock.UserProviderMock.
 		EXPECT().
@@ -360,8 +359,10 @@ func (s *FirstFactorRedirectionSuite) TestShouldRedirectToDefaultURLWhenURLIsUns
 // Then:
 //   the user should receive 200 without redirection URL.
 func (s *FirstFactorRedirectionSuite) TestShouldReply200WhenNoTargetURLProvidedAndTwoFactorEnabled() {
-	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(schema.AccessControlConfiguration{
-		DefaultPolicy: "two_factor",
+	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(&schema.Configuration{
+		AccessControl: schema.AccessControlConfiguration{
+			DefaultPolicy: "two_factor",
+		},
 	})
 	s.mock.Ctx.Request.SetBodyString(`{
 		"username": "test",
@@ -381,19 +382,20 @@ func (s *FirstFactorRedirectionSuite) TestShouldReply200WhenNoTargetURLProvidedA
 // Then:
 //   the user should receive 200 without redirection URL.
 func (s *FirstFactorRedirectionSuite) TestShouldReply200WhenUnsafeTargetURLProvidedAndTwoFactorEnabled() {
-	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(schema.AccessControlConfiguration{
-		DefaultPolicy: "one_factor",
-		Rules: []schema.ACLRule{
-			{
-				Domains: []string{"test.example.com"},
-				Policy:  "one_factor",
+	s.mock.Ctx.Providers.Authorizer = authorization.NewAuthorizer(&schema.Configuration{
+		AccessControl: schema.AccessControlConfiguration{
+			DefaultPolicy: "one_factor",
+			Rules: []schema.ACLRule{
+				{
+					Domains: []string{"test.example.com"},
+					Policy:  "one_factor",
+				},
+				{
+					Domains: []string{"example.com"},
+					Policy:  "two_factor",
+				},
 			},
-			{
-				Domains: []string{"example.com"},
-				Policy:  "two_factor",
-			},
-		},
-	})
+		}})
 	s.mock.Ctx.Request.SetBodyString(`{
 		"username": "test",
 		"password": "hello",

--- a/internal/handlers/handler_verify_test.go
+++ b/internal/handlers/handler_verify_test.go
@@ -147,13 +147,14 @@ func TestShouldCheckAuthorizationMatching(t *testing.T) {
 	url, _ := url.ParseRequestURI("https://test.example.com")
 
 	for _, rule := range rules {
-		authorizer := authorization.NewAuthorizer(schema.AccessControlConfiguration{
-			DefaultPolicy: "deny",
-			Rules: []schema.ACLRule{{
-				Domains: []string{"test.example.com"},
-				Policy:  rule.Policy,
-			}},
-		})
+		authorizer := authorization.NewAuthorizer(&schema.Configuration{
+			AccessControl: schema.AccessControlConfiguration{
+				DefaultPolicy: "deny",
+				Rules: []schema.ACLRule{{
+					Domains: []string{"test.example.com"},
+					Policy:  rule.Policy,
+				}},
+			}})
 
 		username := ""
 		if rule.AuthLevel > authentication.NotAuthenticated {
@@ -179,16 +180,6 @@ func TestShouldVerifyWrongCredentials(t *testing.T) {
 	_, _, _, _, _, err := verifyBasicAuth(ProxyAuthorizationHeader, []byte("Basic am9objpwYXNzd29yZA=="), *url, mock.Ctx)
 
 	assert.Error(t, err)
-}
-
-type TestCase struct {
-	URL                string
-	Authorization      string
-	ExpectedStatusCode int
-}
-
-func (tc TestCase) String() string {
-	return fmt.Sprintf("url=%s, auth=%s, exp_status=%d", tc.URL, tc.Authorization, tc.ExpectedStatusCode)
 }
 
 type BasicAuthorizationSuite struct {

--- a/internal/mocks/mock_authelia_ctx.go
+++ b/internal/mocks/mock_authelia_ctx.go
@@ -105,7 +105,7 @@ func NewMockAutheliaCtx(t *testing.T) *MockAutheliaCtx {
 	providers.Notifier = mockAuthelia.NotifierMock
 
 	providers.Authorizer = authorization.NewAuthorizer(
-		configuration.AccessControl)
+		&configuration)
 
 	providers.SessionProvider = session.NewProvider(
 		configuration.Session, nil)

--- a/internal/suites/scenario_redirection_check_test.go
+++ b/internal/suites/scenario_redirection_check_test.go
@@ -67,9 +67,6 @@ func (s *RedirectionCheckScenario) TestShouldRedirectOnLoginOnlyWhenDomainIsSafe
 		s.T().Run(url, func(t *testing.T) {
 			s.doLoginTwoFactor(ctx, t, "john", "password", false, secret, url)
 
-			// TODO: Remove this if it's not necessary.
-			// time.Sleep(1000 * time.Millisecond)
-
 			if redirected {
 				s.verifySecretAuthorized(ctx, t)
 			} else {

--- a/internal/suites/scenario_redirection_check_test.go
+++ b/internal/suites/scenario_redirection_check_test.go
@@ -66,7 +66,9 @@ func (s *RedirectionCheckScenario) TestShouldRedirectOnLoginOnlyWhenDomainIsSafe
 	for url, redirected := range redirectionAuthorizations {
 		s.T().Run(url, func(t *testing.T) {
 			s.doLoginTwoFactor(ctx, t, "john", "password", false, secret, url)
-			time.Sleep(500 * time.Millisecond)
+
+			// TODO: Remove this if it's not necessary.
+			// time.Sleep(1000 * time.Millisecond)
 
 			if redirected {
 				s.verifySecretAuthorized(ctx, t)

--- a/internal/suites/scenario_redirection_check_test.go
+++ b/internal/suites/scenario_redirection_check_test.go
@@ -58,7 +58,7 @@ var redirectionAuthorizations = map[string]bool{
 }
 
 func (s *RedirectionCheckScenario) TestShouldRedirectOnLoginOnlyWhenDomainIsSafe() {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
 	defer cancel()
 
 	secret := s.doRegisterThenLogout(ctx, s.T(), "john", "password")
@@ -66,12 +66,14 @@ func (s *RedirectionCheckScenario) TestShouldRedirectOnLoginOnlyWhenDomainIsSafe
 	for url, redirected := range redirectionAuthorizations {
 		s.T().Run(url, func(t *testing.T) {
 			s.doLoginTwoFactor(ctx, t, "john", "password", false, secret, url)
-			time.Sleep(1 * time.Second)
+			time.Sleep(500 * time.Millisecond)
+
 			if redirected {
 				s.verifySecretAuthorized(ctx, t)
 			} else {
 				s.verifyIsAuthenticatedPage(ctx, t)
 			}
+
 			s.doLogout(ctx, t)
 		})
 	}


### PR DESCRIPTION
This resolves an issue where if you have zero two_factor ACL rules but enabled two_factor OIDC clients, 2FA is reported as disabled.