### PR TITLE
fix(configuration): time duration decode hook panic

### DIFF
--- a/internal/configuration/decode_hooks.go
+++ b/internal/configuration/decode_hooks.go
@@ -67,7 +67,11 @@ func ToTimeDurationFunc() mapstructure.DecodeHookFuncType {
 
 		switch {
 		case f.Kind() == reflect.String:
-			break
+			dataStr := data.(string)
+
+			if duration, err = utils.ParseDurationString(dataStr); err != nil {
+				return nil, err
+			}
 		case f.Kind() == reflect.Int:
 			seconds := data.(int)
 
@@ -82,14 +86,6 @@ func ToTimeDurationFunc() mapstructure.DecodeHookFuncType {
 			seconds := data.(int64)
 
 			duration = time.Second * time.Duration(seconds)
-		}
-
-		if duration == 0 {
-			dataStr := data.(string)
-
-			if duration, err = utils.ParseDurationString(dataStr); err != nil {
-				return nil, err
-			}
 		}
 
 		if ptr {

--- a/internal/configuration/decode_hooks_test.go
+++ b/internal/configuration/decode_hooks_test.go
@@ -268,3 +268,25 @@ func TestToTimeDurationFunc_ShouldNotParse_FromBool(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, from, result)
 }
+
+func TestToTimeDurationFunc_ShouldParse_FromZero(t *testing.T) {
+	hook := ToTimeDurationFunc()
+
+	var (
+		from     = 0
+		expected = time.Duration(0)
+
+		to     time.Duration
+		ptrTo  *time.Duration
+		result interface{}
+		err    error
+	)
+
+	result, err = hook(reflect.TypeOf(from), reflect.TypeOf(to), from)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+
+	result, err = hook(reflect.TypeOf(from), reflect.TypeOf(ptrTo), from)
+	assert.NoError(t, err)
+	assert.Equal(t, &expected, result)
+}


### PR DESCRIPTION
This fixes a potential panic in the time duration decode hook when the YAML value is a zero integer.

Fixes #2959