### PR TITLE
docs: fix oidc applications table display

### DIFF
--- a/docs/community/oidc-integrations.md
+++ b/docs/community/oidc-integrations.md
@@ -19,15 +19,13 @@ has_toc: false
 |      GitLab      |            `13.0.0`            |                                                                                                             |
 |     Grafana      |            `8.0.5`             |                                                                                                             |
 | Hashicorp Vault  |            `1.8.1`             |                                                                                                             |
-|      MinIO       | `RELEASE.2021-11-09T03-21-45Z` | must set `MINIO_IDENTITY_OPENID_CLAIM_NAME: groups` in MinIO and set [MinIO policies] as groups in Authelia |
+|      MinIO       | `RELEASE.2021-11-09T03-21-45Z` | must set `MINIO_IDENTITY_OPENID_CLAIM_NAME: groups` in MinIO and set [MinIO policies](https://docs.min.io/minio/baremetal/security/minio-identity-management/policy-based-access-control.html#minio-policy) as groups in Authelia |
 |    Nextcloud     |            `22.1.0`            |   Tested using the `nextcloud-oidc-login` app - [Link](https://github.com/pulsejet/nextcloud-oidc-login)    |
 |      Wekan       |             `5.41`             |                                                                                                             |
 |   Portainer CE   |            `2.6.1`             |   Settings to use username as ID: set `Scopes` to `openid` and `User Identifier` to `preferred_username`    |
 | Bookstack        | `21.10`                        |                                                                                                             |
 | Harbor        |                `1.10`             |   It works on >v2.1 also, but not sure if there is OIDC support on v2.0|
-| Verdaccio        |              `5`               |   Depends on this fork of verdaccio-github-oauth-ui: [Link](https://github.com/OnekO/verdaccio-github-oauth-ui)
-|
-[MinIO policies]: https://docs.min.io/minio/baremetal/security/minio-identity-management/policy-based-access-control.html#minio-policy
+| Verdaccio        |              `5`               |   Depends on this fork of verdaccio-github-oauth-ui: [Link](https://github.com/OnekO/verdaccio-github-oauth-ui) |
 
 ## Known Callback URLs
 


### PR DESCRIPTION
Was looking to add another OIDC application entry, but noticed the Currently Tested Applications table isn't being rendered correctly by Just the Docs and could use adjusting first.

![image](https://user-images.githubusercontent.com/99472455/161365158-1985a330-50b6-42ee-a7fb-78e55a11049f.png)

This change moves the 'MinIO policies' link from the footer into the applicable row and shifts the closing pipe up one line.