### PR TITLE
ci(buildkite): allow retry on successful docker deploy steps

### DIFF
--- a/.buildkite/steps/deployimages.sh
+++ b/.buildkite/steps/deployimages.sh
@@ -5,6 +5,9 @@ for BUILD_ARCH in amd64 arm32v7 arm64v8; do
 cat << EOF
   - label: ":docker: Deploy Image [${BUILD_ARCH}]"
     command: "authelia-scripts docker push-image --arch=${BUILD_ARCH}"
+    retry:
+      manual:
+        permit_on_passed: true
     depends_on:
 EOF
 if [[ "${BUILD_ARCH}" == "amd64" ]]; then


### PR DESCRIPTION
Occasionally during a manifest deployment tags can be removed and the step may fail. To ensure the manifest step can be completed successfully it would require re-pushing the tags that had been removed.

Turning on the `permit_on_passed` option allows us to control this all through the Buildkite interface as opposed to manual intervention.