### PR TITLE
feat(oidc): include introspection_endpoint in .well-known/openid-configuration

### DIFF
--- a/internal/handlers/handler_oidc_wellknown.go
+++ b/internal/handlers/handler_oidc_wellknown.go
@@ -27,6 +27,7 @@ func oidcWellKnown(ctx *middlewares.AutheliaCtx) {
 		TokenEndpoint:         fmt.Sprintf("%s%s", issuer, pathOpenIDConnectToken),
 		RevocationEndpoint:    fmt.Sprintf("%s%s", issuer, pathOpenIDConnectRevocation),
 		UserinfoEndpoint:      fmt.Sprintf("%s%s", issuer, pathOpenIDConnectUserinfo),
+		IntrospectionEndpoint: fmt.Sprintf("%s%s", issuer, pathOpenIDConnectIntrospection),
 
 		Algorithms:         []string{"RS256"},
 		UserinfoAlgorithms: []string{"none", "RS256"},

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -93,6 +93,7 @@ type WellKnownConfiguration struct {
 	TokenEndpoint         string `json:"token_endpoint"`
 	RevocationEndpoint    string `json:"revocation_endpoint"`
 	UserinfoEndpoint      string `json:"userinfo_endpoint"`
+	IntrospectionEndpoint string `json:"introspection_endpoint"`
 
 	Algorithms         []string `json:"id_token_signing_alg_values_supported"`
 	UserinfoAlgorithms []string `json:"userinfo_signing_alg_values_supported"`


### PR DESCRIPTION
Hello,

I've got a pretty trivial change which I couldn't test locally, so I'm going to rely on CI to tell me about build failures :) 

This adds the already existing token introspection endpoint to the openid-configuration file.