### PR TITLE
fix(models): potential panic generating jwt

### DIFF
--- a/internal/handlers/handler_register_u2f_step1_test.go
+++ b/internal/handlers/handler_register_u2f_step1_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -35,7 +36,7 @@ func (s *HandlerRegisterU2FStep1Suite) TearDownTest() {
 }
 
 func createToken(ctx *mocks.MockAutheliaCtx, username, action string, expiresAt time.Time) (data string, verification models.IdentityVerification) {
-	verification = models.NewIdentityVerification(username, action, ctx.Ctx.RemoteIP())
+	verification = models.NewIdentityVerification(uuid.New(), username, action, ctx.Ctx.RemoteIP())
 
 	verification.ExpiresAt = expiresAt
 

--- a/internal/middlewares/identity_verification.go
+++ b/internal/middlewares/identity_verification.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
 
 	"github.com/authelia/authelia/v4/internal/models"
 	"github.com/authelia/authelia/v4/internal/templates"
@@ -27,7 +28,14 @@ func IdentityVerificationStart(args IdentityVerificationStartArgs) RequestHandle
 			return
 		}
 
-		verification := models.NewIdentityVerification(identity.Username, args.ActionClaim, ctx.RemoteIP())
+		var jti uuid.UUID
+
+		if jti, err = uuid.NewUUID(); err != nil {
+			ctx.Error(err, messageOperationFailed)
+			return
+		}
+
+		verification := models.NewIdentityVerification(jti, identity.Username, args.ActionClaim, ctx.RemoteIP())
 
 		// Create the claim with the action to sign it.
 		claims := verification.ToIdentityVerificationClaim()

--- a/internal/middlewares/identity_verification_test.go
+++ b/internal/middlewares/identity_verification_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
@@ -166,7 +167,7 @@ func (s *IdentityVerificationFinishProcess) TearDownTest() {
 }
 
 func createToken(ctx *mocks.MockAutheliaCtx, username, action string, expiresAt time.Time) (data string, verification models.IdentityVerification) {
-	verification = models.NewIdentityVerification(username, action, ctx.Ctx.RemoteIP())
+	verification = models.NewIdentityVerification(uuid.New(), username, action, ctx.Ctx.RemoteIP())
 
 	verification.ExpiresAt = expiresAt
 

--- a/internal/models/identity_verification.go
+++ b/internal/models/identity_verification.go
@@ -9,9 +9,9 @@ import (
 )
 
 // NewIdentityVerification creates a new IdentityVerification from a given username and action.
-func NewIdentityVerification(username, action string, ip net.IP) (verification IdentityVerification) {
+func NewIdentityVerification(jti uuid.UUID, username, action string, ip net.IP) (verification IdentityVerification) {
 	return IdentityVerification{
-		JTI:       uuid.New(),
+		JTI:       jti,
 		IssuedAt:  time.Now(),
 		ExpiresAt: time.Now().Add(5 * time.Minute),
 		Action:    action,

--- a/internal/storage/sql_provider_encryption.go
+++ b/internal/storage/sql_provider_encryption.go
@@ -279,7 +279,10 @@ func (p *SQLProvider) getEncryptionValue(ctx context.Context, name string) (valu
 }
 
 func (p *SQLProvider) setNewEncryptionCheckValue(ctx context.Context, key *[32]byte, e sqlx.ExecerContext) (err error) {
-	valueClearText := uuid.New()
+	valueClearText, err := uuid.NewUUID()
+	if err != nil {
+		return err
+	}
 
 	value, err := utils.Encrypt([]byte(valueClearText.String()), key)
 	if err != nil {


### PR DESCRIPTION
This ensures that at the time the JWT is generated for identity verification requests that a panic can't occur and instead an error will be returned.