### PR TITLE
fix(server): remove obselete memory check warning

### DIFF
--- a/web/.commitlintrc.js
+++ b/web/.commitlintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
     extends: ["@commitlint/config-conventional"],
     rules: {
+        "body-max-line-length": [2, "always", "Infinity"],
         "body-min-length": [2, "always", 20],
         "header-case": [2, "always", "lower-case"],
         "header-max-length": [2, "always", 72],


### PR DESCRIPTION
Given the fact that many Linux OSes are defaulting to CGroups v2 and also Authelia changing the default memory config for argon2id this warning is now obselete.

Fixes: #2369.