### PR TITLE
fix(session): change keyprefix of redis provider

### DIFF
--- a/internal/session/provider_config.go
+++ b/internal/session/provider_config.go
@@ -92,7 +92,7 @@ func NewProviderConfig(configuration schema.SessionConfiguration, certPool *x509
 				MinIdleConns:     configuration.Redis.MinimumIdleConnections,
 				IdleTimeout:      300,
 				TLSConfig:        tlsConfig,
-				KeyPrefix:        "authelia-session",
+				KeyPrefix:        "{authelia-session}",
 			}
 		} else {
 			providerName = "redis"
@@ -117,7 +117,7 @@ func NewProviderConfig(configuration schema.SessionConfiguration, certPool *x509
 				MinIdleConns: configuration.Redis.MinimumIdleConnections,
 				IdleTimeout:  300,
 				TLSConfig:    tlsConfig,
-				KeyPrefix:    "authelia-session",
+				KeyPrefix:    "{authelia-session}",
 			}
 		}
 


### PR DESCRIPTION
Change KeyPrefix of Redis provider by wrapping it in curly braces, so all entries are stored in single slot.

Hashing algorithm of open-source Redis (including Sentinel) does not allow customization, but has one built-in policy: if curly braces are found, string in it is taken as input to hashing function instead if entire key. https://redis.com/blog/redis-clustering-best-practices-with-keys/

This resolves #2323 where `CROSSSLOT` error occurred.