### PR TITLE
fix(web): update client rendering method

### DIFF
--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import "@root/index.css";
 import App from "@root/App";
 import * as serviceWorker from "@root/serviceWorker";
-import "./i18n/index.ts";
+import "@i18n/index.ts";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+const root = createRoot(document.getElementById("root")!);
+root.render(<App />);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
This PR utilises the React 18 Client Rendering API along with createRoot as opposed to the React 17 ReactDOM.render method.