### PR TITLE
fix(configuration): make notifier logging consistent and more accurate

### DIFF
--- a/docs/configuration/migration.md
+++ b/docs/configuration/migration.md
@@ -42,6 +42,11 @@ The following changes occurred in 4.30.0:
 |log_file_path|log.file_path         |
 |log_format   |log.format            |
 
+_**Please Note:** you can no longer define secrets for providers that you are not using. For example if you're using the 
+[filesystem notifier](./notifier/filesystem.md) you must ensure that the `AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE` 
+environment variable or other environment variables set. This also applies to other providers like 
+[storage](./storage/index.md) and [authentication backend](./authentication/index.md)._
+
 #### Kubernetes 4.30.0
 
 _**Please Note:** if you're using Authelia with Kubernetes and are not using the provided [helm chart](https://charts.authelia.com)

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -43,6 +43,17 @@ const (
 	testTLSKey        = "/tmp/key.pem"
 )
 
+const (
+	errFmtNotifierMultipleConfigured = "notifier: you can't configure more than one notifier, please ensure " +
+		"only 'smtp' or 'filesystem' is configured"
+	errFmtNotifierMultipleConfiguredSecret = "notifier: you can't configure more than one notifier, please ensure " +
+		"only 'smtp' or 'filesystem' is configured, and it appears you have the smtp notifier password secret configured"
+	errFmtNotifierNotConfigured = "notifier: you must ensure either the 'smtp' or 'filesystem' notifier " +
+		"is configured"
+	errFmtNotifierFileSystemFileNameNotConfigured = "filesystem notifier: the filename must be configured"
+	errFmtNotifierSMTPNotConfigured               = "smtp notifier: the %s must be configured"
+)
+
 // OpenID Error constants.
 const (
 	errFmtOIDCClientsDuplicateID        = "openid connect provider: one or more clients have the same ID"

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -47,12 +47,12 @@ const (
 	errFmtNotifierMultipleConfigured = "notifier: you can't configure more than one notifier, please ensure " +
 		"only 'smtp' or 'filesystem' is configured"
 	errFmtNotifierMultipleConfiguredSecret = "notifier: you can't configure more than one notifier, please ensure " +
-		"only 'smtp' or 'filesystem' is configured, and it appears you may have the smtp notifier password secret " +
+		"only 'smtp' or 'filesystem' is configured, it appears you may have the smtp notifier 'password' secret " +
 		"configured unintentionally"
 	errFmtNotifierNotConfigured = "notifier: you must ensure either the 'smtp' or 'filesystem' notifier " +
 		"is configured"
-	errFmtNotifierFileSystemFileNameNotConfigured = "filesystem notifier: the filename must be configured"
-	errFmtNotifierSMTPNotConfigured               = "smtp notifier: the %s must be configured"
+	errFmtNotifierFileSystemFileNameNotConfigured = "filesystem notifier: the 'filename' must be configured"
+	errFmtNotifierSMTPNotConfigured               = "smtp notifier: the '%s' must be configured"
 )
 
 // OpenID Error constants.

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -43,12 +43,10 @@ const (
 	testTLSKey        = "/tmp/key.pem"
 )
 
+// Notifier Error constants.
 const (
 	errFmtNotifierMultipleConfigured = "notifier: you can't configure more than one notifier, please ensure " +
 		"only 'smtp' or 'filesystem' is configured"
-	errFmtNotifierMultipleConfiguredSecret = "notifier: you can't configure more than one notifier, please ensure " +
-		"only 'smtp' or 'filesystem' is configured, it appears you may have the smtp notifier 'password' secret " +
-		"configured unintentionally"
 	errFmtNotifierNotConfigured = "notifier: you must ensure either the 'smtp' or 'filesystem' notifier " +
 		"is configured"
 	errFmtNotifierFileSystemFileNameNotConfigured = "filesystem notifier: the 'filename' must be configured"

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -47,7 +47,8 @@ const (
 	errFmtNotifierMultipleConfigured = "notifier: you can't configure more than one notifier, please ensure " +
 		"only 'smtp' or 'filesystem' is configured"
 	errFmtNotifierMultipleConfiguredSecret = "notifier: you can't configure more than one notifier, please ensure " +
-		"only 'smtp' or 'filesystem' is configured, and it appears you have the smtp notifier password secret configured"
+		"only 'smtp' or 'filesystem' is configured, and it appears you may have the smtp notifier password secret " +
+		"configured unintentionally"
 	errFmtNotifierNotConfigured = "notifier: you must ensure either the 'smtp' or 'filesystem' notifier " +
 		"is configured"
 	errFmtNotifierFileSystemFileNameNotConfigured = "filesystem notifier: the filename must be configured"

--- a/internal/configuration/validator/notifier.go
+++ b/internal/configuration/validator/notifier.go
@@ -13,7 +13,6 @@ func ValidateNotifier(configuration *schema.NotifierConfiguration, validator *sc
 
 		return
 	} else if configuration.SMTP != nil && configuration.FileSystem != nil {
-
 		if configuration.SMTP.Password != "" &&
 			configuration.SMTP.Host == "" && configuration.SMTP.Port == 0 && configuration.SMTP.Sender == "" &&
 			configuration.SMTP.Subject == "" && configuration.SMTP.Identifier == "" && configuration.SMTP.Username == "" {

--- a/internal/configuration/validator/notifier.go
+++ b/internal/configuration/validator/notifier.go
@@ -13,13 +13,7 @@ func ValidateNotifier(configuration *schema.NotifierConfiguration, validator *sc
 
 		return
 	} else if configuration.SMTP != nil && configuration.FileSystem != nil {
-		if configuration.SMTP.Password != "" &&
-			configuration.SMTP.Host == "" && configuration.SMTP.Port == 0 && configuration.SMTP.Sender == "" &&
-			configuration.SMTP.Subject == "" && configuration.SMTP.Identifier == "" && configuration.SMTP.Username == "" {
-			validator.Push(fmt.Errorf(errFmtNotifierMultipleConfiguredSecret))
-		} else {
-			validator.Push(fmt.Errorf(errFmtNotifierMultipleConfigured))
-		}
+		validator.Push(fmt.Errorf(errFmtNotifierMultipleConfigured))
 
 		return
 	}

--- a/internal/configuration/validator/notifier.go
+++ b/internal/configuration/validator/notifier.go
@@ -8,16 +8,26 @@ import (
 
 // ValidateNotifier validates and update notifier configuration.
 func ValidateNotifier(configuration *schema.NotifierConfiguration, validator *schema.StructValidator) {
-	if configuration.SMTP == nil && configuration.FileSystem == nil ||
-		configuration.SMTP != nil && configuration.FileSystem != nil {
-		validator.Push(fmt.Errorf("Notifier should be either `smtp` or `filesystem`"))
+	if configuration.SMTP == nil && configuration.FileSystem == nil {
+		validator.Push(fmt.Errorf(errFmtNotifierNotConfigured))
+
+		return
+	} else if configuration.SMTP != nil && configuration.FileSystem != nil {
+
+		if configuration.SMTP.Password != "" &&
+			configuration.SMTP.Host == "" && configuration.SMTP.Port == 0 && configuration.SMTP.Sender == "" &&
+			configuration.SMTP.Subject == "" && configuration.SMTP.Identifier == "" && configuration.SMTP.Username == "" {
+			validator.Push(fmt.Errorf(errFmtNotifierMultipleConfiguredSecret))
+		} else {
+			validator.Push(fmt.Errorf(errFmtNotifierMultipleConfigured))
+		}
 
 		return
 	}
 
 	if configuration.FileSystem != nil {
 		if configuration.FileSystem.Filename == "" {
-			validator.Push(fmt.Errorf("Filename of filesystem notifier must not be empty"))
+			validator.Push(fmt.Errorf(errFmtNotifierFileSystemFileNameNotConfigured))
 		}
 
 		return
@@ -32,15 +42,15 @@ func validateSMTPNotifier(configuration *schema.SMTPNotifierConfiguration, valid
 	}
 
 	if configuration.Host == "" {
-		validator.Push(fmt.Errorf("Host of SMTP notifier must be provided"))
+		validator.Push(fmt.Errorf(errFmtNotifierSMTPNotConfigured, "host"))
 	}
 
 	if configuration.Port == 0 {
-		validator.Push(fmt.Errorf("Port of SMTP notifier must be provided"))
+		validator.Push(fmt.Errorf(errFmtNotifierSMTPNotConfigured, "port"))
 	}
 
 	if configuration.Sender == "" {
-		validator.Push(fmt.Errorf("Sender of SMTP notifier must be provided"))
+		validator.Push(fmt.Errorf(errFmtNotifierSMTPNotConfigured, "sender"))
 	}
 
 	if configuration.Subject == "" {

--- a/internal/configuration/validator/notifier_test.go
+++ b/internal/configuration/validator/notifier_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/authelia/authelia/internal/configuration/schema"
@@ -132,24 +130,4 @@ func (suite *NotifierSuite) TestShouldEnsureSenderOfSMTPNotifierAreProvided() {
 
 func TestNotifierSuite(t *testing.T) {
 	suite.Run(t, new(NotifierSuite))
-}
-
-func TestShouldEnsureFilesystemNotifierIsNotConfiguredWithSMTPSecret(t *testing.T) {
-	configuration := &schema.NotifierConfiguration{
-		FileSystem: &schema.FileSystemNotifierConfiguration{
-			Filename: "/tmp/file.txt",
-		},
-		SMTP: &schema.SMTPNotifierConfiguration{
-			Password: "apple",
-		},
-	}
-
-	validator := schema.NewStructValidator()
-
-	ValidateNotifier(configuration, validator)
-
-	assert.Len(t, validator.Warnings(), 0)
-	require.Len(t, validator.Errors(), 1)
-
-	assert.EqualError(t, validator.Errors()[0], errFmtNotifierMultipleConfiguredSecret)
 }

--- a/internal/configuration/validator/notifier_test.go
+++ b/internal/configuration/validator/notifier_test.go
@@ -1,8 +1,11 @@
 package validator
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/authelia/authelia/internal/configuration/schema"
@@ -40,7 +43,7 @@ func (suite *NotifierSuite) TestShouldEnsureAtLeastSMTPOrFilesystemIsProvided() 
 
 	suite.Assert().Len(suite.validator.Errors(), 1)
 
-	suite.Assert().EqualError(suite.validator.Errors()[0], "Notifier should be either `smtp` or `filesystem`")
+	suite.Assert().EqualError(suite.validator.Errors()[0], errFmtNotifierNotConfigured)
 }
 
 func (suite *NotifierSuite) TestShouldEnsureEitherSMTPOrFilesystemIsProvided() {
@@ -59,7 +62,7 @@ func (suite *NotifierSuite) TestShouldEnsureEitherSMTPOrFilesystemIsProvided() {
 
 	suite.Assert().Len(suite.validator.Errors(), 1)
 
-	suite.Assert().EqualError(suite.validator.Errors()[0], "Notifier should be either `smtp` or `filesystem`")
+	suite.Assert().EqualError(suite.validator.Errors()[0], errFmtNotifierMultipleConfigured)
 }
 
 func (suite *NotifierSuite) TestShouldEnsureFilenameOfFilesystemNotifierIsProvided() {
@@ -81,7 +84,7 @@ func (suite *NotifierSuite) TestShouldEnsureFilenameOfFilesystemNotifierIsProvid
 
 	suite.Assert().Len(suite.validator.Errors(), 1)
 
-	suite.Assert().EqualError(suite.validator.Errors()[0], "Filename of filesystem notifier must not be empty")
+	suite.Assert().EqualError(suite.validator.Errors()[0], errFmtNotifierFileSystemFileNameNotConfigured)
 }
 
 func (suite *NotifierSuite) TestShouldEnsureHostAndPortOfSMTPNotifierAreProvided() {
@@ -103,8 +106,8 @@ func (suite *NotifierSuite) TestShouldEnsureHostAndPortOfSMTPNotifierAreProvided
 
 	suite.Require().Len(errors, 2)
 
-	suite.Assert().EqualError(errors[0], "Host of SMTP notifier must be provided")
-	suite.Assert().EqualError(errors[1], "Port of SMTP notifier must be provided")
+	suite.Assert().EqualError(errors[0], fmt.Sprintf(errFmtNotifierSMTPNotConfigured, "host"))
+	suite.Assert().EqualError(errors[1], fmt.Sprintf(errFmtNotifierSMTPNotConfigured, "port"))
 }
 
 func (suite *NotifierSuite) TestShouldEnsureSenderOfSMTPNotifierAreProvided() {
@@ -124,9 +127,29 @@ func (suite *NotifierSuite) TestShouldEnsureSenderOfSMTPNotifierAreProvided() {
 
 	suite.Assert().Len(suite.validator.Errors(), 1)
 
-	suite.Assert().EqualError(suite.validator.Errors()[0], "Sender of SMTP notifier must be provided")
+	suite.Assert().EqualError(suite.validator.Errors()[0], fmt.Sprintf(errFmtNotifierSMTPNotConfigured, "sender"))
 }
 
 func TestNotifierSuite(t *testing.T) {
 	suite.Run(t, new(NotifierSuite))
+}
+
+func TestShouldEnsureFilesystemNotifierIsNotConfiguredWithSMTPSecret(t *testing.T) {
+	configuration := &schema.NotifierConfiguration{
+		FileSystem: &schema.FileSystemNotifierConfiguration{
+			Filename: "/tmp/file.txt",
+		},
+		SMTP: &schema.SMTPNotifierConfiguration{
+			Password: "apple",
+		},
+	}
+
+	validator := schema.NewStructValidator()
+
+	ValidateNotifier(configuration, validator)
+
+	assert.Len(t, validator.Warnings(), 0)
+	require.Len(t, validator.Errors(), 1)
+
+	assert.EqualError(t, validator.Errors()[0], errFmtNotifierMultipleConfiguredSecret)
 }


### PR DESCRIPTION
This ensures the notifier logs are more accurate to give people a clear picture of if they either have no notifier specified or multiple.