### PR TITLE
feat: hardened authelia binaries

### DIFF
--- a/.buildkite/annotations/artifacts
+++ b/.buildkite/annotations/artifacts
@@ -5,6 +5,8 @@
     <dd>
       <a href="artifact://authelia-linux-amd64.tar.gz">authelia-linux-amd64.tar.gz</a><br>
       <a href="artifact://authelia-linux-amd64.tar.gz.sha256">authelia-linux-amd64.tar.gz.sha256</a><br>
+      <a href="artifact://authelia-linux-amd64-musl.tar.gz">authelia-linux-amd64-musl.tar.gz</a><br>
+      <a href="artifact://authelia-linux-amd64-musl.tar.gz.sha256">authelia-linux-amd64-musl.tar.gz.sha256</a><br>
       <a href="artifact://authelia-freebsd-amd64.tar.gz">authelia-freebsd-amd64.tar.gz</a><br>
       <a href="artifact://authelia-freebsd-amd64.tar.gz.sha256">authelia-freebsd-amd64.tar.gz.sha256</a><br>
       <a href="artifact://authelia_amd64.deb">authelia_amd64.deb</a><br>
@@ -16,6 +18,8 @@
     <dd>
       <a href="artifact://authelia-linux-arm.tar.gz">authelia-linux-arm.tar.gz</a><br>
       <a href="artifact://authelia-linux-arm.tar.gz.sha256">authelia-linux-arm.tar.gz.sha256</a><br>
+      <a href="artifact://authelia-linux-arm-musl.tar.gz">authelia-linux-arm-musl.tar.gz</a><br>
+      <a href="artifact://authelia-linux-arm-musl.tar.gz.sha256">authelia-linux-arm-musl.tar.gz.sha256</a><br>
       <a href="artifact://authelia_armhf.deb">authelia_armhf.deb</a><br>
       <a href="artifact://authelia_armhf.deb.sha256">authelia_armhf.deb.sha256</a>
     </dd>
@@ -25,6 +29,8 @@
     <dd>
       <a href="artifact://authelia-linux-arm64.tar.gz">authelia-linux-arm64.tar.gz</a><br>
       <a href="artifact://authelia-linux-arm64.tar.gz.sha256">authelia-linux-arm64.tar.gz.sha256</a><br>
+      <a href="artifact://authelia-linux-arm64-musl.tar.gz">authelia-linux-arm64-musl.tar.gz</a><br>
+      <a href="artifact://authelia-linux-arm64-musl.tar.gz.sha256">authelia-linux-arm64-musl.tar.gz.sha256</a><br>
       <a href="artifact://authelia_arm64.deb">authelia_arm64.deb</a><br>
       <a href="artifact://authelia_arm64.deb.sha256">authelia_arm64.deb.sha256</a>
     </dd>

--- a/.buildkite/hooks/pre-artifact
+++ b/.buildkite/hooks/pre-artifact
@@ -2,7 +2,7 @@
 
 set +u
 
-declare -A BUILDS=(["linux"]="amd64 arm arm64" ["freebsd"]="amd64")
+declare -A BUILDS=(["linux"]="amd64 arm arm64 amd64-musl arm-musl arm64-musl" ["freebsd"]="amd64")
 DOCKER_IMAGE=authelia/authelia
 
 if [[ "${BUILDKITE_LABEL}" == ":hammer_and_wrench: Unit Test" ]]; then

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -6,6 +6,10 @@ if [[ "${BUILDKITE_LABEL}" == ":service_dog: Linting" ]]; then
   cd web && yarn install && cd ../
 fi
 
+if [[ "${BUILDKITE_LABEL}" == ":hammer_and_wrench: Unit Test" ]]; then
+  docker pull authelia/crossbuild
+fi
+
 if [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
   DEFAULT_ARCH=coverage
   echo "--- :docker: Extract, load and tag build container"
@@ -18,15 +22,10 @@ if [[ "${BUILDKITE_LABEL}" =~ ":debian: Build Package" ]]; then
   buildkite-agent artifact download "authelia-linux-${ARCH}.tar.gz" .
 fi
 
-if [[ "${BUILDKITE_LABEL}" =~ ":docker: Deploy Image" ]]; then
-  buildkite-agent artifact download "authelia-image-${ARCH}*" .
-  zstdcat "authelia-image-${ARCH}.tar.zst" | docker load
-fi
-
 if [[ "${BUILDKITE_LABEL}" == ":docker: Deploy Manifest" ]]; then
   echo "--- :go: :react: :swagger: Extract pre-built binary"
-  buildkite-agent artifact download "authelia-linux-*.tar.gz" .
-  for archive in authelia-linux-*.tar.gz; do tar xzf ${archive} --wildcards "authelia-linux-*"; done
+  buildkite-agent artifact download "authelia-linux-*-musl.tar.gz" .
+  for archive in authelia-linux-*-musl.tar.gz; do tar xzf ${archive} --wildcards "authelia-linux-*"; done
 fi
 
 if [[ "${BUILDKITE_LABEL}" == ":github: Deploy Artifacts" ]]; then

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -6,10 +6,6 @@ if [[ "${BUILDKITE_LABEL}" == ":service_dog: Linting" ]]; then
   cd web && yarn install && cd ../
 fi
 
-if [[ "${BUILDKITE_LABEL}" == ":hammer_and_wrench: Unit Test" ]]; then
-  docker pull authelia/crossbuild
-fi
-
 if [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
   DEFAULT_ARCH=coverage
   echo "--- :docker: Extract, load and tag build container"

--- a/.buildkite/steps/ghartifacts.sh
+++ b/.buildkite/steps/ghartifacts.sh
@@ -7,6 +7,9 @@ for FILE in \
   authelia-linux-amd64.tar.gz authelia-linux-amd64.tar.gz.sha256 \
   authelia-linux-arm.tar.gz authelia-linux-arm.tar.gz.sha256 \
   authelia-linux-arm64.tar.gz authelia-linux-arm64.tar.gz.sha256 \
+  authelia-linux-amd64-musl.tar.gz authelia-linux-amd64-musl.tar.gz.sha256 \
+  authelia-linux-arm-musl.tar.gz authelia-linux-arm-musl.tar.gz.sha256 \
+  authelia-linux-arm64-musl.tar.gz authelia-linux-arm64-musl.tar.gz.sha256 \
   authelia-freebsd-amd64.tar.gz authelia-freebsd-amd64.tar.gz.sha256 \
   authelia-public_html.tar.gz authelia-public_html.tar.gz.sha256;
 do

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY LICENSE .healthcheck.env entrypoint.sh healthcheck.sh ./
 RUN \
 chmod 0666 /app/.healthcheck.env
 
-COPY authelia-${TARGETOS}-${TARGETARCH} ./authelia
+COPY authelia-${TARGETOS}-${TARGETARCH}-musl ./authelia
 
 EXPOSE 9091
 

--- a/cmd/authelia-scripts/cmd_build.go
+++ b/cmd/authelia-scripts/cmd_build.go
@@ -138,6 +138,17 @@ func cleanAssets() {
 func Build(cobraCmd *cobra.Command, args []string) {
 	log.Info("Building Authelia...")
 
+	buildkite, _ := cobraCmd.Flags().GetBool("buildkite")
+
+	if buildkite {
+		cmd := utils.CommandWithStdout("bash", "-c", "docker pull authelia/crossbuild -q &")
+
+		err := cmd.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	Clean(cobraCmd, args)
 
 	xflags, err := getXFlags(os.Getenv("BUILDKITE_BRANCH"), os.Getenv("BUILDKITE_BUILD_NUMBER"), "")
@@ -158,7 +169,6 @@ func Build(cobraCmd *cobra.Command, args []string) {
 	log.Debug("Building swagger-ui frontend...")
 	buildSwagger()
 
-	buildkite, _ := cobraCmd.Flags().GetBool("buildkite")
 	if buildkite {
 		log.Debug("Building Authelia Go binaries with gox...")
 	} else {

--- a/cmd/authelia-scripts/cmd_build.go
+++ b/cmd/authelia-scripts/cmd_build.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -11,21 +13,55 @@ import (
 )
 
 func buildAutheliaBinary(xflags []string, buildkite bool) {
-	cmd := utils.CommandWithStdout("go", "build", "-tags", "netgo", "-trimpath", "-o", OutputDir+"/authelia", "-ldflags", "-s -w "+strings.Join(xflags, " "), "./cmd/authelia/")
-
-	cmd.Env = append(os.Environ(),
-		"CGO_ENABLED=0")
-
 	if buildkite {
-		cmd = utils.CommandWithStdout("gox", "-tags=netgo", "-output={{.Dir}}-{{.OS}}-{{.Arch}}", "-ldflags=-s -w "+strings.Join(xflags, " "), "-osarch=linux/amd64 linux/arm linux/arm64 freebsd/amd64", "./cmd/authelia/")
+		var wg sync.WaitGroup
+
+		s := time.Now()
+
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			cmd := utils.CommandWithStdout("gox", "-output={{.Dir}}-{{.OS}}-{{.Arch}}-musl", "-buildmode=pie", "-trimpath", "-cgo", "-ldflags=-linkmode=external -s -w "+strings.Join(xflags, " "), "-osarch=linux/amd64 linux/arm linux/arm64", "./cmd/authelia/")
+
+			cmd.Env = append(os.Environ(),
+				"CGO_CPPFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong", "CGO_LDFLAGS=-Wl,-z,relro,-z,now",
+				"GOX_LINUX_ARM_CC=arm-linux-musleabihf-gcc", "GOX_LINUX_ARM64_CC=aarch64-linux-musl-gcc")
+
+			err := cmd.Run()
+			if err != nil {
+				log.Fatal(err)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			cmd := utils.CommandWithStdout("bash", "-c", "docker run --rm -e GOX_LINUX_ARM_CC=arm-linux-gnueabihf-gcc -e GOX_LINUX_ARM64_CC=aarch64-linux-gnu-gcc -e GOX_FREEBSD_AMD64_CC=x86_64-pc-freebsd13-gcc -v ${PWD}:/workdir -v /buildkite/.go:/root/go authelia/crossbuild "+
+				"gox -output={{.Dir}}-{{.OS}}-{{.Arch}} -buildmode=pie -trimpath -cgo -ldflags=\"-linkmode=external -s -w "+strings.Join(xflags, " ")+"\" -osarch=\"linux/amd64 linux/arm linux/arm64 freebsd/amd64\" ./cmd/authelia/")
+
+			err := cmd.Run()
+			if err != nil {
+				log.Fatal(err)
+			}
+		}()
+
+		wg.Wait()
+
+		e := time.Since(s)
+
+		log.Debugf("Binary compilation completed in %s.", e)
+	} else {
+		cmd := utils.CommandWithStdout("go", "build", "-buildmode=pie", "-trimpath", "-o", OutputDir+"/authelia", "-ldflags", "-linkmode=external -s -w "+strings.Join(xflags, " "), "./cmd/authelia/")
 
 		cmd.Env = append(os.Environ(),
-			"GOFLAGS=-trimpath", "CGO_ENABLED=0")
-	}
+			"CGO_CPPFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong", "CGO_LDFLAGS=-Wl,-z,relro,-z,now")
 
-	err := cmd.Run()
-	if err != nil {
-		log.Fatal(err)
+		err := cmd.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This change ensures that all Authelia binaries which are compiled and distributed are hardened with the following standards:

* RELRO
* Stack canary
* NX
* PIE/ASLR
* Stripped RPATH AND RUNPATH
* Stripped Symbols
* Fortify

The musl variants currently [do not support Fortify](https://wiki.musl-libc.org/future-ideas.html#Fortify).