### PR TITLE
feat(oidc): apply basic cors policy to config

### DIFF
--- a/internal/handlers/oidc_register.go
+++ b/internal/handlers/oidc_register.go
@@ -9,7 +9,7 @@ import (
 // RegisterOIDC registers the handlers with the fasthttp *router.Router. TODO: Add paths for UserInfo, Flush, Logout.
 func RegisterOIDC(router *router.Router, middleware middlewares.RequestHandlerBridge) {
 	// TODO: Add OPTIONS handler.
-	router.GET(pathOpenIDConnectWellKnown, middleware(oidcWellKnown))
+	router.GET(pathOpenIDConnectWellKnown, middleware(middlewares.CORSApplyAutomaticBasicPolicy(oidcWellKnown)))
 
 	router.GET(pathOpenIDConnectConsent, middleware(oidcConsent))
 

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -14,6 +14,22 @@ var (
 	headerXForwardedURI    = []byte("X-Forwarded-URI")
 	headerXOriginalURL     = []byte("X-Original-URL")
 	headerXForwardedMethod = []byte("X-Forwarded-Method")
+
+	headerVary                          = []byte(fasthttp.HeaderVary)
+	headerOrigin                        = []byte(fasthttp.HeaderOrigin)
+	headerAccessControlAllowCredentials = []byte(fasthttp.HeaderAccessControlAllowCredentials)
+	headerAccessControlAllowHeaders     = []byte(fasthttp.HeaderAccessControlAllowHeaders)
+	headerAccessControlAllowMethods     = []byte(fasthttp.HeaderAccessControlAllowMethods)
+	headerAccessControlAllowOrigin      = []byte(fasthttp.HeaderAccessControlAllowOrigin)
+	headerAccessControlMaxAge           = []byte(fasthttp.HeaderAccessControlMaxAge)
+	headerAccessControlRequestHeaders   = []byte(fasthttp.HeaderAccessControlRequestHeaders)
+)
+
+var (
+	headerValueFalse     = []byte("false")
+	headerValueMaxAge    = []byte("100")
+	headerValueVary      = []byte("Accept-Encoding, Origin")
+	headerValueMethodGET = []byte("GET")
 )
 
 const (

--- a/internal/middlewares/cors.go
+++ b/internal/middlewares/cors.go
@@ -1,0 +1,49 @@
+package middlewares
+
+import (
+	"net/url"
+	"strings"
+)
+
+// CORSApplyAutomaticBasicPolicy applies a CORS policy that automatically grants all Origins as well
+// as all Request Headers other than Cookie and *. It does not allow credentials, and has a max age of 100. Vary is applied
+// to both Accept-Encoding and Origin. It grants the GET Request Method only.
+func CORSApplyAutomaticBasicPolicy(next RequestHandler) RequestHandler {
+	return func(ctx *AutheliaCtx) {
+		if origin := ctx.Request.Header.PeekBytes(headerOrigin); origin != nil {
+			corsApplyAutomaticBasicPolicy(ctx, origin)
+		}
+
+		next(ctx)
+	}
+}
+
+func corsApplyAutomaticBasicPolicy(ctx *AutheliaCtx, origin []byte) {
+	originURL, err := url.Parse(string(origin))
+	if err != nil || originURL.Scheme != "https" {
+		return
+	}
+
+	ctx.Response.Header.SetBytesKV(headerVary, headerValueVary)
+	ctx.Response.Header.SetBytesKV(headerAccessControlAllowOrigin, origin)
+	ctx.Response.Header.SetBytesKV(headerAccessControlAllowCredentials, headerValueFalse)
+	ctx.Response.Header.SetBytesKV(headerAccessControlMaxAge, headerValueMaxAge)
+
+	if headers := ctx.Request.Header.PeekBytes(headerAccessControlRequestHeaders); headers != nil {
+		requestedHeaders := strings.Split(string(headers), ",")
+		finalHeaders := make([]string, len(requestedHeaders))
+
+		for _, header := range requestedHeaders {
+			headerTrimmed := strings.Trim(header, " ")
+			if !strings.EqualFold("*", headerTrimmed) && !strings.EqualFold("Cookie", headerTrimmed) {
+				finalHeaders = append(finalHeaders, headerTrimmed)
+			}
+		}
+
+		if len(finalHeaders) != 0 {
+			ctx.Response.Header.SetBytesKV(headerAccessControlAllowHeaders, []byte(strings.Join(finalHeaders, ", ")))
+		}
+	}
+
+	ctx.Response.Header.SetBytesKV(headerAccessControlAllowMethods, headerValueMethodGET)
+}


### PR DESCRIPTION
This applies a generous automatic CORS policy to the openid-configuration well-known endpoint. We prevent any credential information from being sent, only allow the GET method, but the Origin and all other headers are automated with a max age of 100 and vary applied to Accept-Encoding and Origin.