### PR TITLE
fix(handlers): ensure server path is appended to the oidc issuer

### DIFF
--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -60,6 +60,8 @@ const (
 
 // OIDC constants.
 const (
+	pathOpenIDConnectWellKnown = "/.well-known/openid-configuration"
+
 	pathOpenIDConnectJWKs          = "/api/oidc/jwks"
 	pathOpenIDConnectAuthorization = "/api/oidc/authorize"
 	pathOpenIDConnectToken         = "/api/oidc/token" //nolint:gosec // This is not a hard coded credential, it's a path.

--- a/internal/handlers/handler_oidc_wellknown.go
+++ b/internal/handlers/handler_oidc_wellknown.go
@@ -21,6 +21,7 @@ func oidcWellKnown(ctx *middlewares.AutheliaCtx) {
 		return
 	}
 
+	// TODO (james-d-elliott): figure out a cleaner way to handle this.
 	if ctx.Configuration.Server.Path != "" {
 		issuerURL, err := url.Parse(issuer)
 		if err == nil {

--- a/internal/handlers/oidc_register.go
+++ b/internal/handlers/oidc_register.go
@@ -9,7 +9,7 @@ import (
 // RegisterOIDC registers the handlers with the fasthttp *router.Router. TODO: Add paths for UserInfo, Flush, Logout.
 func RegisterOIDC(router *router.Router, middleware middlewares.RequestHandlerBridge) {
 	// TODO: Add OPTIONS handler.
-	router.GET("/.well-known/openid-configuration", middleware(oidcWellKnown))
+	router.GET(pathOpenIDConnectWellKnown, middleware(oidcWellKnown))
 
 	router.GET(pathOpenIDConnectConsent, middleware(oidcConsent))
 


### PR DESCRIPTION
This ensures the server path is appended to the oidc well-known issuer information.