### PR TITLE
refactor: directly return error where sufficient

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -120,7 +120,7 @@ func doStartupChecks(config *schema.Configuration, providers *middlewares.Provid
 	}
 }
 
-func doStartupCheck(logger *logrus.Logger, name string, provider models.StartupCheck, disabled bool) (err error) {
+func doStartupCheck(logger *logrus.Logger, name string, provider models.StartupCheck, disabled bool) error {
 	if disabled {
 		logger.Debugf("%s provider: startup check skipped as it is disabled", name)
 		return nil
@@ -130,9 +130,5 @@ func doStartupCheck(logger *logrus.Logger, name string, provider models.StartupC
 		return fmt.Errorf("unrecognized provider or it is not configured properly")
 	}
 
-	if err = provider.StartupCheck(); err != nil {
-		return err
-	}
-
-	return nil
+	return provider.StartupCheck()
 }

--- a/internal/commands/storage_run.go
+++ b/internal/commands/storage_run.go
@@ -33,10 +33,8 @@ func storagePersistentPreRunE(cmd *cobra.Command, _ []string) (err error) {
 
 			sources = append(sources, configuration.NewYAMLFileSource(configFile))
 		}
-	} else {
-		if _, err := os.Stat(configs[0]); err == nil {
-			sources = append(sources, configuration.NewYAMLFileSource(configs[0]))
-		}
+	} else if _, err := os.Stat(configs[0]); err == nil {
+		sources = append(sources, configuration.NewYAMLFileSource(configs[0]))
 	}
 
 	mapping := map[string]string{

--- a/internal/notification/file_notifier.go
+++ b/internal/notification/file_notifier.go
@@ -38,22 +38,12 @@ func (n *FileNotifier) StartupCheck() (err error) {
 		}
 	}
 
-	if err := os.WriteFile(n.path, []byte(""), fileNotifierMode); err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(n.path, []byte(""), fileNotifierMode)
 }
 
 // Send send a identity verification link to a user.
 func (n *FileNotifier) Send(recipient, subject, body, _ string) error {
 	content := fmt.Sprintf("Date: %s\nRecipient: %s\nSubject: %s\nBody: %s", time.Now(), recipient, subject, body)
 
-	err := os.WriteFile(n.path, []byte(content), fileNotifierMode)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(n.path, []byte(content), fileNotifierMode)
 }

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -243,11 +243,7 @@ func (n *SMTPNotifier) StartupCheck() (err error) {
 		return err
 	}
 
-	if err := n.client.Reset(); err != nil {
-		return err
-	}
-
-	return nil
+	return n.client.Reset()
 }
 
 // Send is used to send an email to a recipient.

--- a/internal/suites/suite_standalone.go
+++ b/internal/suites/suite_standalone.go
@@ -10,8 +10,8 @@ var standaloneSuiteName = "Standalone"
 
 func init() {
 	_ = os.MkdirAll("/tmp/authelia/StandaloneSuite/", 0700)
-	_ = os.WriteFile("/tmp/authelia/StandaloneSuite/jwt", []byte("very_important_secret"), 0600)       //nolint:gosec
-	_ = os.WriteFile("/tmp/authelia/StandaloneSuite/session", []byte("unsecure_session_secret"), 0600) //nolint:gosec
+	_ = os.WriteFile("/tmp/authelia/StandaloneSuite/jwt", []byte("very_important_secret"), 0600)
+	_ = os.WriteFile("/tmp/authelia/StandaloneSuite/session", []byte("unsecure_session_secret"), 0600)
 
 	dockerEnvironment := NewDockerEnvironment([]string{
 		"internal/suites/docker-compose.yml",

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -54,7 +54,7 @@ func (rs *RodSession) collectScreenshot(err error, page *rod.Page) {
 		build := os.Getenv("BUILDKITE_BUILD_NUMBER")
 		suite := strings.ToLower(os.Getenv("SUITE"))
 		job := os.Getenv("BUILDKITE_JOB_ID")
-		path := filepath.Join(fmt.Sprintf("%s/%s/%s/%s", base, build, suite, job)) //nolint: gocritic
+		path := filepath.Join(fmt.Sprintf("%s/%s/%s/%s", base, build, suite, job))
 
 		if err := os.MkdirAll(path, 0755); err != nil {
 			log.Fatal(err)

--- a/internal/utils/const.go
+++ b/internal/utils/const.go
@@ -33,7 +33,7 @@ const (
 
 const (
 	// Hour is an int based representation of the time unit.
-	Hour = time.Minute * 60 //nolint: revive
+	Hour = time.Minute * 60
 
 	// Day is an int based representation of the time unit.
 	Day = Hour * 24


### PR DESCRIPTION
this fixes lint issues raised by revive and gocritic