### PR TITLE
fix(server): healthcheck ipv6 format is invalid

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -179,9 +179,9 @@ func Start(configuration schema.Configuration, providers middlewares.Providers) 
 		WriteBufferSize:       configuration.Server.WriteBufferSize,
 	}
 
-	addrPattern := net.JoinHostPort(configuration.Server.Host, strconv.Itoa(configuration.Server.Port))
+	address := net.JoinHostPort(configuration.Server.Host, strconv.Itoa(configuration.Server.Port))
 
-	listener, err := net.Listen("tcp", addrPattern)
+	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		logger.Fatalf("Error initializing listener: %s", err)
 	}
@@ -192,9 +192,9 @@ func Start(configuration schema.Configuration, providers middlewares.Providers) 
 		}
 
 		if configuration.Server.Path == "" {
-			logger.Infof("Listening for TLS connections on '%s' path '/'", addrPattern)
+			logger.Infof("Listening for TLS connections on '%s' path '/'", address)
 		} else {
-			logger.Infof("Listening for TLS connections on '%s' paths '/' and '%s'", addrPattern, configuration.Server.Path)
+			logger.Infof("Listening for TLS connections on '%s' paths '/' and '%s'", address, configuration.Server.Path)
 		}
 
 		logger.Fatal(server.ServeTLS(listener, configuration.Server.TLS.Certificate, configuration.Server.TLS.Key))
@@ -204,9 +204,9 @@ func Start(configuration schema.Configuration, providers middlewares.Providers) 
 		}
 
 		if configuration.Server.Path == "" {
-			logger.Infof("Listening for non-TLS connections on '%s' path '/'", addrPattern)
+			logger.Infof("Listening for non-TLS connections on '%s' path '/'", address)
 		} else {
-			logger.Infof("Listening for non-TLS connections on '%s' paths '/' and '%s'", addrPattern, configuration.Server.Path)
+			logger.Infof("Listening for non-TLS connections on '%s' paths '/' and '%s'", address, configuration.Server.Path)
 		}
 		logger.Fatal(server.Serve(listener))
 	}

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -117,6 +117,8 @@ func writeHealthCheckEnv(disabled bool, scheme, host, path string, port int) (er
 
 	if host == "0.0.0.0" {
 		host = "localhost"
+	} else if strings.Contains(host, ":") {
+		host = "[" + host + "]"
 	}
 
 	_, err = file.WriteString(fmt.Sprintf(healthCheckEnv, scheme, host, port, path))


### PR DESCRIPTION
This fixes an issue with the healthcheck writting the IPv6 host without brackets.

Fixes #3050