### PR TITLE
perf(authentication): improve active directory default users filter

### DIFF
--- a/docs/configuration/authentication/ldap.md
+++ b/docs/configuration/authentication/ldap.md
@@ -206,8 +206,12 @@ makes sure that value is not 0 which means the password requires changing at the
 |Implementation |Users Filter  |Groups Filter|
 |:-------------:|:------------:|:-----------:|
 |custom         |n/a           |n/a       |
-|activedirectory|(&(&#124;({username_attribute}={input})({mail_attribute}={input}))(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2)(!pwdLastSet=0))|(&(member={dn})(objectClass=group)(objectCategory=group))|
+|activedirectory|(&(&#124;({username_attribute}={input})({mail_attribute}={input}))(sAMAccountType=805306368)(!(userAccountControl:1.2.840.113556.1.4.803:=2))(!(pwdLastSet=0)))|(&(member={dn})(objectClass=group)(objectCategory=group))|
 
+
+_**Note:**_ The Active Directory filter `(sAMAccountType=805306368)` is exactly the same as 
+`(&(objectCategory=person)(objectClass=user))` except that the former is more performant, you can read more about this
+and other Active Directory filters on the [TechNet wiki](https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx).
 
 ## Refresh Interval
 

--- a/internal/configuration/schema/authentication.go
+++ b/internal/configuration/schema/authentication.go
@@ -84,7 +84,7 @@ var DefaultLDAPAuthenticationBackendConfiguration = LDAPAuthenticationBackendCon
 
 // DefaultLDAPAuthenticationBackendImplementationActiveDirectoryConfiguration represents the default LDAP config for the MSAD Implementation.
 var DefaultLDAPAuthenticationBackendImplementationActiveDirectoryConfiguration = LDAPAuthenticationBackendConfiguration{
-	UsersFilter:          "(&(|({username_attribute}={input})({mail_attribute}={input}))(objectCategory=person)(objectClass=user)(!userAccountControl:1.2.840.113556.1.4.803:=2)(!pwdLastSet=0))",
+	UsersFilter:          "(&(|({username_attribute}={input})({mail_attribute}={input}))(sAMAccountType=805306368)(!(userAccountControl:1.2.840.113556.1.4.803:=2))(!(pwdLastSet=0)))",
 	UsernameAttribute:    "sAMAccountName",
 	MailAttribute:        "mail",
 	DisplayNameAttribute: "displayName",

--- a/internal/suites/ActiveDirectory/configuration.yml
+++ b/internal/suites/ActiveDirectory/configuration.yml
@@ -26,7 +26,7 @@ authentication_backend:
     base_dn: DC=example,DC=com
     username_attribute: sAMAccountName
     additional_users_dn: OU=Users
-    users_filter: (&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=person)(objectClass=user))
+    # users_filter: (&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=person)(objectClass=user))
     additional_groups_dn: OU=Groups
     groups_filter: (&(member={dn})(objectClass=group))
     group_name_attribute: cn

--- a/internal/suites/ActiveDirectory/configuration.yml
+++ b/internal/suites/ActiveDirectory/configuration.yml
@@ -24,14 +24,8 @@ authentication_backend:
       skip_verify: true
     start_tls: true
     base_dn: DC=example,DC=com
-    username_attribute: sAMAccountName
     additional_users_dn: OU=Users
-    # users_filter: (&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=person)(objectClass=user))
     additional_groups_dn: OU=Groups
-    groups_filter: (&(member={dn})(objectClass=group))
-    group_name_attribute: cn
-    mail_attribute: mail
-    display_name_attribute: displayName
     user: CN=Administrator,CN=Users,DC=example,DC=com
     password: password
 


### PR DESCRIPTION
This adds a performance change to the default Active Directory users filter. Basically as per TechNet the (sAMAccountType=805306368) filter is the same as (&(objectCategory=person)(objectClass=user)) except the performance is better.