### PR TITLE
refactor(web): eslint glob pattern

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "start": "craco start",
     "build": "craco build",
-    "lint": "eslint '*/**/*.{js,ts,tsx}' --fix",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "coverage": "COVERAGE=true craco build",
     "test": "craco test --coverage --no-cache",
     "report": "nyc report -r clover -r json -r lcov -r text",


### PR DESCRIPTION
The current eslint glob pattern is not Windows friendly, this change works for both Linux and Windows.