### PR TITLE
fix(storage): postgres schema hardcoded for tables query

### DIFF
--- a/internal/configuration/schema/storage.go
+++ b/internal/configuration/schema/storage.go
@@ -54,3 +54,11 @@ type StorageConfiguration struct {
 var DefaultSQLStorageConfiguration = SQLStorageConfiguration{
 	Timeout: 5 * time.Second,
 }
+
+// DefaultPostgreSQLStorageConfiguration represents the default PostgreSQL configuration.
+var DefaultPostgreSQLStorageConfiguration = PostgreSQLStorageConfiguration{
+	Schema: "public",
+	SSL: PostgreSQLSSLStorageConfiguration{
+		Mode: "disable",
+	},
+}

--- a/internal/configuration/validator/storage.go
+++ b/internal/configuration/validator/storage.go
@@ -52,13 +52,17 @@ func validateSQLConfiguration(configuration *schema.SQLStorageConfiguration, val
 func validatePostgreSQLConfiguration(configuration *schema.PostgreSQLStorageConfiguration, validator *schema.StructValidator) {
 	validateSQLConfiguration(&configuration.SQLStorageConfiguration, validator, "postgres")
 
+	if configuration.Schema == "" {
+		configuration.Schema = schema.DefaultPostgreSQLStorageConfiguration.Schema
+	}
+
 	// Deprecated. TODO: Remove in v4.36.0.
 	if configuration.SSLMode != "" && configuration.SSL.Mode == "" {
 		configuration.SSL.Mode = configuration.SSLMode
 	}
 
 	if configuration.SSL.Mode == "" {
-		configuration.SSL.Mode = testModeDisabled
+		configuration.SSL.Mode = schema.DefaultPostgreSQLStorageConfiguration.SSL.Mode
 	} else if !utils.IsStringInSlice(configuration.SSL.Mode, storagePostgreSQLValidSSLModes) {
 		validator.Push(fmt.Errorf(errFmtStoragePostgreSQLInvalidSSLMode, configuration.SSL.Mode, strings.Join(storagePostgreSQLValidSSLModes, "', '")))
 	}

--- a/internal/configuration/validator/storage_test.go
+++ b/internal/configuration/validator/storage_test.go
@@ -104,7 +104,7 @@ func (suite *StorageSuite) TestShouldValidatePostgreSQLHostUsernamePasswordAndDa
 	suite.Assert().Len(suite.validator.Errors(), 0)
 }
 
-func (suite *StorageSuite) TestShouldValidatePostgresSSLModeIsDisableByDefault() {
+func (suite *StorageSuite) TestShouldValidatePostgresSSLModeAndSchemaDefaults() {
 	suite.configuration.PostgreSQL = &schema.PostgreSQLStorageConfiguration{
 		SQLStorageConfiguration: schema.SQLStorageConfiguration{
 			Host:     "db1",
@@ -120,6 +120,30 @@ func (suite *StorageSuite) TestShouldValidatePostgresSSLModeIsDisableByDefault()
 	suite.Assert().Len(suite.validator.Errors(), 0)
 
 	suite.Assert().Equal("disable", suite.configuration.PostgreSQL.SSL.Mode)
+	suite.Assert().Equal("public", suite.configuration.PostgreSQL.Schema)
+}
+
+func (suite *StorageSuite) TestShouldValidatePostgresDefaultsDontOverrideConfiguration() {
+	suite.configuration.PostgreSQL = &schema.PostgreSQLStorageConfiguration{
+		SQLStorageConfiguration: schema.SQLStorageConfiguration{
+			Host:     "db1",
+			Username: "myuser",
+			Password: "pass",
+			Database: "database",
+		},
+		Schema: "authelia",
+		SSL: schema.PostgreSQLSSLStorageConfiguration{
+			Mode: "require",
+		},
+	}
+
+	ValidateStorage(suite.configuration, suite.validator)
+
+	suite.Assert().Len(suite.validator.Warnings(), 0)
+	suite.Assert().Len(suite.validator.Errors(), 0)
+
+	suite.Assert().Equal("require", suite.configuration.PostgreSQL.SSL.Mode)
+	suite.Assert().Equal("authelia", suite.configuration.PostgreSQL.Schema)
 }
 
 func (suite *StorageSuite) TestShouldValidatePostgresSSLModeMustBeValid() {

--- a/internal/storage/sql_provider.go
+++ b/internal/storage/sql_provider.go
@@ -79,6 +79,7 @@ type SQLProvider struct {
 	key        [32]byte
 	name       string
 	driverName string
+	schema     string
 	config     *schema.Configuration
 	errOpen    error
 

--- a/internal/storage/sql_provider_backend_postgres.go
+++ b/internal/storage/sql_provider_backend_postgres.go
@@ -57,6 +57,8 @@ func NewPostgreSQLProvider(config *schema.Configuration) (provider *PostgreSQLPr
 	provider.sqlSelectLatestMigration = provider.db.Rebind(provider.sqlSelectLatestMigration)
 	provider.sqlSelectEncryptionValue = provider.db.Rebind(provider.sqlSelectEncryptionValue)
 
+	provider.schema = config.Storage.PostgreSQL.Schema
+
 	return provider
 }
 
@@ -66,18 +68,12 @@ func dataSourceNamePostgreSQL(config schema.PostgreSQLStorageConfiguration) (dat
 		fmt.Sprintf("user='%s'", config.Username),
 		fmt.Sprintf("password='%s'", config.Password),
 		fmt.Sprintf("dbname=%s", config.Database),
+		fmt.Sprintf("search_path=%s", config.Schema),
+		fmt.Sprintf("sslmode=%s", config.SSL.Mode),
 	}
 
 	if config.Port > 0 {
 		args = append(args, fmt.Sprintf("port=%d", config.Port))
-	}
-
-	if config.Schema != "" {
-		args = append(args, fmt.Sprintf("search_path=%s", config.Schema))
-	}
-
-	if config.SSL.Mode != "" {
-		args = append(args, fmt.Sprintf("sslmode=%s", config.SSL.Mode))
 	}
 
 	if config.SSL.RootCertificate != "" {

--- a/internal/storage/sql_provider_queries.go
+++ b/internal/storage/sql_provider_queries.go
@@ -25,7 +25,7 @@ const (
 	queryPostgreSelectExistingTables = `
 		SELECT table_name
 		FROM information_schema.tables
-		WHERE table_type = 'BASE TABLE' AND table_schema = 'public';`
+		WHERE table_type = 'BASE TABLE' AND table_schema = ?;`
 
 	querySQLiteSelectExistingTables = `
 		SELECT name

--- a/internal/storage/sql_provider_queries.go
+++ b/internal/storage/sql_provider_queries.go
@@ -25,7 +25,7 @@ const (
 	queryPostgreSelectExistingTables = `
 		SELECT table_name
 		FROM information_schema.tables
-		WHERE table_type = 'BASE TABLE' AND table_schema = ?;`
+		WHERE table_type = 'BASE TABLE' AND table_schema = $1;`
 
 	querySQLiteSelectExistingTables = `
 		SELECT name

--- a/internal/storage/sql_provider_schema.go
+++ b/internal/storage/sql_provider_schema.go
@@ -7,15 +7,26 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/authelia/authelia/v4/internal/models"
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
 // SchemaTables returns a list of tables.
 func (p *SQLProvider) SchemaTables(ctx context.Context) (tables []string, err error) {
-	rows, err := p.db.QueryxContext(ctx, p.sqlSelectExistingTables)
-	if err != nil {
-		return tables, err
+	var rows *sqlx.Rows
+
+	if p.schema != "" {
+		rows, err = p.db.QueryxContext(ctx, p.sqlSelectExistingTables, p.schema)
+		if err != nil {
+			return tables, err
+		}
+	} else {
+		rows, err = p.db.QueryxContext(ctx, p.sqlSelectExistingTables)
+		if err != nil {
+			return tables, err
+		}
 	}
 
 	defer func() {

--- a/internal/storage/sql_provider_schema.go
+++ b/internal/storage/sql_provider_schema.go
@@ -17,16 +17,15 @@ import (
 func (p *SQLProvider) SchemaTables(ctx context.Context) (tables []string, err error) {
 	var rows *sqlx.Rows
 
-	if p.schema != "" {
-		rows, err = p.db.QueryxContext(ctx, p.sqlSelectExistingTables, p.schema)
-		if err != nil {
-			return tables, err
-		}
-	} else {
+	switch p.schema {
+	case "":
 		rows, err = p.db.QueryxContext(ctx, p.sqlSelectExistingTables)
-		if err != nil {
-			return tables, err
-		}
+	default:
+		rows, err = p.db.QueryxContext(ctx, p.sqlSelectExistingTables, p.schema)
+	}
+
+	if err != nil {
+		return tables, err
 	}
 
 	defer func() {


### PR DESCRIPTION
This removes the hardcoded schema value from the PostgreSQL existing tables query, making it compatible with the new schema config option.