### PR TITLE
refactor: drop qemu binary requirement

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -28,11 +28,8 @@ FROM arm32v7/alpine:3.14.0
 
 WORKDIR /app
 
-COPY ./qemu-arm-static /usr/bin/qemu-arm-static
-
 RUN \
-apk --no-cache add ca-certificates su-exec tzdata && \
-rm /usr/bin/qemu-arm-static
+apk --no-cache add ca-certificates su-exec tzdata
 
 COPY --from=builder-backend /go/src/app/authelia /go/src/app/LICENSE /go/src/app/entrypoint.sh /go/src/app/healthcheck.sh ./
 

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -28,11 +28,8 @@ FROM arm64v8/alpine:3.14.0
 
 WORKDIR /app
 
-COPY ./qemu-aarch64-static /usr/bin/qemu-aarch64-static
-
 RUN \
-apk --no-cache add ca-certificates su-exec tzdata && \
-rm /usr/bin/qemu-aarch64-static
+apk --no-cache add ca-certificates su-exec tzdata
 
 COPY --from=builder-backend /go/src/app/authelia /go/src/app/LICENSE /go/src/app/entrypoint.sh /go/src/app/healthcheck.sh ./
 

--- a/cmd/authelia-scripts/cmd_docker.go
+++ b/cmd/authelia-scripts/cmd_docker.go
@@ -46,8 +46,6 @@ func dockerBuildOfficialImage(arch string) error {
 	docker := &Docker{}
 	// Set default Architecture Dockerfile to amd64.
 	dockerfile := "Dockerfile"
-	// Set version of QEMU.
-	qemuversion := "v5.2.0-2"
 
 	// If not the default value.
 	if arch != defaultArch {
@@ -61,24 +59,12 @@ func dockerBuildOfficialImage(arch string) error {
 				log.Fatal(err)
 			}
 		}
-
-		err := utils.CommandWithStdout("bash", "-c", "wget https://github.com/multiarch/qemu-user-static/releases/download/"+qemuversion+"/qemu-arm-static -O ./qemu-arm-static && chmod +x ./qemu-arm-static").Run()
-
-		if err != nil {
-			log.Fatal(err)
-		}
 	} else if arch == "arm64v8" {
 		if buildkiteQEMU != stringTrue {
 			err := utils.CommandWithStdout("docker", "run", "--rm", "--privileged", "multiarch/qemu-user-static", "--reset", "-p", "yes").Run()
 			if err != nil {
 				log.Fatal(err)
 			}
-		}
-
-		err := utils.CommandWithStdout("bash", "-c", "wget https://github.com/multiarch/qemu-user-static/releases/download/"+qemuversion+"/qemu-aarch64-static -O ./qemu-aarch64-static && chmod +x ./qemu-aarch64-static").Run()
-
-		if err != nil {
-			log.Fatal(err)
 		}
 	}
 


### PR DESCRIPTION
QEMU binaries no longer need to be baked into containers.