### PR TITLE
fix(docs): oidc group claim description incorrect

### DIFF
--- a/docs/configuration/identity-providers/oidc.md
+++ b/docs/configuration/identity-providers/oidc.md
@@ -441,7 +441,7 @@ This scope includes the groups the authentication backend reports the user is a 
 
 | Claim  |   JWT Type    | Authelia Attribute |      Description       |
 |:------:|:-------------:|:------------------:|:----------------------:|
-| groups | array[string] |       groups       | The users display name |
+| groups | array[string] |       groups       | List of user's groups discovered via [authentication](https://www.authelia.com/docs/configuration/authentication/) |
 
 ### email
 


### PR DESCRIPTION
OIDC groups claim actually contains the user's groups, not the user's display name.