### PR TITLE
fix(docker): fix bootstrap and dev docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,26 +1,5 @@
-# CI/Git Directories
-.git
-.cache
-.buildkite
-.github
-coverage.txt
-Dockerfile*
-
-# Node Modules Directories
-**/node_modules
-
-# Documentation
-docs
-examples
-
-# Dot Files and Markdown
-.*
-*.md
-
-# Other
-internal/server/public_html
-authelia.service
-bootstrap.sh
+# Ignore All
+*
 
 # Overrides
 !authelia-linux-*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -55,7 +55,7 @@ ENV PATH="/app:${PATH}" \
 RUN \
 apk --no-cache add ca-certificates su-exec tzdata
 
-COPY --from=builder-backend /go/src/app/cmd/authelia/authelia /go/src/app/LICENSE /go/src/app/entrypoint.sh /go/src/app/healthcheck.sh /go/src/app/.healthcheck.env ./
+COPY --from=builder-backend /go/src/app/authelia /go/src/app/LICENSE /go/src/app/entrypoint.sh /go/src/app/healthcheck.sh /go/src/app/.healthcheck.env ./
 
 RUN \
 chmod 0666 /app/.healthcheck.env

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -55,7 +55,7 @@ ENV PATH="/app:${PATH}" \
 RUN \
 apk --no-cache add ca-certificates su-exec tzdata
 
-COPY --from=builder-backend /go/src/app/authelia /go/src/app/LICENSE /go/src/app/entrypoint.sh /go/src/app/healthcheck.sh /go/src/app/.healthcheck.env ./
+COPY --from=builder-backend /go/src/app/cmd/authelia/authelia /go/src/app/LICENSE /go/src/app/entrypoint.sh /go/src/app/healthcheck.sh /go/src/app/.healthcheck.env ./
 
 RUN \
 chmod 0666 /app/.healthcheck.env

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,8 @@ if [[ $(uname) == "Darwin" ]]; then
   exit
 fi
 
-export PATH=$PATH:./cmd/authelia-scripts/:./.buildkite/steps/:$GOPATH/bin:./web/node_modules/.bin:/tmp
+export PATH=$PATH:./cmd/authelia-scripts/:./.buildkite/steps/:$GOPATH/bin:./web/node_modules/.bin:/tmp \
+DOCKER_BUILDKIT=1
 
 if [[ -z "$OLD_PS1" ]]; then
   OLD_PS1="$PS1"


### PR DESCRIPTION
This change ensures that BUILDKIT is enabled to pick up the correct Dockerfile and .dockerignore files during the build process of the dev image.

Fixes #2843. Closes #2844.