### PR TITLE
refactor: cra build path

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -33,7 +33,7 @@ steps:
     if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/
 
   - label: ":hammer_and_wrench: Unit Test"
-    command: "authelia-scripts --log-level debug ci"
+    command: "authelia-scripts --log-level debug ci --buildkite"
     agents:
       build: "unit-test"
     artifact_paths:

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -26,7 +26,7 @@ go mod download
 COPY / ./
 
 # Prepare static files to be embedded in Go binary
-COPY --from=builder-frontend /node/src/app/build internal/server/public_html
+COPY --from=builder-frontend /node/src/internal/server/public_html internal/server/public_html
 
 ARG LDFLAGS_EXTRA
 RUN \

--- a/cmd/authelia-scripts/cmd_build.go
+++ b/cmd/authelia-scripts/cmd_build.go
@@ -41,18 +41,6 @@ func buildFrontend() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	cmd = utils.CommandWithStdout("rm", "-rf", "internal/server/public_html")
-
-	err = cmd.Run()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = os.Rename("web/build", "internal/server/public_html")
-	if err != nil {
-		log.Fatal(err)
-	}
 }
 
 func buildSwagger() {
@@ -128,7 +116,13 @@ func Build(cobraCmd *cobra.Command, args []string) {
 	log.Debug("Building swagger-ui frontend...")
 	buildSwagger()
 
-	log.Debug("Building Authelia Go binary...")
-	buildAutheliaBinary(xflags)
+	buildkite, _ := cobraCmd.Flags().GetBool("buildkite")
+	if buildkite {
+		log.Debug("Buildkite job detected, skipping Authelia Go binary build")
+	} else {
+		log.Debug("Building Authelia Go binary...")
+		buildAutheliaBinary(xflags)
+	}
+
 	cleanAssets()
 }

--- a/cmd/authelia-scripts/cmd_ci.go
+++ b/cmd/authelia-scripts/cmd_ci.go
@@ -11,8 +11,15 @@ import (
 func RunCI(cmd *cobra.Command, args []string) {
 	log.Info("=====> Build stage <=====")
 
-	if err := utils.CommandWithStdout("authelia-scripts", "--log-level", "debug", "build").Run(); err != nil {
-		log.Fatal(err)
+	buildkite, _ := cmd.Flags().GetBool("buildkite")
+	if buildkite {
+		if err := utils.CommandWithStdout("authelia-scripts", "--log-level", "debug", "--buildkite", "build").Run(); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		if err := utils.CommandWithStdout("authelia-scripts", "--log-level", "debug", "build").Run(); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	log.Info("=====> Unit testing stage <=====")

--- a/cmd/authelia-scripts/cmd_docker.go
+++ b/cmd/authelia-scripts/cmd_docker.go
@@ -52,14 +52,7 @@ func dockerBuildOfficialImage(arch string) error {
 		dockerfile = fmt.Sprintf("%s.%s", dockerfile, arch)
 	}
 
-	if arch == "arm32v7" {
-		if buildkiteQEMU != stringTrue {
-			err := utils.CommandWithStdout("docker", "run", "--rm", "--privileged", "multiarch/qemu-user-static", "--reset", "-p", "yes").Run()
-			if err != nil {
-				log.Fatal(err)
-			}
-		}
-	} else if arch == "arm64v8" {
+	if arch == "arm32v7" || arch == "arm64v8" {
 		if buildkiteQEMU != stringTrue {
 			err := utils.CommandWithStdout("docker", "run", "--rm", "--privileged", "multiarch/qemu-user-static", "--reset", "-p", "yes").Run()
 			if err != nil {

--- a/cmd/authelia-scripts/main.go
+++ b/cmd/authelia-scripts/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/authelia/authelia/internal/utils"
 )
 
+var buildkite bool
 var logLevel string
 
 // AutheliaCommandDefinition is the definition of one authelia-scripts command.
@@ -137,6 +138,7 @@ func main() {
 
 	cobraCommands = append(cobraCommands, commands.HashPasswordCmd, commands.CertificatesCmd, commands.RSACmd, xflagsCmd)
 
+	rootCmd.PersistentFlags().BoolVar(&buildkite, "buildkite", false, "Set CI flag for Buildkite")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Set the log level for the command")
 	rootCmd.AddCommand(cobraCommands...)
 	cobra.OnInitialize(initConfig)

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,3 +1,4 @@
+BUILD_PATH=../internal/server/public_html
 PUBLIC_URL={{.Base}}
 REACT_APP_REMEMBER_ME={{.RememberMe}}
 REACT_APP_RESET_PASSWORD={{.ResetPassword}}


### PR DESCRIPTION
The `authelia-scripts` helper currently performs steps to move files around in different stages of development and CI/CD.

We now utilise the `BUILD_PATH` environment variable to adjust the output directory for the web frontend from the default of `./web/build/` simplifying the helper somewhat.

Additionally we no longer build the Go binary in the unit test stage of our CI/CD as this is not necessary.