### PR TITLE
fix(configuration): ldap timeout option not recognized as valid

### DIFF
--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -244,6 +244,7 @@ var ValidKeys = []string{
 	// LDAP Authentication Backend Keys.
 	"authentication_backend.ldap.implementation",
 	"authentication_backend.ldap.url",
+	"authentication_backend.ldap.timeout",
 	"authentication_backend.ldap.base_dn",
 	"authentication_backend.ldap.username_attribute",
 	"authentication_backend.ldap.additional_users_dn",


### PR DESCRIPTION
This is so an unexpected error doesn't occur when someone uses the new ldap timeout key which we missed adding to the list of valid keys in b2a49e1780041943862590984070a2268a87d823.