### PR TITLE
feat(oidc): add automatic allow all cors to discovery

### DIFF
--- a/internal/handlers/oidc_register.go
+++ b/internal/handlers/oidc_register.go
@@ -10,8 +10,8 @@ import (
 // RegisterOIDC registers the handlers with the fasthttp *router.Router. TODO: Add paths for Flush, Logout.
 func RegisterOIDC(router *router.Router, middleware middlewares.RequestHandlerBridge) {
 	// TODO: Add OPTIONS handler.
-	router.GET(oidc.WellKnownOpenIDConfigurationPath, middleware(wellKnownOpenIDConnectConfigurationGET))
-	router.GET(oidc.WellKnownOAuthAuthorizationServerPath, middleware(wellKnownOAuthAuthorizationServerGET))
+	router.GET(oidc.WellKnownOpenIDConfigurationPath, middleware(middlewares.CORSApplyAutomaticAllowAllPolicy(wellKnownOpenIDConnectConfigurationGET)))
+	router.GET(oidc.WellKnownOAuthAuthorizationServerPath, middleware(middlewares.CORSApplyAutomaticAllowAllPolicy(wellKnownOAuthAuthorizationServerGET)))
 
 	router.GET(pathOpenIDConnectConsent, middleware(oidcConsent))
 

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -23,13 +23,13 @@ var (
 	headerAccessControlAllowOrigin      = []byte(fasthttp.HeaderAccessControlAllowOrigin)
 	headerAccessControlMaxAge           = []byte(fasthttp.HeaderAccessControlMaxAge)
 	headerAccessControlRequestHeaders   = []byte(fasthttp.HeaderAccessControlRequestHeaders)
+	headerAccessControlRequestMethod    = []byte(fasthttp.HeaderAccessControlRequestMethod)
 )
 
 var (
-	headerValueFalse     = []byte("false")
-	headerValueMaxAge    = []byte("100")
-	headerValueVary      = []byte("Accept-Encoding, Origin")
-	headerValueMethodGET = []byte("GET")
+	headerValueFalse  = []byte("false")
+	headerValueMaxAge = []byte("100")
+	headerValueVary   = []byte("Accept-Encoding, Origin")
 )
 
 var (

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -15,6 +15,24 @@ var (
 	headerXOriginalURL     = []byte("X-Original-URL")
 	headerXForwardedMethod = []byte("X-Forwarded-Method")
 
+	headerVary                          = []byte(fasthttp.HeaderVary)
+	headerOrigin                        = []byte(fasthttp.HeaderOrigin)
+	headerAccessControlAllowCredentials = []byte(fasthttp.HeaderAccessControlAllowCredentials)
+	headerAccessControlAllowHeaders     = []byte(fasthttp.HeaderAccessControlAllowHeaders)
+	headerAccessControlAllowMethods     = []byte(fasthttp.HeaderAccessControlAllowMethods)
+	headerAccessControlAllowOrigin      = []byte(fasthttp.HeaderAccessControlAllowOrigin)
+	headerAccessControlMaxAge           = []byte(fasthttp.HeaderAccessControlMaxAge)
+	headerAccessControlRequestHeaders   = []byte(fasthttp.HeaderAccessControlRequestHeaders)
+)
+
+var (
+	headerValueFalse     = []byte("false")
+	headerValueMaxAge    = []byte("100")
+	headerValueVary      = []byte("Accept-Encoding, Origin")
+	headerValueMethodGET = []byte("GET")
+)
+
+var (
 	protoHTTPS = []byte("https")
 	protoHTTP  = []byte("http")
 

--- a/internal/middlewares/cors.go
+++ b/internal/middlewares/cors.go
@@ -1,0 +1,49 @@
+package middlewares
+
+import (
+	"net/url"
+	"strings"
+)
+
+// CORSApplyAutomaticAllowAllPolicy applies a CORS policy that automatically grants all Origins as well
+// as all Request Headers other than Cookie and *. It does not allow credentials, and has a max age of 100. Vary is applied
+// to both Accept-Encoding and Origin. It grants the GET Request Method only.
+func CORSApplyAutomaticAllowAllPolicy(next RequestHandler) RequestHandler {
+	return func(ctx *AutheliaCtx) {
+		if origin := ctx.Request.Header.PeekBytes(headerOrigin); origin != nil {
+			corsApplyAutomaticAllowAllPolicy(ctx, origin)
+		}
+
+		next(ctx)
+	}
+}
+
+func corsApplyAutomaticAllowAllPolicy(ctx *AutheliaCtx, origin []byte) {
+	originURL, err := url.Parse(string(origin))
+	if err != nil || originURL.Scheme != "https" {
+		return
+	}
+
+	ctx.Response.Header.SetBytesKV(headerVary, headerValueVary)
+	ctx.Response.Header.SetBytesKV(headerAccessControlAllowOrigin, origin)
+	ctx.Response.Header.SetBytesKV(headerAccessControlAllowCredentials, headerValueFalse)
+	ctx.Response.Header.SetBytesKV(headerAccessControlMaxAge, headerValueMaxAge)
+
+	if headers := ctx.Request.Header.PeekBytes(headerAccessControlRequestHeaders); headers != nil {
+		requestedHeaders := strings.Split(string(headers), ",")
+		finalHeaders := make([]string, len(requestedHeaders))
+
+		for _, header := range requestedHeaders {
+			headerTrimmed := strings.Trim(header, " ")
+			if !strings.EqualFold("*", headerTrimmed) && !strings.EqualFold("Cookie", headerTrimmed) {
+				finalHeaders = append(finalHeaders, headerTrimmed)
+			}
+		}
+
+		if len(finalHeaders) != 0 {
+			ctx.Response.Header.SetBytesKV(headerAccessControlAllowHeaders, []byte(strings.Join(finalHeaders, ", ")))
+		}
+	}
+
+	ctx.Response.Header.SetBytesKV(headerAccessControlAllowMethods, headerValueMethodGET)
+}

--- a/internal/middlewares/cors_test.go
+++ b/internal/middlewares/cors_test.go
@@ -1,0 +1,65 @@
+package middlewares
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func Test_CORSApplyAutomaticAllowAllPolicy_WithoutRequestMethod(t *testing.T) {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.Response{}
+
+	origin := []byte("https://myapp.example.com")
+
+	req.Header.SetBytesK(headerAccessControlRequestHeaders, "X-Example-Header")
+
+	corsApplyAutomaticAllowAllPolicy(req, &resp, origin)
+
+	assert.Equal(t, []byte("Accept-Encoding, Origin"), resp.Header.PeekBytes(headerVary))
+	assert.Equal(t, origin, resp.Header.PeekBytes(headerAccessControlAllowOrigin))
+	assert.Equal(t, headerValueFalse, resp.Header.PeekBytes(headerAccessControlAllowCredentials))
+	assert.Equal(t, headerValueMaxAge, resp.Header.PeekBytes(headerAccessControlMaxAge))
+	assert.Equal(t, []byte("X-Example-Header"), resp.Header.PeekBytes(headerAccessControlAllowHeaders))
+	assert.Equal(t, []byte(nil), resp.Header.PeekBytes(headerAccessControlAllowMethods))
+}
+
+func Test_CORSApplyAutomaticAllowAllPolicy_WithRequestMethod(t *testing.T) {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.Response{}
+
+	origin := []byte("https://myapp.example.com")
+
+	req.Header.SetBytesK(headerAccessControlRequestHeaders, "X-Example-Header")
+	req.Header.SetBytesK(headerAccessControlRequestMethod, "GET")
+
+	corsApplyAutomaticAllowAllPolicy(req, &resp, origin)
+
+	assert.Equal(t, []byte("Accept-Encoding, Origin"), resp.Header.PeekBytes(headerVary))
+	assert.Equal(t, origin, resp.Header.PeekBytes(headerAccessControlAllowOrigin))
+	assert.Equal(t, headerValueFalse, resp.Header.PeekBytes(headerAccessControlAllowCredentials))
+	assert.Equal(t, headerValueMaxAge, resp.Header.PeekBytes(headerAccessControlMaxAge))
+	assert.Equal(t, []byte("X-Example-Header"), resp.Header.PeekBytes(headerAccessControlAllowHeaders))
+	assert.Equal(t, []byte("GET"), resp.Header.PeekBytes(headerAccessControlAllowMethods))
+}
+
+func Test_CORSApplyAutomaticAllowAllPolicy_ShouldNotModifyFotNonHTTPSRequests(t *testing.T) {
+	req := fasthttp.AcquireRequest()
+
+	resp := fasthttp.Response{}
+
+	origin := []byte("http://myapp.example.com")
+
+	req.Header.SetBytesK(headerAccessControlRequestHeaders, "X-Example-Header")
+	req.Header.SetBytesK(headerAccessControlRequestMethod, "GET")
+
+	corsApplyAutomaticAllowAllPolicy(req, &resp, origin)
+
+	assert.Equal(t, []byte(nil), resp.Header.PeekBytes(headerVary))
+	assert.Equal(t, []byte(nil), resp.Header.PeekBytes(headerAccessControlAllowOrigin))
+	assert.Equal(t, []byte(nil), resp.Header.PeekBytes(headerAccessControlAllowCredentials))
+	assert.Equal(t, []byte(nil), resp.Header.PeekBytes(headerAccessControlMaxAge))
+	assert.Equal(t, []byte(nil), resp.Header.PeekBytes(headerAccessControlAllowHeaders))
+	assert.Equal(t, []byte(nil), resp.Header.PeekBytes(headerAccessControlAllowMethods))
+}


### PR DESCRIPTION
This adds a Cross Origin Resource Sharing policy that automatically allows any cross-origin request to the OpenID Connect discovery documents.