### PR TITLE
fix(oidc): userinfo jti claim potential panic

### DIFF
--- a/internal/handlers/handler_oidc_userinfo.go
+++ b/internal/handlers/handler_oidc_userinfo.go
@@ -94,7 +94,15 @@ func oidcUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, req *htt
 
 	switch client.UserinfoSigningAlgorithm {
 	case "RS256":
-		claims["jti"] = uuid.New()
+		var jti uuid.UUID
+
+		if jti, err = uuid.NewRandom(); err != nil {
+			ctx.Providers.OpenIDConnect.WriteError(rw, req, fosite.ErrServerError.WithHintf("Could not generate JWT ID."))
+
+			return
+		}
+
+		claims["jti"] = jti.String()
 		claims["iat"] = time.Now().Unix()
 
 		if keyID, err = ctx.Providers.OpenIDConnect.KeyManager.Strategy().GetPublicKeyID(req.Context()); err != nil {

--- a/internal/middlewares/identity_verification.go
+++ b/internal/middlewares/identity_verification.go
@@ -38,7 +38,7 @@ func IdentityVerificationStart(args IdentityVerificationStartArgs, delayFunc Tim
 
 		var jti uuid.UUID
 
-		if jti, err = uuid.NewUUID(); err != nil {
+		if jti, err = uuid.NewRandom(); err != nil {
 			ctx.Error(err, messageOperationFailed)
 			return
 		}

--- a/internal/storage/sql_provider_encryption.go
+++ b/internal/storage/sql_provider_encryption.go
@@ -279,7 +279,7 @@ func (p *SQLProvider) getEncryptionValue(ctx context.Context, name string) (valu
 }
 
 func (p *SQLProvider) setNewEncryptionCheckValue(ctx context.Context, key *[32]byte, e sqlx.ExecerContext) (err error) {
-	valueClearText, err := uuid.NewUUID()
+	valueClearText, err := uuid.NewRandom()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes a usage of uuid.New() which can potentially panic. Instead we use a uuid.NewRandom() which also generates a UUID V4 instead of a UUID V1. In addition all uuid.NewUUID() calls have been replaced by uuid.NewRandom().