### PR TITLE
fix(suites): disable cgo for delve during development

### DIFF
--- a/internal/suites/example/compose/authelia/resources/run-backend-dev.sh
+++ b/internal/suites/example/compose/authelia/resources/run-backend-dev.sh
@@ -4,6 +4,6 @@ set -e
 
 while true;
 do
-    dlv --listen 0.0.0.0:2345 --headless=true --output=./authelia --continue --accept-multiclient debug cmd/authelia/*.go -- --config /config/configuration.yml
+    CGO_ENABLED=0 dlv --listen 0.0.0.0:2345 --headless=true --output=./authelia --continue --accept-multiclient debug cmd/authelia/*.go -- --config /config/configuration.yml
     sleep 10
 done


### PR DESCRIPTION
following #2101 I was receiving the following error when using the authelia scripts suite for developing
```
[00] # runtime/cgo
[00] cgo: exec gcc: exec: "gcc": executable file not found in $PATH
```
adding the CGO_ENABLED=0 before the dlv build command fixes the issue
must have been overlooked :)