### PR TITLE
fix(api): /api/checks/safe-redirection missing schemas

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -570,6 +570,19 @@ components:
         type: string
         enum: ["basic"]
   schemas:
+    handlers.checkURIWithinDomainRequestBody:
+      type: object
+      properties:
+        uri:
+          type: string
+          example: https://secure.example.com
+    handlers.checkURIWithinDomainResponseBody:
+      type: object
+      properties:
+        ok:
+          type: boolean
+          example: true
+          description: If redirection URL is safe.
     handlers.configuration.ConfigurationBody:
       type: object
       properties:


### PR DESCRIPTION
The following schemas for `/api/checks/safe-redirection` were missed in #2082:

* handlers.checkURIWithinDomainRequestBody
* handlers.checkURIWithinDomainResponseBody

Fixes #2338.