### PR TITLE
fix(storage): new auth log schema request method length

### DIFF
--- a/internal/storage/migrations/V0001.Initial_Schema.mysql.up.sql
+++ b/internal/storage/migrations/V0001.Initial_Schema.mysql.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS authentication_logs (
     auth_type VARCHAR(5) NOT NULL DEFAULT '1FA',
     remote_ip VARCHAR(47) NULL DEFAULT NULL,
     request_uri TEXT NOT NULL,
-    request_method VARCHAR(4) NOT NULL DEFAULT '',
+    request_method VARCHAR(8) NOT NULL DEFAULT '',
     PRIMARY KEY (id)
 );
 

--- a/internal/storage/migrations/V0001.Initial_Schema.postgres.up.sql
+++ b/internal/storage/migrations/V0001.Initial_Schema.postgres.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS authentication_logs (
     auth_type VARCHAR(5) NOT NULL DEFAULT '1FA',
     remote_ip VARCHAR(47) NULL DEFAULT NULL,
     request_uri TEXT,
-    request_method VARCHAR(4) NOT NULL DEFAULT '',
+    request_method VARCHAR(8) NOT NULL DEFAULT '',
     PRIMARY KEY (id)
 );
 

--- a/internal/storage/migrations/V0001.Initial_Schema.sqlite.up.sql
+++ b/internal/storage/migrations/V0001.Initial_Schema.sqlite.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS authentication_logs (
     auth_type VARCHAR(5) NOT NULL DEFAULT '1FA',
     remote_ip VARCHAR(47) NULL DEFAULT NULL,
     request_uri TEXT,
-    request_method VARCHAR(4) NOT NULL DEFAULT '',
+    request_method VARCHAR(8) NOT NULL DEFAULT '',
     PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
This is a fix to the authentication_logs schema that prevents the VARCHAR from being insufficient for HTTP request methods such as PATCH, DELETE, OPTIONS, CONNECT.