### PR TITLE
docs: add oidc details for miniflux app

### DIFF
--- a/docs/community/oidc-integrations.md
+++ b/docs/community/oidc-integrations.md
@@ -26,6 +26,7 @@ has_toc: false
 | Bookstack        | `21.10`                        |                                                                                                             |
 | Harbor        |                `1.10`             |   It works on >v2.1 also, but not sure if there is OIDC support on v2.0|
 | Verdaccio        |              `5`               |   Depends on this fork of verdaccio-github-oauth-ui: [Link](https://github.com/OnekO/verdaccio-github-oauth-ui) |
+| Miniflux         | `2.0.21`                       |                                                                                                             |
 
 ## Known Callback URLs
 
@@ -45,3 +46,4 @@ If you do not find the application in the list below, you will need to search fo
 | Bookstack       | `21.10`                               |        `<DOMAIN>/oidc/callback`                                          |                                                                                                                                                                                                                                                                                                  |
 | Harbor          | `1.10`                                |        `<DOMAIN>/-/oauth/callback`                                       |                                                                                                                                                                                                                                                                                                  |
 | Verdaccio       | `5`                                   |        `<DOMAIN>/oidc/callback`                                          |                                                                                                                                                                                                                                                                                                  |
+| Miniflux        | `2.0.21`                              | `<DOMAIN>/oauth2/oidc/callback`                                          | Set via Miniflux `OAUTH2_REDIRECT_URL` [configuration parameter](https://miniflux.app/docs/configuration.html#oauth2-redirect-url). Example value follows this format                                                                                                                                            |


### PR DESCRIPTION
Tested working Miniflux feed reader OIDC settings.

Miniflux added generic OpenID Connect provider support in version 2.0.21 [(PR#583)](https://github.com/miniflux/v2/pull/583).

Tried to keep table markup aligned with existing entries but it does get a bit messy.