### PR TITLE
fix(handlers): handle xhr requests to /api/verify with 401

### DIFF
--- a/docs/community/oidc-integrations.md
+++ b/docs/community/oidc-integrations.md
@@ -12,10 +12,10 @@ nav_order: 4
 ## Currently Tested Applications
 
 - GitLab (>= 13.0.0)
-- Grafana (8.0.5)
-- MinIO (problems with the `state` option which is not supplied by MinIO, see [minio/minio#11398])
+- Grafana (>= 8.0.5)
+- MinIO (missing JWT claims / policies, see [minio/minio#12722])
 
-[minio/minio#11398]: https://github.com/minio/minio/issues/11398
+[minio/minio#12722]: https://github.com/minio/minio/issues/12722
 
 ## Known Callback URLs
 
@@ -23,7 +23,8 @@ If you do not find the application in the list below, you will need to search fo
 
 `<DOMAIN>` needs to be substituted with the full URL on which the application runs on. If GitLab, as an example, was reachable under `https://gitlab.example.com`, `<DOMAIN>` would be exactly the same.
 
-| Application | Version              | Callback URL                                             |
-| :---------: | :------------------: | :------------------------------------------------------: |
-| GitLab      | `14.0.1`             | `<DOMAIN>/users/auth/openid_connect/callback`    |
-| MinIO       | `RELEASE.2021-06-17` | `<DOMAIN>/minio/login/openid`                    |
+| Application | Version                        | Callback URL                                             |
+| :---------: | :----------------------------: | :------------------------------------------------------: |
+| GitLab      | `14.0.1`                       | `<DOMAIN>/users/auth/openid_connect/callback`            |
+| MinIO       | `RELEASE.2021-07-12T02-44-53Z` | `<DOMAIN>/oauth_callback`                                |
+| MinIO       | `RELEASE.2021-06-17`           | `<DOMAIN>/minio/login/openid`                            |

--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -1,29 +1,31 @@
 package handlers
 
-// TOTPRegistrationAction is the string representation of the action for which the token has been produced.
-const TOTPRegistrationAction = "RegisterTOTPDevice"
+const (
+	// ActionTOTPRegistration is the string representation of the action for which the token has been produced.
+	ActionTOTPRegistration = "RegisterTOTPDevice"
 
-// U2FRegistrationAction is the string representation of the action for which the token has been produced.
-const U2FRegistrationAction = "RegisterU2FDevice"
+	// ActionU2FRegistration is the string representation of the action for which the token has been produced.
+	ActionU2FRegistration = "RegisterU2FDevice"
 
-// ResetPasswordAction is the string representation of the action for which the token has been produced.
-const ResetPasswordAction = "ResetPassword"
+	// ActionResetPassword is the string representation of the action for which the token has been produced.
+	ActionResetPassword = "ResetPassword"
+)
 
-const authPrefix = "Basic "
+const (
+	// HeaderProxyAuthorization is the basic-auth HTTP header Authelia utilises.
+	HeaderProxyAuthorization = "Proxy-Authorization"
 
-// ProxyAuthorizationHeader is the basic-auth HTTP header Authelia utilises.
-const ProxyAuthorizationHeader = "Proxy-Authorization"
+	// HeaderAuthorization is the basic-auth HTTP header Authelia utilises with "auth=basic" query param.
+	HeaderAuthorization = "Authorization"
 
-// AuthorizationHeader is the basic-auth HTTP header Authelia utilises with "auth=basic" query param.
-const AuthorizationHeader = "Authorization"
+	// HeaderSessionUsername is used as additional protection to validate a user for things like pam_exec.
+	HeaderSessionUsername = "Session-Username"
 
-// SessionUsernameHeader is used as additional protection to validate a user for things like pam_exec.
-const SessionUsernameHeader = "Session-Username"
-
-const remoteUserHeader = "Remote-User"
-const remoteNameHeader = "Remote-Name"
-const remoteEmailHeader = "Remote-Email"
-const remoteGroupsHeader = "Remote-Groups"
+	headerRemoteUser   = "Remote-User"
+	headerRemoteName   = "Remote-Name"
+	headerRemoteEmail  = "Remote-Email"
+	headerRemoteGroups = "Remote-Groups"
+)
 
 const (
 	// Forbidden means the user is forbidden the access to a resource.
@@ -34,47 +36,56 @@ const (
 	Authorized authorizationMatching = iota
 )
 
-const operationFailedMessage = "Operation failed."
-const authenticationFailedMessage = "Authentication failed. Check your credentials."
-const userBannedMessage = "Please retry in a few minutes."
-const unableToRegisterOneTimePasswordMessage = "Unable to set up one-time passwords." //nolint:gosec
-const unableToRegisterSecurityKeyMessage = "Unable to register your security key."
-const unableToResetPasswordMessage = "Unable to reset your password."
-const mfaValidationFailedMessage = "Authentication failed, please retry later."
+const (
+	messageOperationFailed                 = "Operation failed."
+	messageAuthenticationFailed            = "Authentication failed. Check your credentials."
+	messageUserBanned                      = "Please retry in a few minutes."
+	messageUnableToRegisterOneTimePassword = "Unable to set up one-time passwords." //nolint:gosec
+	messageUnableToRegisterSecurityKey     = "Unable to register your security key."
+	messageUnableToResetPassword           = "Unable to reset your password."
+	messageMFAValidationFailed             = "Authentication failed, please retry later."
+)
 
-const ldapPasswordComplexityCode = "0000052D."
+const (
+	testInactivity     = "10"
+	testRedirectionURL = "http://redirection.local"
+	testResultAllow    = "allow"
+	testUsername       = "john"
+)
 
-var ldapPasswordComplexityCodes = []string{
-	"0000052D", "SynoNumber", "SynoMixedCase", "SynoExcludeNameDesc", "SynoSpecialChar",
-}
-var ldapPasswordComplexityErrors = []string{
-	"LDAP Result Code 19 \"Constraint Violation\": Password fails quality checking policy",
-	"LDAP Result Code 19 \"Constraint Violation\": Password is too young to change",
-}
-
-const testInactivity = "10"
-const testRedirectionURL = "http://redirection.local"
-const testResultAllow = "allow"
-const testUsername = "john"
-
-const movingAverageWindow = 10
-const msMinimumDelay1FA = float64(250)
-const msMaximumRandomDelay = int64(85)
+const (
+	loginDelayMovingAverageWindow            = 10
+	loginDelayMinimumDelayMilliseconds       = float64(250)
+	loginDelayMaximumRandomDelayMilliseconds = int64(85)
+)
 
 // OIDC constants.
 const (
-	oidcJWKsPath       = "/api/oidc/jwks"
-	oidcAuthorizePath  = "/api/oidc/authorize"
-	oidcTokenPath      = "/api/oidc/token" //nolint:gosec // This is not a hard coded credential, it's a path.
-	oidcIntrospectPath = "/api/oidc/introspect"
-	oidcRevokePath     = "/api/oidc/revoke"
-	oidcUserinfoPath   = "/api/oidc/userinfo"
+	pathOpenIDConnectJWKs          = "/api/oidc/jwks"
+	pathOpenIDConnectAuthorization = "/api/oidc/authorize"
+	pathOpenIDConnectToken         = "/api/oidc/token" //nolint:gosec // This is not a hard coded credential, it's a path.
+	pathOpenIDConnectIntrospection = "/api/oidc/introspect"
+	pathOpenIDConnectRevocation    = "/api/oidc/revoke"
+	pathOpenIDConnectUserinfo      = "/api/oidc/userinfo"
 
 	// Note: If you change this const you must also do so in the frontend at web/src/services/Api.ts.
-	oidcConsentPath = "/api/oidc/consent"
+	pathOpenIDConnectConsent = "/api/oidc/consent"
 )
 
 const (
 	accept = "accept"
 	reject = "reject"
 )
+
+const authPrefix = "Basic "
+
+const ldapPasswordComplexityCode = "0000052D."
+
+var ldapPasswordComplexityCodes = []string{
+	"0000052D", "SynoNumber", "SynoMixedCase", "SynoExcludeNameDesc", "SynoSpecialChar",
+}
+
+var ldapPasswordComplexityErrors = []string{
+	"LDAP Result Code 19 \"Constraint Violation\": Password fails quality checking policy",
+	"LDAP Result Code 19 \"Constraint Violation\": Password is too young to change",
+}

--- a/internal/handlers/handler_firstfactor_test.go
+++ b/internal/handlers/handler_firstfactor_test.go
@@ -454,16 +454,16 @@ func TestFirstFactorDelayCalculations(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		delay := calculateActualDelay(mock.Ctx, execDuration, avgExecDurationMs, &successful)
 		assert.True(t, delay >= expectedMinimumDelayMs)
-		assert.True(t, delay <= expectedMinimumDelayMs+float64(msMaximumRandomDelay))
+		assert.True(t, delay <= expectedMinimumDelayMs+float64(loginDelayMaximumRandomDelayMilliseconds))
 	}
 
 	execDuration = 5 * time.Millisecond
 	avgExecDurationMs = 5.0
-	expectedMinimumDelayMs = msMinimumDelay1FA - float64(execDuration.Milliseconds())
+	expectedMinimumDelayMs = loginDelayMinimumDelayMilliseconds - float64(execDuration.Milliseconds())
 
 	for i := 0; i < 100; i++ {
 		delay := calculateActualDelay(mock.Ctx, execDuration, avgExecDurationMs, &successful)
 		assert.True(t, delay >= expectedMinimumDelayMs)
-		assert.True(t, delay <= expectedMinimumDelayMs+float64(msMaximumRandomDelay))
+		assert.True(t, delay <= expectedMinimumDelayMs+float64(loginDelayMaximumRandomDelayMilliseconds))
 	}
 }

--- a/internal/handlers/handler_logout.go
+++ b/internal/handlers/handler_logout.go
@@ -25,14 +25,14 @@ func LogoutPost(ctx *middlewares.AutheliaCtx) {
 
 	err := ctx.ParseBody(&body)
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to parse body during logout: %s", err), operationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to parse body during logout: %s", err), messageOperationFailed)
 	}
 
 	ctx.Logger.Tracef("Attempting to destroy session")
 
 	err = ctx.Providers.SessionProvider.DestroySession(ctx.RequestCtx)
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to destroy session during logout: %s", err), operationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to destroy session during logout: %s", err), messageOperationFailed)
 	}
 
 	redirectionURL, err := url.Parse(body.TargetURL)
@@ -46,6 +46,6 @@ func LogoutPost(ctx *middlewares.AutheliaCtx) {
 
 	err = ctx.SetJSONBody(responseBody)
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to set body during logout: %s", err), operationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to set body during logout: %s", err), messageOperationFailed)
 	}
 }

--- a/internal/handlers/handler_oidc_wellknown.go
+++ b/internal/handlers/handler_oidc_wellknown.go
@@ -22,12 +22,12 @@ func oidcWellKnown(ctx *middlewares.AutheliaCtx) {
 
 	wellKnown := oidc.WellKnownConfiguration{
 		Issuer:  issuer,
-		JWKSURI: fmt.Sprintf("%s%s", issuer, oidcJWKsPath),
+		JWKSURI: fmt.Sprintf("%s%s", issuer, pathOpenIDConnectJWKs),
 
-		AuthorizationEndpoint: fmt.Sprintf("%s%s", issuer, oidcAuthorizePath),
-		TokenEndpoint:         fmt.Sprintf("%s%s", issuer, oidcTokenPath),
-		RevocationEndpoint:    fmt.Sprintf("%s%s", issuer, oidcRevokePath),
-		UserinfoEndpoint:      fmt.Sprintf("%s%s", issuer, oidcUserinfoPath),
+		AuthorizationEndpoint: fmt.Sprintf("%s%s", issuer, pathOpenIDConnectAuthorization),
+		TokenEndpoint:         fmt.Sprintf("%s%s", issuer, pathOpenIDConnectToken),
+		RevocationEndpoint:    fmt.Sprintf("%s%s", issuer, pathOpenIDConnectRevocation),
+		UserinfoEndpoint:      fmt.Sprintf("%s%s", issuer, pathOpenIDConnectUserinfo),
 
 		Algorithms:         []string{"RS256"},
 		UserinfoAlgorithms: []string{"none", "RS256"},

--- a/internal/handlers/handler_register_totp.go
+++ b/internal/handlers/handler_register_totp.go
@@ -32,7 +32,7 @@ var SecondFactorTOTPIdentityStart = middlewares.IdentityVerificationStart(middle
 	MailTitle:             "Register your mobile",
 	MailButtonContent:     "Register",
 	TargetEndpoint:        "/one-time-password/register",
-	ActionClaim:           TOTPRegistrationAction,
+	ActionClaim:           ActionTOTPRegistration,
 	IdentityRetrieverFunc: identityRetrieverFromSession,
 })
 
@@ -45,13 +45,13 @@ func secondFactorTOTPIdentityFinish(ctx *middlewares.AutheliaCtx, username strin
 	})
 
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to generate TOTP key: %s", err), unableToRegisterOneTimePasswordMessage)
+		ctx.Error(fmt.Errorf("Unable to generate TOTP key: %s", err), messageUnableToRegisterOneTimePassword)
 		return
 	}
 
 	err = ctx.Providers.StorageProvider.SaveTOTPSecret(username, key.Secret())
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to save TOTP secret in DB: %s", err), unableToRegisterOneTimePasswordMessage)
+		ctx.Error(fmt.Errorf("Unable to save TOTP secret in DB: %s", err), messageUnableToRegisterOneTimePassword)
 		return
 	}
 
@@ -69,6 +69,6 @@ func secondFactorTOTPIdentityFinish(ctx *middlewares.AutheliaCtx, username strin
 // SecondFactorTOTPIdentityFinish the handler for finishing the identity validation.
 var SecondFactorTOTPIdentityFinish = middlewares.IdentityVerificationFinish(
 	middlewares.IdentityVerificationFinishArgs{
-		ActionClaim:          TOTPRegistrationAction,
+		ActionClaim:          ActionTOTPRegistration,
 		IsTokenUserValidFunc: isTokenUserValidFor2FARegistration,
 	}, secondFactorTOTPIdentityFinish)

--- a/internal/handlers/handler_register_u2f_step1.go
+++ b/internal/handlers/handler_register_u2f_step1.go
@@ -19,18 +19,18 @@ var SecondFactorU2FIdentityStart = middlewares.IdentityVerificationStart(middlew
 	MailTitle:             "Register your key",
 	MailButtonContent:     "Register",
 	TargetEndpoint:        "/security-key/register",
-	ActionClaim:           U2FRegistrationAction,
+	ActionClaim:           ActionU2FRegistration,
 	IdentityRetrieverFunc: identityRetrieverFromSession,
 })
 
 func secondFactorU2FIdentityFinish(ctx *middlewares.AutheliaCtx, username string) {
 	if ctx.XForwardedProto() == nil {
-		ctx.Error(errMissingXForwardedProto, operationFailedMessage)
+		ctx.Error(errMissingXForwardedProto, messageOperationFailed)
 		return
 	}
 
 	if ctx.XForwardedHost() == nil {
-		ctx.Error(errMissingXForwardedHost, operationFailedMessage)
+		ctx.Error(errMissingXForwardedHost, messageOperationFailed)
 		return
 	}
 
@@ -42,7 +42,7 @@ func secondFactorU2FIdentityFinish(ctx *middlewares.AutheliaCtx, username string
 	challenge, err := u2f.NewChallenge(appID, trustedFacets)
 
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to generate new U2F challenge for registration: %s", err), operationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to generate new U2F challenge for registration: %s", err), messageOperationFailed)
 		return
 	}
 
@@ -52,7 +52,7 @@ func secondFactorU2FIdentityFinish(ctx *middlewares.AutheliaCtx, username string
 	err = ctx.SaveSession(userSession)
 
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to save U2F challenge in session: %s", err), operationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to save U2F challenge in session: %s", err), messageOperationFailed)
 		return
 	}
 
@@ -65,6 +65,6 @@ func secondFactorU2FIdentityFinish(ctx *middlewares.AutheliaCtx, username string
 // SecondFactorU2FIdentityFinish the handler for finishing the identity validation.
 var SecondFactorU2FIdentityFinish = middlewares.IdentityVerificationFinish(
 	middlewares.IdentityVerificationFinishArgs{
-		ActionClaim:          U2FRegistrationAction,
+		ActionClaim:          ActionU2FRegistration,
 		IsTokenUserValidFunc: isTokenUserValidFor2FARegistration,
 	}, secondFactorU2FIdentityFinish)

--- a/internal/handlers/handler_register_u2f_step1_test.go
+++ b/internal/handlers/handler_register_u2f_step1_test.go
@@ -50,7 +50,7 @@ func createToken(secret string, username string, action string, expiresAt time.T
 }
 
 func (s *HandlerRegisterU2FStep1Suite) TestShouldRaiseWhenXForwardedProtoIsMissing() {
-	token := createToken(s.mock.Ctx.Configuration.JWTSecret, "john", U2FRegistrationAction,
+	token := createToken(s.mock.Ctx.Configuration.JWTSecret, "john", ActionU2FRegistration,
 		time.Now().Add(1*time.Minute))
 	s.mock.Ctx.Request.SetBodyString(fmt.Sprintf("{\"token\":\"%s\"}", token))
 
@@ -70,7 +70,7 @@ func (s *HandlerRegisterU2FStep1Suite) TestShouldRaiseWhenXForwardedProtoIsMissi
 
 func (s *HandlerRegisterU2FStep1Suite) TestShouldRaiseWhenXForwardedHostIsMissing() {
 	s.mock.Ctx.Request.Header.Add("X-Forwarded-Proto", "http")
-	token := createToken(s.mock.Ctx.Configuration.JWTSecret, "john", U2FRegistrationAction,
+	token := createToken(s.mock.Ctx.Configuration.JWTSecret, "john", ActionU2FRegistration,
 		time.Now().Add(1*time.Minute))
 	s.mock.Ctx.Request.SetBodyString(fmt.Sprintf("{\"token\":\"%s\"}", token))
 

--- a/internal/handlers/handler_register_u2f_step2.go
+++ b/internal/handlers/handler_register_u2f_step2.go
@@ -16,13 +16,13 @@ func SecondFactorU2FRegister(ctx *middlewares.AutheliaCtx) {
 	err := ctx.ParseBody(&responseBody)
 
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to parse response body: %v", err), unableToRegisterSecurityKeyMessage)
+		ctx.Error(fmt.Errorf("Unable to parse response body: %v", err), messageUnableToRegisterSecurityKey)
 	}
 
 	userSession := ctx.GetSession()
 
 	if userSession.U2FChallenge == nil {
-		ctx.Error(fmt.Errorf("U2F registration has not been initiated yet"), unableToRegisterSecurityKeyMessage)
+		ctx.Error(fmt.Errorf("U2F registration has not been initiated yet"), messageUnableToRegisterSecurityKey)
 		return
 	}
 	// Ensure the challenge is cleared if anything goes wrong.
@@ -38,7 +38,7 @@ func SecondFactorU2FRegister(ctx *middlewares.AutheliaCtx) {
 	registration, err := u2f.Register(responseBody, *userSession.U2FChallenge, u2fConfig)
 
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to verify U2F registration: %v", err), unableToRegisterSecurityKeyMessage)
+		ctx.Error(fmt.Errorf("Unable to verify U2F registration: %v", err), messageUnableToRegisterSecurityKey)
 		return
 	}
 
@@ -48,7 +48,7 @@ func SecondFactorU2FRegister(ctx *middlewares.AutheliaCtx) {
 	err = ctx.Providers.StorageProvider.SaveU2FDeviceHandle(userSession.Username, registration.KeyHandle, publicKey)
 
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to register U2F device for user %s: %v", userSession.Username, err), unableToRegisterSecurityKeyMessage)
+		ctx.Error(fmt.Errorf("Unable to register U2F device for user %s: %v", userSession.Username, err), messageUnableToRegisterSecurityKey)
 		return
 	}
 

--- a/internal/handlers/handler_reset_password_step1.go
+++ b/internal/handlers/handler_reset_password_step1.go
@@ -38,7 +38,7 @@ var ResetPasswordIdentityStart = middlewares.IdentityVerificationStart(middlewar
 	MailTitle:             "Reset your password",
 	MailButtonContent:     "Reset",
 	TargetEndpoint:        "/reset-password/step2",
-	ActionClaim:           ResetPasswordAction,
+	ActionClaim:           ActionResetPassword,
 	IdentityRetrieverFunc: identityRetrieverFromStorage,
 })
 
@@ -57,4 +57,4 @@ func resetPasswordIdentityFinish(ctx *middlewares.AutheliaCtx, username string) 
 
 // ResetPasswordIdentityFinish the handler for finishing the identity validation.
 var ResetPasswordIdentityFinish = middlewares.IdentityVerificationFinish(
-	middlewares.IdentityVerificationFinishArgs{ActionClaim: ResetPasswordAction}, resetPasswordIdentityFinish)
+	middlewares.IdentityVerificationFinishArgs{ActionClaim: ActionResetPassword}, resetPasswordIdentityFinish)

--- a/internal/handlers/handler_reset_password_step2.go
+++ b/internal/handlers/handler_reset_password_step2.go
@@ -15,7 +15,7 @@ func ResetPasswordPost(ctx *middlewares.AutheliaCtx) {
 	// otherwise PasswordReset would not be set to true. We can improve the security of this check by making the
 	// request expire at some point because here it only expires when the cookie expires.
 	if userSession.PasswordResetUsername == nil {
-		ctx.Error(fmt.Errorf("No identity verification process has been initiated"), unableToResetPasswordMessage)
+		ctx.Error(fmt.Errorf("No identity verification process has been initiated"), messageUnableToResetPassword)
 		return
 	}
 
@@ -23,7 +23,7 @@ func ResetPasswordPost(ctx *middlewares.AutheliaCtx) {
 	err := ctx.ParseBody(&requestBody)
 
 	if err != nil {
-		ctx.Error(err, unableToResetPasswordMessage)
+		ctx.Error(err, messageUnableToResetPassword)
 		return
 	}
 
@@ -35,7 +35,7 @@ func ResetPasswordPost(ctx *middlewares.AutheliaCtx) {
 			utils.IsStringInSliceContains(err.Error(), ldapPasswordComplexityErrors):
 			ctx.Error(fmt.Errorf("%s", err), ldapPasswordComplexityCode)
 		default:
-			ctx.Error(fmt.Errorf("%s", err), unableToResetPasswordMessage)
+			ctx.Error(fmt.Errorf("%s", err), messageUnableToResetPassword)
 		}
 
 		return
@@ -48,7 +48,7 @@ func ResetPasswordPost(ctx *middlewares.AutheliaCtx) {
 	err = ctx.SaveSession(userSession)
 
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to update password reset state: %s", err), operationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to update password reset state: %s", err), messageOperationFailed)
 		return
 	}
 

--- a/internal/handlers/handler_sign_duo.go
+++ b/internal/handlers/handler_sign_duo.go
@@ -15,7 +15,7 @@ func SecondFactorDuoPost(duoAPI duo.API) middlewares.RequestHandler {
 		err := ctx.ParseBody(&requestBody)
 
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, err, mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, err, messageMFAValidationFailed)
 			return
 		}
 
@@ -37,7 +37,7 @@ func SecondFactorDuoPost(duoAPI duo.API) middlewares.RequestHandler {
 
 		duoResponse, err := duoAPI.Call(values, ctx)
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Duo API errored: %s", err), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Duo API errored: %s", err), messageMFAValidationFailed)
 			return
 		}
 
@@ -60,7 +60,7 @@ func SecondFactorDuoPost(duoAPI duo.API) middlewares.RequestHandler {
 		err = ctx.Providers.SessionProvider.RegenerateSession(ctx.RequestCtx)
 
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to regenerate session for user %s: %s", userSession.Username, err), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to regenerate session for user %s: %s", userSession.Username, err), messageMFAValidationFailed)
 			return
 		}
 
@@ -68,7 +68,7 @@ func SecondFactorDuoPost(duoAPI duo.API) middlewares.RequestHandler {
 
 		err = ctx.SaveSession(userSession)
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to update authentication level with Duo: %s", err), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to update authentication level with Duo: %s", err), messageMFAValidationFailed)
 			return
 		}
 

--- a/internal/handlers/handler_sign_totp.go
+++ b/internal/handlers/handler_sign_totp.go
@@ -13,7 +13,7 @@ func SecondFactorTOTPPost(totpVerifier TOTPVerifier) middlewares.RequestHandler 
 		err := ctx.ParseBody(&requestBody)
 
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, err, mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, err, messageMFAValidationFailed)
 			return
 		}
 
@@ -21,25 +21,25 @@ func SecondFactorTOTPPost(totpVerifier TOTPVerifier) middlewares.RequestHandler 
 
 		secret, err := ctx.Providers.StorageProvider.LoadTOTPSecret(userSession.Username)
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to load TOTP secret: %s", err), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to load TOTP secret: %s", err), messageMFAValidationFailed)
 			return
 		}
 
 		isValid, err := totpVerifier.Verify(requestBody.Token, secret)
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Error occurred during OTP validation for user %s: %s", userSession.Username, err), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Error occurred during OTP validation for user %s: %s", userSession.Username, err), messageMFAValidationFailed)
 			return
 		}
 
 		if !isValid {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Wrong passcode during TOTP validation for user %s", userSession.Username), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Wrong passcode during TOTP validation for user %s", userSession.Username), messageMFAValidationFailed)
 			return
 		}
 
 		err = ctx.Providers.SessionProvider.RegenerateSession(ctx.RequestCtx)
 
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to regenerate session for user %s: %s", userSession.Username, err), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to regenerate session for user %s: %s", userSession.Username, err), messageMFAValidationFailed)
 			return
 		}
 
@@ -47,7 +47,7 @@ func SecondFactorTOTPPost(totpVerifier TOTPVerifier) middlewares.RequestHandler 
 
 		err = ctx.SaveSession(userSession)
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to update the authentication level with TOTP: %s", err), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to update the authentication level with TOTP: %s", err), messageMFAValidationFailed)
 			return
 		}
 

--- a/internal/handlers/handler_sign_u2f_step1.go
+++ b/internal/handlers/handler_sign_u2f_step1.go
@@ -14,12 +14,12 @@ import (
 // SecondFactorU2FSignGet handler for initiating a signing request.
 func SecondFactorU2FSignGet(ctx *middlewares.AutheliaCtx) {
 	if ctx.XForwardedProto() == nil {
-		ctx.Error(errMissingXForwardedProto, mfaValidationFailedMessage)
+		ctx.Error(errMissingXForwardedProto, messageMFAValidationFailed)
 		return
 	}
 
 	if ctx.XForwardedHost() == nil {
-		ctx.Error(errMissingXForwardedHost, mfaValidationFailedMessage)
+		ctx.Error(errMissingXForwardedHost, messageMFAValidationFailed)
 		return
 	}
 
@@ -29,7 +29,7 @@ func SecondFactorU2FSignGet(ctx *middlewares.AutheliaCtx) {
 	challenge, err := u2f.NewChallenge(appID, trustedFacets)
 
 	if err != nil {
-		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to create U2F challenge: %s", err), mfaValidationFailedMessage)
+		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to create U2F challenge: %s", err), messageMFAValidationFailed)
 		return
 	}
 
@@ -38,11 +38,11 @@ func SecondFactorU2FSignGet(ctx *middlewares.AutheliaCtx) {
 
 	if err != nil {
 		if err == storage.ErrNoU2FDeviceHandle {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("No device handle found for user %s", userSession.Username), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("No device handle found for user %s", userSession.Username), messageMFAValidationFailed)
 			return
 		}
 
-		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to retrieve U2F device handle: %s", err), mfaValidationFailedMessage)
+		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to retrieve U2F device handle: %s", err), messageMFAValidationFailed)
 
 		return
 	}
@@ -63,7 +63,7 @@ func SecondFactorU2FSignGet(ctx *middlewares.AutheliaCtx) {
 	err = ctx.SaveSession(userSession)
 
 	if err != nil {
-		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to save U2F challenge and registration in session: %s", err), mfaValidationFailedMessage)
+		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to save U2F challenge and registration in session: %s", err), messageMFAValidationFailed)
 		return
 	}
 
@@ -71,7 +71,7 @@ func SecondFactorU2FSignGet(ctx *middlewares.AutheliaCtx) {
 	err = ctx.SetJSONBody(signRequest)
 
 	if err != nil {
-		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to set sign request in body: %s", err), mfaValidationFailedMessage)
+		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to set sign request in body: %s", err), messageMFAValidationFailed)
 		return
 	}
 }

--- a/internal/handlers/handler_sign_u2f_step2.go
+++ b/internal/handlers/handler_sign_u2f_step2.go
@@ -13,18 +13,18 @@ func SecondFactorU2FSignPost(u2fVerifier U2FVerifier) middlewares.RequestHandler
 		err := ctx.ParseBody(&requestBody)
 
 		if err != nil {
-			ctx.Error(err, mfaValidationFailedMessage)
+			ctx.Error(err, messageMFAValidationFailed)
 			return
 		}
 
 		userSession := ctx.GetSession()
 		if userSession.U2FChallenge == nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("U2F signing has not been initiated yet (no challenge)"), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("U2F signing has not been initiated yet (no challenge)"), messageMFAValidationFailed)
 			return
 		}
 
 		if userSession.U2FRegistration == nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("U2F signing has not been initiated yet (no registration)"), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("U2F signing has not been initiated yet (no registration)"), messageMFAValidationFailed)
 			return
 		}
 
@@ -35,14 +35,14 @@ func SecondFactorU2FSignPost(u2fVerifier U2FVerifier) middlewares.RequestHandler
 			*userSession.U2FChallenge)
 
 		if err != nil {
-			ctx.Error(err, mfaValidationFailedMessage)
+			ctx.Error(err, messageMFAValidationFailed)
 			return
 		}
 
 		err = ctx.Providers.SessionProvider.RegenerateSession(ctx.RequestCtx)
 
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to regenerate session for user %s: %s", userSession.Username, err), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to regenerate session for user %s: %s", userSession.Username, err), messageMFAValidationFailed)
 			return
 		}
 
@@ -50,7 +50,7 @@ func SecondFactorU2FSignPost(u2fVerifier U2FVerifier) middlewares.RequestHandler
 
 		err = ctx.SaveSession(userSession)
 		if err != nil {
-			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to update authentication level with U2F: %s", err), mfaValidationFailedMessage)
+			handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to update authentication level with U2F: %s", err), messageMFAValidationFailed)
 			return
 		}
 

--- a/internal/handlers/handler_user_info.go
+++ b/internal/handlers/handler_user_info.go
@@ -87,7 +87,7 @@ func UserInfoGet(ctx *middlewares.AutheliaCtx) {
 	errors := loadInfo(userSession.Username, ctx.Providers.StorageProvider, &userInfo, ctx.Logger)
 
 	if len(errors) > 0 {
-		ctx.Error(fmt.Errorf("Unable to load user information"), operationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to load user information"), messageOperationFailed)
 		return
 	}
 
@@ -110,12 +110,12 @@ func MethodPreferencePost(ctx *middlewares.AutheliaCtx) {
 
 	err := ctx.ParseBody(&bodyJSON)
 	if err != nil {
-		ctx.Error(err, operationFailedMessage)
+		ctx.Error(err, messageOperationFailed)
 		return
 	}
 
 	if !utils.IsStringInSlice(bodyJSON.Method, authentication.PossibleMethods) {
-		ctx.Error(fmt.Errorf("Unknown method '%s', it should be one of %s", bodyJSON.Method, strings.Join(authentication.PossibleMethods, ", ")), operationFailedMessage)
+		ctx.Error(fmt.Errorf("Unknown method '%s', it should be one of %s", bodyJSON.Method, strings.Join(authentication.PossibleMethods, ", ")), messageOperationFailed)
 		return
 	}
 
@@ -124,7 +124,7 @@ func MethodPreferencePost(ctx *middlewares.AutheliaCtx) {
 	err = ctx.Providers.StorageProvider.SavePreferred2FAMethod(userSession.Username, bodyJSON.Method)
 
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to save new preferred 2FA method: %s", err), operationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to save new preferred 2FA method: %s", err), messageOperationFailed)
 		return
 	}
 

--- a/internal/handlers/handler_verify.go
+++ b/internal/handlers/handler_verify.go
@@ -253,20 +253,8 @@ func handleUnauthorized(ctx *middlewares.AutheliaCtx, targetURL fmt.Stringer, is
 		ctx.Logger.Infof("Access to %s (method %s) is not authorized to user %s, responding with status code %d with location redirect to %s", targetURL.String(), friendlyRequestMethod, friendlyUsername, statusCode, redirectionURL)
 		ctx.SpecialRedirect(redirectionURL, statusCode)
 	} else {
-		valueXAutheliaRedirectStatus := "303"
-
-		switch {
-		case ctx.IsXHR() || !ctx.AcceptsMIME("text/html"):
-			valueXAutheliaRedirectStatus = "401"
-		case rm == fasthttp.MethodGet, rm == fasthttp.MethodOptions, rm == "":
-			valueXAutheliaRedirectStatus = "302"
-		}
-		ctx.Logger.Infof("Access to %s (method %s) is not authorized to user %s, responding with status code %d and header code %s", targetURL.String(), friendlyRequestMethod, friendlyUsername, statusCode, valueXAutheliaRedirectStatus)
-
+		ctx.Logger.Infof("Access to %s (method %s) is not authorized to user %s, responding with status code %d", targetURL.String(), friendlyRequestMethod, friendlyUsername, statusCode)
 		ctx.ReplyUnauthorized()
-		ctx.Response.Header.Set("X-Authelia-Redirect-Status", valueXAutheliaRedirectStatus)
-
-		ctx.Logger.Debugf("Header Set X-Authelia-Redirect-Status: %s", string(ctx.Response.Header.Peek("X-Authelia-Redirect-Status")))
 	}
 }
 

--- a/internal/handlers/handler_verify.go
+++ b/internal/handlers/handler_verify.go
@@ -253,8 +253,20 @@ func handleUnauthorized(ctx *middlewares.AutheliaCtx, targetURL fmt.Stringer, is
 		ctx.Logger.Infof("Access to %s (method %s) is not authorized to user %s, responding with status code %d with location redirect to %s", targetURL.String(), friendlyRequestMethod, friendlyUsername, statusCode, redirectionURL)
 		ctx.SpecialRedirect(redirectionURL, statusCode)
 	} else {
-		ctx.Logger.Infof("Access to %s (method %s) is not authorized to user %s, responding with status code %d", targetURL.String(), friendlyRequestMethod, friendlyUsername, statusCode)
+		valueXAutheliaRedirectStatus := "303"
+
+		switch {
+		case ctx.IsXHR() || !ctx.AcceptsMIME("text/html"):
+			valueXAutheliaRedirectStatus = "401"
+		case rm == fasthttp.MethodGet, rm == fasthttp.MethodOptions, rm == "":
+			valueXAutheliaRedirectStatus = "302"
+		}
+		ctx.Logger.Infof("Access to %s (method %s) is not authorized to user %s, responding with status code %d and header code %s", targetURL.String(), friendlyRequestMethod, friendlyUsername, statusCode, valueXAutheliaRedirectStatus)
+
 		ctx.ReplyUnauthorized()
+		ctx.Response.Header.Set("X-Authelia-Redirect-Status", valueXAutheliaRedirectStatus)
+
+		ctx.Logger.Debugf("Header Set X-Authelia-Redirect-Status: %s", string(ctx.Response.Header.Peek("X-Authelia-Redirect-Status")))
 	}
 }
 

--- a/internal/handlers/oidc_register.go
+++ b/internal/handlers/oidc_register.go
@@ -11,22 +11,22 @@ func RegisterOIDC(router *router.Router, middleware middlewares.RequestHandlerBr
 	// TODO: Add OPTIONS handler.
 	router.GET("/.well-known/openid-configuration", middleware(oidcWellKnown))
 
-	router.GET(oidcConsentPath, middleware(oidcConsent))
+	router.GET(pathOpenIDConnectConsent, middleware(oidcConsent))
 
-	router.POST(oidcConsentPath, middleware(oidcConsentPOST))
+	router.POST(pathOpenIDConnectConsent, middleware(oidcConsentPOST))
 
-	router.GET(oidcJWKsPath, middleware(oidcJWKs))
+	router.GET(pathOpenIDConnectJWKs, middleware(oidcJWKs))
 
-	router.GET(oidcAuthorizePath, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcAuthorize)))
-
-	// TODO: Add OPTIONS handler.
-	router.POST(oidcTokenPath, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcToken)))
-
-	router.POST(oidcIntrospectPath, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcIntrospect)))
-
-	router.GET(oidcUserinfoPath, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcUserinfo)))
-	router.POST(oidcUserinfoPath, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcUserinfo)))
+	router.GET(pathOpenIDConnectAuthorization, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcAuthorize)))
 
 	// TODO: Add OPTIONS handler.
-	router.POST(oidcRevokePath, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcRevoke)))
+	router.POST(pathOpenIDConnectToken, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcToken)))
+
+	router.POST(pathOpenIDConnectIntrospection, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcIntrospect)))
+
+	router.GET(pathOpenIDConnectUserinfo, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcUserinfo)))
+	router.POST(pathOpenIDConnectUserinfo, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcUserinfo)))
+
+	// TODO: Add OPTIONS handler.
+	router.POST(pathOpenIDConnectRevocation, middleware(middlewares.NewHTTPToAutheliaHandlerAdaptor(oidcRevoke)))
 }

--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -25,7 +25,7 @@ func handleOIDCWorkflowResponse(ctx *middlewares.AutheliaCtx) {
 	uri, err := ctx.ForwardedProtoHost()
 	if err != nil {
 		ctx.Logger.Errorf("%v", err)
-		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to get forward facing URI"), authenticationFailedMessage)
+		handleAuthenticationUnauthorized(ctx, fmt.Errorf("Unable to get forward facing URI"), messageAuthenticationFailed)
 
 		return
 	}
@@ -64,7 +64,7 @@ func Handle1FAResponse(ctx *middlewares.AutheliaCtx, targetURI, requestMethod st
 
 	targetURL, err := url.ParseRequestURI(targetURI)
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to parse target URL %s: %s", targetURI, err), authenticationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to parse target URL %s: %s", targetURI, err), messageAuthenticationFailed)
 		return
 	}
 
@@ -128,7 +128,7 @@ func Handle2FAResponse(ctx *middlewares.AutheliaCtx, targetURI string) {
 	targetURL, err := url.ParseRequestURI(targetURI)
 
 	if err != nil {
-		ctx.Error(fmt.Errorf("Unable to parse target URL: %s", err), mfaValidationFailedMessage)
+		ctx.Error(fmt.Errorf("Unable to parse target URL: %s", err), messageMFAValidationFailed)
 		return
 	}
 

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -2,19 +2,39 @@ package middlewares
 
 const jwtIssuer = "Authelia"
 
-const xForwardedProtoHeader = "X-Forwarded-Proto"
-const xForwardedMethodHeader = "X-Forwarded-Method"
-const xForwardedHostHeader = "X-Forwarded-Host"
-const xForwardedURIHeader = "X-Forwarded-URI"
+const (
+	headerXForwardedProto  = "X-Forwarded-Proto"
+	headerXForwardedMethod = "X-Forwarded-Method"
+	headerXForwardedHost   = "X-Forwarded-Host"
+	headerXForwardedURI    = "X-Forwarded-URI"
+	headerXOriginalURL     = "X-Original-URL"
+	headerXRequestedWith   = "X-Requested-With"
+)
 
-const xOriginalURLHeader = "X-Original-URL"
+const (
+	headerValueXRequestedWithXHR = "XMLHttpRequest"
+)
 
-const applicationJSONContentType = "application/json"
+const (
+	statusTextMovedPermanently  = "Moved Permanently"
+	statusTextFound             = "Found"
+	statusTextSeeOther          = "See Other"
+	statusTextTemporaryRedirect = "Temporary Redirect"
+	statusTextPermanentRedirect = "Permanent Redirect"
+	statusTextUnauthorized      = "Unauthorized"
+)
+
+const (
+	contentTypeApplicationJSON = "application/json"
+	contentTypeTextHTML        = "text/html"
+)
 
 var okMessageBytes = []byte("{\"status\":\"OK\"}")
 
-const operationFailedMessage = "Operation failed"
-const identityVerificationTokenAlreadyUsedMessage = "The identity verification token has already been used"
-const identityVerificationTokenHasExpiredMessage = "The identity verification token has expired"
+const (
+	messageOperationFailed                      = "Operation failed"
+	messageIdentityVerificationTokenAlreadyUsed = "The identity verification token has already been used"
+	messageIdentityVerificationTokenHasExpired  = "The identity verification token has expired"
+)
 
 var protoHostSeparator = []byte("://")

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -16,15 +16,6 @@ const (
 )
 
 const (
-	statusTextMovedPermanently  = "Moved Permanently"
-	statusTextFound             = "Found"
-	statusTextSeeOther          = "See Other"
-	statusTextTemporaryRedirect = "Temporary Redirect"
-	statusTextPermanentRedirect = "Permanent Redirect"
-	statusTextUnauthorized      = "Unauthorized"
-)
-
-const (
 	contentTypeApplicationJSON = "application/json"
 	contentTypeTextHTML        = "text/html"
 )

--- a/internal/server/options_handler.go
+++ b/internal/server/options_handler.go
@@ -1,0 +1,11 @@
+package server
+
+import (
+	"github.com/valyala/fasthttp"
+
+	"github.com/authelia/authelia/internal/middlewares"
+)
+
+func handleOPTIONS(ctx *middlewares.AutheliaCtx) {
+	ctx.SetStatusCode(fasthttp.StatusNoContent)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,8 @@ func registerRoutes(configuration schema.Configuration, providers middlewares.Pr
 
 	r := router.New()
 	r.GET("/", serveIndexHandler)
+	r.OPTIONS("/", autheliaMiddleware(handleOPTIONS))
+
 	r.GET("/api/", serveSwaggerHandler)
 	r.GET("/api/"+apiFile, serveSwaggerAPIHandler)
 

--- a/internal/suites/suite_standalone_test.go
+++ b/internal/suites/suite_standalone_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/authelia/authelia/internal/storage"
+	"github.com/authelia/authelia/internal/utils"
 )
 
 type StandaloneWebDriverSuite struct {
@@ -110,6 +111,7 @@ func (s *StandaloneSuite) TestShouldRespectMethodsACL() {
 	req.Header.Set("X-Forwarded-Proto", "https")
 	req.Header.Set("X-Forwarded-Host", fmt.Sprintf("secure.%s", BaseDomain))
 	req.Header.Set("X-Forwarded-URI", "/")
+	req.Header.Set("Accept", "text/html; charset=utf8")
 
 	client := NewHTTPClient()
 	res, err := client.Do(req)
@@ -119,7 +121,7 @@ func (s *StandaloneSuite) TestShouldRespectMethodsACL() {
 	s.Assert().NoError(err)
 
 	urlEncodedAdminURL := url.QueryEscape(SecureBaseURL + "/")
-	s.Assert().Equal(fmt.Sprintf("Found. Redirecting to %s?rd=%s&rm=GET", GetLoginBaseURL(), urlEncodedAdminURL), string(body))
+	s.Assert().Equal(fmt.Sprintf("<a href=\"%s\">Found</a>", utils.StringHTMLEscape(fmt.Sprintf("%s/?rd=%s&rm=GET", GetLoginBaseURL(), urlEncodedAdminURL))), string(body))
 
 	req.Header.Set("X-Forwarded-Method", "OPTIONS")
 
@@ -128,12 +130,44 @@ func (s *StandaloneSuite) TestShouldRespectMethodsACL() {
 	s.Assert().Equal(res.StatusCode, 200)
 }
 
+func (s *StandaloneSuite) TestShouldRespondWithCorrectStatusCode() {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/verify?rd=%s", AutheliaBaseURL, GetLoginBaseURL()), nil)
+	s.Assert().NoError(err)
+	req.Header.Set("X-Forwarded-Method", "GET")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", fmt.Sprintf("secure.%s", BaseDomain))
+	req.Header.Set("X-Forwarded-URI", "/")
+	req.Header.Set("Accept", "text/html; charset=utf8")
+
+	client := NewHTTPClient()
+	res, err := client.Do(req)
+	s.Assert().NoError(err)
+	s.Assert().Equal(res.StatusCode, 302)
+	body, err := ioutil.ReadAll(res.Body)
+	s.Assert().NoError(err)
+
+	urlEncodedAdminURL := url.QueryEscape(SecureBaseURL + "/")
+	s.Assert().Equal(fmt.Sprintf("<a href=\"%s\">Found</a>", utils.StringHTMLEscape(fmt.Sprintf("%s/?rd=%s&rm=GET", GetLoginBaseURL(), urlEncodedAdminURL))), string(body))
+
+	req.Header.Set("X-Forwarded-Method", "POST")
+
+	res, err = client.Do(req)
+	s.Assert().NoError(err)
+	s.Assert().Equal(res.StatusCode, 303)
+	body, err = ioutil.ReadAll(res.Body)
+	s.Assert().NoError(err)
+
+	urlEncodedAdminURL = url.QueryEscape(SecureBaseURL + "/")
+	s.Assert().Equal(fmt.Sprintf("<a href=\"%s\">See Other</a>", utils.StringHTMLEscape(fmt.Sprintf("%s/?rd=%s&rm=POST", GetLoginBaseURL(), urlEncodedAdminURL))), string(body))
+}
+
 // Standard case using nginx.
-func (s *StandaloneSuite) TestShouldVerifyAPIVerifyUnauthorize() {
+func (s *StandaloneSuite) TestShouldVerifyAPIVerifyUnauthorized() {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/verify", AutheliaBaseURL), nil)
 	s.Assert().NoError(err)
 	req.Header.Set("X-Forwarded-Proto", "https")
 	req.Header.Set("X-Original-URL", AdminBaseURL)
+	req.Header.Set("Accept", "text/html; charset=utf8")
 
 	client := NewHTTPClient()
 	res, err := client.Do(req)
@@ -141,7 +175,7 @@ func (s *StandaloneSuite) TestShouldVerifyAPIVerifyUnauthorize() {
 	s.Assert().Equal(res.StatusCode, 401)
 	body, err := ioutil.ReadAll(res.Body)
 	s.Assert().NoError(err)
-	s.Assert().Equal(string(body), "Unauthorized")
+	s.Assert().Equal("Unauthorized", string(body))
 }
 
 // Standard case using Kubernetes.
@@ -150,6 +184,7 @@ func (s *StandaloneSuite) TestShouldVerifyAPIVerifyRedirectFromXOriginalURL() {
 	s.Assert().NoError(err)
 	req.Header.Set("X-Forwarded-Proto", "https")
 	req.Header.Set("X-Original-URL", AdminBaseURL)
+	req.Header.Set("Accept", "text/html; charset=utf8")
 
 	client := NewHTTPClient()
 	res, err := client.Do(req)
@@ -159,7 +194,7 @@ func (s *StandaloneSuite) TestShouldVerifyAPIVerifyRedirectFromXOriginalURL() {
 	s.Assert().NoError(err)
 
 	urlEncodedAdminURL := url.QueryEscape(AdminBaseURL)
-	s.Assert().Equal(fmt.Sprintf("Found. Redirecting to %s?rd=%s", GetLoginBaseURL(), urlEncodedAdminURL), string(body))
+	s.Assert().Equal(fmt.Sprintf("<a href=\"%s\">Found</a>", utils.StringHTMLEscape(fmt.Sprintf("%s/?rd=%s", GetLoginBaseURL(), urlEncodedAdminURL))), string(body))
 }
 
 func (s *StandaloneSuite) TestShouldVerifyAPIVerifyRedirectFromXOriginalHostURI() {
@@ -168,6 +203,7 @@ func (s *StandaloneSuite) TestShouldVerifyAPIVerifyRedirectFromXOriginalHostURI(
 	req.Header.Set("X-Forwarded-Proto", "https")
 	req.Header.Set("X-Forwarded-Host", "secure.example.com:8080")
 	req.Header.Set("X-Forwarded-URI", "/")
+	req.Header.Set("Accept", "text/html; charset=utf8")
 
 	client := NewHTTPClient()
 	res, err := client.Do(req)
@@ -177,7 +213,7 @@ func (s *StandaloneSuite) TestShouldVerifyAPIVerifyRedirectFromXOriginalHostURI(
 	s.Assert().NoError(err)
 
 	urlEncodedAdminURL := url.QueryEscape(SecureBaseURL + "/")
-	s.Assert().Equal(fmt.Sprintf("Found. Redirecting to %s?rd=%s", GetLoginBaseURL(), urlEncodedAdminURL), string(body))
+	s.Assert().Equal(fmt.Sprintf("<a href=\"%s\">Found</a>", utils.StringHTMLEscape(fmt.Sprintf("%s/?rd=%s", GetLoginBaseURL(), urlEncodedAdminURL))), string(body))
 }
 
 func (s *StandaloneSuite) TestStandaloneWebDriverScenario() {

--- a/internal/utils/const.go
+++ b/internal/utils/const.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -54,3 +55,11 @@ var AlphaNumericCharacters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ
 
 // ErrTLSVersionNotSupported returned when an unknown TLS version supplied.
 var ErrTLSVersionNotSupported = errors.New("supplied TLS version isn't supported")
+
+var htmlEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+	`"`, "&#34;",
+	"'", "&#39;",
+)

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -139,3 +139,8 @@ func RandomString(n int, characters []rune) (randomString string) {
 
 	return string(b)
 }
+
+// StringHTMLEscape escapes chars for a HTML body.
+func StringHTMLEscape(input string) (output string) {
+	return htmlEscaper.Replace(input)
+}


### PR DESCRIPTION
This changes the way XML HTTP requests are handled on the /api/verify endpoint so that they are redirected properly using a 401 instead of a 302/303. Additionally implements some style refactoring.