### PR TITLE
build: utilize new makedeb spec

### DIFF
--- a/.buildkite/steps/debhelper.sh
+++ b/.buildkite/steps/debhelper.sh
@@ -9,7 +9,7 @@ else
 fi
 
 wget https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=authelia-bin -qO PKGBUILD && \
-sed -i -e '/^pkgname=/c pkgname=authelia' -e "/pkgver=/c $VERSION" -e '10,14d' \
+sed -i -e '/^pkgname=/c pkgname=authelia' -e "/pkgver=/c $VERSION" -e '10,14d' -e "s/'etc/'\/etc/g" \
 -e 's/source_x86_64.*/source_x86_64=("authelia-linux-amd64.tar.gz")/' \
 -e 's/source_aarch64.*/source_aarch64=("authelia-linux-arm64.tar.gz")/' \
 -e 's/source_armv7h.*/source_armv7l=("authelia-linux-arm.tar.gz")/' \


### PR DESCRIPTION
This adds the adjustments needed for the new `makedeb` version to package conffiles.

Fixes #2817