### PR TITLE
fix(configuration): invalid password algorithm tag

### DIFF
--- a/internal/configuration/schema/authentication.go
+++ b/internal/configuration/schema/authentication.go
@@ -38,7 +38,7 @@ type PasswordConfiguration struct {
 	Iterations  int    `koanf:"iterations"`
 	KeyLength   int    `koanf:"key_length"`
 	SaltLength  int    `koanf:"salt_length"`
-	Algorithm   string `mapstrucutre:"algorithm"`
+	Algorithm   string `koaanf:"algorithm"`
 	Memory      int    `koanf:"memory"`
 	Parallelism int    `koanf:"parallelism"`
 }


### PR DESCRIPTION
This fixes a configuration parsing issue that could potentially occur if we were to change the internal name of the struct field.