### PR TITLE
feat(oidc): opaque subject identifiers

### DIFF
--- a/docs/configuration/identity-providers/oidc.md
+++ b/docs/configuration/identity-providers/oidc.md
@@ -519,12 +519,12 @@ characters. For Kubernetes, see [this section too](../secrets.md#Kubernetes).
 This is the default scope for openid. This field is forced on every client by the configuration validation that Authelia
 does.
 
-_**Important Note:** The claim `sub` is planned to be changed in the future to a randomly unique value to identify the
-individual user. Please use the claim `preferred_username` instead._
+_**Important Note:** The subject identifiers or `sub` claim has been changed to a [RFC4122] UUID V4 to identify the 
+individual user as per the [Subject Identifier Types] specification. Please use the claim `preferred_username` instead._
 
 |   Claim   |   JWT Type    | Authelia Attribute |                         Description                         |
 |:---------:|:-------------:|:------------------:|:-----------------------------------------------------------:|
-|    sub    |    string     |      username      |       A unique value linked to the user who logged in       |
+|    sub    |    string     |      username      |    A [RFC4122] UUID V4 linked to the user who logged in     |
 |   scope   |    string     |       scopes       |              Granted scopes (space delimited)               |
 |    scp    | array[string] |       scopes       |                       Granted scopes                        |
 |    iss    |    string     |      hostname      |             The issuer name, determined by URL              |
@@ -534,7 +534,7 @@ individual user. Please use the claim `preferred_username` instead._
 | auth_time |    number     |       _N/A_        |        The time the user authenticated with Authelia        |
 |    rat    |    number     |       _N/A_        |            The time when the token was requested            |
 |    iat    |    number     |       _N/A_        |             The time when the token was issued              |
-|    jti    | string(uuid)  |       _N/A_        |                       JWT Identifier                        |
+|    jti    | string(uuid)  |       _N/A_        |     A JWT Identifier in the form of a [RFC4122] UUID V4     |
 |    amr    | array[string] |       _N/A_        | An [RFC8176] list of authentication method reference values |
 
 ### groups
@@ -625,6 +625,7 @@ These endpoints implement OpenID Connect elements.
 
 [JSON Web Key Sets]: https://datatracker.ietf.org/doc/html/rfc7517#section-5
 [OpenID Connect]: https://openid.net/connect/
+[Subject Identifier Types]:https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes
 [OpenID Connect Discovery]: https://openid.net/specs/openid-connect-discovery-1_0.html
 [OAuth 2.0 Authorization Server Metadata]: https://datatracker.ietf.org/doc/html/rfc8414
 [Authorization]: https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
@@ -633,4 +634,5 @@ These endpoints implement OpenID Connect elements.
 [Introspection]: https://datatracker.ietf.org/doc/html/rfc7662
 [Revocation]: https://datatracker.ietf.org/doc/html/rfc7009
 [RFC8176]: https://datatracker.ietf.org/doc/html/rfc8176
+[RFC4122]: https://datatracker.ietf.org/doc/html/rfc4122
 [token lifespan]: https://docs.apigee.com/api-platform/antipatterns/oauth-long-expiration

--- a/docs/roadmap/oidc.md
+++ b/docs/roadmap/oidc.md
@@ -96,7 +96,7 @@ for which stage will have each feature, and may evolve over time:
         <td class="tbl-beta-stage">Authentication Methods References Claim</td>
       </tr>
       <tr>
-        <td class="tbl-beta-stage">UUID v4 <code>sub</code> claim</td>
+        <td class="tbl-beta-stage">Opaque Subject Identifiers (<a href="https://datatracker.ietf.org/doc/html/rfc4122" target="_blank">UUID</a> V4) for <code>sub</code> Claim</td>
       </tr>
       <tr>
         <td rowspan="2" class="tbl-header tbl-beta-stage">beta5 <sup>1</sup></td>


### PR DESCRIPTION
This is a meta commit documenting the change from using the username as a subject identifier to a specification compliant subject identifier in the form of RFC4122 https://datatracker.ietf.org/doc/html/rfc4122 UUID V4 subject identifiers. This is a required change in order to be compliant with the specification as per https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes. Relying parties which utilize the subject identifier / sub claim may need manual intervention in order to relink accounts. Users who have issues will have to consult with the documentation of their individual relying parties in order to relink accounts. Users who utilized the subject identifier as a means to provision their users are also encouraged to utilize the preferred_username claim from the profile scope.