### PR TITLE
fix: healthcheck always returns healthy

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
+source /app/.healthcheck.env
+
 if [ -z "${X_AUTHELIA_HEALTHCHECK}" ]; then
   exit 0
 fi
-
-source /app/.healthcheck.env
 
 if [ -z "${X_AUTHELIA_HEALTHCHECK_SCHEME}" ]; then
   X_AUTHELIA_HEALTHCHECK_SCHEME=http


### PR DESCRIPTION
The healthcheck will always return 0 (healthy) since we don't source the env file before checking the ENV var.