### PR TITLE
feat(handlers): "Authorization"-header with HTML login page

### DIFF
--- a/internal/handlers/handler_verify.go
+++ b/internal/handlers/handler_verify.go
@@ -410,6 +410,9 @@ func verifyAuth(ctx *middlewares.AutheliaCtx, targetURL *url.URL, refreshProfile
 	}
 
 	authValue := ctx.Request.Header.PeekBytes(authHeader)
+	if authValue == nil && bytes.Equal(ctx.QueryArgs().Peek("auth"), []byte("both")) {
+		authValue = ctx.Request.Header.PeekBytes(headerAuthorization)
+	}
 	if authValue != nil {
 		isBasicAuth = true
 	} else if isBasicAuth {

--- a/internal/handlers/handler_verify.go
+++ b/internal/handlers/handler_verify.go
@@ -413,6 +413,7 @@ func verifyAuth(ctx *middlewares.AutheliaCtx, targetURL *url.URL, refreshProfile
 	if authValue == nil && bytes.Equal(ctx.QueryArgs().Peek("auth"), []byte("both")) {
 		authValue = ctx.Request.Header.PeekBytes(headerAuthorization)
 	}
+
 	if authValue != nil {
 		isBasicAuth = true
 	} else if isBasicAuth {


### PR DESCRIPTION
Currently there are two ways to login with headers:
- using `Proxy-Authorization` header with default endpoint `/api/verify`
- using `Authorization` header with endpoint `/api/verify?auth=basic`.  
  But this sends `WWW-authenticate` when the login header is missing, triggering the basic auth login dialog.

This implements a new endpoint. `/api/verify?auth=both`, which checks both for the `Proxy-Authorization` **and** `Authorization` header, and forwards to the HTML login page if none is found.
The endpoint name `both` is not ideal, I'm happy to change it to something more descriptive.

More details on why this is needed in related issue #2753 

TODO:
- [X] Implement new endpoint
- [ ] Add test for endpoint
- [ ] Update documentation

Closes #2753 