### PR TITLE
ci(buildkite): allow manual retry on successful steps

### DIFF
--- a/.buildkite/deployment.sh
+++ b/.buildkite/deployment.sh
@@ -31,6 +31,9 @@ steps:
 
   - label: ":docker: Deploy Manifests"
     command: "authelia-scripts docker push-manifest"
+    retry:
+      manual:
+        permit_on_passed: true
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     agents:

--- a/.buildkite/steps/buildimages.sh
+++ b/.buildkite/steps/buildimages.sh
@@ -8,6 +8,9 @@ for BUILD_OS in "${!BUILDS[@]}"; do
 cat << EOF
   - label: ":docker: Build Image [${BUILD_ARCH}]"
     command: "authelia-scripts docker build --arch=${BUILD_ARCH}"
+    retry:
+      manual:
+        permit_on_passed: true
     agents:
       build: "${BUILD_OS}-${BUILD_ARCH}"
     artifact_paths:


### PR DESCRIPTION
This permits manual retry on specific steps which can cause problematic issues for example when a node runs out of disk space.

By allowing this we should be able to recover problematic builds instead of forcing a complete rebuild which may be undesirable on the `master` or other production branches.