### PR TITLE
fix(commands): use consistent config file name

### DIFF
--- a/internal/commands/storage.go
+++ b/internal/commands/storage.go
@@ -13,7 +13,7 @@ func NewStorageCmd() (cmd *cobra.Command) {
 		PersistentPreRunE: storagePersistentPreRunE,
 	}
 
-	cmdWithConfigFlags(cmd, true, []string{"config.yml"})
+	cmdWithConfigFlags(cmd, true, []string{"configuration.yml"})
 
 	cmd.PersistentFlags().String("encryption-key", "", "the storage encryption key to use")
 

--- a/internal/commands/validate.go
+++ b/internal/commands/validate.go
@@ -16,7 +16,7 @@ func newValidateConfigCmd() (cmd *cobra.Command) {
 		RunE:  cmdValidateConfigRunE,
 	}
 
-	cmdWithConfigFlags(cmd, false, []string{"config.yml"})
+	cmdWithConfigFlags(cmd, false, []string{"configuration.yml"})
 
 	return cmd
 }


### PR DESCRIPTION
Adjusts the default filename for all configuration files to configuration.yml.

Fixes #2939.