### PR TITLE
refactor(oidc): add client id to two factor log message

### DIFF
--- a/docs/configuration/identity-providers/oidc.md
+++ b/docs/configuration/identity-providers/oidc.md
@@ -90,7 +90,14 @@ for which stage will have each feature, and may evolve over time:
         <td class="tbl-beta-stage">Audit Storage</td>
       </tr>
       <tr>
-        <td rowspan="4" class="tbl-header tbl-beta-stage">beta4 <sup>1</sup></td>
+        <td rowspan="2" class="tbl-header tbl-beta-stage">beta4 <sup>1</sup></td>
+        <td class="tbl-beta-stage">Prompt Handling</td>
+      </tr>
+      <tr>
+        <td class="tbl-beta-stage">Display Handling</td>
+      </tr>
+      <tr>
+        <td rowspan="4" class="tbl-header tbl-beta-stage">beta5 <sup>1</sup></td>
         <td><a href="https://openid.net/specs/openid-connect-backchannel-1_0.html" target="_blank" rel="noopener noreferrer">Back-Channel Logout</a></td>
       </tr>
       <tr>

--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -17,7 +17,7 @@ func handleOIDCWorkflowResponse(ctx *middlewares.AutheliaCtx) {
 	userSession := ctx.GetSession()
 
 	if !authorization.IsAuthLevelSufficient(userSession.AuthenticationLevel, userSession.OIDCWorkflowSession.RequiredAuthorizationLevel) {
-		ctx.Logger.Warn("OpenID Connect requires 2FA, cannot be redirected yet")
+		ctx.Logger.Warnf("OpenID Connect client '%s' requires 2FA, cannot be redirected yet", userSession.OIDCWorkflowSession.ClientID)
 		ctx.ReplyOK()
 
 		return
@@ -36,13 +36,13 @@ func handleOIDCWorkflowResponse(ctx *middlewares.AutheliaCtx) {
 		userSession.OIDCWorkflowSession,
 		userSession.OIDCWorkflowSession.RequestedScopes,
 		userSession.OIDCWorkflowSession.RequestedAudience) {
-		err := ctx.SetJSONBody(redirectResponse{Redirect: fmt.Sprintf("%s/consent", uri)})
+		err = ctx.SetJSONBody(redirectResponse{Redirect: fmt.Sprintf("%s/consent", uri)})
 
 		if err != nil {
 			ctx.Logger.Errorf("Unable to set default redirection URL in body: %s", err)
 		}
 	} else {
-		err := ctx.SetJSONBody(redirectResponse{Redirect: userSession.OIDCWorkflowSession.AuthURI})
+		err = ctx.SetJSONBody(redirectResponse{Redirect: userSession.OIDCWorkflowSession.AuthURI})
 		if err != nil {
 			ctx.Logger.Errorf("Unable to set default redirection URL in body: %s", err)
 		}


### PR DESCRIPTION
Adds the client id to a log message where it's likely useful. Additionally adds beta stage for prompt/display handling.