### PR TITLE
ci(buildkite): use armv7l architecture and ignore check

### DIFF
--- a/.buildkite/steps/debhelper.sh
+++ b/.buildkite/steps/debhelper.sh
@@ -12,15 +12,15 @@ wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=authelia-bin -qO PK
 sed -i -e '/^pkgname=/c pkgname=authelia' -e "/pkgver=/c $VERSION" -e '10,14d' \
 -e 's/source_x86_64.*/source_x86_64=("authelia-linux-amd64.tar.gz")/' \
 -e 's/source_aarch64.*/source_aarch64=("authelia-linux-arm64.tar.gz")/' \
--e 's/source_armv7h.*/source_armv7h=("authelia-linux-arm.tar.gz")/' \
+-e 's/source_armv7h.*/source_armv7l=("authelia-linux-arm.tar.gz")/' \
 -e 's/sha256sums_x86_64.*/sha256sums_x86_64=("SKIP")/' \
 -e 's/sha256sums_aarch64.*/sha256sums_aarch64=("SKIP")/' \
--e 's/sha256sums_armv7h.*/sha256sums_armv7h=("SKIP")/' PKGBUILD
+-e 's/sha256sums_armv7h.*/sha256sums_armv7l=("SKIP")/' PKGBUILD
 
 if [[ "${PACKAGE}" == "amd64" ]]; then
   docker run --rm -v $PWD:/build authelia/aurpackager bash -c "cd /build && makedeb"
 elif [[ "${PACKAGE}" == "armhf" ]]; then
-  docker run --rm --platform linux/arm/v7 -v $PWD:/build authelia/debpackager bash -c "cd /build && makedeb"
+  docker run --rm --platform linux/arm/v7 -v $PWD:/build authelia/debpackager bash -c "cd /build && makedeb -A"
 else
-  docker run --rm --platform linux/arm64 -v $PWD:/build authelia/debpackager bash -c "cd /build && makedeb"
+  docker run --rm --platform linux/arm64 -v $PWD:/build authelia/debpackager bash -c "cd /build && makedeb -A"
 fi

--- a/.buildkite/steps/debhelper.sh
+++ b/.buildkite/steps/debhelper.sh
@@ -22,5 +22,5 @@ if [[ "${PACKAGE}" == "amd64" ]]; then
 elif [[ "${PACKAGE}" == "armhf" ]]; then
   docker run --rm --platform linux/arm/v7 -v $PWD:/build authelia/debpackager bash -c "cd /build && makedeb -A"
 else
-  docker run --rm --platform linux/arm64 -v $PWD:/build authelia/debpackager bash -c "cd /build && makedeb -A"
+  docker run --rm --platform linux/arm64 -v $PWD:/build authelia/debpackager bash -c "cd /build && makedeb"
 fi


### PR DESCRIPTION
Due to changes upstream with makedeb the architecture is now deteremined through a query of `uname -m` this was causing the armhf build for the Debian package to fail.

We now provide the specific architecture that is detected to resolve the issue.