### PR TITLE
test(web): integration test auto theme

### DIFF
--- a/internal/suites/Standalone/configuration.yml
+++ b/internal/suites/Standalone/configuration.yml
@@ -7,6 +7,8 @@ port: 9091
 tls_cert: /config/ssl/cert.pem
 tls_key: /config/ssl/key.pem
 
+theme: auto
+
 log:
   level: debug
 


### PR DESCRIPTION
Allows capturing of code coverage for the `auto` theme in the Standalone suite.