### PR TITLE
ci(buildkite): fix apt repo readme

### DIFF
--- a/.buildkite/steps/aptdeploy.sh
+++ b/.buildkite/steps/aptdeploy.sh
@@ -8,7 +8,8 @@ for ARCH in amd64 arm64 armhf; do
   echo "--- :debian: :fedora: :ubuntu: Deploy APT repository package for architecture: ${ARCH}"
   curl -s -H "Authorization: Bearer ${BALTO_TOKEN}" \
   -F "distribution=all" \
-  -F "readme=<$(echo README.md | sed -r 's/(\<img\ src\=\")(\.\/)/\1https:\/\/github.com\/authelia\/authelia\/raw\/master\//' | sed 's/\.\//https:\/\/github.com\/authelia\/authelia\/blob\/master\//g')" \
   -F "package=@authelia_${BUILDKITE_TAG//v}-1_${ARCH}.deb" \
+  --form-string "readme=$(cat README.md | sed -r 's/(\<img\ src\=\")(\.\/)/\1https:\/\/github.com\/authelia\/authelia\/raw\/master\//' | sed 's/\.\//https:\/\/github.com\/authelia\/authelia\/blob\/master\//g')" \
   https://apt.authelia.com/stable/debian/upload/
+  echo -e "\n"
 done


### PR DESCRIPTION
Image links in the apt repo README.md were broken as the file uploaded without the necessary modifications.