### PR TITLE
feat(web): add user display name to oidc consent view

### DIFF
--- a/internal/server/locales/en/portal.json
+++ b/internal/server/locales/en/portal.json
@@ -63,5 +63,5 @@
   "Must be at least {{len}} characters in length": "Must be at least {{len}} characters in length",
   "Must not be more than {{len}} characters in length": "Must not be more than {{len}} characters in length",
   "Consent Request": "Consent Request",
-  "Client ID": "Client ID: {{id}}"
+  "Client ID": "Client ID: {{client_id}}"
 }

--- a/internal/server/locales/en/portal.json
+++ b/internal/server/locales/en/portal.json
@@ -61,5 +61,7 @@
   "Must have at least one number": "Must have at least one number",
   "Must have at least one special character": "Must have at least one special character",
   "Must be at least {{len}} characters in length": "Must be at least {{len}} characters in length",
-  "Must not be more than {{len}} characters in length": "Must not be more than {{len}} characters in length"
+  "Must not be more than {{len}} characters in length": "Must not be more than {{len}} characters in length",
+  "Consent Request": "Consent Request",
+  "Client ID": "Client ID: {{id}}"
 }

--- a/web/src/components/TypographyWithTooltip.test.tsx
+++ b/web/src/components/TypographyWithTooltip.test.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import { render } from "@testing-library/react";
+
+import TypographyWithTooltip from "@components/TypographyWithTootip";
+
+it("renders without crashing", () => {
+    render(<TypographyWithTooltip value={"Example"} variant={"h5"} />);
+});
+
+it("renders with tooltip without crashing", () => {
+    render(<TypographyWithTooltip value={"Example"} tooltip={"A tooltip"} variant={"h5"} />);
+});

--- a/web/src/components/TypographyWithTootip.tsx
+++ b/web/src/components/TypographyWithTootip.tsx
@@ -1,0 +1,33 @@
+import React, { Fragment } from "react";
+
+import { Tooltip, Typography } from "@material-ui/core";
+import { Variant } from "@material-ui/core/styles/createTypography";
+import { CSSProperties } from "@material-ui/styles";
+
+export interface Props {
+    variant: Variant;
+
+    value?: string;
+    style?: CSSProperties;
+
+    tooltip?: string;
+    tooltipStyle?: CSSProperties;
+}
+
+export default function TypographyWithTooltip(props: Props): JSX.Element {
+    return (
+        <Fragment>
+            {props.tooltip ? (
+                <Tooltip title={props.tooltip} style={props.tooltipStyle}>
+                    <Typography variant={props.variant} style={props.style}>
+                        {props.value}
+                    </Typography>
+                </Tooltip>
+            ) : (
+                <Typography variant={props.variant} style={props.style}>
+                    {props.value}
+                </Typography>
+            )}
+        </Fragment>
+    );
+}

--- a/web/src/hooks/UserInfo.ts
+++ b/web/src/hooks/UserInfo.ts
@@ -1,6 +1,10 @@
 import { useRemoteCall } from "@hooks/RemoteCall";
-import { postUserInfo } from "@services/UserInfo";
+import { getUserInfo, postUserInfo } from "@services/UserInfo";
 
 export function useUserInfoPOST() {
     return useRemoteCall(postUserInfo, []);
+}
+
+export function useUserInfoGET() {
+    return useRemoteCall(getUserInfo, []);
 }

--- a/web/src/layouts/LoginLayout.tsx
+++ b/web/src/layouts/LoginLayout.tsx
@@ -1,15 +1,19 @@
 import React, { ReactNode } from "react";
 
-import { Grid, makeStyles, Container, Typography, Link } from "@material-ui/core";
+import { Grid, makeStyles, Container, Link } from "@material-ui/core";
 import { grey } from "@material-ui/core/colors";
 
 import { ReactComponent as UserSvg } from "@assets/images/user.svg";
+import TypographyWithTooltip from "@components/TypographyWithTootip";
 import { getLogoOverride } from "@utils/Configuration";
 
 export interface Props {
     id?: string;
     children?: ReactNode;
     title?: string;
+    titleTooltip?: string;
+    subtitle?: string;
+    subtitleTooltip?: string;
     showBrand?: boolean;
 }
 
@@ -29,9 +33,16 @@ const LoginLayout = function (props: Props) {
                     </Grid>
                     {props.title ? (
                         <Grid item xs={12}>
-                            <Typography variant="h5" className={style.title}>
-                                {props.title}
-                            </Typography>
+                            <TypographyWithTooltip variant={"h5"} value={props.title} tooltip={props.titleTooltip} />
+                        </Grid>
+                    ) : null}
+                    {props.subtitle ? (
+                        <Grid item xs={12}>
+                            <TypographyWithTooltip
+                                variant={"h6"}
+                                value={props.subtitle}
+                                tooltip={props.subtitleTooltip}
+                            />
                         </Grid>
                     ) : null}
                     <Grid item xs={12} className={style.body}>
@@ -66,6 +77,7 @@ const useStyles = makeStyles((theme) => ({
         paddingRight: 32,
     },
     title: {},
+    subtitle: {},
     icon: {
         margin: theme.spacing(),
         width: "64px",

--- a/web/src/services/UserInfo.ts
+++ b/web/src/services/UserInfo.ts
@@ -1,7 +1,7 @@
 import { SecondFactorMethod } from "@models/Methods";
 import { UserInfo } from "@models/UserInfo";
 import { UserInfo2FAMethodPath, UserInfoPath } from "@services/Api";
-import { Post, PostWithOptionalResponse } from "@services/Client";
+import { Get, Post, PostWithOptionalResponse } from "@services/Client";
 
 export type Method2FA = "webauthn" | "totp" | "mobile_push";
 
@@ -41,6 +41,11 @@ export function toString(method: SecondFactorMethod): Method2FA {
 
 export async function postUserInfo(): Promise<UserInfo> {
     const res = await Post<UserInfoPayload>(UserInfoPath);
+    return { ...res, method: toEnum(res.method) };
+}
+
+export async function getUserInfo(): Promise<UserInfo> {
+    const res = await Get<UserInfoPayload>(UserInfoPath);
     return { ...res, method: toEnum(res.method) };
 }
 


### PR DESCRIPTION
This adds the current logged in users display name to the consent page as well as some other minor tweaks.

Closes #2595