### PR TITLE
 fix(web): locales are not consistent with localization platforms

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -263,8 +263,8 @@ Authelia will automatically resize the logo to an appropriate size to present in
 
 The locales folder holds folders of internationalization locales. This folder can be utilized to override these locales.
 They are the names of locales that are returned by the `navigator.langauge` ECMAScript command. These are generally
-those in the [RFC5646 / BCP47 Format](https://datatracker.ietf.org/doc/html/rfc5646) except the name normalized to
-lowercase for consistency ease; for example the `en-US` locale should be in the directory `en-us`.
+those in the [RFC5646 / BCP47 Format](https://datatracker.ietf.org/doc/html/rfc5646) specifically the language codes
+from [Crowdin](https://support.crowdin.com/api/language-codes/).
 
 Each directory has json files which you can explore the format of in the
 [internal/server/locales](https://github.com/authelia/authelia/tree/master/internal/server/locales) directory on
@@ -275,7 +275,7 @@ of current namespaces are below:
 |:---------:|:-------------------:|
 |  portal   | Portal translations |
 
-A full example for the `en-US` locale for the portal namespace is `locales/en-us/portal.json`.
+A full example for the `en-US` locale for the portal namespace is `locales/en-US/portal.json`.
 
 Languages in browsers are supported in two forms. In their language only form such as `en` for English, and in their
 variant form such as `en-AU` for English (Australian). If a user has the browser language `en-AU` we automatically load

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -65,7 +65,7 @@ func registerRoutes(configuration schema.Configuration, providers middlewares.Pr
 	r.GET("/static/{filepath:*}", handlerPublicHTML)
 
 	// Locales.
-	r.GET("/locales/{language:[a-z]{1,3}}-{variant:[a-z0-9-]+}/{namespace:[a-z]+}.json", middlewares.AssetOverrideMiddleware(configuration.Server.AssetPath, 0, handlerLocales))
+	r.GET("/locales/{language:[a-z]{1,3}}-{variant:[a-zA-Z0-9-]+}/{namespace:[a-z]+}.json", middlewares.AssetOverrideMiddleware(configuration.Server.AssetPath, 0, handlerLocales))
 	r.GET("/locales/{language:[a-z]{1,3}}/{namespace:[a-z]+}.json", middlewares.AssetOverrideMiddleware(configuration.Server.AssetPath, 0, handlerLocales))
 
 	// Swagger.

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -21,7 +21,7 @@ i18n.use(Backend)
         },
         load: "all",
         supportedLngs: ["en", "es", "de"],
-        lowerCaseLng: true,
+        lowerCaseLng: false,
         nonExplicitSupportedLngs: true,
         interpolation: {
             escapeValue: false,


### PR DESCRIPTION
This fixes an issue with localization platforms and the docs regarding localization, and the forcing locale names to lowercase.