### PR TITLE
feat(server): automatic cross-origin resource sharing

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -44,8 +44,26 @@ server:
   ## Cross-Origin Resource Sharing configuration options.
   cors:
 
-    ## Disable the automatic CORS middleware.
-    disable: false
+    ## Enable the CORS middleware.
+    enable: false
+
+    ## When overriding the origins, when this is set to true it will consider protected domains valid in addition to those above.
+    include_protected: false
+
+    ## Override the automatic origin checking.
+    origins: []
+
+    ## If empty the allowed headers are automatically configured based on the request headers if the origin is valid.
+    headers: []
+
+    ## If empty the allowed methods are automatically configured based on the request headers if the origin is valid.
+    methods: []
+
+    ## If empty the Vary header will be set to Accept-Encoding, Origin.
+    vary: []
+
+    ## Sets the Access-Control-Max-Age header value. Disable with -1.
+    max_age: 100
 
 log:
   ## Level of verbosity for logs: info, debug, trace.

--- a/config.template.yml
+++ b/config.template.yml
@@ -41,6 +41,12 @@ server:
   ## Enables the expvars endpoint.
   enable_expvars: false
 
+  ## Cross-Origin Resource Sharing configuration options.
+  cors:
+
+    ## Disable the automatic CORS middleware.
+    disable: false
+
 log:
   ## Level of verbosity for logs: info, debug, trace.
   level: debug

--- a/config.template.yml
+++ b/config.template.yml
@@ -47,7 +47,8 @@ server:
     ## Enable the CORS middleware.
     enable: false
 
-    ## When overriding the origins, when this is set to true it will consider protected domains valid in addition to those above.
+    ## Includes configured protected domain in the session settings and subdomains of that domain automatically.
+    ## This is assumed true if the origins list below does not have any values.
     include_protected: false
 
     ## Override the automatic origin checking.

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -100,6 +100,121 @@ required: no
 
 Enables the go expvars endpoints.
 
+### cors
+
+#### enable
+<div markdown="1">
+type: boolean
+{: .label .label-config .label-purple } 
+default: false
+{: .label .label-config .label-blue }
+required: no
+{: .label .label-config .label-green }
+</div>
+
+Before enabling [CORS] you should read the MDN [CORS] documentation or have some specific instructions from an app that
+requires it. The general rule is you should configure this as accurately as possible to your specific needs.
+
+This enables the automatic handling of [CORS] headers. If enabled we add CORS headers to GET/OPTIONS requests on the root
+path when the [Origin] header has a valid value. It is determined as valid if all of the following conditions are true:
+
+- the scheme of the origin is `https`
+- the domain of the origin is a subdomain of the value set in session domain
+
+The following headers will be set on these requests:
+
+|Header                            |Value                                                   |
+|:--------------------------------:|:------------------------------------------------------:|
+|[Vary]                            |Accept-Encoding, [Origin]                               |
+|[Access-Control-Allow-Origin]     |<value of [Origin] header>                              |
+|[Access-Control-Allow-Credentials]|false                                                   |
+|[Access-Control-Allow-Headers]    |<value of [Access-Control-Request-Headers] header>      |
+|[Access-Control-Allow-Methods]    |<value of [Access-Control-Request-Method] header or GET>|
+|[Access-Control-Max-Age]          |100                                                     |
+
+#### include_protected
+<div markdown="1">
+type: boolean
+{: .label .label-config .label-purple }
+default: false
+{: .label .label-config .label-blue }
+required: no
+{: .label .label-config .label-green }
+</div>
+
+If you override [origins](#origins) and you want to also automatically include any domain that is a subdomain of the 
+session domain, you can achieve this by enabling this option. This is particularly useful if you want to allow origins
+that are not protected but also keep all protected domains allowed.
+
+#### origins
+<div markdown="1">
+type: list(string)
+{: .label .label-config .label-purple } 
+required: no
+{: .label .label-config .label-green }
+</div>
+
+Overrides the default behaviour for validating the [Origin] header. Instead of checking the domain is protected by
+Authelia it checks this list of URLs (which must all start with `https`).
+
+You can alternatively set this to exactly `*` and it will allow all origins, however this not recommended for anyone
+without a deep understanding of [CORS].
+
+MDN Header Documentation: [Access-Control-Allow-Origin].
+
+#### headers
+<div markdown="1">
+type: list(string)
+{: .label .label-config .label-purple } 
+required: no
+{: .label .label-config .label-green }
+</div>
+
+Overrides the default behaviour of automatically allowing the headers requested by the CORS preflight.
+
+MDN Header Documentation: [Access-Control-Allow-Headers].
+
+#### methods
+<div markdown="1">
+type: list(string)
+{: .label .label-config .label-purple } 
+required: no
+{: .label .label-config .label-green }
+</div>
+
+Overrides the default behaviour of automatically allowing the methods requested by the CORS preflight. Is a list of valid
+HTTP request methods, or can be a single item `*` which allows all methods.
+
+MDN Header Documentation: [Access-Control-Allow-Methods].
+
+#### vary
+<div markdown="1">
+type: list(string)
+{: .label .label-config .label-purple }
+default: Accept-Encoding, Origin
+{: .label .label-config .label-blue }
+required: no
+{: .label .label-config .label-green }
+</div>
+
+A list of headers to be included in the Vary header.
+
+MDN Header Documentation: [Vary](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary).
+
+#### max_age
+<div markdown="1">
+type: int
+{: .label .label-config .label-purple }
+default: 100
+{: .label .label-config .label-blue }
+required: no
+{: .label .label-config .label-green }
+</div>
+
+The value of the [Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age) 
+header. Setting this to -1 disables it.
+
+MDN Header Documentation: [Access-Control-Max-Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age).
 
 ## Additional Notes
 
@@ -108,3 +223,14 @@ Enables the go expvars endpoints.
 The read and write buffer sizes generally should be the same. This is because when Authelia verifies
 if the user is authorized to visit a URL, it also sends back nearly the same size response as the request. However
 you're able to tune these individually depending on your needs.
+
+[CORS]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+[Vary]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
+[Origin]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
+[Access-Control-Allow-Origin]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+[Access-Control-Allow-Credentials]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials
+[Access-Control-Allow-Headers]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+[Access-Control-Allow-Methods]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
+[Access-Control-Max-Age]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
+[Access-Control-Request-Headers]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Headers
+[Access-Control-Request-Method]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -18,6 +18,8 @@ server:
   path: ""
   enable_pprof: false
   enable_expvars: false
+  cors:
+    disable: false
 ```
 
 ## Options

--- a/internal/authorization/util.go
+++ b/internal/authorization/util.go
@@ -168,13 +168,13 @@ func schemaSubjectsToACL(subjectRules [][]string) (subjects []AccessControlSubje
 }
 
 func domainToPrefixSuffix(domain string) (prefix, suffix string) {
-	parts := strings.Split(domain, ".")
+	parts := strings.SplitN(domain, ".", 2)
 
 	if len(parts) == 1 {
 		return "", parts[0]
 	}
 
-	return parts[0], strings.Join(parts[1:], ".")
+	return parts[0], parts[1]
 }
 
 // IsAuthLevelSufficient returns true if the current authenticationLevel is above the authorizationLevel.

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -44,8 +44,26 @@ server:
   ## Cross-Origin Resource Sharing configuration options.
   cors:
 
-    ## Disable the automatic CORS middleware.
-    disable: false
+    ## Enable the CORS middleware.
+    enable: false
+
+    ## When overriding the origins, when this is set to true it will consider protected domains valid in addition to those above.
+    include_protected: false
+
+    ## Override the automatic origin checking.
+    origins: []
+
+    ## If empty the allowed headers are automatically configured based on the request headers if the origin is valid.
+    headers: []
+
+    ## If empty the allowed methods are automatically configured based on the request headers if the origin is valid.
+    methods: []
+
+    ## If empty the Vary header will be set to Accept-Encoding, Origin.
+    vary: []
+
+    ## Sets the Access-Control-Max-Age header value. Disable with -1.
+    max_age: 100
 
 log:
   ## Level of verbosity for logs: info, debug, trace.

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -41,6 +41,12 @@ server:
   ## Enables the expvars endpoint.
   enable_expvars: false
 
+  ## Cross-Origin Resource Sharing configuration options.
+  cors:
+
+    ## Disable the automatic CORS middleware.
+    disable: false
+
 log:
   ## Level of verbosity for logs: info, debug, trace.
   level: debug

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -47,7 +47,8 @@ server:
     ## Enable the CORS middleware.
     enable: false
 
-    ## When overriding the origins, when this is set to true it will consider protected domains valid in addition to those above.
+    ## Includes configured protected domain in the session settings and subdomains of that domain automatically.
+    ## This is assumed true if the origins list below does not have any values.
     include_protected: false
 
     ## Override the automatic origin checking.

--- a/internal/configuration/schema/server.go
+++ b/internal/configuration/schema/server.go
@@ -13,11 +13,21 @@ type ServerConfiguration struct {
 
 // CORSConfiguration represents the configuration of the http server CORS configuration.
 type CORSConfiguration struct {
-	Disable bool `mapstructure:"disable"`
+	Enable           bool     `mapstructure:"enable"`
+	IncludeProtected bool     `mapstructure:"include_protected"`
+	Origins          []string `mapstructure:"origins,weak"`
+	Headers          []string `mapstructure:"headers,weak"`
+	Methods          []string `mapstructure:"methods,weak"`
+	Vary             []string `mapstructure:"vary,weak"`
+	MaxAge           int      `mapstructure:"max_age,weak"`
 }
 
 // DefaultServerConfiguration represents the default values of the ServerConfiguration.
 var DefaultServerConfiguration = ServerConfiguration{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
+	CORS: CORSConfiguration{
+		Vary:   []string{"Accept-Encoding", "Origin"},
+		MaxAge: 100,
+	},
 }

--- a/internal/configuration/schema/server.go
+++ b/internal/configuration/schema/server.go
@@ -7,6 +7,13 @@ type ServerConfiguration struct {
 	WriteBufferSize int    `mapstructure:"write_buffer_size"`
 	EnablePprof     bool   `mapstructure:"enable_endpoint_pprof"`
 	EnableExpvars   bool   `mapstructure:"enable_endpoint_expvars"`
+
+	CORS CORSConfiguration `mapstructure:"cors"`
+}
+
+// CORSConfiguration represents the configuration of the http server CORS configuration.
+type CORSConfiguration struct {
+	Disable bool `mapstructure:"disable"`
 }
 
 // DefaultServerConfiguration represents the default values of the ServerConfiguration.

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -6,6 +6,13 @@ const (
 )
 
 const (
+	errFmtServerCORSOriginParse  = "server: failed to parse CORS origin %s: %w"
+	errFmtServerCORSOriginScheme = "server: invalid CORS origin %s, scheme must be https"
+	errFmtServerCORSOriginPath   = "server: invalid CORS origin %s, must not have a path"
+	errFmtServerCORSMethods      = "server: invalid CORS method %s, must be one of %s"
+)
+
+const (
 	errFmtDeprecatedConfigurationKey = "[DEPRECATED] The %s configuration option is deprecated and will be " +
 		"removed in %s, please use %s instead"
 	errFmtReplacedConfigurationKey = "invalid configuration key '%s' was replaced by '%s'"
@@ -129,7 +136,15 @@ var validKeys = []string{
 	"server.path",
 	"server.enable_pprof",
 	"server.enable_expvars",
-	"server.cors.disable",
+
+	// Server CORS Keys.
+	"server.cors.enable",
+	"server.cors.origins",
+	"server.cors.include_protected",
+	"server.cors.headers",
+	"server.cors.methods",
+	"server.cors.vary",
+	"server.cors.max_age",
 
 	// TOTP Keys.
 	"totp.issuer",

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -129,6 +129,7 @@ var validKeys = []string{
 	"server.path",
 	"server.enable_pprof",
 	"server.enable_expvars",
+	"server.cors.disable",
 
 	// TOTP Keys.
 	"totp.issuer",

--- a/internal/configuration/validator/server.go
+++ b/internal/configuration/validator/server.go
@@ -2,15 +2,13 @@ package validator
 
 import (
 	"fmt"
+	"net/url"
 	"path"
 	"strings"
 
 	"github.com/authelia/authelia/internal/configuration/schema"
 	"github.com/authelia/authelia/internal/utils"
 )
-
-var defaultReadBufferSize = 4096
-var defaultWriteBufferSize = 4096
 
 // ValidateServer checks a server configuration is correct.
 func ValidateServer(configuration *schema.ServerConfiguration, validator *schema.StructValidator) {
@@ -25,14 +23,53 @@ func ValidateServer(configuration *schema.ServerConfiguration, validator *schema
 	}
 
 	if configuration.ReadBufferSize == 0 {
-		configuration.ReadBufferSize = defaultReadBufferSize
+		configuration.ReadBufferSize = schema.DefaultServerConfiguration.ReadBufferSize
 	} else if configuration.ReadBufferSize < 0 {
 		validator.Push(fmt.Errorf("server read buffer size must be above 0"))
 	}
 
 	if configuration.WriteBufferSize == 0 {
-		configuration.WriteBufferSize = defaultWriteBufferSize
+		configuration.WriteBufferSize = schema.DefaultServerConfiguration.WriteBufferSize
 	} else if configuration.WriteBufferSize < 0 {
 		validator.Push(fmt.Errorf("server write buffer size must be above 0"))
+	}
+
+	validateCORS(&configuration.CORS, validator)
+}
+
+func validateCORS(configuration *schema.CORSConfiguration, validator *schema.StructValidator) {
+	if configuration.MaxAge == 0 {
+		configuration.MaxAge = schema.DefaultServerConfiguration.CORS.MaxAge
+	}
+
+	if len(configuration.Origins) != 1 || configuration.Origins[0] != "*" {
+		for _, origin := range configuration.Origins {
+			originURL, err := url.Parse(origin)
+			if err != nil {
+				validator.Push(fmt.Errorf(errFmtServerCORSOriginParse, origin, err))
+
+				continue
+			}
+
+			if originURL.Scheme != "https" {
+				validator.Push(fmt.Errorf(errFmtServerCORSOriginScheme, origin))
+			}
+
+			if originURL.Path != "" || originURL.RawPath != "" {
+				validator.Push(fmt.Errorf(errFmtServerCORSOriginPath, origin))
+			}
+		}
+	}
+
+	if len(configuration.Methods) != 1 || configuration.Methods[0] != "*" {
+		for _, method := range configuration.Methods {
+			if !utils.IsStringInSlice(method, validHTTPRequestMethods) {
+				validator.Push(fmt.Errorf(errFmtServerCORSMethods, method, strings.Join(validHTTPRequestMethods, ", ")))
+			}
+		}
+	}
+
+	if len(configuration.Vary) == 0 {
+		configuration.Vary = schema.DefaultServerConfiguration.CORS.Vary
 	}
 }

--- a/internal/configuration/validator/server_test.go
+++ b/internal/configuration/validator/server_test.go
@@ -14,8 +14,10 @@ func TestShouldSetDefaultConfig(t *testing.T) {
 	config := schema.ServerConfiguration{}
 	ValidateServer(&config, validator)
 	require.Len(t, validator.Errors(), 0)
-	assert.Equal(t, defaultReadBufferSize, config.ReadBufferSize)
-	assert.Equal(t, defaultWriteBufferSize, config.WriteBufferSize)
+	assert.Equal(t, schema.DefaultServerConfiguration.ReadBufferSize, config.ReadBufferSize)
+	assert.Equal(t, schema.DefaultServerConfiguration.WriteBufferSize, config.WriteBufferSize)
+	assert.Equal(t, schema.DefaultServerConfiguration.CORS.MaxAge, config.CORS.MaxAge)
+	assert.Equal(t, schema.DefaultServerConfiguration.CORS.Vary, config.CORS.Vary)
 }
 
 func TestShouldParsePathCorrectly(t *testing.T) {

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -37,6 +37,13 @@ func NewAutheliaCtx(ctx *fasthttp.RequestCtx, configuration schema.Configuration
 	return autheliaCtx, nil
 }
 
+// AutheliaFastHTTPRequestHandlerMiddleware allows wrapping a fasthttp.RequestHandler in an AutheliaCtx.
+func AutheliaFastHTTPRequestHandlerMiddleware(next fasthttp.RequestHandler) RequestHandler {
+	return func(ctx *AutheliaCtx) {
+		next(ctx.RequestCtx)
+	}
+}
+
 // AutheliaMiddleware is wrapping the RequestCtx into an AutheliaCtx providing Authelia related objects.
 func AutheliaMiddleware(configuration schema.Configuration, providers Providers) RequestHandlerBridge {
 	return func(next RequestHandler) fasthttp.RequestHandler {

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -7,8 +7,20 @@ const (
 	headerXForwardedMethod = "X-Forwarded-Method"
 	headerXForwardedHost   = "X-Forwarded-Host"
 	headerXForwardedURI    = "X-Forwarded-URI"
-	headerXOriginalURL     = "X-Original-URL"
-	headerXRequestedWith   = "X-Requested-With"
+
+	headerXOriginalURL   = "X-Original-URL"
+	headerXRequestedWith = "X-Requested-With"
+
+	headerOrigin = "Origin"
+	headerVary   = "Vary"
+
+	headerAccessControlRequestHeaders = "Access-Control-Request-Headers"
+	headerAccessControlRequestMethod  = "Access-Control-Request-Method"
+
+	headerAccessControlAllowOrigin      = "Access-Control-Allow-Origin"
+	headerAccessControlAllowHeaders     = "Access-Control-Allow-Headers"
+	headerAccessControlAllowMethods     = "Access-Control-Allow-Methods"
+	headerAccessControlAllowCredentials = "Access-Control-Allow-Credentials"
 )
 
 const (

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -21,6 +21,7 @@ const (
 	headerAccessControlAllowHeaders     = "Access-Control-Allow-Headers"
 	headerAccessControlAllowMethods     = "Access-Control-Allow-Methods"
 	headerAccessControlAllowCredentials = "Access-Control-Allow-Credentials"
+	headerAccessControlMaxAge           = "Access-Control-Max-Age"
 )
 
 const (

--- a/internal/middlewares/cors.go
+++ b/internal/middlewares/cors.go
@@ -1,0 +1,38 @@
+package middlewares
+
+import (
+	"net/url"
+
+	"github.com/authelia/authelia/internal/utils"
+)
+
+// AutomaticCORSMiddleware automatically adds all relevant CORS headers to a request.
+func AutomaticCORSMiddleware(next RequestHandler) RequestHandler {
+	return func(ctx *AutheliaCtx) {
+		corsOrigin := ctx.Request.Header.Peek(headerOrigin)
+
+		if corsOrigin != nil {
+			corsOriginURL, err := url.Parse(string(corsOrigin))
+
+			if err == nil && corsOriginURL != nil && utils.IsRedirectionSafe(*corsOriginURL, ctx.Configuration.Session.Domain) {
+				ctx.Response.Header.SetBytesV(headerAccessControlAllowOrigin, corsOrigin)
+				ctx.Response.Header.Set(headerVary, "Accept-Encoding, Origin")
+				ctx.Response.Header.Set(headerAccessControlAllowCredentials, "false")
+
+				corsHeaders := ctx.Request.Header.Peek(headerAccessControlRequestHeaders)
+				if corsHeaders != nil {
+					ctx.Response.Header.SetBytesV(headerAccessControlAllowHeaders, corsHeaders)
+				}
+
+				corsMethod := ctx.Request.Header.Peek(headerAccessControlRequestMethod)
+				if corsHeaders != nil {
+					ctx.Response.Header.SetBytesV(headerAccessControlAllowMethods, corsMethod)
+				} else {
+					ctx.Response.Header.Set(headerAccessControlAllowMethods, "GET")
+				}
+			}
+		}
+
+		next(ctx)
+	}
+}

--- a/internal/middlewares/cors.go
+++ b/internal/middlewares/cors.go
@@ -2,37 +2,98 @@ package middlewares
 
 import (
 	"net/url"
+	"strings"
 
+	"github.com/authelia/authelia/internal/configuration/schema"
 	"github.com/authelia/authelia/internal/utils"
 )
 
-// AutomaticCORSMiddleware automatically adds all relevant CORS headers to a request.
-func AutomaticCORSMiddleware(next RequestHandler) RequestHandler {
-	return func(ctx *AutheliaCtx) {
-		corsOrigin := ctx.Request.Header.Peek(headerOrigin)
-
-		if corsOrigin != nil {
-			corsOriginURL, err := url.Parse(string(corsOrigin))
-
-			if err == nil && corsOriginURL != nil && utils.IsRedirectionSafe(*corsOriginURL, ctx.Configuration.Session.Domain) {
-				ctx.Response.Header.SetBytesV(headerAccessControlAllowOrigin, corsOrigin)
-				ctx.Response.Header.Set(headerVary, "Accept-Encoding, Origin")
-				ctx.Response.Header.Set(headerAccessControlAllowCredentials, "false")
-
-				corsHeaders := ctx.Request.Header.Peek(headerAccessControlRequestHeaders)
-				if corsHeaders != nil {
-					ctx.Response.Header.SetBytesV(headerAccessControlAllowHeaders, corsHeaders)
-				}
-
-				corsMethod := ctx.Request.Header.Peek(headerAccessControlRequestMethod)
-				if corsHeaders != nil {
-					ctx.Response.Header.SetBytesV(headerAccessControlAllowMethods, corsMethod)
-				} else {
-					ctx.Response.Header.Set(headerAccessControlAllowMethods, "GET")
-				}
+// CORS generates a middleware for adding CORS headers.
+func CORS(config *schema.CORSConfiguration) Middleware {
+	if config == nil || !config.Enable {
+		return func(next RequestHandler) RequestHandler {
+			return func(ctx *AutheliaCtx) {
+				next(ctx)
 			}
 		}
+	}
 
-		next(ctx)
+	headerOriginBytes := []byte(headerOrigin)
+	processCORS := generateProcessCORS(config)
+
+	return func(next RequestHandler) RequestHandler {
+		return func(ctx *AutheliaCtx) {
+			corsOrigin := ctx.Request.Header.PeekBytes(headerOriginBytes)
+
+			if corsOrigin != nil {
+				corsOriginURL, err := url.Parse(string(corsOrigin))
+				if err == nil && corsOriginURL != nil && corsOriginURL.Scheme == "https" {
+					processCORS(ctx, config, corsOrigin, *corsOriginURL)
+				}
+			}
+
+			next(ctx)
+		}
+	}
+}
+
+func generateProcessCORS(config *schema.CORSConfiguration) func(ctx *AutheliaCtx, config *schema.CORSConfiguration, corsOrigin []byte, corsOriginURL url.URL) {
+	var (
+		headerVaryBytes                          = []byte(headerVary)
+		headerAccessControlRequestHeadersBytes   = []byte(headerAccessControlRequestHeaders)
+		headerAccessControlRequestMethodBytes    = []byte(headerAccessControlRequestMethod)
+		headerAccessControlAllowOriginBytes      = []byte(headerAccessControlAllowOrigin)
+		headerAccessControlAllowCredentialsBytes = []byte(headerAccessControlAllowCredentials)
+		headerAccessControlAllowHeadersBytes     = []byte(headerAccessControlAllowHeaders)
+		headerAccessControlAllowMethodsBytes     = []byte(headerAccessControlAllowMethods)
+		headerAccessControlMaxAgeBytes           = []byte(headerAccessControlMaxAge)
+
+		falseBytes   = []byte("false")
+		maxAgeBytes  = []byte(string(rune(config.MaxAge)))
+		varyBytes    = []byte(strings.Join(config.Vary, ", "))
+		methodsBytes []byte
+		headersBytes []byte
+	)
+
+	if len(config.Methods) != 0 {
+		methodsBytes = []byte(strings.Join(config.Methods, ", "))
+	}
+
+	if len(config.Headers) != 0 {
+		headersBytes = []byte(strings.Join(config.Headers, ", "))
+	}
+
+	return func(ctx *AutheliaCtx, config *schema.CORSConfiguration, corsOrigin []byte, corsOriginURL url.URL) {
+		if corsOriginURL.Path != "" || corsOriginURL.RawPath != "" {
+			return
+		}
+
+		origins := len(config.Origins)
+
+		switch {
+		case origins == 0 && !utils.IsRedirectionSafe(corsOriginURL, ctx.Configuration.Session.Domain):
+			return
+		case origins != 0 && config.Origins[0] != "*" &&
+			(!config.IncludeProtected || !utils.IsRedirectionSafe(corsOriginURL, ctx.Configuration.Session.Domain)) &&
+			!utils.IsStringInSliceFold(corsOriginURL.String(), config.Origins):
+			return
+		}
+
+		ctx.Response.Header.SetBytesKV(headerAccessControlAllowOriginBytes, corsOrigin)
+		ctx.Response.Header.SetBytesKV(headerVaryBytes, varyBytes)
+		ctx.Response.Header.SetBytesKV(headerAccessControlAllowCredentialsBytes, falseBytes)
+		ctx.Response.Header.SetBytesKV(headerAccessControlMaxAgeBytes, maxAgeBytes)
+
+		if len(methodsBytes) != 0 {
+			ctx.Response.Header.SetBytesKV(headerAccessControlAllowMethodsBytes, methodsBytes)
+		} else {
+			ctx.Response.Header.SetBytesKV(headerAccessControlAllowMethodsBytes, ctx.Request.Header.PeekBytes(headerAccessControlRequestMethodBytes))
+		}
+
+		if len(headersBytes) != 0 {
+			ctx.Response.Header.SetBytesKV(headerAccessControlAllowHeadersBytes, headersBytes)
+		} else {
+			ctx.Response.Header.SetBytesKV(headerAccessControlAllowHeadersBytes, ctx.Request.Header.PeekBytes(headerAccessControlRequestHeadersBytes))
+		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -48,8 +48,6 @@ func registerRoutes(configuration schema.Configuration, providers middlewares.Pr
 	r.GET("/", autheliaMiddleware(middlewareCORS(middlewares.AutheliaFastHTTPRequestHandlerMiddleware(serveIndexHandler))))
 	r.OPTIONS("/", autheliaMiddleware(middlewareCORS(handleOPTIONS)))
 
-	r.OPTIONS("/", autheliaMiddleware(handleOPTIONS))
-
 	r.GET("/api/", serveSwaggerHandler)
 	r.GET("/api/"+apiFile, serveSwaggerAPIHandler)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,7 +42,14 @@ func registerRoutes(configuration schema.Configuration, providers middlewares.Pr
 	serveSwaggerAPIHandler := ServeTemplatedFile(swaggerAssets, apiFile, configuration.Server.Path, rememberMe, resetPassword, configuration.Session.Name, configuration.Theme)
 
 	r := router.New()
-	r.GET("/", serveIndexHandler)
+
+	if configuration.Server.CORS.Disable {
+		r.GET("/", serveIndexHandler)
+	} else {
+		r.GET("/", autheliaMiddleware(middlewares.AutomaticCORSMiddleware(middlewares.AutheliaFastHTTPRequestHandlerMiddleware(serveIndexHandler))))
+		r.OPTIONS("/", autheliaMiddleware(middlewares.AutomaticCORSMiddleware(handleOPTIONS)))
+	}
+
 	r.OPTIONS("/", autheliaMiddleware(handleOPTIONS))
 
 	r.GET("/api/", serveSwaggerHandler)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,8 @@ var assets embed.FS
 
 func registerRoutes(configuration schema.Configuration, providers middlewares.Providers) fasthttp.RequestHandler {
 	autheliaMiddleware := middlewares.AutheliaMiddleware(configuration, providers)
+	middlewareCORS := middlewares.CORS(&configuration.Server.CORS)
+
 	rememberMe := strconv.FormatBool(configuration.Session.RememberMeDuration != "0")
 	resetPassword := strconv.FormatBool(!configuration.AuthenticationBackend.DisableResetPassword)
 
@@ -43,12 +45,8 @@ func registerRoutes(configuration schema.Configuration, providers middlewares.Pr
 
 	r := router.New()
 
-	if configuration.Server.CORS.Disable {
-		r.GET("/", serveIndexHandler)
-	} else {
-		r.GET("/", autheliaMiddleware(middlewares.AutomaticCORSMiddleware(middlewares.AutheliaFastHTTPRequestHandlerMiddleware(serveIndexHandler))))
-		r.OPTIONS("/", autheliaMiddleware(middlewares.AutomaticCORSMiddleware(handleOPTIONS)))
-	}
+	r.GET("/", autheliaMiddleware(middlewareCORS(middlewares.AutheliaFastHTTPRequestHandlerMiddleware(serveIndexHandler))))
+	r.OPTIONS("/", autheliaMiddleware(middlewareCORS(handleOPTIONS)))
 
 	r.OPTIONS("/", autheliaMiddleware(handleOPTIONS))
 


### PR DESCRIPTION
This adds a middleware to Authelia's index handler GET/OPTIONS that automatically configures the CORS headers when a request is made with an Origin header containing a protected Authelia domain.