### PR TITLE
fix(web): description of profile scope is not accurate

### DIFF
--- a/internal/server/locales/de/portal.json
+++ b/internal/server/locales/de/portal.json
@@ -49,7 +49,7 @@
     "You're being signed out and redirected": "Sie werden abgemeldet und umgeleitet",
     "Your supplied password does not meet the password policy requirements": "Ihr angegebenes Passwort entspricht nicht den Anforderungen der Passwortrichtlinie.",
     "Use OpenID to verify your identity": "Verwenden Sie OpenID, um Ihre Identität zu überprüfen",
-    "Access your display name": "Zugriff auf Ihren Anzeigenamen",
+    "Access your profile information": "Zugriff auf Ihren Anzeigenamen",
     "Access your group membership": "Zugriff auf Ihre Gruppenmitgliedschaft",
     "Access your email addresses": "Zugriff auf Ihre E-Mail-Adressen",
     "Accept": "Annehmen",

--- a/internal/server/locales/en/portal.json
+++ b/internal/server/locales/en/portal.json
@@ -49,7 +49,7 @@
   "You're being signed out and redirected": "You're being signed out and redirected",
   "Your supplied password does not meet the password policy requirements": "Your supplied password does not meet the password policy requirements.",
   "Use OpenID to verify your identity": "Use OpenID to verify your identity",
-  "Access your display name": "Access your display name",
+  "Access your profile information": "Access your profile information",
   "Access your group membership": "Access your group membership",
   "Access your email addresses": "Access your email addresses",
   "Accept": "Accept",

--- a/internal/server/locales/es/portal.json
+++ b/internal/server/locales/es/portal.json
@@ -49,7 +49,7 @@
   "You're being signed out and redirected": "Cerrando Sesión y redirigiendo",
   "Your supplied password does not meet the password policy requirements": "La contraseña suministrada no cumple con los requerimientos de la política de contraseñas",
   "Use OpenID to verify your identity": "Utilizar OpenID para verificar su identidad",
-  "Access your display name": "Acceso a su nombre",
+  "Access your profile information": "Acceder a tu información de perfil",
   "Access your group membership": "Acceso a su(s) grupo(s)",
   "Access your email addresses": "Acceso a su dirección de correo",
   "Accept": "Aceptar",

--- a/web/src/views/LoginPortal/ConsentView/ConsentView.tsx
+++ b/web/src/views/LoginPortal/ConsentView/ConsentView.tsx
@@ -85,7 +85,7 @@ const ConsentView = function (props: Props) {
             case "openid":
                 return translate("Use OpenID to verify your identity");
             case "profile":
-                return translate("Access your display name");
+                return translate("Access your profile information");
             case "groups":
                 return translate("Access your group membership");
             case "email":


### PR DESCRIPTION
This adjusts the profile scope to be described as "Access your profile information" as it accesses more than the display name now.