### PR TITLE
docs(configuration): add migration note about k8s

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -42,8 +42,9 @@ environment variables must be prefixed with `AUTHELIA_`.
 _**Please Note:** It is not possible to configure_ the _access control rules section or OpenID Connect identity provider
 section using environment variables at this time._
 
-_**Please Note:** There are compatability issues with Kubernetes and this particular configuration option. You must ensure you
-have the `enableServiceLinks: false` setting in your pod spec._
+_**Please Note:** There are compatability issues with Kubernetes and this particular configuration option. You must 
+ensure you have the `enableServiceLinks: false` setting in your pod spec. You can read more about this in the 
+[migration documentation](./migration.md#kubernetes-4300)._
 
 Underscores replace indented configuration sections or subkeys. For example the following environment variables replace
 the configuration snippet that follows it:

--- a/docs/configuration/migration.md
+++ b/docs/configuration/migration.md
@@ -42,6 +42,24 @@ The following changes occurred in 4.30.0:
 |log_file_path|log.file_path         |
 |log_format   |log.format            |
 
+#### Kubernetes 4.30.0
+
+_**Please Note:** if you're using Authelia with Kubernetes and are not using the provided [helm chart](https://charts.authelia.com)
+you will be required to set the following option in your PodSpec. Keeping in mind this example is for a Pod, not for
+a Deployment, StatefulSet, or DaemonSet; you will need to adapt the `enableServiceLinks` option to fit into the relevant
+location depending on your needs._
+
+```yaml
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: authelia
+spec:
+  enableServiceLinks: false
+...
+```
+
 ### 4.25.0
 
 The following changes occurred in 4.25.0:


### PR DESCRIPTION
This adds some additional information about configuration on k8s for version 4.30+.