### PR TITLE
fix(configuration): missing sentinel_username key in validator

### DIFF
--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -348,6 +348,7 @@ var ValidKeys = []string{
 	"session.redis.tls.skip_verify",
 	"session.redis.tls.server_name",
 	"session.redis.high_availability.sentinel_name",
+	"session.redis.high_availability.sentinel_username",
 	"session.redis.high_availability.sentinel_password",
 	"session.redis.high_availability.nodes",
 	"session.redis.high_availability.route_by_latency",


### PR DESCRIPTION
This fixes an issue where the sentinel_username is not configurable.