### PR TITLE
fix(server): provide correct scheme to templated files

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,9 +34,11 @@ func registerRoutes(configuration schema.Configuration, providers middlewares.Pr
 	embeddedFS := fasthttpadaptor.NewFastHTTPHandler(http.FileServer(http.FS(embeddedPath)))
 	rootFiles := []string{"favicon.ico", "manifest.json", "robots.txt"}
 
-	serveIndexHandler := ServeTemplatedFile(embeddedAssets, indexFile, rememberMe, resetPassword, configuration.Session.Name, configuration.Theme)
-	serveSwaggerHandler := ServeTemplatedFile(swaggerAssets, indexFile, rememberMe, resetPassword, configuration.Session.Name, configuration.Theme)
-	serveSwaggerAPIHandler := ServeTemplatedFile(swaggerAssets, apiFile, rememberMe, resetPassword, configuration.Session.Name, configuration.Theme)
+	https := configuration.Server.TLS.Key != "" && configuration.Server.TLS.Certificate != ""
+
+	serveIndexHandler := ServeTemplatedFile(embeddedAssets, indexFile, rememberMe, resetPassword, configuration.Session.Name, configuration.Theme, https)
+	serveSwaggerHandler := ServeTemplatedFile(swaggerAssets, indexFile, rememberMe, resetPassword, configuration.Session.Name, configuration.Theme, https)
+	serveSwaggerAPIHandler := ServeTemplatedFile(swaggerAssets, apiFile, rememberMe, resetPassword, configuration.Session.Name, configuration.Theme, https)
 
 	r := router.New()
 	r.GET("/", serveIndexHandler)

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -18,7 +18,7 @@ var alphaNumericRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV
 // ServeTemplatedFile serves a templated version of a specified file,
 // this is utilised to pass information between the backend and frontend
 // and generate a nonce to support a restrictive CSP while using material-ui.
-func ServeTemplatedFile(publicDir, file, rememberMe, resetPassword, session, theme string) fasthttp.RequestHandler {
+func ServeTemplatedFile(publicDir, file, rememberMe, resetPassword, session, theme string, https bool) fasthttp.RequestHandler {
 	logger := logging.Logger()
 
 	f, err := assets.Open(publicDir + file)
@@ -42,7 +42,19 @@ func ServeTemplatedFile(publicDir, file, rememberMe, resetPassword, session, the
 			base = baseURL.(string)
 		}
 
-		baseURL := "https://" + string(ctx.Request.Host()) + base + "/"
+		var scheme = "https"
+
+		if !https {
+			proto := string(ctx.Request.Header.Peek(fasthttp.HeaderXForwardedProto))
+			switch proto {
+			case "":
+				scheme = "http"
+			default:
+				scheme = proto
+			}
+		}
+
+		baseURL := scheme + "://" + string(ctx.Request.Host()) + base + "/"
 		nonce := utils.RandomString(32, alphaNumericRunes)
 
 		switch extension := filepath.Ext(file); extension {


### PR DESCRIPTION
This utilizes the context of the request and configuration to determine the correct scheme to use for the base URL.

Fixes #2485. Fixes #2476.