### PR TITLE
docs: fix broken url in config.template.yml

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -390,7 +390,7 @@ session:
   domain: example.com
 
   ## Sets the Cookie SameSite value. Possible options are none, lax, or strict.
-  ## Please read https://www.authelia.com/docs/configuration/session.html#same_site
+  ## Please read https://www.authelia.com/docs/configuration/session/#same_site
   same_site: lax
 
   ## The secret to encrypt the session data. This is only used with Redis / Redis Sentinel.

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -390,7 +390,7 @@ session:
   domain: example.com
 
   ## Sets the Cookie SameSite value. Possible options are none, lax, or strict.
-  ## Please read https://www.authelia.com/docs/configuration/session.html#same_site
+  ## Please read https://www.authelia.com/docs/configuration/session/#same_site
   same_site: lax
 
   ## The secret to encrypt the session data. This is only used with Redis / Redis Sentinel.


### PR DESCRIPTION
Tiny PR to fix a broken link to the SameSite cookie documention in the comments of config.template.yml