### PR TITLE
release: v4.32.1

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authelia",
-  "version": "4.32.0",
+  "version": "4.32.1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.36",


### PR DESCRIPTION
This release updates `authelia/crossbuild` to be based on Debian Stretch so compiled Authelia binaries use glibc <2.28 which provides support for LTS Linux OSes.

Fixes: #2475.