### PR TITLE
ci(buildkite): prevent pre-exit hook on setup steps

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -2,8 +2,8 @@
 
 set +u
 
-if [[ "${BUILDKITE_AGENT_META_DATA_CLEANBUILD}" != "false" ]] || \
-[[ ! "${BUILDKITE_COMMAND}" =~ "buildkite-agent pipeline upload" ]]; then
+if [[ ! "${BUILDKITE_COMMAND}" =~ "buildkite-agent pipeline upload" ]] && \
+[[ "${BUILDKITE_AGENT_META_DATA_CLEANBUILD}" != "false" ]]; then
   echo "--- :docker: Clean environment"
   docker system prune -af --volumes
 fi

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -2,7 +2,8 @@
 
 set +u
 
-if [[ "${BUILDKITE_AGENT_META_DATA_CLEANBUILD}" != "false" ]]; then
+if [[ "${BUILDKITE_AGENT_META_DATA_CLEANBUILD}" != "false" ]] || \
+[[ ! "${BUILDKITE_COMMAND}" =~ "buildkite-agent pipeline upload" ]]; then
   echo "--- :docker: Clean environment"
   docker system prune -af --volumes
 fi


### PR DESCRIPTION
Occasionally due to node issues the pre-exit hook for docker image cleanups can fail, causing the otherwise successful job to bail out. This change ignores the cleanup on setup steps.