### PR TITLE
feat(notifier): smtp sender and sender_name

### DIFF
--- a/internal/configuration/schema/notifier.go
+++ b/internal/configuration/schema/notifier.go
@@ -16,6 +16,7 @@ type SMTPNotifierConfiguration struct {
 	Password            string        `koanf:"password"`
 	Identifier          string        `koanf:"identifier"`
 	Sender              string        `koanf:"sender"`
+	SenderName          string        `koanf:"sender_name"`
 	Subject             string        `koanf:"subject"`
 	StartupCheckAddress string        `koanf:"startup_check_address"`
 	DisableRequireTLS   bool          `koanf:"disable_require_tls"`

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -237,6 +237,7 @@ var ValidKeys = []string{
 	"notifier.smtp.password",
 	"notifier.smtp.identifier",
 	"notifier.smtp.sender",
+	"notifier.smtp.sender_name",
 	"notifier.smtp.subject",
 	"notifier.smtp.startup_check_address",
 	"notifier.smtp.disable_require_tls",

--- a/internal/notification/const.go
+++ b/internal/notification/const.go
@@ -4,16 +4,16 @@ const fileNotifierMode = 0600
 const rfc5322DateTimeLayout = "Mon, 2 Jan 2006 15:04:05 -0700"
 
 var (
-	newline           = []byte("\n")
-	newlineDouble     = []byte("\n\n")
+	newline           = []byte("\r\n")
+	newlineDouble     = []byte("\r\n\r\n")
 	boundarySeparator = []byte("--")
 
 	headerDate        = []byte("Date: ")
-	headerFrom        = []byte("\nFrom: ")
-	headerTo          = []byte("\nTo: ")
-	headerSubject     = []byte("\nSubject: ")
-	headerMIMEVersion = []byte("\nMIME-Version: 1.0\nContent-Type: multipart/alternative; boundary=")
+	headerFrom        = []byte("\r\nFrom: ")
+	headerTo          = []byte("\r\nTo: ")
+	headerSubject     = []byte("\r\nSubject: ")
+	headerMIMEVersion = []byte("\r\nMIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=")
 
-	headerTextPlain       = []byte("\nContent-Type: text/plain; charset=\"UTF-8\"\nContent-Transfer-Encoding: quoted-printable\nContent-Disposition: inline")
-	headerContentTypeHTML = []byte("\nContent-Type: text/html; charset=\"UTF-8\"")
+	headerTextPlain       = []byte("\r\nContent-Type: text/plain; charset=\"UTF-8\"\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Disposition: inline")
+	headerContentTypeHTML = []byte("\r\nContent-Type: text/html; charset=\"UTF-8\"")
 )

--- a/internal/notification/const.go
+++ b/internal/notification/const.go
@@ -2,3 +2,18 @@ package notification
 
 const fileNotifierMode = 0600
 const rfc5322DateTimeLayout = "Mon, 2 Jan 2006 15:04:05 -0700"
+
+var (
+	newline           = []byte("\n")
+	newlineDouble     = []byte("\n\n")
+	boundarySeparator = []byte("--")
+
+	headerDate        = []byte("Date: ")
+	headerFrom        = []byte("\nFrom: ")
+	headerTo          = []byte("\nTo: ")
+	headerSubject     = []byte("\nSubject: ")
+	headerMIMEVersion = []byte("\nMIME-Version: 1.0\nContent-Type: multipart/alternative; boundary=")
+
+	headerTextPlain       = []byte("\nContent-Type: text/plain; charset=\"UTF-8\"\nContent-Transfer-Encoding: quoted-printable\nContent-Disposition: inline")
+	headerContentTypeHTML = []byte("\nContent-Type: text/html; charset=\"UTF-8\"")
+)

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -140,7 +140,6 @@ func (n *SMTPNotifier) compose(recipient, subject, body, htmlBody string) error 
 
 	msg.Write(headerDate)
 	msg.WriteString(now.Format(rfc5322DateTimeLayout))
-	msg.Write(newline)
 
 	msg.Write(headerFrom)
 	if n.configuration.SenderName != "" {
@@ -156,9 +155,8 @@ func (n *SMTPNotifier) compose(recipient, subject, body, htmlBody string) error 
 	msg.WriteString(subject)
 
 	msg.Write(headerMIMEVersion)
-
 	msg.Write(boundary)
-	msg.Write(newline)
+	msg.Write(newlineDouble)
 
 	msg.Write(boundarySeparator)
 	msg.Write(boundary)

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -170,7 +170,6 @@ func (n *SMTPNotifier) compose(recipient, subject, body, htmlBody string) error 
 	if htmlBody != "" {
 		msg.Write(boundarySeparator)
 		msg.Write(boundary)
-		msg.Write(newline)
 
 		msg.Write(headerContentTypeHTML)
 		msg.Write(newlineDouble)


### PR DESCRIPTION
Previously we encouraged users to configure the sender name as part of the sender. However the sender is used to configure the MAIL FROM SMTP command, where it's not appropriate to include this information. This change adds the option to configure them separately.

This will mean we will no longer accept anything other than an email address in the sender configuration option.