### PR TITLE
feat(authentiation): check ldap support for extended operations on startup

### DIFF
--- a/cmd/authelia/main.go
+++ b/cmd/authelia/main.go
@@ -94,13 +94,19 @@ func startServer() {
 		logger.Fatalf("Unrecognized storage backend")
 	}
 
-	var userProvider authentication.UserProvider
+	var (
+		userProvider authentication.UserProvider
+		err          error
+	)
 
 	switch {
 	case config.AuthenticationBackend.File != nil:
 		userProvider = authentication.NewFileUserProvider(config.AuthenticationBackend.File)
 	case config.AuthenticationBackend.LDAP != nil:
-		userProvider = authentication.NewLDAPUserProvider(*config.AuthenticationBackend.LDAP, autheliaCertPool)
+		userProvider, err = authentication.NewLDAPUserProvider(*config.AuthenticationBackend.LDAP, autheliaCertPool)
+		if err != nil {
+			logger.Fatalf("Failed to Check LDAP Authentication Backend: %v", err)
+		}
 	default:
 		logger.Fatalf("Unrecognized authentication backend")
 	}
@@ -117,7 +123,7 @@ func startServer() {
 	}
 
 	if !config.Notifier.DisableStartupCheck {
-		_, err := notifier.StartupCheck()
+		_, err = notifier.StartupCheck()
 		if err != nil {
 			logger.Fatalf("Error during notifier startup check: %s", err)
 		}

--- a/internal/authentication/const.go
+++ b/internal/authentication/const.go
@@ -26,8 +26,8 @@ const (
 )
 
 const (
-	ldapSupportedExtensionsAttribute = "supportedExtension"
-	ldapOIDPasswdModifyExtension     = "1.3.6.1.4.1.4203.1.11.3"
+	ldapSupportedExtensionAttribute = "supportedExtension"
+	ldapOIDPasswdModifyExtension    = "1.3.6.1.4.1.4203.1.11.3"
 )
 
 // PossibleMethods is the set of all possible 2FA methods.

--- a/internal/authentication/const.go
+++ b/internal/authentication/const.go
@@ -25,6 +25,11 @@ const (
 	Push = "mobile_push"
 )
 
+const (
+	ldapSupportedExtensionsAttribute = "supportedExtension"
+	ldapOIDPasswdModifyExtension     = "1.3.6.1.4.1.4203.1.11.3"
+)
+
 // PossibleMethods is the set of all possible 2FA methods.
 var PossibleMethods = []string{TOTP, U2F, Push}
 

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -107,20 +107,20 @@ func (p *LDAPUserProvider) checkServer() (err error) {
 	}
 
 	searchRequest := ldap.NewSearchRequest("", ldap.ScopeBaseObject, ldap.NeverDerefAliases,
-		1, 0, false, "(objectClass=*)", []string{ldapSupportedExtensionsAttribute}, nil)
+		1, 0, false, "(objectClass=*)", []string{ldapSupportedExtensionAttribute}, nil)
 
 	sr, err := conn.Search(searchRequest)
 	if err != nil {
 		return err
 	}
 
-	if len(sr.Entries) == 0 {
+	if len(sr.Entries) != 1 {
 		return nil
 	}
 
 	// Iterate the attribute values to see what the server supports.
 	for _, attr := range sr.Entries[0].Attributes {
-		if attr.Name == ldapSupportedExtensionsAttribute {
+		if attr.Name == ldapSupportedExtensionAttribute {
 			p.logger.Tracef("LDAP Supported Extension OIDs: %s", strings.Join(attr.Values, ", "))
 
 			for _, oid := range attr.Values {
@@ -129,6 +129,8 @@ func (p *LDAPUserProvider) checkServer() (err error) {
 					break
 				}
 			}
+
+			break
 		}
 	}
 

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -30,7 +30,7 @@ type LDAPUserProvider struct {
 
 // NewLDAPUserProvider creates a new instance of LDAPUserProvider.
 func NewLDAPUserProvider(configuration schema.LDAPAuthenticationBackendConfiguration, certPool *x509.CertPool) (provider *LDAPUserProvider, err error) {
-	provider = newLDAPUserProvider(configuration, certPool, NewLDAPConnectionFactoryImpl())
+	provider = newLDAPUserProvider(configuration, certPool, nil)
 
 	err = provider.checkServer()
 	if err != nil {
@@ -46,13 +46,6 @@ func NewLDAPUserProvider(configuration schema.LDAPAuthenticationBackendConfigura
 	return provider, nil
 }
 
-// NewLDAPUserProviderWithFactory creates a new instance of LDAPUserProvider with existing factory.
-func NewLDAPUserProviderWithFactory(configuration schema.LDAPAuthenticationBackendConfiguration, certPool *x509.CertPool, connectionFactory LDAPConnectionFactory) *LDAPUserProvider {
-	provider := newLDAPUserProvider(configuration, certPool, connectionFactory)
-
-	return provider
-}
-
 func newLDAPUserProvider(configuration schema.LDAPAuthenticationBackendConfiguration, certPool *x509.CertPool, factory LDAPConnectionFactory) (provider *LDAPUserProvider) {
 	if configuration.TLS == nil {
 		configuration.TLS = schema.DefaultLDAPAuthenticationBackendConfiguration.TLS
@@ -64,6 +57,10 @@ func newLDAPUserProvider(configuration schema.LDAPAuthenticationBackendConfigura
 
 	if tlsConfig != nil {
 		dialOpts = ldap.DialWithTLSConfig(tlsConfig)
+	}
+
+	if factory == nil {
+		factory = NewLDAPConnectionFactoryImpl()
 	}
 
 	provider = &LDAPUserProvider{

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -129,7 +129,6 @@ func (p *LDAPUserProvider) checkServer() (err error) {
 			for _, oid := range attr.Values {
 				if oid == ldapOIDPasswdModifyExtension {
 					p.supportExtensionPasswdModify = true
-
 					break
 				}
 			}

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -24,10 +24,36 @@ type LDAPUserProvider struct {
 	connectionFactory LDAPConnectionFactory
 	usersBaseDN       string
 	groupsBaseDN      string
+
+	supportExtensionPasswdModify bool
 }
 
 // NewLDAPUserProvider creates a new instance of LDAPUserProvider.
-func NewLDAPUserProvider(configuration schema.LDAPAuthenticationBackendConfiguration, certPool *x509.CertPool) *LDAPUserProvider {
+func NewLDAPUserProvider(configuration schema.LDAPAuthenticationBackendConfiguration, certPool *x509.CertPool) (provider *LDAPUserProvider, err error) {
+	provider = newLDAPUserProvider(configuration, certPool, NewLDAPConnectionFactoryImpl())
+
+	err = provider.checkServer()
+	if err != nil {
+		return provider, err
+	}
+
+	if provider.supportExtensionPasswdModify {
+		provider.logger.Trace("LDAP Server does support passwdModifyOID Extension")
+	} else {
+		provider.logger.Trace("LDAP Server does not support passwdModifyOID Extension")
+	}
+
+	return provider, nil
+}
+
+// NewLDAPUserProviderWithFactory creates a new instance of LDAPUserProvider with existing factory.
+func NewLDAPUserProviderWithFactory(configuration schema.LDAPAuthenticationBackendConfiguration, certPool *x509.CertPool, connectionFactory LDAPConnectionFactory) *LDAPUserProvider {
+	provider := newLDAPUserProvider(configuration, certPool, connectionFactory)
+
+	return provider
+}
+
+func newLDAPUserProvider(configuration schema.LDAPAuthenticationBackendConfiguration, certPool *x509.CertPool, factory LDAPConnectionFactory) (provider *LDAPUserProvider) {
 	if configuration.TLS == nil {
 		configuration.TLS = schema.DefaultLDAPAuthenticationBackendConfiguration.TLS
 	}
@@ -40,23 +66,15 @@ func NewLDAPUserProvider(configuration schema.LDAPAuthenticationBackendConfigura
 		dialOpts = ldap.DialWithTLSConfig(tlsConfig)
 	}
 
-	provider := &LDAPUserProvider{
+	provider = &LDAPUserProvider{
 		configuration:     configuration,
 		tlsConfig:         tlsConfig,
 		dialOpts:          dialOpts,
 		logger:            logging.Logger(),
-		connectionFactory: NewLDAPConnectionFactoryImpl(),
+		connectionFactory: factory,
 	}
 
 	provider.parseDynamicConfiguration()
-
-	return provider
-}
-
-// NewLDAPUserProviderWithFactory creates a new instance of LDAPUserProvider with existing factory.
-func NewLDAPUserProviderWithFactory(configuration schema.LDAPAuthenticationBackendConfiguration, certPool *x509.CertPool, connectionFactory LDAPConnectionFactory) *LDAPUserProvider {
-	provider := NewLDAPUserProvider(configuration, certPool)
-	provider.connectionFactory = connectionFactory
 
 	return provider
 }
@@ -83,6 +101,42 @@ func (p *LDAPUserProvider) parseDynamicConfiguration() {
 	}
 
 	p.logger.Tracef("Dynamically generated groups BaseDN is %s", p.groupsBaseDN)
+}
+
+func (p *LDAPUserProvider) checkServer() (err error) {
+	conn, err := p.connect(p.configuration.User, p.configuration.Password)
+	if err != nil {
+		return err
+	}
+
+	searchRequest := ldap.NewSearchRequest("", ldap.ScopeBaseObject, ldap.NeverDerefAliases,
+		1, 0, false, "(objectClass=*)", []string{ldapSupportedExtensionsAttribute}, nil)
+
+	sr, err := conn.Search(searchRequest)
+	if err != nil {
+		return err
+	}
+
+	if len(sr.Entries) == 0 {
+		return nil
+	}
+
+	// Iterate the attribute values to see what the server supports.
+	for _, attr := range sr.Entries[0].Attributes {
+		if attr.Name == ldapSupportedExtensionsAttribute {
+			p.logger.Tracef("LDAP Supported Extension OIDs: %s", strings.Join(attr.Values, ", "))
+
+			for _, oid := range attr.Values {
+				if oid == ldapOIDPasswdModifyExtension {
+					p.supportExtensionPasswdModify = true
+
+					break
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (p *LDAPUserProvider) connect(userDN string, password string) (LDAPConnection, error) {

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -186,14 +186,14 @@ func TestShouldCheckLDAPServerExtensions(t *testing.T) {
 		Return(nil)
 
 	mockConn.EXPECT().
-		Search(NewExtendedSearchRequestMatcher("(objectClass=*)", "", ldap.ScopeBaseObject, ldap.NeverDerefAliases, false, []string{ldapSupportedExtensionsAttribute})).
+		Search(NewExtendedSearchRequestMatcher("(objectClass=*)", "", ldap.ScopeBaseObject, ldap.NeverDerefAliases, false, []string{ldapSupportedExtensionAttribute})).
 		Return(&ldap.SearchResult{
 			Entries: []*ldap.Entry{
 				{
 					DN: "",
 					Attributes: []*ldap.EntryAttribute{
 						{
-							Name:   ldapSupportedExtensionsAttribute,
+							Name:   ldapSupportedExtensionAttribute,
 							Values: []string{ldapOIDPasswdModifyExtension},
 						},
 					},
@@ -238,14 +238,14 @@ func TestShouldNotEnablePasswdModifyExtension(t *testing.T) {
 		Return(nil)
 
 	mockConn.EXPECT().
-		Search(NewExtendedSearchRequestMatcher("(objectClass=*)", "", ldap.ScopeBaseObject, ldap.NeverDerefAliases, false, []string{ldapSupportedExtensionsAttribute})).
+		Search(NewExtendedSearchRequestMatcher("(objectClass=*)", "", ldap.ScopeBaseObject, ldap.NeverDerefAliases, false, []string{ldapSupportedExtensionAttribute})).
 		Return(&ldap.SearchResult{
 			Entries: []*ldap.Entry{
 				{
 					DN: "",
 					Attributes: []*ldap.EntryAttribute{
 						{
-							Name:   ldapSupportedExtensionsAttribute,
+							Name:   ldapSupportedExtensionAttribute,
 							Values: []string{},
 						},
 					},
@@ -322,7 +322,7 @@ func TestShouldReturnCheckServerSearchError(t *testing.T) {
 		Return(nil)
 
 	mockConn.EXPECT().
-		Search(NewExtendedSearchRequestMatcher("(objectClass=*)", "", ldap.ScopeBaseObject, ldap.NeverDerefAliases, false, []string{ldapSupportedExtensionsAttribute})).
+		Search(NewExtendedSearchRequestMatcher("(objectClass=*)", "", ldap.ScopeBaseObject, ldap.NeverDerefAliases, false, []string{ldapSupportedExtensionAttribute})).
 		Return(nil, errors.New("could not perform the search"))
 
 	err := ldapClient.checkServer()

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -21,7 +21,7 @@ func TestShouldCreateRawConnectionWhenSchemeIsLDAP(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL: "ldap://127.0.0.1:389",
 		},
@@ -48,7 +48,7 @@ func TestShouldCreateTLSConnectionWhenSchemeIsLDAPS(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL: "ldaps://127.0.0.1:389",
 		},
@@ -74,7 +74,7 @@ func TestEscapeSpecialCharsFromUserInput(t *testing.T) {
 
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL: "ldaps://127.0.0.1:389",
 		},
@@ -105,7 +105,7 @@ func TestEscapeSpecialCharsInGroupsFilter(t *testing.T) {
 
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:          "ldaps://127.0.0.1:389",
 			GroupsFilter: "(|(member={dn})(uid={username})(uid={input}))",
@@ -162,7 +162,7 @@ func TestShouldCheckLDAPServerExtensions(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -214,7 +214,7 @@ func TestShouldNotEnablePasswdModifyExtension(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -266,7 +266,7 @@ func TestShouldReturnCheckServerConnectError(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -298,7 +298,7 @@ func TestShouldReturnCheckServerSearchError(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -355,7 +355,7 @@ func TestShouldEscapeUserInput(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -387,7 +387,7 @@ func TestShouldCombineUsernameFilterAndUsersFilter(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -432,7 +432,7 @@ func TestShouldNotCrashWhenGroupsAreNotRetrievedFromLDAP(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -503,7 +503,7 @@ func TestShouldNotCrashWhenEmailsAreNotRetrievedFromLDAP(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:               "ldap://127.0.0.1:389",
 			User:              "cn=admin,dc=example,dc=com",
@@ -563,7 +563,7 @@ func TestShouldReturnUsernameFromLDAP(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -634,7 +634,7 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -701,7 +701,7 @@ func TestShouldCheckValidUserPassword(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -769,7 +769,7 @@ func TestShouldCheckInvalidUserPassword(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -837,7 +837,7 @@ func TestShouldCallStartTLSWhenEnabled(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -911,7 +911,7 @@ func TestShouldParseDynamicConfiguration(t *testing.T) {
 
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -942,7 +942,7 @@ func TestShouldCallStartTLSWithInsecureSkipVerifyWhenSkipVerifyTrue(t *testing.T
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldap://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",
@@ -1020,7 +1020,7 @@ func TestShouldReturnLDAPSAlreadySecuredWhenStartTLSAttempted(t *testing.T) {
 	mockFactory := NewMockLDAPConnectionFactory(ctrl)
 	mockConn := NewMockLDAPConnection(ctrl)
 
-	ldapClient := NewLDAPUserProviderWithFactory(
+	ldapClient := newLDAPUserProvider(
 		schema.LDAPAuthenticationBackendConfiguration{
 			URL:                  "ldaps://127.0.0.1:389",
 			User:                 "cn=admin,dc=example,dc=com",


### PR DESCRIPTION
This PR adds a startup check to the LDAP authentication backend. It additionally adds support for checking supportedExtension OIDs, currently only checking passwdModifyOID (1.3.6.1.4.1.4203.1.11.3). This can relatively easily be enhanced to add detection for other rootDSE capabilities like supportedControl and supportedCapabilities as necessary.