### PR TITLE
feat(authentication): ldap user groups attribute searching

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -209,6 +209,11 @@ authentication_backend:
     ## The attribute holding the display name of the user. This will be used to greet an authenticated user.
     # display_name_attribute: displayname
 
+    ## The groups_attribute value should not be set under normal circumstances. This must not be set at the same time
+    ## as the groups_filter, and is used specifically for LDAP instances that both support the attribute and do not
+    ## support another means to obtain a list of users groups such as FreeIPA.
+    # groups_attribute: memberOf
+
     ## The username and password of the admin user.
     user: cn=admin,dc=example,dc=com
     ## Password can also be set using a secret: https://www.authelia.com/docs/configuration/secrets.html

--- a/config.template.yml
+++ b/config.template.yml
@@ -123,7 +123,8 @@ authentication_backend:
     ## The LDAP implementation, this affects elements like the attribute utilised for resetting a password.
     ## Acceptable options are as follows:
     ## - 'activedirectory' - For Microsoft Active Directory.
-    ## - 'custom' - For custom specifications of attributes and filters.
+    ## - 'freeipa'         - For FreeIPA.
+    ## - 'custom'          - For custom specifications of attributes and filters.
     ## This currently defaults to 'custom' to maintain existing behaviour.
     ##
     ## Depending on the option here certain other values in this section have a default value, notably all of the
@@ -155,7 +156,7 @@ authentication_backend:
     base_dn: dc=example,dc=com
 
     ## The attribute holding the username of the user. This attribute is used to populate the username in the session
-    ## information. It was introduced due to #561 to handle case insensitive search queries. For you information,
+    ## information. It was introduced due to #561 to handle case-insensitive search queries. For you information,
     ## Microsoft Active Directory usually uses 'sAMAccountName' and OpenLDAP usually uses 'uid'. Beware that this
     ## attribute holds the unique identifiers for the users binding the user and the configuration stored in database.
     ## Therefore only single value attributes are allowed and the value must never be changed once attributed to a user
@@ -196,8 +197,8 @@ authentication_backend:
     ## - {mail_attribute} is a placeholder replaced by what is configured in `mail_attribute`.
     ##
     ## If your groups use the `groupOfUniqueNames` structure use this instead:
-    ##    (&(uniquemember={dn})(objectclass=groupOfUniqueNames))
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    ##    (&(uniquemember={dn})(objectClass=groupOfUniqueNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
 
     ## The attribute holding the name of the group.
     # group_name_attribute: cn
@@ -207,7 +208,11 @@ authentication_backend:
     # mail_attribute: mail
 
     ## The attribute holding the display name of the user. This will be used to greet an authenticated user.
-    # display_name_attribute: displayname
+    # display_name_attribute: displayName
+
+    ## The attribute holding the distinguished name of objects. This is currently only used when groups attribute is
+    ## used.
+    # distinguished_name_attribute: dn
 
     ## The groups_attribute value should not be set under normal circumstances. This must not be set at the same time
     ## as the groups_filter, and is used specifically for LDAP instances that both support the attribute and do not

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -32,6 +32,7 @@ authentication_backend:
     groups_filter: (&(member={dn})(objectclass=groupOfNames))
     group_name_attribute: cn
     mail_attribute: mail
+    groups_attribute: ""
     display_name_attribute: displayname
     user: cn=admin,dc=example,dc=com
     password: password
@@ -166,6 +167,12 @@ register a second factor device.
 
 The attribute to retrieve which is shown on the Web UI to the user when they log in.
 
+### groups_attribute
+
+This is a special attribute on user objects that contains a list of the distinguishedNames of the groups they are a
+member of. This cannot be set at the same time as the [groups filter](#groups_filter). Both [base dn](#base_dn) and
+the [additional groups dn](#additional_groups_dn) are still used for the search base.
+
 ### user
 
 The distinguished name of the user paired with the password to bind with for lookup and password change operations.
@@ -177,7 +184,7 @@ Can also be defined using a [secret](../secrets.md) which is the recommended for
 
 ## Implementation Guide
 
-There are currently two implementations, `custom` and `activedirectory`. The `activedirectory` implementation
+The current implementations are `custom`, `freeipa`, and `activedirectory`. The `activedirectory` implementation
 must be used if you wish to allow users to change or reset their password as Active Directory
 uses a custom attribute for this, and an input format other implementations do not use. The long term
 intention of this is to have logical defaults for various RFC implementations of LDAP.
@@ -187,13 +194,15 @@ intention of this is to have logical defaults for various RFC implementations of
 The below tables describes the current attribute defaults for each implementation.
 
 #### Attribute defaults
+
 This table describes the attribute defaults for each implementation. i.e. the username_attribute is
 described by the Username column.
 
-|Implementation |Username      |Display Name|Mail|Group Name|
-|:-------------:|:------------:|:----------:|:--:|:--------:|
-|custom         |n/a           |displayname |mail|cn        |
-|activedirectory|sAMAccountName|displayname |mail|cn        |
+|Implementation |Username      |Display Name|Mail|Group Name|Groups  |
+|:-------------:|:------------:|:----------:|:--:|:--------:|:------:|
+|custom         |n/a           |displayname |mail|cn        |N/A     |
+|activedirectory|sAMAccountName|displayName |mail|cn        |N/A     |
+|freeipa        |uid           |displayName |mail|cn        |memberOf|
 
 #### Filter defaults
 
@@ -207,7 +216,7 @@ makes sure that value is not 0 which means the password requires changing at the
 |:-------------:|:------------:|:-----------:|
 |custom         |n/a           |n/a       |
 |activedirectory|(&(&#124;({username_attribute}={input})({mail_attribute}={input}))(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2)(!pwdLastSet=0))|(&(member={dn})(objectClass=group)(objectCategory=group))|
-
+|freeipa        |(&(&#124;({username_attribute}={input})({mail_attribute}={input}))(objectClass=inetorgperson))|N/A|
 
 ## Refresh Interval
 

--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -29,11 +29,12 @@ authentication_backend:
     additional_users_dn: ou=users
     users_filter: (&({username_attribute}={input})(objectClass=person))
     additional_groups_dn: ou=groups
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
     group_name_attribute: cn
     mail_attribute: mail
+    display_name_attribute: displayName
+    distinguished_name_attribute: dn
     groups_attribute: ""
-    display_name_attribute: displayname
     user: cn=admin,dc=example,dc=com
     password: password
 ```
@@ -144,10 +145,22 @@ The default value is dependent on the [implementation](#implementation), refer t
 [attribute defaults](#attribute-defaults) for more information.
 
 ### additional_groups_dn
+<div markdown="1">
+type: string
+{: .label .label-config .label-purple }
+required: no
+{: .label .label-config .label-green }
+</div>
 
 Similar to [additional_users_dn](#additional_users_dn) but it applies to group searches.
 
 ### groups_filter
+<div markdown="1">
+type: string
+{: .label .label-config .label-purple }
+required: yes
+{: .label .label-config .label-red }
+</div>
 
 Similar to [users_filter](#users_filter) but it applies to group searches. In order to include groups the memeber is not
 a direct member of, but is a member of another group that is a member of those (i.e. recursive groups), you may try
@@ -156,6 +169,12 @@ using the following filter which is currently only tested against Microsoft Acti
 `(&(member:1.2.840.113556.1.4.1941:={dn})(objectClass=group)(objectCategory=group))`
 
 ### mail_attribute
+<div markdown="1">
+type: string
+{: .label .label-config .label-purple }
+required: no
+{: .label .label-config .label-green }
+</div>
 
 The attribute to retrieve which contains the users email addresses. This is important for the device registration and
 password reset processes.
@@ -164,10 +183,33 @@ identity verification when a user attempts to reset their password or
 register a second factor device.
 
 ### display_name_attribute
+<div markdown="1">
+type: string
+{: .label .label-config .label-purple }
+required: no
+{: .label .label-config .label-green }
+</div>
 
 The attribute to retrieve which is shown on the Web UI to the user when they log in.
 
+### distinguished_name_attribute
+<div markdown="1">
+type: string
+{: .label .label-config .label-purple }
+required: no
+{: .label .label-config .label-green }
+</div>
+
+This attribute is used to define the distinguished name attribute when used in sub searches that require it. The only
+current example of this is when the [groups attribute](#groups_attribute) is configured.
+
 ### groups_attribute
+<div markdown="1">
+type: string
+{: .label .label-config .label-purple }
+required: no
+{: .label .label-config .label-green }
+</div>
 
 This is a special attribute on user objects that contains a list of the distinguishedNames of the groups they are a
 member of. This cannot be set at the same time as the [groups filter](#groups_filter). Both [base dn](#base_dn) and
@@ -198,11 +240,23 @@ The below tables describes the current attribute defaults for each implementatio
 This table describes the attribute defaults for each implementation. i.e. the username_attribute is
 described by the Username column.
 
-|Implementation |Username      |Display Name|Mail|Group Name|Groups  |
-|:-------------:|:------------:|:----------:|:--:|:--------:|:------:|
-|custom         |n/a           |displayname |mail|cn        |N/A     |
-|activedirectory|sAMAccountName|displayName |mail|cn        |N/A     |
-|freeipa        |uid           |displayName |mail|cn        |memberOf|
+**Common:** 
+
+|Implementation |Username      |Display Name|Mail |Group Name|
+|:-------------:|:------------:|:----------:|:---:|:--------:|
+|custom         |N/A           |displayName |mail |cn        |
+|activedirectory|sAMAccountName|displayName |mail |cn        |
+|freeipa        |uid           |displayName |mail |cn        |
+
+
+**Uncommon:**
+
+|Implementation |Groups  |Distinguished Name|
+|:-------------:|:------:|:----------------:|
+|custom         |N/A     |dn                |
+|activedirectory|N/A     |distinguishedName |
+|freeipa        |memberOf|dn                |
+
 
 #### Filter defaults
 
@@ -214,15 +268,15 @@ makes sure that value is not 0 which means the password requires changing at the
 
 |Implementation |Users Filter  |Groups Filter|
 |:-------------:|:------------:|:-----------:|
-|custom         |n/a           |n/a       |
+|custom         |N/A           |N/A          |
 |activedirectory|(&(&#124;({username_attribute}={input})({mail_attribute}={input}))(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2)(!pwdLastSet=0))|(&(member={dn})(objectClass=group)(objectCategory=group))|
-|freeipa        |(&(&#124;({username_attribute}={input})({mail_attribute}={input}))(objectClass=inetorgperson))|N/A|
+|freeipa        |(&(&#124;({username_attribute}={input})({mail_attribute}={input}))(objectClass=inetOrgPerson))|N/A|
 
 ## Refresh Interval
 
 This setting takes a [duration notation](../index.md#duration-notation-format) that sets the max frequency
 for how often Authelia contacts the backend to verify the user still exists and that the groups stored
-in the session are up to date. This allows us to destroy sessions when the user no longer matches the
+in the session are up-to-date. This allows us to destroy sessions when the user no longer matches the
 user_filter, or deny access to resources as they are removed from groups.
 
 In addition to the duration notation, you may provide the value `always` or `disable`. Setting to `always`

--- a/internal/authentication/const.go
+++ b/internal/authentication/const.go
@@ -56,11 +56,10 @@ const (
 // HashingPossibleSaltCharacters represents valid hashing runes.
 var HashingPossibleSaltCharacters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/")
 
-// ErrUserNotFound indicates the user wasn't found in the authentication backend.
-var ErrUserNotFound = errors.New("user not found")
-
-const argon2id = "argon2id"
-const sha512 = "sha512"
+const (
+	argon2id = "argon2id"
+	sha512   = "sha512"
+)
 
 const testPassword = "my;secure*password"
 
@@ -69,3 +68,10 @@ const fileAuthenticationMode = 0600
 // OWASP recommends to escape some special characters.
 // https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md
 const specialLDAPRunes = ",#+<>;\"="
+
+var (
+	// ErrUserNotFound indicates the user wasn't found in the authentication backend.
+	ErrUserNotFound = errors.New("user not found")
+
+	errEmptyGroupsFilter = errors.New("empty groups filter")
+)

--- a/internal/authentication/ldap_helpers.go
+++ b/internal/authentication/ldap_helpers.go
@@ -1,0 +1,15 @@
+package authentication
+
+import "fmt"
+
+func ldapBuildGroupsFilterFromGroupsAttribute(groups []string, distinguishedNameAttribute string) (filter string) {
+	for _, group := range groups {
+		filter += fmt.Sprintf("(%s=%s)", distinguishedNameAttribute, group)
+	}
+
+	if filter == "" {
+		return filter
+	}
+
+	return fmt.Sprintf("(|%s)", filter)
+}

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -278,6 +278,8 @@ func (p *LDAPUserProvider) resolveGroupsFilter(inputUsername string, profile *ld
 	if p.configuration.GroupsAttribute != "" {
 		filter = ldapBuildGroupsFilterFromGroupsAttribute(profile.Groups, p.configuration.DistinguishedNameAttribute)
 
+		p.logger.Tracef("Computed groups filter is %s", filter)
+
 		if filter == "" {
 			return filter, errEmptyGroupsFilter
 		}
@@ -288,16 +290,16 @@ func (p *LDAPUserProvider) resolveGroupsFilter(inputUsername string, profile *ld
 	inputUsername = p.ldapEscape(inputUsername)
 
 	// The {input} placeholder is replaced by the users username input.
-	groupFilter := strings.ReplaceAll(p.configuration.GroupsFilter, "{input}", inputUsername)
+	filter = strings.ReplaceAll(p.configuration.GroupsFilter, "{input}", inputUsername)
 
 	if profile != nil {
-		groupFilter = strings.ReplaceAll(groupFilter, "{username}", ldap.EscapeFilter(profile.Username))
-		groupFilter = strings.ReplaceAll(groupFilter, "{dn}", ldap.EscapeFilter(profile.DN))
+		filter = strings.ReplaceAll(filter, "{username}", ldap.EscapeFilter(profile.Username))
+		filter = strings.ReplaceAll(filter, "{dn}", ldap.EscapeFilter(profile.DN))
 	}
 
-	p.logger.Tracef("Computed groups filter is %s", groupFilter)
+	p.logger.Tracef("Computed groups filter is %s", filter)
 
-	return groupFilter, nil
+	return filter, nil
 }
 
 // GetDetails retrieve the groups a user belongs to.

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -120,7 +120,8 @@ func TestEscapeSpecialCharsInGroupsFilter(t *testing.T) {
 		Emails:      []string{"john.doe@authelia.com"},
 	}
 
-	filter, _ := ldapClient.resolveGroupsFilter("john", &profile)
+	filter, err := ldapClient.resolveGroupsFilter("john", &profile)
+	assert.NoError(t, err)
 	assert.Equal(t, "(|(member=cn=john \\28external\\29,dc=example,dc=com)(uid=john)(uid=john))", filter)
 
 	filter, _ = ldapClient.resolveGroupsFilter("john#=(abc,def)", &profile)

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -170,7 +170,7 @@ func TestShouldCheckLDAPServerExtensions(t *testing.T) {
 			UsersFilter:          "(|({username_attribute}={input})({mail_attribute}={input}))",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			Password:             "password",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -222,7 +222,7 @@ func TestShouldNotEnablePasswdModifyExtension(t *testing.T) {
 			UsersFilter:          "(|({username_attribute}={input})({mail_attribute}={input}))",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			Password:             "password",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -274,7 +274,7 @@ func TestShouldReturnCheckServerConnectError(t *testing.T) {
 			UsersFilter:          "(|({username_attribute}={input})({mail_attribute}={input}))",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			Password:             "password",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -306,7 +306,7 @@ func TestShouldReturnCheckServerSearchError(t *testing.T) {
 			UsersFilter:          "(|({username_attribute}={input})({mail_attribute}={input}))",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			Password:             "password",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -363,7 +363,7 @@ func TestShouldEscapeUserInput(t *testing.T) {
 			UsersFilter:          "(|({username_attribute}={input})({mail_attribute}={input}))",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			Password:             "password",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -398,7 +398,7 @@ func TestShouldCombineUsernameFilterAndUsersFilter(t *testing.T) {
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 		},
 		nil,
 		mockFactory)
@@ -440,7 +440,7 @@ func TestShouldNotCrashWhenGroupsAreNotRetrievedFromLDAP(t *testing.T) {
 			Password:             "password",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			UsersFilter:          "uid={input}",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -470,7 +470,7 @@ func TestShouldNotCrashWhenGroupsAreNotRetrievedFromLDAP(t *testing.T) {
 					DN: "uid=test,dc=example,dc=com",
 					Attributes: []*ldap.EntryAttribute{
 						{
-							Name:   "displayname",
+							Name:   "displayName",
 							Values: []string{"John Doe"},
 						},
 						{
@@ -571,7 +571,7 @@ func TestShouldReturnUsernameFromLDAP(t *testing.T) {
 			Password:             "password",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			UsersFilter:          "uid={input}",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -601,7 +601,7 @@ func TestShouldReturnUsernameFromLDAP(t *testing.T) {
 					DN: "uid=test,dc=example,dc=com",
 					Attributes: []*ldap.EntryAttribute{
 						{
-							Name:   "displayname",
+							Name:   "displayName",
 							Values: []string{"John Doe"},
 						},
 						{
@@ -642,7 +642,7 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 			Password:             "password",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			UsersFilter:          "uid={input}",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -694,7 +694,7 @@ func TestShouldUpdateUserPassword(t *testing.T) {
 						DN: "uid=test,dc=example,dc=com",
 						Attributes: []*ldap.EntryAttribute{
 							{
-								Name:   "displayname",
+								Name:   "displayName",
 								Values: []string{"John Doe"},
 							},
 							{
@@ -737,7 +737,7 @@ func TestShouldCheckValidUserPassword(t *testing.T) {
 			Password:             "password",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			UsersFilter:          "uid={input}",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -760,7 +760,7 @@ func TestShouldCheckValidUserPassword(t *testing.T) {
 						DN: "uid=test,dc=example,dc=com",
 						Attributes: []*ldap.EntryAttribute{
 							{
-								Name:   "displayname",
+								Name:   "displayName",
 								Values: []string{"John Doe"},
 							},
 							{
@@ -805,7 +805,7 @@ func TestShouldCheckInvalidUserPassword(t *testing.T) {
 			Password:             "password",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			UsersFilter:          "uid={input}",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -828,7 +828,7 @@ func TestShouldCheckInvalidUserPassword(t *testing.T) {
 						DN: "uid=test,dc=example,dc=com",
 						Attributes: []*ldap.EntryAttribute{
 							{
-								Name:   "displayname",
+								Name:   "displayName",
 								Values: []string{"John Doe"},
 							},
 							{
@@ -873,7 +873,7 @@ func TestShouldCallStartTLSWhenEnabled(t *testing.T) {
 			Password:             "password",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			UsersFilter:          "uid={input}",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -907,7 +907,7 @@ func TestShouldCallStartTLSWhenEnabled(t *testing.T) {
 					DN: "uid=test,dc=example,dc=com",
 					Attributes: []*ldap.EntryAttribute{
 						{
-							Name:   "displayname",
+							Name:   "displayName",
 							Values: []string{"John Doe"},
 						},
 						{
@@ -947,7 +947,7 @@ func TestShouldParseDynamicConfiguration(t *testing.T) {
 			Password:             "password",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			UsersFilter:          "(&(|({username_attribute}={input})({mail_attribute}={input})({display_name_attribute}={input}))(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2)(!pwdLastSet=0))",
 			GroupsFilter:         "(&(|(member={dn})(member={input})(member={username}))(objectClass=group))",
 			AdditionalUsersDN:    "ou=users",
@@ -958,7 +958,7 @@ func TestShouldParseDynamicConfiguration(t *testing.T) {
 		nil,
 		mockFactory)
 
-	assert.Equal(t, "(&(|(uid={input})(mail={input})(displayname={input}))(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2)(!pwdLastSet=0))", ldapClient.configuration.UsersFilter)
+	assert.Equal(t, "(&(|(uid={input})(mail={input})(displayName={input}))(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2)(!pwdLastSet=0))", ldapClient.configuration.UsersFilter)
 	assert.Equal(t, "(&(|(member={dn})(member={input})(member={username}))(objectClass=group))", ldapClient.configuration.GroupsFilter)
 	assert.Equal(t, "ou=users,dc=example,dc=com", ldapClient.usersBaseDN)
 	assert.Equal(t, "ou=groups,dc=example,dc=com", ldapClient.groupsBaseDN)
@@ -978,7 +978,7 @@ func TestShouldCallStartTLSWithInsecureSkipVerifyWhenSkipVerifyTrue(t *testing.T
 			Password:             "password",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			UsersFilter:          "uid={input}",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",
@@ -1015,7 +1015,7 @@ func TestShouldCallStartTLSWithInsecureSkipVerifyWhenSkipVerifyTrue(t *testing.T
 					DN: "uid=test,dc=example,dc=com",
 					Attributes: []*ldap.EntryAttribute{
 						{
-							Name:   "displayname",
+							Name:   "displayName",
 							Values: []string{"John Doe"},
 						},
 						{
@@ -1056,7 +1056,7 @@ func TestShouldReturnLDAPSAlreadySecuredWhenStartTLSAttempted(t *testing.T) {
 			Password:             "password",
 			UsernameAttribute:    "uid",
 			MailAttribute:        "mail",
-			DisplayNameAttribute: "displayname",
+			DisplayNameAttribute: "displayName",
 			UsersFilter:          "uid={input}",
 			AdditionalUsersDN:    "ou=users",
 			BaseDN:               "dc=example,dc=com",

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -209,6 +209,11 @@ authentication_backend:
     ## The attribute holding the display name of the user. This will be used to greet an authenticated user.
     # display_name_attribute: displayname
 
+    ## The groups_attribute value should not be set under normal circumstances. This must not be set at the same time
+    ## as the groups_filter, and is used specifically for LDAP instances that both support the attribute and do not
+    ## support another means to obtain a list of users groups such as FreeIPA.
+    # groups_attribute: memberOf
+
     ## The username and password of the admin user.
     user: cn=admin,dc=example,dc=com
     ## Password can also be set using a secret: https://www.authelia.com/docs/configuration/secrets.html

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -123,7 +123,8 @@ authentication_backend:
     ## The LDAP implementation, this affects elements like the attribute utilised for resetting a password.
     ## Acceptable options are as follows:
     ## - 'activedirectory' - For Microsoft Active Directory.
-    ## - 'custom' - For custom specifications of attributes and filters.
+    ## - 'freeipa'         - For FreeIPA.
+    ## - 'custom'          - For custom specifications of attributes and filters.
     ## This currently defaults to 'custom' to maintain existing behaviour.
     ##
     ## Depending on the option here certain other values in this section have a default value, notably all of the
@@ -155,7 +156,7 @@ authentication_backend:
     base_dn: dc=example,dc=com
 
     ## The attribute holding the username of the user. This attribute is used to populate the username in the session
-    ## information. It was introduced due to #561 to handle case insensitive search queries. For you information,
+    ## information. It was introduced due to #561 to handle case-insensitive search queries. For you information,
     ## Microsoft Active Directory usually uses 'sAMAccountName' and OpenLDAP usually uses 'uid'. Beware that this
     ## attribute holds the unique identifiers for the users binding the user and the configuration stored in database.
     ## Therefore only single value attributes are allowed and the value must never be changed once attributed to a user
@@ -196,8 +197,8 @@ authentication_backend:
     ## - {mail_attribute} is a placeholder replaced by what is configured in `mail_attribute`.
     ##
     ## If your groups use the `groupOfUniqueNames` structure use this instead:
-    ##    (&(uniquemember={dn})(objectclass=groupOfUniqueNames))
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    ##    (&(uniquemember={dn})(objectClass=groupOfUniqueNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
 
     ## The attribute holding the name of the group.
     # group_name_attribute: cn
@@ -207,7 +208,11 @@ authentication_backend:
     # mail_attribute: mail
 
     ## The attribute holding the display name of the user. This will be used to greet an authenticated user.
-    # display_name_attribute: displayname
+    # display_name_attribute: displayName
+
+    ## The attribute holding the distinguished name of objects. This is currently only used when groups attribute is
+    ## used.
+    # distinguished_name_attribute: dn
 
     ## The groups_attribute value should not be set under normal circumstances. This must not be set at the same time
     ## as the groups_filter, and is used specifically for LDAP instances that both support the attribute and do not

--- a/internal/configuration/schema/authentication.go
+++ b/internal/configuration/schema/authentication.go
@@ -2,21 +2,23 @@ package schema
 
 // LDAPAuthenticationBackendConfiguration represents the configuration related to LDAP server.
 type LDAPAuthenticationBackendConfiguration struct {
-	Implementation       string     `mapstructure:"implementation"`
-	URL                  string     `mapstructure:"url"`
-	BaseDN               string     `mapstructure:"base_dn"`
-	AdditionalUsersDN    string     `mapstructure:"additional_users_dn"`
-	UsersFilter          string     `mapstructure:"users_filter"`
-	AdditionalGroupsDN   string     `mapstructure:"additional_groups_dn"`
-	GroupsFilter         string     `mapstructure:"groups_filter"`
-	GroupNameAttribute   string     `mapstructure:"group_name_attribute"`
-	UsernameAttribute    string     `mapstructure:"username_attribute"`
-	MailAttribute        string     `mapstructure:"mail_attribute"`
-	DisplayNameAttribute string     `mapstructure:"display_name_attribute"`
-	User                 string     `mapstructure:"user"`
-	Password             string     `mapstructure:"password"`
-	StartTLS             bool       `mapstructure:"start_tls"`
-	TLS                  *TLSConfig `mapstructure:"tls"`
+	Implementation             string     `mapstructure:"implementation"`
+	URL                        string     `mapstructure:"url"`
+	BaseDN                     string     `mapstructure:"base_dn"`
+	AdditionalUsersDN          string     `mapstructure:"additional_users_dn"`
+	UsersFilter                string     `mapstructure:"users_filter"`
+	AdditionalGroupsDN         string     `mapstructure:"additional_groups_dn"`
+	GroupsFilter               string     `mapstructure:"groups_filter"`
+	GroupNameAttribute         string     `mapstructure:"group_name_attribute"`
+	UsernameAttribute          string     `mapstructure:"username_attribute"`
+	MailAttribute              string     `mapstructure:"mail_attribute"`
+	DisplayNameAttribute       string     `mapstructure:"display_name_attribute"`
+	DistinguishedNameAttribute string     `mapstructure:"distinguished_name_attribute"`
+	GroupsAttribute            string     `mapstructure:"groups_attribute"`
+	User                       string     `mapstructure:"user"`
+	Password                   string     `mapstructure:"password"`
+	StartTLS                   bool       `mapstructure:"start_tls"`
+	TLS                        *TLSConfig `mapstructure:"tls"`
 }
 
 // FileAuthenticationBackendConfiguration represents the configuration related to file-based backend.
@@ -72,11 +74,12 @@ var DefaultPasswordSHA512Configuration = PasswordConfiguration{
 
 // DefaultLDAPAuthenticationBackendConfiguration represents the default LDAP config.
 var DefaultLDAPAuthenticationBackendConfiguration = LDAPAuthenticationBackendConfiguration{
-	Implementation:       LDAPImplementationCustom,
-	UsernameAttribute:    "uid",
-	MailAttribute:        "mail",
-	DisplayNameAttribute: "displayname",
-	GroupNameAttribute:   "cn",
+	Implementation:             LDAPImplementationCustom,
+	UsernameAttribute:          "uid",
+	MailAttribute:              "mail",
+	DisplayNameAttribute:       "displayname",
+	DistinguishedNameAttribute: "dn",
+	GroupNameAttribute:         "cn",
 	TLS: &TLSConfig{
 		MinimumVersion: "TLS1.2",
 	},
@@ -84,10 +87,22 @@ var DefaultLDAPAuthenticationBackendConfiguration = LDAPAuthenticationBackendCon
 
 // DefaultLDAPAuthenticationBackendImplementationActiveDirectoryConfiguration represents the default LDAP config for the MSAD Implementation.
 var DefaultLDAPAuthenticationBackendImplementationActiveDirectoryConfiguration = LDAPAuthenticationBackendConfiguration{
-	UsersFilter:          "(&(|({username_attribute}={input})({mail_attribute}={input}))(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2)(!pwdLastSet=0))",
-	UsernameAttribute:    "sAMAccountName",
-	MailAttribute:        "mail",
-	DisplayNameAttribute: "displayName",
-	GroupsFilter:         "(&(member={dn})(objectClass=group))",
-	GroupNameAttribute:   "cn",
+	UsersFilter:                "(&(|({username_attribute}={input})({mail_attribute}={input}))(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2)(!pwdLastSet=0))",
+	UsernameAttribute:          "sAMAccountName",
+	MailAttribute:              "mail",
+	DisplayNameAttribute:       "displayName",
+	DistinguishedNameAttribute: "distinguishedName",
+	GroupsFilter:               "(&(member={dn})(objectClass=group))",
+	GroupNameAttribute:         "cn",
+}
+
+// DefaultLDAPAuthenticationBackendImplementationFreeIPAConfiguration represents the default LDAP config for the MSAD Implementation.
+var DefaultLDAPAuthenticationBackendImplementationFreeIPAConfiguration = LDAPAuthenticationBackendConfiguration{
+	UsersFilter:                "(&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=inetorgperson))",
+	UsernameAttribute:          "uid",
+	MailAttribute:              "mail",
+	DisplayNameAttribute:       "displayName",
+	DistinguishedNameAttribute: "dn",
+	GroupsAttribute:            "memberOf",
+	GroupNameAttribute:         "cn",
 }

--- a/internal/configuration/schema/authentication.go
+++ b/internal/configuration/schema/authentication.go
@@ -77,7 +77,7 @@ var DefaultLDAPAuthenticationBackendConfiguration = LDAPAuthenticationBackendCon
 	Implementation:             LDAPImplementationCustom,
 	UsernameAttribute:          "uid",
 	MailAttribute:              "mail",
-	DisplayNameAttribute:       "displayname",
+	DisplayNameAttribute:       "displayName",
 	DistinguishedNameAttribute: "dn",
 	GroupNameAttribute:         "cn",
 	TLS: &TLSConfig{
@@ -98,7 +98,7 @@ var DefaultLDAPAuthenticationBackendImplementationActiveDirectoryConfiguration =
 
 // DefaultLDAPAuthenticationBackendImplementationFreeIPAConfiguration represents the default LDAP config for the MSAD Implementation.
 var DefaultLDAPAuthenticationBackendImplementationFreeIPAConfiguration = LDAPAuthenticationBackendConfiguration{
-	UsersFilter:                "(&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=inetorgperson))",
+	UsersFilter:                "(&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=inetOrgPerson))",
 	UsernameAttribute:          "uid",
 	MailAttribute:              "mail",
 	DisplayNameAttribute:       "displayName",

--- a/internal/configuration/schema/const.go
+++ b/internal/configuration/schema/const.go
@@ -6,20 +6,29 @@ import (
 
 const argon2id = "argon2id"
 
-// ProfileRefreshDisabled represents a value for refresh_interval that disables the check entirely.
-const ProfileRefreshDisabled = "disable"
+const (
+	// ProfileRefreshDisabled represents a value for refresh_interval that disables the check entirely.
+	ProfileRefreshDisabled = "disable"
 
-// ProfileRefreshAlways represents a value for refresh_interval that's the same as 0ms.
-const ProfileRefreshAlways = "always"
+	// ProfileRefreshAlways represents a value for refresh_interval that's the same as 0ms.
+	ProfileRefreshAlways = "always"
+)
 
-// RefreshIntervalDefault represents the default value of refresh_interval.
-const RefreshIntervalDefault = "5m"
+const (
+	// RefreshIntervalDefault represents the default value of refresh_interval.
+	RefreshIntervalDefault = "5m"
 
-// RefreshIntervalAlways represents the duration value refresh interval should have if set to always.
-const RefreshIntervalAlways = 0 * time.Millisecond
+	// RefreshIntervalAlways represents the duration value refresh interval should have if set to always.
+	RefreshIntervalAlways = 0 * time.Millisecond
+)
 
-// LDAPImplementationCustom is the string for the custom LDAP implementation.
-const LDAPImplementationCustom = "custom"
+const (
+	// LDAPImplementationCustom is the string for the custom LDAP implementation.
+	LDAPImplementationCustom = "custom"
 
-// LDAPImplementationActiveDirectory is the string for the Active Directory LDAP implementation.
-const LDAPImplementationActiveDirectory = "activedirectory"
+	// LDAPImplementationActiveDirectory is the string for the Active Directory LDAP implementation.
+	LDAPImplementationActiveDirectory = "activedirectory"
+
+	// LDAPImplementationFreeIPA is the string for the FreeIPA LDAP implementation.
+	LDAPImplementationFreeIPA = "freeipa"
+)

--- a/internal/configuration/test_resources/config.yml
+++ b/internal/configuration/test_resources/config.yml
@@ -22,7 +22,7 @@ authentication_backend:
     additional_users_dn: ou=users
     users_filter: (&({username_attribute}={input})(objectCategory=person)(objectClass=user))
     additional_groups_dn: ou=groups
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
     group_name_attribute: cn
     mail_attribute: mail
     user: cn=admin,dc=example,dc=com

--- a/internal/configuration/test_resources/config_alt.yml
+++ b/internal/configuration/test_resources/config_alt.yml
@@ -22,7 +22,7 @@ authentication_backend:
     additional_users_dn: ou=users
     users_filter: (&({username_attribute}={input})(objectCategory=person)(objectClass=user))
     additional_groups_dn: ou=groups
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
     group_name_attribute: cn
     mail_attribute: mail
     user: cn=admin,dc=example,dc=com

--- a/internal/configuration/test_resources/config_bad_keys.yml
+++ b/internal/configuration/test_resources/config_bad_keys.yml
@@ -22,7 +22,7 @@ authentication_backend:
     additional_users_dn: ou=users
     users_filter: (&({username_attribute}={input})(objectCategory=person)(objectClass=user))
     additional_groups_dn: ou=groups
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
     group_name_attribute: cn
     mail_attribute: mail
     user: cn=admin,dc=example,dc=com

--- a/internal/configuration/test_resources/config_with_secret.yml
+++ b/internal/configuration/test_resources/config_with_secret.yml
@@ -23,7 +23,7 @@ authentication_backend:
     additional_users_dn: ou=users
     users_filter: (&({username_attribute}={input})(objectCategory=person)(objectClass=user))
     additional_groups_dn: ou=groups
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
     group_name_attribute: cn
     mail_attribute: mail
     user: cn=admin,dc=example,dc=com

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -123,7 +123,7 @@ func validateLDAPAuthenticationBackend(configuration *schema.LDAPAuthenticationB
 	case schema.LDAPImplementationFreeIPA:
 		setDefaultImplementationFreeIPALDAPAuthenticationBackend(configuration)
 	default:
-		validator.Push(fmt.Errorf("authentication backend ldap implementation must be blank or one of the following values `%s`, `%s`", schema.LDAPImplementationCustom, schema.LDAPImplementationActiveDirectory))
+		validator.Push(fmt.Errorf("authentication backend ldap implementation must be blank or one of the following values '%s', '%s', '%s'", schema.LDAPImplementationCustom, schema.LDAPImplementationActiveDirectory, schema.LDAPImplementationFreeIPA))
 	}
 
 	if strings.Contains(configuration.UsersFilter, "{0}") {

--- a/internal/configuration/validator/authentication_test.go
+++ b/internal/configuration/validator/authentication_test.go
@@ -387,7 +387,7 @@ func (suite *LDAPAuthenticationBackendSuite) TestShouldSetDefaultDisplayNameAttr
 	suite.Assert().False(suite.validator.HasWarnings())
 	suite.Assert().False(suite.validator.HasErrors())
 
-	suite.Assert().Equal("displayname", suite.configuration.LDAP.DisplayNameAttribute)
+	suite.Assert().Equal("displayName", suite.configuration.LDAP.DisplayNameAttribute)
 }
 
 func (suite *LDAPAuthenticationBackendSuite) TestShouldSetDefaultRefreshInterval() {

--- a/internal/configuration/validator/authentication_test.go
+++ b/internal/configuration/validator/authentication_test.go
@@ -35,6 +35,19 @@ func TestShouldRaiseErrorWhenNoBackendProvided(t *testing.T) {
 	assert.EqualError(t, validator.Errors()[0], "Please provide `ldap` or `file` object in `authentication_backend`")
 }
 
+func TestShouldSetFreeIPADefaults(t *testing.T) {
+	validator := schema.NewStructValidator()
+	backendConfig := &schema.AuthenticationBackendConfiguration{
+		LDAP: &schema.LDAPAuthenticationBackendConfiguration{
+			Implementation: schema.LDAPImplementationFreeIPA,
+		},
+	}
+
+	ValidateAuthenticationBackend(backendConfig, validator)
+
+	assert.Equal(t, "dn", backendConfig.LDAP.DistinguishedNameAttribute)
+}
+
 type FileBasedAuthenticationBackend struct {
 	suite.Suite
 	configuration schema.AuthenticationBackendConfiguration
@@ -249,7 +262,7 @@ func (suite *LDAPAuthenticationBackendSuite) TestShouldRaiseErrorWhenImplementat
 	suite.Assert().False(suite.validator.HasWarnings())
 	suite.Require().Len(suite.validator.Errors(), 1)
 
-	suite.Assert().EqualError(suite.validator.Errors()[0], "authentication backend ldap implementation must be blank or one of the following values `custom`, `activedirectory`")
+	suite.Assert().EqualError(suite.validator.Errors()[0], "authentication backend ldap implementation must be blank or one of the following values 'custom', 'activedirectory', 'freeipa'")
 }
 
 func (suite *LDAPAuthenticationBackendSuite) TestShouldRaiseErrorWhenURLNotProvided() {

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -1,6 +1,9 @@
 package validator
 
 const (
+	errFmtLDAPBothGroupsFilterAndGroupsAttributeSet = "authentication backend (ldap): both groups_filter and " +
+		"groups_attribute are set but only one of these can be set"
+
 	errFmtDeprecatedConfigurationKey = "[DEPRECATED] The %s configuration option is deprecated and will be " +
 		"removed in %s, please use %s instead"
 	errFmtReplacedConfigurationKey = "invalid configuration key '%s' was replaced by '%s'"
@@ -217,6 +220,7 @@ var validKeys = []string{
 	"authentication_backend.ldap.group_name_attribute",
 	"authentication_backend.ldap.mail_attribute",
 	"authentication_backend.ldap.display_name_attribute",
+	"authentication_backend.ldap.groups_attribute",
 	"authentication_backend.ldap.user",
 	"authentication_backend.ldap.start_tls",
 	"authentication_backend.ldap.tls.minimum_version",

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -220,6 +220,7 @@ var validKeys = []string{
 	"authentication_backend.ldap.group_name_attribute",
 	"authentication_backend.ldap.mail_attribute",
 	"authentication_backend.ldap.display_name_attribute",
+	"authentication_backend.ldap.distinguished_name_attribute",
 	"authentication_backend.ldap.groups_attribute",
 	"authentication_backend.ldap.user",
 	"authentication_backend.ldap.start_tls",

--- a/internal/suites/HighAvailability/configuration.yml
+++ b/internal/suites/HighAvailability/configuration.yml
@@ -23,7 +23,7 @@ authentication_backend:
     additional_users_dn: ou=users
     users_filter: (&({username_attribute}={input})(objectClass=person))
     additional_groups_dn: ou=groups
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
     group_name_attribute: cn
     mail_attribute: mail
     display_name_attribute: displayName

--- a/internal/suites/LDAP/configuration.yml
+++ b/internal/suites/LDAP/configuration.yml
@@ -26,7 +26,7 @@ authentication_backend:
     additional_users_dn: ou=users
     users_filter: (&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=person)(objectClass=inetOrgPerson))  # yamllint disable-line rule:line-length
     additional_groups_dn: ou=groups
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
     group_name_attribute: cn
     mail_attribute: mail
     display_name_attribute: displayName

--- a/internal/suites/example/compose/ldap/ldif/03-base.ldif
+++ b/internal/suites/example/compose/ldap/ldif/03-base.ldif
@@ -1,78 +1,78 @@
 dn: cn=pwmanager,{{ LDAP_BASE_DN }}
 cn: Password Manager
-displayname: Password Manager
+displayName: Password Manager
 givenName: Password
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: password.manager@authelia.com
 sn: Manager
 uid: pwmanager
 userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
 dn: ou=groups,{{ LDAP_BASE_DN }}
-objectclass: organizationalUnit
-objectclass: top
+objectClass: organizationalUnit
+objectClass: top
 ou: groups
 
 dn: ou=users,{{ LDAP_BASE_DN }}
-objectclass: organizationalUnit
-objectclass: top
+objectClass: organizationalUnit
+objectClass: top
 ou: users
 
 dn: cn=dev,ou=groups,{{ LDAP_BASE_DN }}
 cn: dev
 member: cn=John Doe (external),ou=users,{{ LDAP_BASE_DN }}
 member: cn=Bob Dylan,ou=users,{{ LDAP_BASE_DN }}
-objectclass: groupOfNames
-objectclass: top
+objectClass: groupOfNames
+objectClass: top
 
 dn: cn=admins,ou=groups,{{ LDAP_BASE_DN }}
 cn: admins
 member: cn=John Doe (external),ou=users,{{ LDAP_BASE_DN }}
-objectclass: groupOfNames
-objectclass: top
+objectClass: groupOfNames
+objectClass: top
 
 dn: cn=John Doe (external),ou=users,{{ LDAP_BASE_DN }}
 cn: John Doe (external)
-displayname: John Doe
+displayName: John Doe
 givenName: John
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: john.doe@authelia.com
 sn: Doe
 uid: john
-userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
 dn: cn=Harry Potter,ou=users,{{ LDAP_BASE_DN }}
 cn: Harry Potter
-displayname: Harry Potter
+displayName: Harry Potter
 givenName: Harry
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: harry.potter@authelia.com
 sn: Potter
 uid: harry
-userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
 dn: cn=Bob Dylan,ou=users,{{ LDAP_BASE_DN }}
 cn: Bob Dylan
-displayname: Bob Dylan
+displayName: Bob Dylan
 givenName: Bob
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: bob.dylan@authelia.com
 sn: Dylan
 uid: bob
-userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
 dn: cn=James Dean,ou=users,{{ LDAP_BASE_DN }}
 cn: James Dean
-displayname: James Dean
+displayName: James Dean
 givenName: James
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: james.dean@authelia.com
 sn: Dean
 uid: james
-userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 

--- a/internal/suites/example/kube/authelia/configs/configuration.yml
+++ b/internal/suites/example/kube/authelia/configs/configuration.yml
@@ -22,7 +22,7 @@ authentication_backend:
     additional_users_dn: ou=users
     users_filter: (&({username_attribute}={input})(objectClass=person))
     additional_groups_dn: ou=groups
-    groups_filter: (&(member={dn})(objectclass=groupOfNames))
+    groups_filter: (&(member={dn})(objectClass=groupOfNames))
     group_name_attribute: cn
     mail_attribute: mail
     display_name_attribute: displayName

--- a/internal/suites/example/kube/ldap/base.ldif
+++ b/internal/suites/example/kube/ldap/base.ldif
@@ -1,67 +1,67 @@
 dn: ou=groups,dc=example,dc=com
-objectclass: organizationalUnit
-objectclass: top
+objectClass: organizationalUnit
+objectClass: top
 ou: groups
 
 dn: ou=users,dc=example,dc=com
-objectclass: organizationalUnit
-objectclass: top
+objectClass: organizationalUnit
+objectClass: top
 ou: users
 
 dn: cn=dev,ou=groups,dc=example,dc=com
 cn: dev
 member: uid=john,ou=users,dc=example,dc=com
 member: uid=bob,ou=users,dc=example,dc=com
-objectclass: groupOfNames
-objectclass: top
+objectClass: groupOfNames
+objectClass: top
 
 dn: cn=admins,ou=groups,dc=example,dc=com
 cn: admins
 member: uid=john,ou=users,dc=example,dc=com
-objectclass: groupOfNames
-objectclass: top
+objectClass: groupOfNames
+objectClass: top
 
 dn: uid=john,ou=users,dc=example,dc=com
 uid: john
 cn: john
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: john.doe@authelia.com
 sn: John Doe
-userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
 dn: uid=harry,ou=users,dc=example,dc=com
 uid: harry
 cn: harry
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: harry.potter@authelia.com
 sn: Harry Potter
-userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
 dn: uid=bob,ou=users,dc=example,dc=com
 uid: bob
 cn: bob
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: bob.dylan@authelia.com
 sn: Bob Dylan
-userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
 dn: uid=james,ou=users,dc=example,dc=com
 uid: james
 cn: james
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: james.dean@authelia.com
 sn: James Dean
-userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
 
 dn: uid=blackhat,ou=users,dc=example,dc=com
 uid: blackhat
 cn: blackhat
-objectclass: inetOrgPerson
-objectclass: top
+objectClass: inetOrgPerson
+objectClass: top
 mail: billy.blackhat@authelia.com
 sn: Billy BlackHat
-userpassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/
+userPassword: {CRYPT}$6$rounds=500000$jgiCMRyGXzoqpxS3$w2pJeZnnH8bwW3zzvoMWtTRfQYsHbWbD/hquuQ5vUeIyl9gdwBIt6RWk2S6afBA0DPakbeWgD/4SZPiS0hYtU/


### PR DESCRIPTION
This allows administrators to configure an attribute that exists on user objects which contains a list of distinguishedName's of the users group memberships.