### PR TITLE
docs: fix missing line from the lite guide

### DIFF
--- a/docs/deployment/deployment-lite.md
+++ b/docs/deployment/deployment-lite.md
@@ -32,6 +32,7 @@ setup can easily be adapted to utilise said [service](../configuration/storage/i
 
 - `git clone https://github.com/authelia/authelia.git`
 - `cd authelia/examples/compose/lite`
+- ``git checkout $(git describe --tags `git rev-list --tags --max-count=1`)``
 - Modify the `users_database.yml` the default username and password is `authelia`
 - Modify the `configuration.yml` and `docker-compose.yml` with your respective domains and secrets
 - `docker-compose up -d`

--- a/examples/compose/lite/README.md
+++ b/examples/compose/lite/README.md
@@ -1,0 +1,3 @@
+# Usage
+
+Please see the [documentation](https://www.authelia.com/docs/deployment/deployment-lite.html) for usage instructions.


### PR DESCRIPTION
This ensures users checkout the latest tagged release when using the lite deployment.