### PR TITLE
feat(oidc): resource owner password credentials grant

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -758,6 +758,9 @@ notifier:
     # id_token_lifespan: 1h
     # refresh_token_lifespan: 90m
 
+    ## Enables the OAuth2.0 Resource Owner Password Credentials grant.
+    # enable_grant_ropc: false
+        
     ## Enables additional debug messages.
     # enable_client_debug_messages: false
 

--- a/config.template.yml
+++ b/config.template.yml
@@ -758,7 +758,7 @@ notifier:
     # id_token_lifespan: 1h
     # refresh_token_lifespan: 90m
 
-    ## Enables the OAuth2.0 Resource Owner Password Credentials grant.
+    ## Enables the OAuth2.0 Resource Owner Password Credential Grants.
     # enable_grant_ropc: false
 
     ## Enables additional debug messages.

--- a/config.template.yml
+++ b/config.template.yml
@@ -760,7 +760,7 @@ notifier:
 
     ## Enables the OAuth2.0 Resource Owner Password Credentials grant.
     # enable_grant_ropc: false
-        
+
     ## Enables additional debug messages.
     # enable_client_debug_messages: false
 

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -64,7 +64,7 @@ func getProviders() (providers middlewares.Providers, warnings []error, errors [
 	sessionProvider := session.NewProvider(config.Session, autheliaCertPool)
 	regulator := regulation.NewRegulator(config.Regulation, storageProvider, clock)
 
-	oidcProvider, err := oidc.NewOpenIDConnectProvider(config.IdentityProviders.OIDC, storageProvider)
+	oidcProvider, err := oidc.NewOpenIDConnectProvider(config.IdentityProviders.OIDC, oidc.NewOpenIDConnectStoreProviders(storageProvider, userProvider))
 	if err != nil {
 		errors = append(errors, err)
 	}

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -758,6 +758,9 @@ notifier:
     # id_token_lifespan: 1h
     # refresh_token_lifespan: 90m
 
+    ## Enables the OAuth2.0 Resource Owner Password Credentials grant.
+    # enable_grant_ropc: false
+        
     ## Enables additional debug messages.
     # enable_client_debug_messages: false
 

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -758,7 +758,7 @@ notifier:
     # id_token_lifespan: 1h
     # refresh_token_lifespan: 90m
 
-    ## Enables the OAuth2.0 Resource Owner Password Credentials grant.
+    ## Enables the OAuth2.0 Resource Owner Password Credential Grants.
     # enable_grant_ropc: false
 
     ## Enables additional debug messages.

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -760,7 +760,7 @@ notifier:
 
     ## Enables the OAuth2.0 Resource Owner Password Credentials grant.
     # enable_grant_ropc: false
-        
+
     ## Enables additional debug messages.
     # enable_client_debug_messages: false
 

--- a/internal/configuration/schema/identity_providers.go
+++ b/internal/configuration/schema/identity_providers.go
@@ -20,6 +20,8 @@ type OpenIDConnectConfiguration struct {
 	IDTokenLifespan       time.Duration `koanf:"id_token_lifespan"`
 	RefreshTokenLifespan  time.Duration `koanf:"refresh_token_lifespan"`
 
+	EnableGrantROPC bool `koanf:"enable_grant_ropc"`
+
 	EnableClientDebugMessages bool `koanf:"enable_client_debug_messages"`
 	MinimumParameterEntropy   int  `koanf:"minimum_parameter_entropy"`
 

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -485,6 +485,7 @@ var ValidKeys = []string{
 	"identity_providers.oidc.access_token_lifespan",
 	"identity_providers.oidc.refresh_token_lifespan",
 	"identity_providers.oidc.authorize_code_lifespan",
+	"identity_providers.oidc.enable_grant_ropc",
 	"identity_providers.oidc.enforce_pkce",
 	"identity_providers.oidc.enable_pkce_plain_challenge",
 	"identity_providers.oidc.enable_client_debug_messages",

--- a/internal/oidc/provider_test.go
+++ b/internal/oidc/provider_test.go
@@ -13,7 +13,7 @@ import (
 var exampleIssuerPrivateKey = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAvcMVMB2vEbqI6PlSNJ4HmUyMxBDJ5iY7FS+zDDAHOZBg9S3S\nKcAn1CZcnyL0VvJ7wcdhR6oTnOwR94eKvzUyJZ+GL2hTMm27dubEYsNdhoCl6N3X\nyEEohNfoxiiCYraVauX8X3M9jFzbEz9+pacaDbHB2syaJ1qFmMNR+HSu2jPzOo7M\nlqKIOgUzA0741MaYNt47AEVg4XU5ORLdolbAkItmYg1QbyFndg9H5IvwKkYaXTGE\nlgDBcPUC0yVjAC15Mguquq+jZeQay+6PSbHTD8PQMOkLjyChI2xEhVNbdCXe676R\ncMW2R/gjrcK23zmtmTWRfdC1iZLSlHO+bJj9vQIDAQABAoIBAEZvkP/JJOCJwqPn\nV3IcbmmilmV4bdi1vByDFgyiDyx4wOSA24+PubjvfFW9XcCgRPuKjDtTj/AhWBHv\nB7stfa2lZuNV7/u562mZArA+IAr62Zp0LdIxDV8x3T8gbjVB3HhPYbv0RJZDKTYd\nzV6jhfIrVu9mHpoY6ZnodhapCPYIyk/d49KBIHZuAc25CUjMXgTeaVtf0c996036\nUxW6ef33wAOJAvW0RCvbXAJfmBeEq2qQlkjTIlpYx71fhZWexHifi8Ouv3Zonc+1\n/P2Adq5uzYVBT92f9RKHg9QxxNzVrLjSMaxyvUtWQCAQfW0tFIRdqBGsHYsQrFtI\nF4yzv8ECgYEA7ntpyN9HD9Z9lYQzPCR73sFCLM+ID99aVij0wHuxK97bkSyyvkLd\n7MyTaym3lg1UEqWNWBCLvFULZx7F0Ah6qCzD4ymm3Bj/ADpWWPgljBI0AFml+HHs\nhcATmXUrj5QbLyhiP2gmJjajp1o/rgATx6ED66seSynD6JOH8wUhhZUCgYEAy7OA\n06PF8GfseNsTqlDjNF0K7lOqd21S0prdwrsJLiVzUlfMM25MLE0XLDUutCnRheeh\nIlcuDoBsVTxz6rkvFGD74N+pgXlN4CicsBq5ofK060PbqCQhSII3fmHobrZ9Cr75\nHmBjAxHx998SKaAAGbBbcYGUAp521i1pH5CEPYkCgYEAkUd1Zf0+2RMdZhwm6hh/\nrW+l1I6IoMK70YkZsLipccRNld7Y9LbfYwYtODcts6di9AkOVfueZJiaXbONZfIE\nZrb+jkAteh9wGL9xIrnohbABJcV3Kiaco84jInUSmGDtPokncOENfHIEuEpuSJ2b\nbx1TuhmAVuGWivR0+ULC7RECgYEAgS0cDRpWc9Xzh9Cl7+PLsXEvdWNpPsL9OsEq\n0Ep7z9+/+f/jZtoTRCS/BTHUpDvAuwHglT5j3p5iFMt5VuiIiovWLwynGYwrbnNS\nqfrIrYKUaH1n1oDS+oBZYLQGCe9/7EifAjxtjYzbvSyg//SPG7tSwfBCREbpZXj2\nqSWkNsECgYA/mCDzCTlrrWPuiepo6kTmN+4TnFA+hJI6NccDVQ+jvbqEdoJ4SW4L\nzqfZSZRFJMNpSgIqkQNRPJqMP0jQ5KRtJrjMWBnYxktwKz9fDg2R2MxdFgMF2LH2\nHEMMhFHlv8NDjVOXh1KwRoltNGVWYsSrD9wKU9GhRCEfmNCGrvBcEg==\n-----END RSA PRIVATE KEY-----"
 
 func TestOpenIDConnectProvider_NewOpenIDConnectProvider_NotConfigured(t *testing.T) {
-	provider, err := NewOpenIDConnectProvider(nil, nil)
+	provider, err := NewOpenIDConnectProvider(nil, OpenIDConnectStoreProviders{})
 
 	assert.NoError(t, err)
 	assert.Nil(t, provider.Fosite)
@@ -23,7 +23,7 @@ func TestOpenIDConnectProvider_NewOpenIDConnectProvider_NotConfigured(t *testing
 func TestOpenIDConnectProvider_NewOpenIDConnectProvider_BadIssuerKey(t *testing.T) {
 	_, err := NewOpenIDConnectProvider(&schema.OpenIDConnectConfiguration{
 		IssuerPrivateKey: "BAD KEY",
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	assert.Error(t, err, "abc")
 }
@@ -44,7 +44,7 @@ func TestNewOpenIDConnectProvider_ShouldEnableOptionalDiscoveryValues(t *testing
 				},
 			},
 		},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	assert.NoError(t, err)
 
@@ -94,7 +94,7 @@ func TestOpenIDConnectProvider_NewOpenIDConnectProvider_GoodConfiguration(t *tes
 				},
 			},
 		},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	assert.NotNil(t, provider)
 	assert.NoError(t, err)
@@ -114,7 +114,7 @@ func TestOpenIDConnectProvider_NewOpenIDConnectProvider_GetOpenIDConnectWellKnow
 				},
 			},
 		},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	assert.NoError(t, err)
 
@@ -205,7 +205,7 @@ func TestOpenIDConnectProvider_NewOpenIDConnectProvider_GetOAuth2WellKnownConfig
 				},
 			},
 		},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	assert.NoError(t, err)
 
@@ -283,7 +283,7 @@ func TestOpenIDConnectProvider_NewOpenIDConnectProvider_GetOpenIDConnectWellKnow
 				},
 			},
 		},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	assert.NoError(t, err)
 

--- a/internal/oidc/store.go
+++ b/internal/oidc/store.go
@@ -32,8 +32,9 @@ func NewOpenIDConnectStore(config *schema.OpenIDConnectConfiguration, providers 
 	logger := logging.Logger()
 
 	store = &OpenIDConnectStore{
-		providers: providers,
-		clients:   map[string]*Client{},
+		providers:       providers,
+		clients:         map[string]*Client{},
+		enableGrantROPC: config.EnableGrantROPC,
 	}
 
 	for _, client := range config.Clients {
@@ -292,6 +293,10 @@ func (s *OpenIDConnectStore) MarkJWTUsedForTime(ctx context.Context, jti string,
 // Authenticate implements an interface required for oauth2.ResourceOwnerPasswordCredentialsGrantStorage to implement
 // ROPC as per https://datatracker.ietf.org/doc/html/rfc6749#section-4.3.
 func (s *OpenIDConnectStore) Authenticate(_ context.Context, name, secret string) (err error) {
+	if !s.enableGrantROPC {
+		return errors.New("OAuth 2.0 Resource Owner Password Credentials Grants are not enabled")
+	}
+
 	var valid bool
 
 	if valid, err = s.providers.authentication.CheckUserPassword(name, secret); err == nil && valid {

--- a/internal/oidc/store.go
+++ b/internal/oidc/store.go
@@ -294,7 +294,7 @@ func (s *OpenIDConnectStore) MarkJWTUsedForTime(ctx context.Context, jti string,
 // ROPC as per https://datatracker.ietf.org/doc/html/rfc6749#section-4.3.
 func (s *OpenIDConnectStore) Authenticate(_ context.Context, name, secret string) (err error) {
 	if !s.enableGrantROPC {
-		return errors.New("OAuth 2.0 Resource Owner Password Credentials Grants are not enabled")
+		return errors.New("OAuth 2.0 Resource Owner Password Credential Grants are not enabled")
 	}
 
 	var valid bool

--- a/internal/oidc/store_test.go
+++ b/internal/oidc/store_test.go
@@ -30,7 +30,7 @@ func TestOpenIDConnectStore_GetClientPolicy(t *testing.T) {
 				Secret:      "mysecret",
 			},
 		},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	policyOne := s.GetClientPolicy("myclient")
 	assert.Equal(t, authorization.OneFactor, policyOne)
@@ -54,7 +54,7 @@ func TestOpenIDConnectStore_GetInternalClient(t *testing.T) {
 				Secret:      "mysecret",
 			},
 		},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	client, err := s.GetClient(context.Background(), "myinvalidclient")
 	assert.EqualError(t, err, "not_found")
@@ -78,7 +78,7 @@ func TestOpenIDConnectStore_GetInternalClient_ValidClient(t *testing.T) {
 	s := NewOpenIDConnectStore(&schema.OpenIDConnectConfiguration{
 		IssuerPrivateKey: exampleIssuerPrivateKey,
 		Clients:          []schema.OpenIDConnectClientConfiguration{c1},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	client, err := s.GetFullClient(c1.ID)
 	require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestOpenIDConnectStore_GetInternalClient_InvalidClient(t *testing.T) {
 	s := NewOpenIDConnectStore(&schema.OpenIDConnectConfiguration{
 		IssuerPrivateKey: exampleIssuerPrivateKey,
 		Clients:          []schema.OpenIDConnectClientConfiguration{c1},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	client, err := s.GetFullClient("another-client")
 	assert.Nil(t, client)
@@ -124,7 +124,7 @@ func TestOpenIDConnectStore_IsValidClientID(t *testing.T) {
 				Secret:      "mysecret",
 			},
 		},
-	}, nil)
+	}, OpenIDConnectStoreProviders{})
 
 	validClient := s.IsValidClientID("myclient")
 	invalidClient := s.IsValidClientID("myinvalidclient")

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ory/herodot"
 	"gopkg.in/square/go-jose.v2"
 
+	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/storage"
@@ -87,14 +88,20 @@ type OpenIDConnectProvider struct {
 	discovery OpenIDConnectWellKnownConfiguration
 }
 
+// OpenIDConnectStoreProviders just holds other providers the OpenIDConnectStore relies on.
+type OpenIDConnectStoreProviders struct {
+	storage        storage.Provider
+	authentication authentication.UserProvider
+}
+
 // OpenIDConnectStore is Authelia's internal representation of the fosite.Storage interface. It maps the following
 // interfaces to the storage.Provider interface:
 // fosite.Storage, fosite.ClientManager, storage.Transactional, oauth2.AuthorizeCodeStorage, oauth2.AccessTokenStorage,
 // oauth2.RefreshTokenStorage, oauth2.TokenRevocationStorage, pkce.PKCERequestStorage,
 // openid.OpenIDConnectRequestStorage, and partially implements rfc7523.RFC7523KeyStorage.
 type OpenIDConnectStore struct {
-	provider storage.Provider
-	clients  map[string]*Client
+	providers OpenIDConnectStoreProviders
+	clients   map[string]*Client
 }
 
 // Client represents the client internally.

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -100,8 +100,9 @@ type OpenIDConnectStoreProviders struct {
 // oauth2.RefreshTokenStorage, oauth2.TokenRevocationStorage, pkce.PKCERequestStorage,
 // openid.OpenIDConnectRequestStorage, and partially implements rfc7523.RFC7523KeyStorage.
 type OpenIDConnectStore struct {
-	providers OpenIDConnectStoreProviders
-	clients   map[string]*Client
+	providers       OpenIDConnectStoreProviders
+	clients         map[string]*Client
+	enableGrantROPC bool
 }
 
 // Client represents the client internally.


### PR DESCRIPTION
This enables using Authelia usernames and passwords for the OAuth 2.0 Resource Owner Password Credentials grant type as per https://datatracker.ietf.org/doc/html/rfc6749.

We probably will not implement this as it's considered deprecated and somewhat insecure.