### PR TITLE
docs: add hashicorp vault oidc configuration and update minio tested version

### DIFF
--- a/docs/community/oidc-integrations.md
+++ b/docs/community/oidc-integrations.md
@@ -11,15 +11,16 @@ nav_order: 4
 
 ## Currently Tested Applications
 
-| Application | Minimal Version                | Notes   |
-| :---------: | :----------------------------: | :-----: |
-| Gitea       | `1.14.6`                       | |
-| GitLab      | `13.0.0`                       | |
-| Grafana     | `8.0.5`                        | |
-| MinIO       | `RELEASE.2021-07-12T02-44-53Z` | must set `MINIO_IDENTITY_OPENID_CLAIM_NAME: groups` in MinIO and set [MinIO policies] as groups in Authelia |
-| Nextcloud   | `22.1.0`                       | Tested using the `nextcloud-oidc-login` app - [Link](https://github.com/pulsejet/nextcloud-oidc-login)|
-| Wekan       | `5.41`                         | |
-| Portainer CE| `2.6.1`                        | Settings to use username as ID: set `Scopes` to `openid` and `User Identifier` to `sub` |
+| Application    | Minimal Version                | Notes   |
+| :------------: | :----------------------------: | :-----: |
+| Gitea          | `1.14.6`                       | |
+| GitLab         | `13.0.0`                       | |
+| Grafana        | `8.0.5`                        | |
+| Hashicorp Vault| `1.8.1`                        | |
+| MinIO          | `RELEASE.2021-11-09T03-21-45Z` | must set `MINIO_IDENTITY_OPENID_CLAIM_NAME: groups` in MinIO and set [MinIO policies] as groups in Authelia |
+| Nextcloud      | `22.1.0`                       | Tested using the `nextcloud-oidc-login` app - [Link](https://github.com/pulsejet/nextcloud-oidc-login)|
+| Wekan          | `5.41`                         | |
+| Portainer CE   | `2.6.1`                        | Settings to use username as ID: set `Scopes` to `openid` and `User Identifier` to `sub` |
 
 [MinIO policies]: https://docs.min.io/minio/baremetal/security/minio-identity-management/policy-based-access-control.html#minio-policy
 
@@ -29,11 +30,12 @@ If you do not find the application in the list below, you will need to search fo
 
 `<DOMAIN>` needs to be substituted with the full URL on which the application runs on. If GitLab, as an example, was reachable under `https://gitlab.example.com`, `<DOMAIN>` would be exactly the same.
 
-| Application | Version                        | Callback URL                                             | Notes   |
-| :---------: | :----------------------------: | :------------------------------------------------------: |:-----:|
-| Gitea       | `1.14.6`                       | `<DOMAIN>/user/oauth2/authelia/callback`                 |`ROOT_URL` in `[server]` section of `app.ini` must be configured correctly. Typically it is `<DOMAIN>/`. The string `authelia` in the callback url is the `Authentication Name` of the configured Authentication Source in Gitea (Authentication Type: OAuth2, OAuth2 Provider: OpenID Connect).
-| GitLab      | `14.0.1`                       | `<DOMAIN>/users/auth/openid_connect/callback`            | |
-| MinIO       | `RELEASE.2021-07-12T02-44-53Z` | `<DOMAIN>/oauth_callback`                                | |
-| Nextcloud   | `22.1.0` + `nextcloud-oidc-login` app | `<DOMAIN>/apps/oidc_login/oidc`                                | |
-| Wekan       | `5.41`                          | `<DOMAIN>/_oauth_oidc`            | |
-| Portainer CE| `2.6.1`                         | `<DOMAIN>`            | |
+| Application   | Version                               | Callback URL                                             | Notes   |
+| :-----------: | :-----------------------------------: | :------------------------------------------------------: |:-----:|
+| Gitea         | `1.14.6`                              | `<DOMAIN>/user/oauth2/authelia/callback`                 |`ROOT_URL` in `[server]` section of `app.ini` must be configured correctly. Typically it is `<DOMAIN>/`. The string `authelia` in the callback url is the `Authentication Name` of the configured Authentication Source in Gitea (Authentication Type: OAuth2, OAuth2 Provider: OpenID Connect).
+| GitLab        | `14.0.1`                              | `<DOMAIN>/users/auth/openid_connect/callback`            | |
+| Hasicorp Vault| `14.0.1`                              | `<DOMAIN>/oidc/callback` and `<DOMAIN>/ui/vault/auth/oidc/oidc/callback`             | |
+| MinIO         | `RELEASE.2021-07-12T02-44-53Z`        | `<DOMAIN>/oauth_callback`                                | |
+| Nextcloud     | `22.1.0` + `nextcloud-oidc-login` app | `<DOMAIN>/apps/oidc_login/oidc`                          | |
+| Wekan         | `5.41`                                | `<DOMAIN>/_oauth_oidc`                                   | |
+| Portainer CE  | `2.6.1`                               | `<DOMAIN>`                                               | |


### PR DESCRIPTION
Add Hashicorp Vault oidc callback URLs and update tested version of MinIO in community docs.

Closes #2310.