### PR TITLE
docs: update and unify contact options

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     url: https://www.authelia.com/docs/
     about: Read the Documentation
   - name: Matrix
-    url: https://riot.im/app/#/room/#authelia:matrix.org
+    url: https://matrix.to/#/#authelia:matrix.org
     about: Discuss Authelia with the Developers on Matrix which is the preferred method of contact
   - name: Discord
     url: https://discord.authelia.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing
 
-Anybody willing to contribute to the project either with code, documentation, security reviews or whatever, are very welcome to create or review pull requests and take part to discussions in our public chatroom on [Matrix](https://riot.im/app/#/room/#authelia:matrix.org).
+Anybody willing to contribute to the project either with code, documentation, security reviews or whatever, are very 
+welcome to create or review pull requests and take part in discussions in any of our public 
+[chat rooms](./README.md#contact-options).
 
 It's also possible to contribute financially in order to support the community.
 
@@ -35,20 +37,7 @@ Read more about this in the [GitHub docs, Re-requesting a review](https://docs.g
 
 ## Collaboration with maintainers
 
-Sometimes the codebase can be a challenge to navigate, especially for a first-time contributor.
-We don't want you spending an hour trying to work out something that would take us only a minute to explain.
+Sometimes the codebase can be a challenge to navigate, especially for a first-time contributor. We don't want you 
+spending an hour trying to work out something that would take us only a minute to explain.
 
-For that reason, we have [Matrix](#matrix) and [Discord](#discord) channels dedicated to helping anyone who's working on Pull Requests for Authelia.
-
-## Contact Options
-
-### Matrix
-
-Join the [Matrix Room](https://riot.im/app/#/room/#authelia:matrix.org) and locate one of the maintainers.
-You can identify them as they are the room administrators. Alternatively you can just ask for one of the
-maintainers.
-
-### Discord
-
-Join the [Discord Server](https://discord.authelia.com) and message the
-[#contributing](https://discord.com/channels/707844280412012608/804943261265297408) chat and contact a maintainer.
+If you'd like some help getting started we have several [contact options](./README.md#contact-options) available.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   [![License](https://img.shields.io/github/license/authelia/authelia?logo=apache&style=flat-square&color=blue)][Apache 2.0]
   [![Sponsor](https://img.shields.io/opencollective/all/authelia-sponsors?logo=Open%20Collective&label=financial%20contributors&style=flat-square&color=blue)](https://opencollective.com/authelia-sponsors)
   [![Discord](https://img.shields.io/discord/707844280412012608?label=discord&logo=discord&style=flat-square&color=blue)](https://discord.authelia.com)
-  [![Matrix](https://img.shields.io/matrix/authelia:matrix.org?label=matrix&logo=matrix&style=flat-square&color=blue)](https://riot.im/app/#/room/#authelia:matrix.org)
+  [![Matrix](https://img.shields.io/matrix/authelia-support:matrix.org?label=matrix&logo=matrix&style=flat-square&color=blue)](https://matrix.to/#/#authelia-support:matrix.org)
 
 **Authelia** is an open-source authentication and authorization server providing two-factor authentication and single 
 sign-on (SSO) for your applications via a web portal. It acts as a companion for reverse proxies like [nginx], [Traefik] 
@@ -142,25 +142,28 @@ For more information about [security](https://www.authelia.com/docs/security/) r
 
 ## Contact Options
 
-Several contact options exist for our community, the primary one being [Matrix](#matrix).
+Several contact options exist for our community, the primary one being [Matrix](#matrix). These are in addition to
+[GitHub issues](https://github.com/authelia/authelia/issues) for creating a [new issue](https://github.com/authelia/authelia/issues/new/choose).
 
 ### Matrix
 
-You can join the [Matrix Space](https://app.element.io/#/room/!qcxpPdXBiGBSTbFAJE:matrix.org?via=matrix.org) which 
-includes both the [Support Room](https://riot.im/app/#/room/#authelia:matrix.org) and the 
-[Contributing Room](https://riot.im/app/#/room/#authelia-contributing:matrix.org). The core team members are identified
-as administrators in the Rooms and Space.
+Community members are invited to join the [Matrix Space](https://matrix.to/#/#authelia:matrix.org) which includes both
+the [Support Room](https://matrix.to/#/#authelia-support:matrix.org) and the [Contributing Room](https://matrix.to/#/#authelia-contributing:matrix.org).
+
+- The core team members are identified as administrators in the Space and individual Rooms.
+- All channels are linked to [Discord](#discord).
 
 ### Discord
 
-You can join the [Discord Server](https://discord.authelia.com) where the
-[#support](https://discord.com/channels/707844280412012608/707844280412012612) and 
-[#contributing](https://discord.com/channels/707844280412012608/804943261265297408) channels link to [Matrix](#matrix).
+Community members are invited to join the [Discord Server](https://discord.authelia.com).
+
+- The core team members are identified by the <span style="color:#BA55D3;">**CORE TEAM**</span> role in Discord.
+- The [#support] and [#contributing] channels are linked to [Matrix](#matrix).
 
 ### Email
 
 You can contact the core team by email via [team@authelia.com](mailto:team@authelia.com). Please note the  
-[security@authelia.com](mailto:security@authelia.com) is also available but is strictly reserved for security related 
+[security@authelia.com](mailto:security@authelia.com) is also available but is strictly reserved for [security] related
 matters.
 
 ## Breaking changes
@@ -342,3 +345,6 @@ for providing us with free licenses to their great tools.
 [HAProxy]: https://www.haproxy.org/
 [Docker]: https://docker.com/
 [Kubernetes]: https://kubernetes.io/
+[security]: https://github.com/authelia/authelia/security/policy
+[#support]: https://discord.com/channels/707844280412012608/707844280412012612
+[#contributing]: https://discord.com/channels/707844280412012608/804943261265297408

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,43 +6,27 @@ Authelia takes security very seriously. We follow the rule of
 [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure), and we urge our community to do so as
 well instead of making the vulnerability public. This allows time for the security issue to be patched quickly.
 
-If you discover a vulnerability in Authelia, please first contact one of the maintainers privately either via 
-[Matrix](#matrix), [Discord](#discord), or [email](#email) as described in the [contact options](#contact-options) 
-below. We urge you not to disclose the bug publicly at least until we've had a chance to fix it.
+If you discover a vulnerability in Authelia, please first contact one of the maintainers privately  as described in the 
+[contact options](#contact-options) below. 
+
+We urge you not to disclose the bug publicly at least until we've had a
+reasonable chance to fix it, and to clearly communicate any public disclosure timeline in your initial contact with us. 
+If you do not have a particular public disclosure timeline, we will clearly communicate ours as we publish security
+advisories. 
 
 For more information about [security](https://www.authelia.com/docs/security/) related matters, please read 
 [the documentation](https://www.authelia.com/docs/security/).
 
 ## Contact Options
 
-### Matrix
-
-Join the [Matrix Space](https://app.element.io/#/room/!qcxpPdXBiGBSTbFAJE:matrix.org?via=matrix.org) which
-includes both the [Support Room](https://riot.im/app/#/room/#authelia:matrix.org) and the
-[Contributing Room](https://riot.im/app/#/room/#authelia-contributing:matrix.org). You can check the members list for
-one of the core team members who are identified as administrators in the rooms and space, alternatively you can just ask
-for one of the core team members in one of the rooms. Once you've made contact with a core team member we ask you
-privately message them to divulge the vulnerability.
-
-### Discord
-
-Join the [Discord Server](https://discord.authelia.com) and message the
-[#support](https://discord.com/channels/707844280412012608/707844280412012612) or 
-[#contributing](https://discord.com/channels/707844280412012608/804943261265297408) channels which link to 
-[Matrix](#matrix) and contact a core team member. Once you've made contact with a core team member we ask you privately
-message them to divulge the vulnerability.
-
-### Email
-
-You can contact any of the core team members for security vulnerability related issues by emailing
-[security@authelia.com](mailto:security@authelia.com). This email is strictly reserved for security and vulnerability
-disclosure related matters. If you need to contact us for any other reason please use 
-[team@authelia.com](mailto:team@authelia.com) or another [contact option](#contact-options).
+Several [contact options](./README.md#contact-options) exist, it's important to make sure you contact the maintainers
+privately which is described in each available contact method. The methods include our [security email](./README.md#security),
+[Matrix](./README.md#matrix), and [Discord](./README.md#discord).
 
 ## Credit
 
-Users who report bugs will optionally be creditted for the discovery. Both in the
-[security advisory](https://github.com/authelia/authelia/security/advisories) and in our all contributors configuration.
+Users who report bugs will optionally be creditted for the discovery. Both in the [security advisory] and in our 
+[all contributors](./README.md#contribute) configuration/documentation.
 
 ## Process
 
@@ -52,8 +36,7 @@ Users who report bugs will optionally be creditted for the discovery. Both in th
 4. The bug is patched, and if possible the user reporting te bug is given access to a fixed version or git patch.
 5. The fix is confirmed to resolve the vulnerability.
 6. The fix is released.
-7. The [security advisory](https://github.com/authelia/authelia/security/advisories) is published sometime after users 
-   have had a chance to update.
+7. The [security advisory] is published sometime after users have had a chance to update.
 
 ## Help Wanted
 
@@ -61,3 +44,4 @@ We are actively looking for sponsorship to obtain either a code security audit, 
 related to improving the security of Authelia. If your company or you personally are willing to offer discounts, pro
 bono, or funding towards services like these please feel free to contact us on *any* of the methods above.
 
+[security advisory]: https://github.com/authelia/authelia/security/advisories

--- a/docs/about-us.md
+++ b/docs/about-us.md
@@ -1,0 +1,69 @@
+---
+layout: default
+title: About Us
+nav_order: 10
+---
+
+## Core Team
+
+<table>
+    <td align="center">
+        <a href="https://github.com/clems4ever">
+            <img src="https://avatars.githubusercontent.com/u/3193257?v=4?s=100" width="100px;" alt=""/>
+            <br />
+            <sub>
+                <b>Clément Michaud</b>
+            </sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/nightah">
+            <img src="https://avatars.githubusercontent.com/u/3339418?v=4?s=100" width="100px;" alt=""/>
+            <br />
+            <sub>
+                <b>Amir Zarrinkafsh</b>
+            </sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/james-d-elliott">
+            <img src="https://avatars.githubusercontent.com/u/3903683?v=4?s=100" width="100px;" alt=""/>
+            <br />
+            <sub>
+                <b>James Elliott</b>
+            </sub>
+        </a>
+    </td>
+</table>
+
+
+## Contact Options
+
+Several contact options exist for our community, the primary one being [Matrix](#matrix). These are in addition to
+[GitHub issues](https://github.com/authelia/authelia/issues) for creating a [new issue](https://github.com/authelia/authelia/issues/new/choose).
+
+### Matrix
+
+Community members are invited to join the [Matrix Space](https://matrix.to/#/#authelia:matrix.org) which includes both
+the [Support Room](https://matrix.to/#/#authelia-support:matrix.org) and the [Contributing Room](https://matrix.to/#/#authelia-contributing:matrix.org). 
+
+- The core team members are identified as administrators in the Space and individual Rooms.
+- All channels are linked to [Discord](#discord).
+
+### Discord
+
+Community members are invited to join the [Discord Server](https://discord.authelia.com).
+
+- The core team members are identified by the <span style="color:#BA55D3;">**CORE TEAM**</span> role in Discord.
+- The [#support] and [#contributing] channels are linked to [Matrix](#matrix).
+
+### Email
+
+You can contact the core team by email via [team@authelia.com](mailto:team@authelia.com). Please note the  
+[security@authelia.com](mailto:security@authelia.com) is also available but is strictly reserved for [security] related
+matters.
+
+
+[security]: https://github.com/authelia/authelia/security/policy
+[#support]: https://discord.com/channels/707844280412012608/707844280412012612
+[#contributing]: https://discord.com/channels/707844280412012608/804943261265297408

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Community
-nav_order: 10
+nav_order: 11
 has_children: true
 ---
 

--- a/docs/deployment/deployment-kubernetes.md
+++ b/docs/deployment/deployment-kubernetes.md
@@ -19,8 +19,7 @@ The following areas are actively being worked on for Kubernetes:
 3. Kustomize Deployment
 4. Manifest Examples
 
-Users are welcome to reach out directly on our [Matrix Room](https://riot.im/app/#/room/#authelia:matrix.org) or 
-[Discord Server](https://discord.authelia.com) if they are looking for help setting up on Kubernetes in the meantime. 
+Users are welcome to reach out directly by using any of our various [contact options](../about-us.md#contact-options). 
 
 ## FAQ
 


### PR DESCRIPTION
This updates and unifies the contact options so it is easier to maintain. All contact options now link back to one of two locations, and both of these locations are a copy and paste for the most part.