### PR TITLE
fix(storage): don't check exp against time using sql

### DIFF
--- a/internal/models/types.go
+++ b/internal/models/types.go
@@ -51,6 +51,8 @@ func (ip *IP) Scan(src interface{}) (err error) {
 	switch v := src.(type) {
 	case string:
 		value = v
+	case []byte:
+		value = string(v)
 	default:
 		return fmt.Errorf("invalid type %T for IP %v", src, src)
 	}
@@ -86,6 +88,8 @@ func (ip *NullIP) Scan(src interface{}) (err error) {
 	switch v := src.(type) {
 	case string:
 		value = v
+	case []byte:
+		value = string(v)
 	default:
 		return fmt.Errorf("invalid type %T for NullIP %v", src, src)
 	}

--- a/internal/storage/sql_provider_backend_postgres.go
+++ b/internal/storage/sql_provider_backend_postgres.go
@@ -36,7 +36,7 @@ func NewPostgreSQLProvider(config *schema.Configuration) (provider *PostgreSQLPr
 	provider.sqlFmtRenameTable = provider.db.Rebind(provider.sqlFmtRenameTable)
 	provider.sqlSelectPreferred2FAMethod = provider.db.Rebind(provider.sqlSelectPreferred2FAMethod)
 	provider.sqlSelectUserInfo = provider.db.Rebind(provider.sqlSelectUserInfo)
-	provider.sqlSelectExistsIdentityVerification = provider.db.Rebind(provider.sqlSelectExistsIdentityVerification)
+	provider.sqlSelectIdentityVerification = provider.db.Rebind(provider.sqlSelectIdentityVerification)
 	provider.sqlInsertIdentityVerification = provider.db.Rebind(provider.sqlInsertIdentityVerification)
 	provider.sqlConsumeIdentityVerification = provider.db.Rebind(provider.sqlConsumeIdentityVerification)
 	provider.sqlSelectTOTPConfig = provider.db.Rebind(provider.sqlSelectTOTPConfig)

--- a/internal/storage/sql_provider_queries.go
+++ b/internal/storage/sql_provider_queries.go
@@ -56,12 +56,10 @@ const (
 )
 
 const (
-	queryFmtSelectExistsIdentityVerification = `
-		SELECT EXISTS (
-			SELECT id
-			FROM %s
-			WHERE jti = ? AND exp > CURRENT_TIMESTAMP AND consumed IS NULL
-		);`
+	queryFmtSelectIdentityVerification = `
+		SELECT id, jti, iat, issued_ip, exp, username, action, consumed, consumed_ip
+		FROM %s
+		WHERE jti = ?;`
 
 	queryFmtInsertIdentityVerification = `
 		INSERT INTO %s (jti, iat, issued_ip, exp, username, action)


### PR DESCRIPTION
This is already checked by JWT validation. There is no need and it's leading to timezone issues.

Fixes #2672