### PR TITLE
fix(handlers): send status 307 auth requests that are not get/head

### DIFF
--- a/internal/handlers/handler_verify.go
+++ b/internal/handlers/handler_verify.go
@@ -228,8 +228,15 @@ func handleUnauthorized(ctx *middlewares.AutheliaCtx, targetURL fmt.Stringer, is
 		}
 
 		ctx.Logger.Infof("Access to %s (method %s) is not authorized to user %s, redirecting to %s", targetURL.String(), friendlyMethod, friendlyUsername, redirectionURL)
-		ctx.Redirect(redirectionURL, 302)
-		ctx.SetBodyString(fmt.Sprintf("Found. Redirecting to %s", redirectionURL))
+
+		switch rm {
+		case fasthttp.MethodGet, fasthttp.MethodHead, "":
+			ctx.Redirect(redirectionURL, 302)
+			ctx.SetBodyString(fmt.Sprintf("Found. Redirecting to %s", redirectionURL))
+		default:
+			ctx.Redirect(redirectionURL, 307)
+			ctx.SetBodyString(fmt.Sprintf("See Other. Redirecting to %s", redirectionURL))
+		}
 	} else {
 		ctx.Logger.Infof("Access to %s (method %s) is not authorized to user %s, sending 401 response", targetURL.String(), friendlyMethod, friendlyUsername)
 		ctx.ReplyUnauthorized()


### PR DESCRIPTION
When a request occurs, if the browser is not performing a HTTP GET/HEAD request, the 302 status code is not valid. This commit resolves this. MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302. This PR changes the behaviour, so that if the request method is blank, `GET`, `HEAD`; the response code is `302`, otherwise it is `307`.

Fixes #2173