### PR TITLE
fix(oidc): missing amr claim supported in discovery

### DIFF
--- a/internal/oidc/discovery.go
+++ b/internal/oidc/discovery.go
@@ -30,6 +30,7 @@ func NewOpenIDConnectWellKnownConfiguration(enablePKCEPlainChallenge, pairwise b
 				ScopeEmail,
 			},
 			ClaimsSupported: []string{
+				"amr",
 				"aud",
 				"exp",
 				"iat",

--- a/internal/oidc/provider_test.go
+++ b/internal/oidc/provider_test.go
@@ -170,7 +170,8 @@ func TestOpenIDConnectProvider_NewOpenIDConnectProvider_GetOpenIDConnectWellKnow
 	assert.Contains(t, disco.RequestObjectSigningAlgValuesSupported, "RS256")
 	assert.Contains(t, disco.RequestObjectSigningAlgValuesSupported, "none")
 
-	assert.Len(t, disco.ClaimsSupported, 15)
+	assert.Len(t, disco.ClaimsSupported, 16)
+	assert.Contains(t, disco.ClaimsSupported, "amr")
 	assert.Contains(t, disco.ClaimsSupported, "aud")
 	assert.Contains(t, disco.ClaimsSupported, "exp")
 	assert.Contains(t, disco.ClaimsSupported, "iat")
@@ -244,8 +245,9 @@ func TestOpenIDConnectProvider_NewOpenIDConnectProvider_GetOAuth2WellKnownConfig
 	assert.Contains(t, disco.ResponseTypesSupported, "code token id_token")
 	assert.Contains(t, disco.ResponseTypesSupported, "none")
 
-	assert.Len(t, disco.ClaimsSupported, 15)
+	assert.Len(t, disco.ClaimsSupported, 16)
 	assert.Contains(t, disco.ClaimsSupported, "aud")
+	assert.Contains(t, disco.ClaimsSupported, "amr")
 	assert.Contains(t, disco.ClaimsSupported, "exp")
 	assert.Contains(t, disco.ClaimsSupported, "iat")
 	assert.Contains(t, disco.ClaimsSupported, "iss")


### PR DESCRIPTION
This adds the AMR claim to discovery.