### PR TITLE
fix(configuration): pkce config keys not allowed

### DIFF
--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -451,6 +451,8 @@ var ValidKeys = []string{
 	"identity_providers.oidc.access_token_lifespan",
 	"identity_providers.oidc.refresh_token_lifespan",
 	"identity_providers.oidc.authorize_code_lifespan",
+	"identity_providers.oidc.enforce_pkce",
+	"identity_providers.oidc.enable_pkce_plain_challenge",
 	"identity_providers.oidc.enable_client_debug_messages",
 	"identity_providers.oidc.minimum_parameter_entropy",
 	"identity_providers.oidc.clients",


### PR DESCRIPTION
This fixes a bug that prevents the PKCE configuration keys from being configurable.