### PR TITLE
fix(notifier): regression in startup check

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -127,7 +127,7 @@ func getProviders(config *schema.Configuration) (providers middlewares.Providers
 		errors = append(errors, fmt.Errorf("unrecognized notifier provider"))
 	}
 
-	if notifier != nil {
+	if notifier != nil && !config.Notifier.DisableStartupCheck {
 		if _, err := notifier.StartupCheck(); err != nil {
 			errors = append(errors, fmt.Errorf("failed to check notification provider: %w", err))
 		}


### PR DESCRIPTION
The changes in the koanf commit a7e867a699a77f0b9d564defd81094fd410e4404 introduced a regression in the startup procedure that prevented the option to disable the startup check from having an effect. This ensures the startup check is not performed if it is disabled as it was intended.