### PR TITLE
feat(authentication): use the passwordmodify exop for pwd resets with ldap

### DIFF
--- a/internal/authentication/ldap_connection_factory.go
+++ b/internal/authentication/ldap_connection_factory.go
@@ -15,6 +15,7 @@ type LDAPConnection interface {
 
 	Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error)
 	Modify(modifyRequest *ldap.ModifyRequest) error
+	PasswordModify(pwdModifyRequest *ldap.PasswordModifyRequest) error
 	StartTLS(config *tls.Config) error
 }
 
@@ -46,6 +47,12 @@ func (lc *LDAPConnectionImpl) Search(searchRequest *ldap.SearchRequest) (*ldap.S
 // Modify modifies an ldap object.
 func (lc *LDAPConnectionImpl) Modify(modifyRequest *ldap.ModifyRequest) error {
 	return lc.conn.Modify(modifyRequest)
+}
+
+// PasswordModify modifies an ldap objects password
+func (lc *LDAPConnectionImpl) PasswordModify(pwdModifyRequest *ldap.PasswordModifyRequest) error {
+	_, err := lc.conn.PasswordModify(pwdModifyRequest)
+	return err
 }
 
 // StartTLS requests the LDAP server upgrades to TLS encryption.

--- a/internal/authentication/ldap_connection_factory.go
+++ b/internal/authentication/ldap_connection_factory.go
@@ -49,7 +49,7 @@ func (lc *LDAPConnectionImpl) Modify(modifyRequest *ldap.ModifyRequest) error {
 	return lc.conn.Modify(modifyRequest)
 }
 
-// PasswordModify modifies an ldap objects password
+// PasswordModify modifies an ldap objects password.
 func (lc *LDAPConnectionImpl) PasswordModify(pwdModifyRequest *ldap.PasswordModifyRequest) error {
 	_, err := lc.conn.PasswordModify(pwdModifyRequest)
 	return err

--- a/internal/authentication/ldap_connection_factory_mock.go
+++ b/internal/authentication/ldap_connection_factory_mock.go
@@ -88,6 +88,21 @@ func (mr *MockLDAPConnectionMockRecorder) Modify(modifyRequest interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Modify", reflect.TypeOf((*MockLDAPConnection)(nil).Modify), modifyRequest)
 }
 
+// PasswordModify mocks base method
+func (m *MockLDAPConnection) PasswordModify(pwdModifyRequest *ldap.PasswordModifyRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PasswordModify", pwdModifyRequest)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PasswordModify indicates an expected call of PasswordModify
+func (mr *MockLDAPConnectionMockRecorder) PasswordModify(pwdModifyRequest interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PasswordModify", reflect.TypeOf((*MockLDAPConnection)(nil).Modify), pwdModifyRequest)
+}
+
+
 // StartTLS mocks base method
 func (m *MockLDAPConnection) StartTLS(config *tls.Config) error {
 	m.ctrl.T.Helper()

--- a/internal/authentication/ldap_connection_factory_mock.go
+++ b/internal/authentication/ldap_connection_factory_mock.go
@@ -102,7 +102,6 @@ func (mr *MockLDAPConnectionMockRecorder) PasswordModify(pwdModifyRequest interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PasswordModify", reflect.TypeOf((*MockLDAPConnection)(nil).Modify), pwdModifyRequest)
 }
 
-
 // StartTLS mocks base method
 func (m *MockLDAPConnection) StartTLS(config *tls.Config) error {
 	m.ctrl.T.Helper()

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -342,20 +342,25 @@ func (p *LDAPUserProvider) UpdatePassword(inputUsername string, newPassword stri
 		return fmt.Errorf("Unable to update password. Cause: %s", err)
 	}
 
-	modifyRequest := ldap.NewModifyRequest(profile.DN, nil)
-
 	switch p.configuration.Implementation {
 	case schema.LDAPImplementationActiveDirectory:
+		modifyRequest := ldap.NewModifyRequest(profile.DN, nil)
 		utf16 := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
 		// The password needs to be enclosed in quotes
 		// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6e803168-f140-4d23-b2d3-c3a8ab5917d2
 		pwdEncoded, _ := utf16.NewEncoder().String(fmt.Sprintf("\"%s\"", newPassword))
 		modifyRequest.Replace("unicodePwd", []string{pwdEncoded})
-	default:
-		modifyRequest.Replace("userPassword", []string{newPassword})
-	}
 
-	err = conn.Modify(modifyRequest)
+		err = conn.Modify(modifyRequest)
+	default:
+		modifyRequest := ldap.NewPasswordModifyRequest(
+			profile.DN,
+			"",
+			newPassword,
+		)
+
+		err = conn.PasswordModify(modifyRequest)
+	}
 
 	if err != nil {
 		return fmt.Errorf("Unable to update password. Cause: %s", err)

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -710,8 +710,9 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 	)
 
 	err := ldapClient.checkServer()
-	err := ldapClient.UpdatePassword("john", "password")
+	require.NoError(t, err)
 
+	err = ldapClient.UpdatePassword("john", "password")
 	require.NoError(t, err)
 }
 

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -677,7 +677,7 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil),
 
 		mockConn.EXPECT().
 			Search(gomock.Any()).

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -678,8 +678,8 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 				},
 			},
 		}, nil),
-		mockConn.EXPECT()
-			.Close(),
+		mockConn.EXPECT().
+			Close(),
 
 		mockFactory.EXPECT().
 			DialURL(gomock.Eq("ldap://127.0.0.1:389"), gomock.Any()).

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -665,19 +665,19 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 
 		mockConn.EXPECT().
 			Search(NewExtendedSearchRequestMatcher("(objectClass=*)", "", ldap.ScopeBaseObject, ldap.NeverDerefAliases, false, []string{ldapSupportedExtensionAttribute})).
-		Return(&ldap.SearchResult{
-			Entries: []*ldap.Entry{
-				{
-					DN: "",
-					Attributes: []*ldap.EntryAttribute{
-						{
-							Name:   ldapSupportedExtensionAttribute,
-							Values: []string{ldapOIDPasswdModifyExtension},
+			Return(&ldap.SearchResult{
+				Entries: []*ldap.Entry{
+					{
+						DN: "",
+						Attributes: []*ldap.EntryAttribute{
+							{
+								Name:   ldapSupportedExtensionAttribute,
+								Values: []string{ldapOIDPasswdModifyExtension},
+							},
 						},
 					},
 				},
-			},
-		}, nil),
+			}, nil),
 
 		mockFactory.EXPECT().
 			DialURL(gomock.Eq("ldap://127.0.0.1:389"), gomock.Any()).

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -678,7 +678,15 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 				},
 			},
 		}, nil),
+		mockConn.EXPECT()
+			.Close(),
 
+		mockFactory.EXPECT().
+			DialURL(gomock.Eq("ldap://127.0.0.1:389"), gomock.Any()).
+			Return(mockConn, nil),
+		mockConn.EXPECT().
+			Bind(gomock.Eq("cn=admin,dc=example,dc=com"), gomock.Eq("password")).
+			Return(nil),
 		mockConn.EXPECT().
 			Search(gomock.Any()).
 			Return(&ldap.SearchResult{

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -662,6 +662,23 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 		mockConn.EXPECT().
 			Bind(gomock.Eq("cn=admin,dc=example,dc=com"), gomock.Eq("password")).
 			Return(nil),
+
+		mockConn.EXPECT().
+			Search(NewExtendedSearchRequestMatcher("(objectClass=*)", "", ldap.ScopeBaseObject, ldap.NeverDerefAliases, false, []string{ldapSupportedExtensionAttribute})).
+		Return(&ldap.SearchResult{
+			Entries: []*ldap.Entry{
+				{
+					DN: "",
+					Attributes: []*ldap.EntryAttribute{
+						{
+							Name:   ldapSupportedExtensionAttribute,
+							Values: []string{ldapOIDPasswdModifyExtension},
+						},
+					},
+				},
+			},
+		}, nil)
+
 		mockConn.EXPECT().
 			Search(gomock.Any()).
 			Return(&ldap.SearchResult{
@@ -692,6 +709,7 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 			Close(),
 	)
 
+	err := ldapClient.checkServer()
 	err := ldapClient.UpdatePassword("john", "password")
 
 	require.NoError(t, err)

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -649,8 +649,11 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 		nil,
 		mockFactory)
 
-	modifyRequest := ldap.NewModifyRequest("uid=test,dc=example,dc=com", nil)
-	modifyRequest.Replace("userPassword", []string{"password"})
+	pwdModifyRequest := ldap.NewPasswordModifyRequest(
+		"uid=test,dc=example,dc=com",
+		"",
+		"password",
+	)
 
 	gomock.InOrder(
 		mockFactory.EXPECT().
@@ -683,7 +686,7 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 				},
 			}, nil),
 		mockConn.EXPECT().
-			Modify(modifyRequest).
+			PasswordModify(pwdModifyRequest).
 			Return(nil),
 		mockConn.EXPECT().
 			Close(),

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -678,8 +678,6 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 				},
 			},
 		}, nil),
-		mockConn.EXPECT().
-			Close(),
 
 		mockFactory.EXPECT().
 			DialURL(gomock.Eq("ldap://127.0.0.1:389"), gomock.Any()).


### PR DESCRIPTION
This was tested for OpenLDAP, I am unable to test for ActiveDirectory.