### PR TITLE
fixed cloudflare NTP wrong port

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -133,7 +133,7 @@ duo_api:
 ## This is used to validate the servers time is accurate enough to validate TOTP.
 ntp:
   ## NTP server address.
-  address: "time.cloudflare.com:123"
+  address: "time.cloudflare.com:1234"
 
   ## NTP version.
   version: 4

--- a/docs/configuration/ntp.md
+++ b/docs/configuration/ntp.md
@@ -17,7 +17,7 @@ In the instance of inability to contact the NTP server Authelia will just log an
 
 ```yaml
 ntp:
-  address: "time.cloudflare.com:123"
+  address: "time.cloudflare.com:1234"
   version: 3
   max_desync: 3s
   disable_startup_check: false
@@ -29,8 +29,8 @@ ntp:
 ### address
 <div markdown="1">
 type: string
-{: .label .label-config .label-purple } 
-default: time.cloudflare.com:123
+{: .label .label-config .label-purple }
+default: time.cloudflare.com:1234
 {: .label .label-config .label-blue }
 required: no
 {: .label .label-config .label-green }
@@ -42,7 +42,7 @@ required.
 ### version
 <div markdown="1">
 type: integer
-{: .label .label-config .label-purple } 
+{: .label .label-config .label-purple }
 default: 4
 {: .label .label-config .label-blue }
 required: no
@@ -54,20 +54,20 @@ Determines the NTP verion supported. Valid values are 3 or 4.
 ### max_desync
 <div markdown="1">
 type: duration
-{: .label .label-config .label-purple } 
+{: .label .label-config .label-purple }
 default: 3s
 {: .label .label-config .label-blue }
 required: no
 {: .label .label-config .label-green }
 </div>
 
-This is used to tune the acceptable desync from the time reported from the NTP server. This uses our 
+This is used to tune the acceptable desync from the time reported from the NTP server. This uses our
 [duration notation](./index.md#duration-notation-format) format.
 
 ### disable_startup_check
 <div markdown="1">
 type: boolean
-{: .label .label-config .label-purple } 
+{: .label .label-config .label-purple }
 default: false
 {: .label .label-config .label-blue }
 required: no
@@ -79,7 +79,7 @@ Setting this to true will disable the startup check entirely.
 ### disable_failure
 <div markdown="1">
 type: boolean
-{: .label .label-config .label-purple } 
+{: .label .label-config .label-purple }
 default: false
 {: .label .label-config .label-blue }
 required: no

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -133,7 +133,7 @@ duo_api:
 ## This is used to validate the servers time is accurate enough to validate TOTP.
 ntp:
   ## NTP server address.
-  address: "time.cloudflare.com:123"
+  address: "time.cloudflare.com:1234"
 
   ## NTP version.
   version: 4

--- a/internal/configuration/schema/ntp.go
+++ b/internal/configuration/schema/ntp.go
@@ -11,7 +11,7 @@ type NTPConfiguration struct {
 
 // DefaultNTPConfiguration represents default configuration parameters for the NTP server.
 var DefaultNTPConfiguration = NTPConfiguration{
-	Address:       "time.cloudflare.com:123",
+	Address:       "time.cloudflare.com:1234",
 	Version:       4,
 	MaximumDesync: "3s",
 }

--- a/internal/ntp/ntp_test.go
+++ b/internal/ntp/ntp_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestShouldCheckNTP(t *testing.T) {
 	config := schema.NTPConfiguration{
-		Address:             "time.cloudflare.com:123",
+		Address:             "time.cloudflare.com:1234",
 		Version:             4,
 		MaximumDesync:       "3s",
 		DisableStartupCheck: false,

--- a/internal/suites/Standalone/configuration.yml
+++ b/internal/suites/Standalone/configuration.yml
@@ -92,7 +92,7 @@ notifier:
     disable_require_tls: true
 ntp:
   ## NTP server address
-  address: "time.cloudflare.com:123"
+  address: "time.cloudflare.com:1234"
   ## ntp version
   version: 4
   ## "maximum desynchronization" is the allowed offset time between the host and the ntp server


### PR DESCRIPTION
Fixed the wrong reference to `time.cloudflare.com:123` - the actual correct port is `1234`.

Unintended: trimmed some trailing white space.