### PR TITLE
ci(buildkite): make test concurrency gate conditional

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -78,11 +78,11 @@ steps:
     if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.env("CI_BYPASS") != "true"
 
   - wait:
-    if: build.env("CI_BYPASS") != "true"
+    if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.env("CI_BYPASS") != "true"
 
   - label: ":vertical_traffic_light: Test Concurrency Gate"
     command: "echo End of concurrency gate"
     concurrency: 3
     concurrency_group: "tests"
-    if: build.env("CI_BYPASS") != "true"
+    if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.env("CI_BYPASS") != "true"
 EOF


### PR DESCRIPTION
This ensures that the test concurrency gate step does not run on tagged releases are the integration steps are also skipped.