### PR TITLE
fix(handlers): make user banned message consistent

### DIFF
--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -39,7 +39,6 @@ const (
 const (
 	messageOperationFailed                 = "Operation failed."
 	messageAuthenticationFailed            = "Authentication failed. Check your credentials."
-	messageUserBanned                      = "Please retry in a few minutes."
 	messageUnableToRegisterOneTimePassword = "Unable to set up one-time passwords." //nolint:gosec
 	messageUnableToRegisterSecurityKey     = "Unable to register your security key."
 	messageUnableToResetPassword           = "Unable to reset your password."

--- a/internal/handlers/handler_firstfactor.go
+++ b/internal/handlers/handler_firstfactor.go
@@ -81,7 +81,7 @@ func FirstFactorPost(msInitialDelay time.Duration, delayEnabled bool) middleware
 
 		if err != nil {
 			if err == regulation.ErrUserIsBanned {
-				handleAuthenticationUnauthorized(ctx, fmt.Errorf("User %s is banned until %s", bodyJSON.Username, bannedUntil), messageUserBanned)
+				handleAuthenticationUnauthorized(ctx, fmt.Errorf("User %s is banned until %s", bodyJSON.Username, bannedUntil), messageAuthenticationFailed)
 				return
 			}
 


### PR DESCRIPTION
This is so the user banned API message is consistent with other authentication failed messages, even in the API.

Fixes #2195