### PR TITLE
refactor(suites): replace selenium with go-rod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/fasthttp/router v1.4.4
 	github.com/fasthttp/session/v2 v2.4.4
 	github.com/go-ldap/ldap/v3 v3.4.1
+	github.com/go-rod/rod v0.101.8
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/golang/mock v1.6.0
@@ -30,7 +31,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
-	github.com/tebeka/selenium v0.9.9
 	github.com/tstranex/u2f v1.0.0
 	github.com/valyala/fasthttp v1.31.0
 	golang.org/x/sys v0.0.0-20210902050250-f475640dd07b // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,10 +43,7 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 h1:1BDTz0u9nC3//pOCMdNH+CiXJVYJh5UQNCOBG7jbELc=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/BurntSushi/xgbutil v0.0.0-20160919175755-f7c97cef3b4e h1:4ZrkT/RzpnROylmoQL57iVUL57wGKTR5O6KpVnbm2tA=
-github.com/BurntSushi/xgbutil v0.0.0-20160919175755-f7c97cef3b4e/go.mod h1:uw9h2sd4WWHOPdJ13MQpwK5qYWKYDumDqxWWIknEQ+k=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
@@ -89,8 +86,6 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
-github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -119,8 +114,6 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar/v2 v2.0.3/go.mod h1:QMmcs3H2AUQICWhfzLXz+IYln8lRQmTZRptLie8RgRw=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
@@ -315,6 +308,8 @@ github.com/go-openapi/validate v0.19.3/go.mod h1:90Vh6jjkTn+OT1Eefm0ZixWNFjhtOH7
 github.com/go-openapi/validate v0.19.10/go.mod h1:RKEZTUWDkxKQxN2jDT7ZnZi2bhZlbNMAuKvKB+IaGx8=
 github.com/go-redis/redis/v8 v8.11.4 h1:kHoYkfZP6+pe04aFTnhDH6GDROa5yJdHJVNxV3F46Tg=
 github.com/go-redis/redis/v8 v8.11.4/go.mod h1:2Z2wHZXdQpCDXEGzqMockDpNyYvi2l4Pxt6RJr792+w=
+github.com/go-rod/rod v0.101.8 h1:oV0O97uwjkCVyAP0hD6K6bBE8FUMIjs0dtF7l6kEBsU=
+github.com/go-rod/rod v0.101.8/go.mod h1:N/zlT53CfSpq74nb6rOR0K8UF0SPUPBmzBnArrms+mY=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -646,10 +641,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github/v27 v27.0.4/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
 github.com/google/go-jsonnet v0.16.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
 github.com/google/go-jsonnet v0.17.0/go.mod h1:sOcuej3UW1vpPTZOr8L7RQimqai1a57bt5j22LzGZCw=
-github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -1297,8 +1290,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.1.1/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/tebeka/selenium v0.9.9 h1:cNziB+etNgyH/7KlNI7RMC1ua5aH1+5wUlFQyzeMh+w=
-github.com/tebeka/selenium v0.9.9/go.mod h1:5Fr8+pUvU6B1OiPfkdCKdXZyr5znvVkxuPd0NOdZCQc=
 github.com/tidwall/gjson v1.11.0 h1:C16pk7tQNiH6VlCrtIXL1w8GaOsi1X3W8KDkE1BuYd4=
 github.com/tidwall/gjson v1.11.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -1342,6 +1333,16 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
+github.com/ysmood/goob v0.3.0 h1:XZ51cZJ4W3WCoCiUktixzMIQF86W7G5VFL4QQ/Q2uS0=
+github.com/ysmood/goob v0.3.0/go.mod h1:S3lq113Y91y1UBf1wj1pFOxeahvfKkCk6mTWTWbDdWs=
+github.com/ysmood/got v0.15.1 h1:X5jAbMyBf5yeezuFMp9HaMGXZWMSqIQcUlAHI+kJmUs=
+github.com/ysmood/got v0.15.1/go.mod h1:pE1l4LOwOBhQg6A/8IAatkGp7uZjnalzrZolnlhhMgY=
+github.com/ysmood/gotrace v0.2.2 h1:006KHGRThSRf8lwh4EyhNmuuq/l+Ygs+JqojkhEG1/E=
+github.com/ysmood/gotrace v0.2.2/go.mod h1:TzhIG7nHDry5//eYZDYcTzuJLYQIkykJzCRIo4/dzQM=
+github.com/ysmood/gson v0.6.4 h1:Yb6tosv6bk59HqjZu2/7o4BFherpYEMkDkXmlhgryZ4=
+github.com/ysmood/gson v0.6.4/go.mod h1:3Kzs5zDl21g5F/BlLTNcuAGAYLKt2lV5G8D1zF3RNmg=
+github.com/ysmood/leakless v0.7.0 h1:XCGdaPExyoreoQd+H5qgxM3ReNbSPFsEXpSKwbXbwQw=
+github.com/ysmood/leakless v0.7.0/go.mod h1:R8iAXPRaG97QJwqxs74RdwzcRHT1SWCGTNqY8q0JvMQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/suites/action_2fa_methods.go
+++ b/internal/suites/action_2fa_methods.go
@@ -1,17 +1,17 @@
 package suites
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
+	"github.com/go-rod/rod"
 	"github.com/stretchr/testify/require"
 )
 
-func (wds *WebDriverSession) doChangeMethod(ctx context.Context, t *testing.T, method string) {
-	err := wds.WaitElementLocatedByID(ctx, t, "methods-button").Click()
+func (rs *RodSession) doChangeMethod(t *testing.T, page *rod.Page, method string) {
+	err := rs.WaitElementLocatedByCSSSelector(t, page, "methods-button").Click("left")
 	require.NoError(t, err)
-	wds.WaitElementLocatedByID(ctx, t, "methods-dialog")
-	err = wds.WaitElementLocatedByID(ctx, t, fmt.Sprintf("%s-option", method)).Click()
+	rs.WaitElementLocatedByCSSSelector(t, page, "methods-dialog")
+	err = rs.WaitElementLocatedByCSSSelector(t, page, fmt.Sprintf("%s-option", method)).Click("left")
 	require.NoError(t, err)
 }

--- a/internal/suites/action_login.go
+++ b/internal/suites/action_login.go
@@ -1,44 +1,44 @@
 package suites
 
 import (
-	"context"
 	"testing"
 	"time"
 
+	"github.com/go-rod/rod"
 	"github.com/stretchr/testify/require"
 )
 
-func (wds *WebDriverSession) doFillLoginPageAndClick(ctx context.Context, t *testing.T, username, password string, keepMeLoggedIn bool) {
-	usernameElement := wds.WaitElementLocatedByID(ctx, t, "username-textfield")
-	err := usernameElement.SendKeys(username)
+func (rs *RodSession) doFillLoginPageAndClick(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool) {
+	usernameElement := rs.WaitElementLocatedByCSSSelector(t, page, "username-textfield")
+	err := usernameElement.Input(username)
 	require.NoError(t, err)
 
-	passwordElement := wds.WaitElementLocatedByID(ctx, t, "password-textfield")
-	err = passwordElement.SendKeys(password)
+	passwordElement := rs.WaitElementLocatedByCSSSelector(t, page, "password-textfield")
+	err = passwordElement.Input(password)
 	require.NoError(t, err)
 
 	if keepMeLoggedIn {
-		keepMeLoggedInElement := wds.WaitElementLocatedByID(ctx, t, "remember-checkbox")
-		err = keepMeLoggedInElement.Click()
+		keepMeLoggedInElement := rs.WaitElementLocatedByCSSSelector(t, page, "remember-checkbox")
+		err = keepMeLoggedInElement.Click("left")
 		require.NoError(t, err)
 	}
 
-	buttonElement := wds.WaitElementLocatedByID(ctx, t, "sign-in-button")
-	err = buttonElement.Click()
+	buttonElement := rs.WaitElementLocatedByCSSSelector(t, page, "sign-in-button")
+	err = buttonElement.Click("left")
 	require.NoError(t, err)
 }
 
 // Login 1FA.
-func (wds *WebDriverSession) doLoginOneFactor(ctx context.Context, t *testing.T, username, password string, keepMeLoggedIn bool, targetURL string) {
-	wds.doVisitLoginPage(ctx, t, targetURL)
-	wds.doFillLoginPageAndClick(ctx, t, username, password, keepMeLoggedIn)
+func (rs *RodSession) doLoginOneFactor(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool, targetURL string) {
+	rs.doVisitLoginPage(t, page, targetURL)
+	rs.doFillLoginPageAndClick(t, page, username, password, keepMeLoggedIn)
 }
 
 // Login 1FA and 2FA subsequently (must already be registered).
-func (wds *WebDriverSession) doLoginTwoFactor(ctx context.Context, t *testing.T, username, password string, keepMeLoggedIn bool, otpSecret, targetURL string) {
-	wds.doLoginOneFactor(ctx, t, username, password, keepMeLoggedIn, targetURL)
-	wds.verifyIsSecondFactorPage(ctx, t)
-	wds.doValidateTOTP(ctx, t, otpSecret)
+func (rs *RodSession) doLoginTwoFactor(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool, otpSecret, targetURL string) {
+	rs.doLoginOneFactor(t, page, username, password, keepMeLoggedIn, targetURL)
+	rs.verifyIsSecondFactorPage(t, page)
+	rs.doValidateTOTP(t, page, otpSecret)
 	// timeout when targetURL is not defined to prevent a show stopping redirect when visiting a protected domain
 	if targetURL == "" {
 		time.Sleep(1 * time.Second)
@@ -46,20 +46,20 @@ func (wds *WebDriverSession) doLoginTwoFactor(ctx context.Context, t *testing.T,
 }
 
 // Login 1FA and register 2FA.
-func (wds *WebDriverSession) doLoginAndRegisterTOTP(ctx context.Context, t *testing.T, username, password string, keepMeLoggedIn bool) string {
-	wds.doLoginOneFactor(ctx, t, username, password, keepMeLoggedIn, "")
-	secret := wds.doRegisterTOTP(ctx, t)
-	wds.doVisit(t, GetLoginBaseURL())
-	wds.verifyIsSecondFactorPage(ctx, t)
+func (rs *RodSession) doLoginAndRegisterTOTP(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool) string {
+	rs.doLoginOneFactor(t, page, username, password, keepMeLoggedIn, "")
+	secret := rs.doRegisterTOTP(t, page)
+	rs.doVisit(t, page, GetLoginBaseURL())
+	rs.verifyIsSecondFactorPage(t, page)
 
 	return secret
 }
 
 // Register a user with TOTP, logout and then authenticate until TOTP-2FA.
-func (wds *WebDriverSession) doRegisterAndLogin2FA(ctx context.Context, t *testing.T, username, password string, keepMeLoggedIn bool, targetURL string) string { //nolint:unparam
+func (rs *RodSession) doRegisterAndLogin2FA(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool, targetURL string) string { //nolint:unparam
 	// Register TOTP secret and logout.
-	secret := wds.doRegisterThenLogout(ctx, t, username, password)
-	wds.doLoginTwoFactor(ctx, t, username, password, keepMeLoggedIn, secret, targetURL)
+	secret := rs.doRegisterThenLogout(t, page, username, password)
+	rs.doLoginTwoFactor(t, page, username, password, keepMeLoggedIn, secret, targetURL)
 
 	return secret
 }

--- a/internal/suites/action_logout.go
+++ b/internal/suites/action_logout.go
@@ -1,25 +1,28 @@
 package suites
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
-func (wds *WebDriverSession) doLogout(ctx context.Context, t *testing.T) {
-	wds.doVisit(t, fmt.Sprintf("%s%s", GetLoginBaseURL(), "/logout"))
-	wds.verifyIsFirstFactorPage(ctx, t)
+func (rs *RodSession) doLogout(t *testing.T, page *rod.Page) {
+	rs.doVisit(t, page, fmt.Sprintf("%s%s", GetLoginBaseURL(), "/logout"))
+	rs.verifyIsFirstFactorPage(t, page)
 }
 
-func (wds *WebDriverSession) doLogoutWithRedirect(ctx context.Context, t *testing.T, targetURL string, firstFactor bool) {
-	wds.doVisit(t, fmt.Sprintf("%s%s%s", GetLoginBaseURL(), "/logout?rd=", url.QueryEscape(targetURL)))
+func (rs *RodSession) doLogoutWithRedirect(t *testing.T, page *rod.Page, targetURL string, firstFactor bool) {
+	rs.doVisit(t, page, fmt.Sprintf("%s%s%s", GetLoginBaseURL(), "/logout?rd=", url.QueryEscape(targetURL)))
 
 	if firstFactor {
-		wds.verifyIsFirstFactorPage(ctx, t)
+		rs.verifyIsFirstFactorPage(t, page)
 
 		return
 	}
 
-	wds.verifyURLIs(ctx, t, targetURL)
+	page.MustElementR("h1", "Public resource")
+
+	rs.verifyURLIs(t, page, targetURL)
 }

--- a/internal/suites/action_register.go
+++ b/internal/suites/action_register.go
@@ -1,13 +1,14 @@
 package suites
 
 import (
-	"context"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
-func (wds *WebDriverSession) doRegisterThenLogout(ctx context.Context, t *testing.T, username, password string) string {
-	secret := wds.doLoginAndRegisterTOTP(ctx, t, username, password, false)
-	wds.doLogout(ctx, t)
+func (rs *RodSession) doRegisterThenLogout(t *testing.T, page *rod.Page, username, password string) string {
+	secret := rs.doLoginAndRegisterTOTP(t, page, username, password, false)
+	rs.doLogout(t, page)
 
 	return secret
 }

--- a/internal/suites/action_visit.go
+++ b/internal/suites/action_visit.go
@@ -1,28 +1,36 @@
 package suites
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
 	"github.com/stretchr/testify/assert"
 )
 
-func (wds *WebDriverSession) doVisit(t *testing.T, url string) {
-	err := wds.WebDriver.Get(url)
+func (rs *RodSession) doCreateTab(t *testing.T, url string) *rod.Page {
+	p, err := rs.WebDriver.MustIncognito().Page(proto.TargetCreateTarget{URL: url})
+	assert.NoError(t, err)
+
+	return p
+}
+
+func (rs *RodSession) doVisit(t *testing.T, page *rod.Page, url string) {
+	err := page.Navigate(url)
 	assert.NoError(t, err)
 }
 
-func (wds *WebDriverSession) doVisitAndVerifyOneFactorStep(ctx context.Context, t *testing.T, url string) {
-	wds.doVisit(t, url)
-	wds.verifyIsFirstFactorPage(ctx, t)
+func (rs *RodSession) doVisitAndVerifyOneFactorStep(t *testing.T, page *rod.Page, url string) {
+	rs.doVisit(t, page, url)
+	rs.verifyIsFirstFactorPage(t, page)
 }
 
-func (wds *WebDriverSession) doVisitLoginPage(ctx context.Context, t *testing.T, targetURL string) {
+func (rs *RodSession) doVisitLoginPage(t *testing.T, page *rod.Page, targetURL string) {
 	suffix := ""
 	if targetURL != "" {
 		suffix = fmt.Sprintf("?rd=%s", targetURL)
 	}
 
-	wds.doVisitAndVerifyOneFactorStep(ctx, t, fmt.Sprintf("%s/%s", GetLoginBaseURL(), suffix))
+	rs.doVisitAndVerifyOneFactorStep(t, page, fmt.Sprintf("%s/%s", GetLoginBaseURL(), suffix))
 }

--- a/internal/suites/const.go
+++ b/internal/suites/const.go
@@ -51,7 +51,6 @@ var DuoBaseURL = "https://duo.example.com"
 var AutheliaBaseURL = "https://authelia.example.com:9091"
 
 const stringTrue = "true"
-const defaultChromeDriverPort = "4444"
 
 const testUsername = "john"
 const testPassword = "password"

--- a/internal/suites/example/compose/authelia/resources/reflex.conf
+++ b/internal/suites/example/compose/authelia/resources/reflex.conf
@@ -1,1 +1,1 @@
--R '^web/' -r '(\.go$|go\.mod|\.sh|\.yml)' -s /resources/run-backend-dev.sh
+-R '^web/' -R 'users.yml' -r '(\.go$|go\.mod|\.sh|\.yml)' -s /resources/run-backend-dev.sh

--- a/internal/suites/example/compose/haproxy/haproxy.cfg
+++ b/internal/suites/example/compose/haproxy/haproxy.cfg
@@ -4,10 +4,14 @@ global
     log stdout format raw local0 debug
 
 defaults
+    default-server init-addr none
     mode http
     log global
     option httplog
     option forwardfor
+
+resolvers docker
+    nameserver ip 127.0.0.11:53
 
 frontend fe_api
     bind *:8081 ssl crt /usr/local/etc/haproxy/haproxy.pem
@@ -63,13 +67,13 @@ backend be_auth_request
 listen be_auth_request_proxy
     mode http
     bind 127.0.0.1:8085
-    server authelia-backend authelia-backend:9091 ssl verify none
+    server authelia-backend authelia-backend:9091 resolvers docker ssl verify none
 
 backend be_authelia
-    server authelia-backend authelia-backend:9091 ssl verify none
+    server authelia-backend authelia-backend:9091 resolvers docker ssl verify none
 
 backend fe_authelia
-    server authelia-frontend authelia-frontend:3000
+    server authelia-frontend authelia-frontend:3000 resolvers docker
 
 backend be_httpbin
     acl remote_user_exist var(req.auth_response_header.remote_user) -m found
@@ -81,10 +85,10 @@ backend be_httpbin
     http-request set-header Remote-Name %[var(req.auth_response_header.remote_name)] if remote_name_exist
     http-request set-header Remote-Email %[var(req.auth_response_header.remote_email)] if remote_email_exist
 
-    server httpbin-backend httpbin:8000
+    server httpbin-backend httpbin:8000 resolvers docker
 
 backend be_mail
-    server smtp-backend smtp:1080
+    server smtp-backend smtp:1080 resolvers docker
 
 backend be_protected
-    server nginx-backend nginx-backend:80
+    server nginx-backend nginx-backend:80 resolvers docker

--- a/internal/suites/scenario_user_preferences_test.go
+++ b/internal/suites/scenario_user_preferences_test.go
@@ -10,27 +10,27 @@ import (
 )
 
 type UserPreferencesScenario struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewUserPreferencesScenario() *UserPreferencesScenario {
 	return &UserPreferencesScenario{
-		SeleniumSuite: new(SeleniumSuite),
+		RodSuite: new(RodSuite),
 	}
 }
 
 func (s *UserPreferencesScenario) SetupSuite() {
-	wds, err := StartWebDriver()
+	browser, err := StartRod()
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	s.WebDriverSession = wds
+	s.RodSession = browser
 }
 
 func (s *UserPreferencesScenario) TearDownSuite() {
-	err := s.WebDriverSession.Stop()
+	err := s.RodSession.Stop()
 
 	if err != nil {
 		log.Fatal(err)
@@ -38,59 +38,63 @@ func (s *UserPreferencesScenario) TearDownSuite() {
 }
 
 func (s *UserPreferencesScenario) SetupTest() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	s.Page = s.doCreateTab(s.T(), HomeBaseURL)
+	s.verifyIsHome(s.T(), s.Page)
+}
 
-	s.doLogout(ctx, s.T())
-	s.doVisit(s.T(), HomeBaseURL)
-	s.verifyIsHome(ctx, s.T())
+func (s *UserPreferencesScenario) TearDownTest() {
+	s.collectCoverage(s.Page)
+	s.MustClose()
 }
 
 func (s *UserPreferencesScenario) TestShouldRememberLastUsed2FAMethod() {
-	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
-	defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer func() {
+		cancel()
+		s.collectScreenshot(ctx.Err(), s.Page)
+	}()
 
 	// Authenticate
-	s.doLoginOneFactor(ctx, s.T(), "john", "password", false, "")
-	s.verifyIsSecondFactorPage(ctx, s.T())
+	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, "")
+	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
 
 	// Then switch to push notification method
-	s.doChangeMethod(ctx, s.T(), "push-notification")
-	s.WaitElementLocatedByID(ctx, s.T(), "push-notification-method")
+	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")
+	s.WaitElementLocatedByCSSSelector(s.T(), s.Context(ctx), "push-notification-method")
 
 	// Switch context to clean up state in portal.
-	s.doVisit(s.T(), HomeBaseURL)
-	s.verifyIsHome(ctx, s.T())
+	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
+	s.verifyIsHome(s.T(), s.Context(ctx))
 
 	// Then go back to portal.
-	s.doVisit(s.T(), GetLoginBaseURL())
-	s.verifyIsSecondFactorPage(ctx, s.T())
+	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL())
+	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
 	// And check the latest method is still used.
-	s.WaitElementLocatedByID(ctx, s.T(), "push-notification-method")
+	s.WaitElementLocatedByCSSSelector(s.T(), s.Context(ctx), "push-notification-method")
 	// Meaning the authentication is successful
-	s.verifyIsHome(ctx, s.T())
+	s.verifyIsHome(s.T(), s.Context(ctx))
 
 	// Logout the user and see what user 'harry' sees.
-	s.doLogout(ctx, s.T())
-	s.doLoginOneFactor(ctx, s.T(), "harry", "password", false, "")
-	s.verifyIsSecondFactorPage(ctx, s.T())
-	s.WaitElementLocatedByID(ctx, s.T(), "one-time-password-method")
+	s.doLogout(s.T(), s.Context(ctx))
+	s.doLoginOneFactor(s.T(), s.Context(ctx), "harry", "password", false, "")
+	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+	s.WaitElementLocatedByCSSSelector(s.T(), s.Context(ctx), "one-time-password-method")
 
-	s.doLogout(ctx, s.T())
-	s.verifyIsFirstFactorPage(ctx, s.T())
+	s.doLogout(s.T(), s.Context(ctx))
+	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
 	// Then log back as previous user and verify the push notification is still the default method
-	s.doLoginOneFactor(ctx, s.T(), "john", "password", false, "")
-	s.verifyIsSecondFactorPage(ctx, s.T())
-	s.WaitElementLocatedByID(ctx, s.T(), "push-notification-method")
-	s.verifyIsHome(ctx, s.T())
+	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, "")
+	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+	s.WaitElementLocatedByCSSSelector(s.T(), s.Context(ctx), "push-notification-method")
+	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	s.doLogout(ctx, s.T())
-	s.doLoginOneFactor(ctx, s.T(), "john", "password", false, "")
+	s.doLogout(s.T(), s.Context(ctx))
+	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, "")
 
 	// Eventually restore the default method
-	s.doChangeMethod(ctx, s.T(), "one-time-password")
-	s.WaitElementLocatedByID(ctx, s.T(), "one-time-password-method")
+	s.doChangeMethod(s.T(), s.Context(ctx), "one-time-password")
+	s.WaitElementLocatedByCSSSelector(s.T(), s.Context(ctx), "one-time-password-method")
 }
 
 func TestUserPreferencesScenario(t *testing.T) {

--- a/internal/suites/suite_activedirectory_test.go
+++ b/internal/suites/suite_activedirectory_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type ActiveDirectorySuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewActiveDirectorySuite() *ActiveDirectorySuite {
-	return &ActiveDirectorySuite{SeleniumSuite: new(SeleniumSuite)}
+	return &ActiveDirectorySuite{RodSuite: new(RodSuite)}
 }
 
 func (s *ActiveDirectorySuite) TestOneFactorScenario() {

--- a/internal/suites/suite_docker_test.go
+++ b/internal/suites/suite_docker_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type DockerSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewDockerSuite() *DockerSuite {
-	return &DockerSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &DockerSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *DockerSuite) TestOneFactorScenario() {

--- a/internal/suites/suite_duo_push_test.go
+++ b/internal/suites/suite_duo_push_test.go
@@ -10,25 +10,25 @@ import (
 )
 
 type DuoPushWebDriverSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewDuoPushWebDriverSuite() *DuoPushWebDriverSuite {
-	return &DuoPushWebDriverSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &DuoPushWebDriverSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *DuoPushWebDriverSuite) SetupSuite() {
-	wds, err := StartWebDriver()
+	browser, err := StartRod()
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	s.WebDriverSession = wds
+	s.RodSession = browser
 }
 
 func (s *DuoPushWebDriverSuite) TearDownSuite() {
-	err := s.WebDriverSession.Stop()
+	err := s.RodSession.Stop()
 
 	if err != nil {
 		log.Fatal(err)
@@ -36,65 +36,75 @@ func (s *DuoPushWebDriverSuite) TearDownSuite() {
 }
 
 func (s *DuoPushWebDriverSuite) SetupTest() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	s.doLogout(ctx, s.T())
+	s.Page = s.doCreateTab(s.T(), HomeBaseURL)
+	s.verifyIsHome(s.T(), s.Page)
 }
 
 func (s *DuoPushWebDriverSuite) TearDownTest() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	defer func() {
+		cancel()
+		s.collectScreenshot(ctx.Err(), s.Page)
 
-	s.doLogout(ctx, s.T())
-	s.doLoginOneFactor(ctx, s.T(), "john", "password", false, "")
-	s.verifyIsSecondFactorPage(ctx, s.T())
-	s.doChangeMethod(ctx, s.T(), "one-time-password")
-	s.WaitElementLocatedByID(ctx, s.T(), "one-time-password-method")
+		s.collectCoverage(s.Page)
+		s.MustClose()
+	}()
+
+	s.doLogout(s.T(), s.Context(ctx))
+	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, "")
+	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+	s.doChangeMethod(s.T(), s.Context(ctx), "one-time-password")
+	s.WaitElementLocatedByCSSSelector(s.T(), s.Context(ctx), "one-time-password-method")
 }
 
 func (s *DuoPushWebDriverSuite) TestShouldSucceedAuthentication() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
+	defer func() {
+		cancel()
+		s.collectScreenshot(ctx.Err(), s.Page)
+	}()
 
 	ConfigureDuo(s.T(), Allow)
 
-	s.doLoginOneFactor(ctx, s.T(), "john", "password", false, "")
-	s.doChangeMethod(ctx, s.T(), "push-notification")
-	s.verifyIsHome(ctx, s.T())
+	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, "")
+	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")
+	s.verifyIsHome(s.T(), s.Context(ctx))
 }
 
 func (s *DuoPushWebDriverSuite) TestShouldFailAuthentication() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
+	defer func() {
+		cancel()
+		s.collectScreenshot(ctx.Err(), s.Page)
+	}()
 
 	ConfigureDuo(s.T(), Deny)
 
-	s.doLoginOneFactor(ctx, s.T(), "john", "password", false, "")
-	s.doChangeMethod(ctx, s.T(), "push-notification")
-	s.WaitElementLocatedByClassName(ctx, s.T(), "failure-icon")
+	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, "")
+	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")
+	s.WaitElementLocatedByClassName(s.T(), s.Context(ctx), "failure-icon")
 }
 
 type DuoPushDefaultRedirectionSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewDuoPushDefaultRedirectionSuite() *DuoPushDefaultRedirectionSuite {
-	return &DuoPushDefaultRedirectionSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &DuoPushDefaultRedirectionSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *DuoPushDefaultRedirectionSuite) SetupSuite() {
-	wds, err := StartWebDriver()
+	browser, err := StartRod()
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	s.WebDriverSession = wds
+	s.RodSession = browser
 }
 
 func (s *DuoPushDefaultRedirectionSuite) TearDownSuite() {
-	err := s.WebDriverSession.Stop()
+	err := s.RodSession.Stop()
 
 	if err != nil {
 		log.Fatal(err)
@@ -102,19 +112,25 @@ func (s *DuoPushDefaultRedirectionSuite) TearDownSuite() {
 }
 
 func (s *DuoPushDefaultRedirectionSuite) SetupTest() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	s.Page = s.doCreateTab(s.T(), HomeBaseURL)
+	s.verifyIsHome(s.T(), s.Page)
+}
 
-	s.doLogout(ctx, s.T())
+func (s *DuoPushDefaultRedirectionSuite) TearDownTest() {
+	s.collectCoverage(s.Page)
+	s.MustClose()
 }
 
 func (s *DuoPushDefaultRedirectionSuite) TestUserIsRedirectedToDefaultURL() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
+	defer func() {
+		cancel()
+		s.collectScreenshot(ctx.Err(), s.Page)
+	}()
 
-	s.doLoginOneFactor(ctx, s.T(), "john", "password", false, "")
-	s.doChangeMethod(ctx, s.T(), "push-notification")
-	s.verifyURLIs(ctx, s.T(), HomeBaseURL+"/")
+	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, "")
+	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")
+	s.verifyIsHome(s.T(), s.Page)
 }
 
 type DuoPushSuite struct {

--- a/internal/suites/suite_haproxy.go
+++ b/internal/suites/suite_haproxy.go
@@ -42,6 +42,13 @@ func init() {
 
 		fmt.Println(frontendLogs)
 
+		haproxyLogs, err := dockerEnvironment.Logs("haproxy", nil)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(haproxyLogs)
+
 		return nil
 	}
 

--- a/internal/suites/suite_haproxy_test.go
+++ b/internal/suites/suite_haproxy_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type HAProxySuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewHAProxySuite() *HAProxySuite {
-	return &HAProxySuite{SeleniumSuite: new(SeleniumSuite)}
+	return &HAProxySuite{RodSuite: new(RodSuite)}
 }
 
 func (s *HAProxySuite) TestOneFactorScenario() {

--- a/internal/suites/suite_kubernetes_test.go
+++ b/internal/suites/suite_kubernetes_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type KubernetesSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewKubernetesSuite() *KubernetesSuite {
-	return &KubernetesSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &KubernetesSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *KubernetesSuite) TestOneFactorScenario() {

--- a/internal/suites/suite_ldap_test.go
+++ b/internal/suites/suite_ldap_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type LDAPSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewLDAPSuite() *LDAPSuite {
-	return &LDAPSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &LDAPSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *LDAPSuite) TestOneFactorScenario() {

--- a/internal/suites/suite_mariadb_test.go
+++ b/internal/suites/suite_mariadb_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type MariadbSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewMariadbSuite() *MariadbSuite {
-	return &MariadbSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &MariadbSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *MariadbSuite) TestOneFactorScenario() {

--- a/internal/suites/suite_mysql_test.go
+++ b/internal/suites/suite_mysql_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type MySQLSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewMySQLSuite() *MySQLSuite {
-	return &MySQLSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &MySQLSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *MySQLSuite) TestOneFactorScenario() {

--- a/internal/suites/suite_oidc_test.go
+++ b/internal/suites/suite_oidc_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type OIDCSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewOIDCSuite() *OIDCSuite {
-	return &OIDCSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &OIDCSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *OIDCSuite) TestOIDCScenario() {

--- a/internal/suites/suite_oidc_traefik_test.go
+++ b/internal/suites/suite_oidc_traefik_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type OIDCTraefikSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewOIDCTraefikSuite() *OIDCTraefikSuite {
-	return &OIDCTraefikSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &OIDCTraefikSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *OIDCTraefikSuite) TestOIDCScenario() {

--- a/internal/suites/suite_pathprefix_test.go
+++ b/internal/suites/suite_pathprefix_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type PathPrefixSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewPathPrefixSuite() *PathPrefixSuite {
-	return &PathPrefixSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &PathPrefixSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *PathPrefixSuite) TestOneFactorScenario() {

--- a/internal/suites/suite_postgres_test.go
+++ b/internal/suites/suite_postgres_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type PostgresSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewPostgresSuite() *PostgresSuite {
-	return &PostgresSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &PostgresSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *PostgresSuite) TestOneFactorScenario() {

--- a/internal/suites/suite_short_timeouts_test.go
+++ b/internal/suites/suite_short_timeouts_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type ShortTimeoutsSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewShortTimeoutsSuite() *ShortTimeoutsSuite {
-	return &ShortTimeoutsSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &ShortTimeoutsSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *ShortTimeoutsSuite) TestDefaultRedirectionURLScenario() {

--- a/internal/suites/suite_traefik_test.go
+++ b/internal/suites/suite_traefik_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type TraefikSuite struct {
-	*SeleniumSuite
+	*RodSuite
 }
 
 func NewTraefikSuite() *TraefikSuite {
-	return &TraefikSuite{SeleniumSuite: new(SeleniumSuite)}
+	return &TraefikSuite{RodSuite: new(RodSuite)}
 }
 
 func (s *TraefikSuite) TestOneFactorScenario() {

--- a/internal/suites/suites.go
+++ b/internal/suites/suites.go
@@ -1,15 +1,16 @@
 package suites
 
 import (
+	"github.com/go-rod/rod"
 	"github.com/stretchr/testify/suite"
-	"github.com/tebeka/selenium"
 )
 
-// SeleniumSuite is a selenium suite.
-type SeleniumSuite struct {
+// RodSuite is a go-rod suite.
+type RodSuite struct {
 	suite.Suite
 
-	*WebDriverSession
+	*RodSession
+	*rod.Page
 }
 
 // CommandSuite is a command line interface suite.
@@ -20,9 +21,4 @@ type CommandSuite struct {
 	coverageArg string //nolint:structcheck // TODO: Remove when bug fixed: https://github.com/golangci/golangci-lint/issues/537.
 
 	*DockerEnvironment
-}
-
-// WebDriver return the webdriver of the suite.
-func (s *SeleniumSuite) WebDriver() selenium.WebDriver {
-	return s.WebDriverSession.WebDriver
 }

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -55,7 +55,7 @@ func (rs *RodSession) collectScreenshot(err error, page *rod.Page) {
 		build := os.Getenv("BUILDKITE_BUILD_NUMBER")
 		suite := strings.ToLower(os.Getenv("SUITE"))
 		job := os.Getenv("BUILDKITE_JOB_ID")
-		path := filepath.Join(fmt.Sprintf("%s/%s/%s/%s", base, build, suite, job))
+		path := filepath.Join(fmt.Sprintf("%s/%s/%s/%s", base, build, suite, job)) //nolint: gocritic
 
 		if err := os.MkdirAll(path, 0755); err != nil {
 			log.Fatal(err)

--- a/internal/suites/verify_body_contains.go
+++ b/internal/suites/verify_body_contains.go
@@ -1,33 +1,29 @@
 package suites
 
 import (
-	"context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/go-rod/rod"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tebeka/selenium"
 )
 
-func (wds *WebDriverSession) verifyBodyContains(ctx context.Context, t *testing.T, pattern string) {
-	err := wds.Wait(ctx, func(wd selenium.WebDriver) (bool, error) {
-		bodyElement, err := wds.WebDriver.FindElement(selenium.ByTagName, "body")
+func (rs *RodSession) verifyBodyContains(t *testing.T, page *rod.Page, pattern string) {
+	body, err := page.Element("body")
+	assert.NoError(t, err)
+	assert.NotNil(t, body)
 
-		if err != nil {
-			return false, err
-		}
+	text, err := body.Text()
+	assert.NoError(t, err)
+	assert.NotNil(t, text)
 
-		if bodyElement == nil {
-			return false, nil
-		}
+	if strings.Contains(text, pattern) {
+		err = nil
+	} else {
+		err = fmt.Errorf("body does not contain pattern: %s", pattern)
+	}
 
-		content, err := bodyElement.Text()
-
-		if err != nil {
-			return false, err
-		}
-
-		return strings.Contains(content, pattern), nil
-	})
 	require.NoError(t, err)
 }

--- a/internal/suites/verify_is_authenticated_page.go
+++ b/internal/suites/verify_is_authenticated_page.go
@@ -1,10 +1,11 @@
 package suites
 
 import (
-	"context"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
-func (wds *WebDriverSession) verifyIsAuthenticatedPage(ctx context.Context, t *testing.T) {
-	wds.WaitElementLocatedByID(ctx, t, "authenticated-stage")
+func (rs *RodSession) verifyIsAuthenticatedPage(t *testing.T, page *rod.Page) {
+	rs.WaitElementLocatedByCSSSelector(t, page, "authenticated-stage")
 }

--- a/internal/suites/verify_is_consent_page.go
+++ b/internal/suites/verify_is_consent_page.go
@@ -1,10 +1,11 @@
 package suites
 
 import (
-	"context"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
-func (wds *WebDriverSession) verifyIsConsentPage(ctx context.Context, t *testing.T) {
-	wds.WaitElementLocatedByID(ctx, t, "consent-stage")
+func (rs *RodSession) verifyIsConsentPage(t *testing.T, page *rod.Page) {
+	rs.WaitElementLocatedByCSSSelector(t, page, "consent-stage")
 }

--- a/internal/suites/verify_is_first_factor_page.go
+++ b/internal/suites/verify_is_first_factor_page.go
@@ -1,10 +1,11 @@
 package suites
 
 import (
-	"context"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
-func (wds *WebDriverSession) verifyIsFirstFactorPage(ctx context.Context, t *testing.T) {
-	wds.WaitElementLocatedByID(ctx, t, "first-factor-stage")
+func (rs *RodSession) verifyIsFirstFactorPage(t *testing.T, page *rod.Page) {
+	rs.WaitElementLocatedByCSSSelector(t, page, "first-factor-stage")
 }

--- a/internal/suites/verify_is_home.go
+++ b/internal/suites/verify_is_home.go
@@ -1,11 +1,13 @@
 package suites
 
 import (
-	"context"
 	"fmt"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
-func (wds *WebDriverSession) verifyIsHome(ctx context.Context, t *testing.T) {
-	wds.verifyURLIs(ctx, t, fmt.Sprintf("%s/", HomeBaseURL))
+func (rs *RodSession) verifyIsHome(t *testing.T, page *rod.Page) {
+	page.MustElementR("h1", "Access the secret")
+	rs.verifyURLIs(t, page, fmt.Sprintf("%s/", HomeBaseURL))
 }

--- a/internal/suites/verify_is_oidc.go
+++ b/internal/suites/verify_is_oidc.go
@@ -1,0 +1,12 @@
+package suites
+
+import (
+	"testing"
+
+	"github.com/go-rod/rod"
+)
+
+func (rs *RodSession) verifyIsOIDC(t *testing.T, page *rod.Page, pattern, url string) {
+	page.MustElementR("body", pattern)
+	rs.verifyURLIs(t, page, url)
+}

--- a/internal/suites/verify_is_public.go
+++ b/internal/suites/verify_is_public.go
@@ -1,0 +1,13 @@
+package suites
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-rod/rod"
+)
+
+func (rs *RodSession) verifyIsPublic(t *testing.T, page *rod.Page) {
+	page.MustElementR("body", "headers")
+	rs.verifyURLIs(t, page, fmt.Sprintf("%s/headers", PublicBaseURL))
+}

--- a/internal/suites/verify_is_second_factor_page.go
+++ b/internal/suites/verify_is_second_factor_page.go
@@ -1,10 +1,11 @@
 package suites
 
 import (
-	"context"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
-func (wds *WebDriverSession) verifyIsSecondFactorPage(ctx context.Context, t *testing.T) {
-	wds.WaitElementLocatedByID(ctx, t, "second-factor-stage")
+func (rs *RodSession) verifyIsSecondFactorPage(t *testing.T, page *rod.Page) {
+	rs.WaitElementLocatedByCSSSelector(t, page, "second-factor-stage")
 }

--- a/internal/suites/verify_mail.go
+++ b/internal/suites/verify_mail.go
@@ -1,10 +1,11 @@
 package suites
 
 import (
-	"context"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
-func (wds *WebDriverSession) verifyMailNotificationDisplayed(ctx context.Context, t *testing.T) {
-	wds.verifyNotificationDisplayed(ctx, t, "An email has been sent to your address to complete the process.")
+func (rs *RodSession) verifyMailNotificationDisplayed(t *testing.T, page *rod.Page) {
+	rs.verifyNotificationDisplayed(t, page, "An email has been sent to your address to complete the process.")
 }

--- a/internal/suites/verify_notification.go
+++ b/internal/suites/verify_notification.go
@@ -1,14 +1,14 @@
 package suites
 
 import (
-	"context"
 	"testing"
 
+	"github.com/go-rod/rod"
 	"github.com/stretchr/testify/assert"
 )
 
-func (wds *WebDriverSession) verifyNotificationDisplayed(ctx context.Context, t *testing.T, message string) {
-	el := wds.WaitElementLocatedByClassName(ctx, t, "notification")
+func (rs *RodSession) verifyNotificationDisplayed(t *testing.T, page *rod.Page, message string) {
+	el, err := page.ElementR(".notification", message)
+	assert.NoError(t, err)
 	assert.NotNil(t, el)
-	wds.WaitElementTextContains(ctx, t, el, message)
 }

--- a/internal/suites/verify_secret_authorized.go
+++ b/internal/suites/verify_secret_authorized.go
@@ -1,10 +1,11 @@
 package suites
 
 import (
-	"context"
 	"testing"
+
+	"github.com/go-rod/rod"
 )
 
-func (wds *WebDriverSession) verifySecretAuthorized(ctx context.Context, t *testing.T) {
-	wds.WaitElementLocatedByID(ctx, t, "secret")
+func (rs *RodSession) verifySecretAuthorized(t *testing.T, page *rod.Page) {
+	rs.WaitElementLocatedByCSSSelector(t, page, "secret")
 }

--- a/internal/suites/verify_url_is.go
+++ b/internal/suites/verify_url_is.go
@@ -1,23 +1,13 @@
 package suites
 
 import (
-	"context"
 	"testing"
 
+	"github.com/go-rod/rod"
 	"github.com/stretchr/testify/require"
-	"github.com/tebeka/selenium"
 )
 
-func (wds *WebDriverSession) verifyURLIs(ctx context.Context, t *testing.T, url string) {
-	err := wds.Wait(ctx, func(driver selenium.WebDriver) (bool, error) {
-		currentURL, err := driver.CurrentURL()
-
-		if err != nil {
-			return false, err
-		}
-
-		return currentURL == url, nil
-	})
-
-	require.NoError(t, err)
+func (rs *RodSession) verifyURLIs(t *testing.T, page *rod.Page, url string) {
+	currentURL := page.MustInfo().URL
+	require.Equal(t, url, currentURL, "they should be equal")
 }

--- a/internal/suites/webdriver.go
+++ b/internal/suites/webdriver.go
@@ -1,250 +1,115 @@
 package suites
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
 	"github.com/stretchr/testify/require"
-	"github.com/tebeka/selenium"
-	"github.com/tebeka/selenium/chrome"
 )
 
-// WebDriverSession binding a selenium service and a webdriver.
-type WebDriverSession struct {
-	service   *selenium.Service
-	WebDriver selenium.WebDriver
+// RodSession binding a chrome session with devtool protocol.
+type RodSession struct {
+	Launcher  *launcher.Launcher
+	WebDriver *rod.Browser
 }
 
-// StartWebDriverWithProxy create a selenium session.
-func StartWebDriverWithProxy(proxy string, port int) (*WebDriverSession, error) {
-	driverPath := os.Getenv("CHROMEDRIVER_PATH")
-	if driverPath == "" {
-		driverPath = "/usr/bin/chromedriver"
-	}
-
-	service, err := selenium.NewChromeDriverService(driverPath, port)
-
-	if err != nil {
-		return nil, err
-	}
-
+// StartRodWithProxy create a rod/chromedp session.
+func StartRodWithProxy(proxy string) (*RodSession, error) {
 	browserPath := os.Getenv("BROWSER_PATH")
 	if browserPath == "" {
 		browserPath = "/usr/bin/chromium-browser"
 	}
 
-	chromeCaps := chrome.Capabilities{
-		Path: browserPath,
-	}
-
-	chromeCaps.Args = append(chromeCaps.Args, "--ignore-certificate-errors")
+	headless := false
+	trace := true
+	motion := 0 * time.Second
 
 	if os.Getenv("HEADLESS") != "" {
-		chromeCaps.Args = append(chromeCaps.Args, "--headless")
-		chromeCaps.Args = append(chromeCaps.Args, "--no-sandbox")
+		headless = true
+		trace = false
+		motion = 0 * time.Second
 	}
 
-	if proxy != "" {
-		chromeCaps.Args = append(chromeCaps.Args, fmt.Sprintf("--proxy-server=%s", proxy))
-	}
+	l := launcher.New().
+		Bin(browserPath).
+		Proxy(proxy).
+		Headless(headless).
+		Devtools(true)
+	url := l.MustLaunch()
 
-	caps := selenium.Capabilities{}
-	caps.AddChrome(chromeCaps)
+	browser := rod.New().
+		ControlURL(url).
+		Trace(trace).
+		SlowMotion(motion).
+		MustConnect()
 
-	wd, err := selenium.NewRemote(caps, fmt.Sprintf("http://localhost:%d/wd/hub", port))
-	if err != nil {
-		_ = service.Stop()
+	browser.MustIgnoreCertErrors(true)
 
-		log.Fatal(err)
-	}
-
-	return &WebDriverSession{
-		service:   service,
-		WebDriver: wd,
+	return &RodSession{
+		Launcher:  l,
+		WebDriver: browser,
 	}, nil
 }
 
-// StartWebDriver create a selenium session.
-func StartWebDriver() (*WebDriverSession, error) {
-	return StartWebDriverWithProxy("", GetWebDriverPort())
+// StartRod create a rod/chromedp session.
+func StartRod() (*RodSession, error) {
+	return StartRodWithProxy("")
 }
 
-// Stop stop the selenium session.
-func (wds *WebDriverSession) Stop() error {
-	var coverage map[string]interface{}
-
-	coverageDir := "../../web/.nyc_output"
-	time := time.Now()
-
-	resp, err := wds.WebDriver.ExecuteScriptRaw("return JSON.stringify(window.__coverage__)", nil)
+// Stop stop the rod/chromedp session.
+func (rs *RodSession) Stop() error {
+	err := rs.WebDriver.Close()
 	if err != nil {
 		return err
 	}
 
-	err = json.Unmarshal(resp, &coverage)
-	if err != nil {
-		return err
-	}
+	rs.Launcher.Cleanup()
 
-	coverageData := fmt.Sprintf("%s", coverage["value"])
-
-	_ = os.MkdirAll(coverageDir, 0775)
-
-	err = ioutil.WriteFile(fmt.Sprintf("%s/coverage-%d.json", coverageDir, time.Unix()), []byte(coverageData), 0664) //nolint:gosec
-	if err != nil {
-		return err
-	}
-
-	err = filepath.Walk("../../web/.nyc_output", fixCoveragePath)
-	if err != nil {
-		return err
-	}
-
-	err = wds.WebDriver.Quit()
-	if err != nil {
-		return err
-	}
-
-	return wds.service.Stop()
-}
-
-// WithWebdriver run some actions against a webdriver.
-func WithWebdriver(fn func(webdriver selenium.WebDriver) error) error {
-	wds, err := StartWebDriver()
-
-	if err != nil {
-		return err
-	}
-
-	defer wds.Stop() //nolint:errcheck // TODO: Legacy code, consider refactoring time permitting.
-
-	return fn(wds.WebDriver)
-}
-
-// Wait wait until condition holds true.
-func (wds *WebDriverSession) Wait(ctx context.Context, condition selenium.Condition) error {
-	done := make(chan error, 1)
-
-	go func() {
-		done <- wds.WebDriver.Wait(condition)
-	}()
-
-	select {
-	case <-ctx.Done():
-		return errors.New("waiting timeout reached")
-	case err := <-done:
-		return err
-	}
-}
-
-func (wds *WebDriverSession) waitElementLocated(ctx context.Context, t *testing.T, by, value string) selenium.WebElement {
-	var el selenium.WebElement
-
-	err := wds.Wait(ctx, func(driver selenium.WebDriver) (bool, error) {
-		var err error
-		el, err = driver.FindElement(by, value)
-
-		if err != nil {
-			if strings.Contains(err.Error(), "no such element") {
-				return false, nil
-			}
-			return false, err
-		}
-
-		return el != nil, nil
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, el)
-
-	return el
-}
-
-func (wds *WebDriverSession) waitElementsLocated(ctx context.Context, t *testing.T, by, value string) []selenium.WebElement {
-	var el []selenium.WebElement
-
-	err := wds.Wait(ctx, func(driver selenium.WebDriver) (bool, error) {
-		var err error
-		el, err = driver.FindElements(by, value)
-
-		if err != nil {
-			if strings.Contains(err.Error(), "no such element") {
-				return false, nil
-			}
-			return false, err
-		}
-
-		return el != nil, nil
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, el)
-
-	return el
-}
-
-// WaitElementLocatedByID wait an element is located by id.
-func (wds *WebDriverSession) WaitElementLocatedByID(ctx context.Context, t *testing.T, id string) selenium.WebElement {
-	return wds.waitElementLocated(ctx, t, selenium.ByID, id)
-}
-
-// WaitElementLocatedByTagName wait an element is located by tag name.
-func (wds *WebDriverSession) WaitElementLocatedByTagName(ctx context.Context, t *testing.T, tagName string) selenium.WebElement {
-	return wds.waitElementLocated(ctx, t, selenium.ByTagName, tagName)
+	return err
 }
 
 // WaitElementLocatedByClassName wait an element is located by class name.
-func (wds *WebDriverSession) WaitElementLocatedByClassName(ctx context.Context, t *testing.T, className string) selenium.WebElement {
-	return wds.waitElementLocated(ctx, t, selenium.ByClassName, className)
-}
+func (rs *RodSession) WaitElementLocatedByClassName(t *testing.T, page *rod.Page, className string) *rod.Element {
+	e, err := page.Element("." + className)
+	require.NoError(t, err)
+	require.NotNil(t, e)
 
-// WaitElementLocatedByLinkText wait an element is located by link text.
-func (wds *WebDriverSession) WaitElementLocatedByLinkText(ctx context.Context, t *testing.T, linkText string) selenium.WebElement {
-	return wds.waitElementLocated(ctx, t, selenium.ByLinkText, linkText)
+	return e
 }
 
 // WaitElementLocatedByCSSSelector wait an element is located by class name.
-func (wds *WebDriverSession) WaitElementLocatedByCSSSelector(ctx context.Context, t *testing.T, cssSelector string) selenium.WebElement {
-	return wds.waitElementLocated(ctx, t, selenium.ByCSSSelector, cssSelector)
+func (rs *RodSession) WaitElementLocatedByCSSSelector(t *testing.T, page *rod.Page, cssSelector string) *rod.Element {
+	e, err := page.Element("#" + cssSelector)
+	require.NoError(t, err)
+	require.NotNil(t, e)
+
+	return e
 }
 
 // WaitElementsLocatedByCSSSelector wait an element is located by CSS selector.
-func (wds *WebDriverSession) WaitElementsLocatedByCSSSelector(ctx context.Context, t *testing.T, cssSelector string) []selenium.WebElement {
-	return wds.waitElementsLocated(ctx, t, selenium.ByCSSSelector, cssSelector)
-}
-
-// WaitElementTextContains wait the text of an element contains a pattern.
-func (wds *WebDriverSession) WaitElementTextContains(ctx context.Context, t *testing.T, element selenium.WebElement, pattern string) {
-	err := wds.Wait(ctx, func(driver selenium.WebDriver) (bool, error) {
-		text, err := element.Text()
-
-		if err != nil {
-			return false, err
-		}
-
-		return strings.Contains(text, pattern), nil
-	})
+func (rs *RodSession) WaitElementsLocatedByCSSSelector(t *testing.T, page *rod.Page, cssSelector string) rod.Elements {
+	e, err := page.Elements("#" + cssSelector)
 	require.NoError(t, err)
+	require.NotNil(t, e)
+
+	return e
 }
 
-func (wds *WebDriverSession) waitBodyContains(ctx context.Context, t *testing.T, pattern string) {
-	err := wds.Wait(ctx, func(driver selenium.WebDriver) (bool, error) {
-		text, err := wds.WaitElementLocatedByTagName(ctx, t, "body").Text()
+func (rs *RodSession) waitBodyContains(t *testing.T, page *rod.Page, pattern string) {
+	text, err := page.MustElementR("body", pattern).Text()
+	require.NoError(t, err)
+	require.NotNil(t, text)
 
-		if err != nil {
-			return false, err
-		}
+	if strings.Contains(text, pattern) {
+		err = nil
+	} else {
+		err = fmt.Errorf("body does not contain pattern: %s", pattern)
+	}
 
-		return strings.Contains(text, pattern), nil
-	})
 	require.NoError(t, err)
 }

--- a/internal/utils/const.go
+++ b/internal/utils/const.go
@@ -33,7 +33,7 @@ const (
 
 const (
 	// Hour is an int based representation of the time unit.
-	Hour = time.Minute * 60
+	Hour = time.Minute * 60 //nolint: revive
 
 	// Day is an int based representation of the time unit.
 	Day = Hour * 24


### PR DESCRIPTION
This change replaces [tebeka/selenium](https://github.com/tebeka/selenium) with [go-rod](https://github.com/go-rod/rod).

We no longer have a Chromedriver/external driver dependency to utilise Selenium as we instead utilise the Chrome Devtools Protocol to communicate with the browser.

Rod [documents](https://go-rod.github.io/#/why-rod) benefits of choosing the library as opposed to the available alternatives.