### PR TITLE
fix(suites): prevent dev workflow overriding .healthcheck.env

### DIFF
--- a/internal/suites/example/compose/authelia/resources/run-backend-dev.sh
+++ b/internal/suites/example/compose/authelia/resources/run-backend-dev.sh
@@ -4,6 +4,6 @@ set -e
 
 while true;
 do
-    CGO_ENABLED=0 dlv --listen 0.0.0.0:2345 --headless=true --output=./authelia --continue --accept-multiclient debug cmd/authelia/*.go -- --config /config/configuration.yml
+    AUTHELIA_SERVER_DISABLE_HEALTHCHECK=true CGO_ENABLED=0 dlv --listen 0.0.0.0:2345 --headless=true --output=./authelia --continue --accept-multiclient debug cmd/authelia/*.go -- --config /config/configuration.yml
     sleep 10
 done


### PR DESCRIPTION
Due to how the dev workflow allows Authelia developers to run the binary hot-reloaded we should disable the Docker health check for said workflow to prevent accidental commits upstream.