### PR TITLE
fix(middlewares): strip path middleware strips path indiscriminately

### DIFF
--- a/internal/middlewares/strip_path.go
+++ b/internal/middlewares/strip_path.go
@@ -1,21 +1,17 @@
 package middlewares
 
 import (
-	"bytes"
+	"strings"
 
 	"github.com/valyala/fasthttp"
 )
 
 // StripPathMiddleware strips the first level of a path.
-func StripPathMiddleware(next fasthttp.RequestHandler) fasthttp.RequestHandler {
-	return func(ctx *fasthttp.RequestCtx) {
-		uri := ctx.Request.RequestURI()
-		n := bytes.IndexByte(uri[1:], '/')
+func StripPathMiddleware(path string, next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	path = "/" + path + "/"
 
-		if n >= 0 {
-			uri = uri[n+1:]
-			ctx.Request.SetRequestURI(string(uri))
-		}
+	return func(ctx *fasthttp.RequestCtx) {
+		ctx.Request.SetRequestURI(strings.TrimPrefix(string(ctx.RequestURI()), path))
 
 		next(ctx)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -143,7 +143,7 @@ func registerRoutes(configuration schema.Configuration, providers middlewares.Pr
 
 	handler := middlewares.LogRequestMiddleware(r.Handler)
 	if configuration.Server.Path != "" {
-		handler = middlewares.StripPathMiddleware(handler)
+		handler = middlewares.StripPathMiddleware(configuration.Server.Path, r.Handler)
 	}
 
 	if providers.OpenIDConnect.Fosite != nil {


### PR DESCRIPTION
…ured path

This adjusts the server.path configuration to only strip the configured path instead of entirely the first level regardless of its content.