### PR TITLE
fix(server): locale format incorrect

### DIFF
--- a/internal/server/asset.go
+++ b/internal/server/asset.go
@@ -48,7 +48,7 @@ func newLocalesEmbeddedHandler() (handler fasthttp.RequestHandler) {
 
 		if v := ctx.UserValue("variant"); v != nil {
 			variant = v.(string)
-			locale = fmt.Sprintf("%s-%s", language, locale)
+			locale = fmt.Sprintf("%s-%s", language, variant)
 		}
 
 		var data []byte


### PR DESCRIPTION
This fixes an issue where the locale would be formatted as en-en instead of en-US.