### PR TITLE
docs: fix misleading config

### DIFF
--- a/docs/configuration/access-control.md
+++ b/docs/configuration/access-control.md
@@ -28,7 +28,8 @@ access_control:
     - internal
     - 1.1.1.1
     subject:
-    - ["user:adam", "user:fred"]
+    - ["user:adam"]
+    - ["user:fred"]
     - ["group:admins"]
     methods:
     - GET


### PR DESCRIPTION
This adjusts a misleading configuration example.

Fixes #2770