### PR TITLE
docs: add nextcloud community tested oidc apps

### DIFF
--- a/docs/community/oidc-integrations.md
+++ b/docs/community/oidc-integrations.md
@@ -17,6 +17,7 @@ nav_order: 4
 | GitLab      | `13.0.0`                       | |
 | Grafana     | `8.0.5`                        | |
 | MinIO       | `RELEASE.2021-07-12T02-44-53Z` | must set `MINIO_IDENTITY_OPENID_CLAIM_NAME: groups` in MinIO and set [MinIO policies] as groups in Authelia |
+| Nextcloud   | `22.1.0`                       | Tested using the `nextcloud-oidc-login` app - [Link](https://github.com/pulsejet/nextcloud-oidc-login)|
 
 [MinIO policies]: https://docs.min.io/minio/baremetal/security/minio-identity-management/policy-based-access-control.html#minio-policy
 
@@ -31,3 +32,4 @@ If you do not find the application in the list below, you will need to search fo
 | Gitea       | `1.14.6`                       | `<DOMAIN>/user/oauth2/authelia/callback`                 |`ROOT_URL` in `[server]` section of `app.ini` must be configured correctly. Typically it is `<DOMAIN>/`. The string `authelia` in the callback url is the `Authentication Name` of the configured Authentication Source in Gitea (Authentication Type: OAuth2, OAuth2 Provider: OpenID Connect).
 | GitLab      | `14.0.1`                       | `<DOMAIN>/users/auth/openid_connect/callback`            | |
 | MinIO       | `RELEASE.2021-07-12T02-44-53Z` | `<DOMAIN>/oauth_callback`                                | |
+| Nextcloud   | `22.1.0` + `nextcloud-oidc-login` app | `<DOMAIN>/apps/oidc_login/oidc`                                | |


### PR DESCRIPTION
Heya! Just did some trial and error until I managed to get Nextcloud to auth through OpenID Connect with Authelia and figured I'd post the callback URL I used to get it working. 

I put the latest stable nextcloud version (currently `22.1.0`) as the minimum version because that's what I have at hand to test on but since the OIDC login stuff actually depends on an app from their app store and seems to be available going back several versions it might very well work just the same with older installations. 

Let me know if you need any more info or if there are any tests/best-practices/whatever I should follow with the PR. 

Thanks for the awesome work on this :D.