### PR TITLE
docs: fix required flag for smtp notifier sender option

### DIFF
--- a/.github/commit-msg
+++ b/.github/commit-msg
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/required-apps"
 
-cd web && ${PMGR} run commitlint --edit $1
+cd web && ${PMGR} commitlint --edit $1

--- a/docs/configuration/notifier/smtp.md
+++ b/docs/configuration/notifier/smtp.md
@@ -99,8 +99,8 @@ The password sent for authentication with the SMTP server. Paired with the usern
 <div markdown="1">
 type: string
 {: .label .label-config .label-purple } 
-required: no
-{: .label .label-config .label-green }
+required: yes
+{: .label .label-config .label-red }
 </div>
 
 The address sent in the FROM header for the email. Basically who the email appears to come from. It should be noted


### PR DESCRIPTION
Fixes: #2445.