### PR TITLE
fix(authentication): ldap connection left open

### DIFF
--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -107,6 +107,8 @@ func (p *LDAPUserProvider) checkServer() (err error) {
 		return err
 	}
 
+	defer conn.Close()
+
 	searchRequest := ldap.NewSearchRequest("", ldap.ScopeBaseObject, ldap.NeverDerefAliases,
 		1, 0, false, "(objectClass=*)", []string{ldapSupportedExtensionAttribute}, nil)
 


### PR DESCRIPTION
The recent ldap changes in cb71df5 left a connection to the LDAP server open at startup. This resolves this which prevents an ugly log message and unnecessary open sockets.