### PR TITLE
fix(suites): add missing traefik routes

### DIFF
--- a/internal/suites/example/compose/authelia/docker-compose.backend.dev.yml
+++ b/internal/suites/example/compose/authelia/docker-compose.backend.dev.yml
@@ -21,10 +21,10 @@ services:
       - '${GOPATH}:/go'
     labels:
       # Traefik 1.x
-      - 'traefik.frontend.rule=Host:login.example.com;PathPrefix:/api'
+      - 'traefik.frontend.rule=Host:login.example.com;PathPrefix:/api,/locales'
       - 'traefik.protocol=https'
       # Traefik 2.x
-      - 'traefik.http.routers.authelia_backend.rule=Host(`login.example.com`) && PathPrefix(`/.well-known/openid-configuration`) || Host(`login.example.com`) && PathPrefix(`/api`) || Host(`login.example.com`) && PathPrefix(`${PathPrefix}/api/`)'  # yamllint disable-line rule:line-length
+      - 'traefik.http.routers.authelia_backend.rule=Host(`login.example.com`) && PathPrefix(`/.well-known`) || Host(`login.example.com`) && PathPrefix(`${PathPrefix}/.well-known`) || Host(`login.example.com`) && PathPrefix(`/api`) || Host(`login.example.com`) && PathPrefix(`${PathPrefix}/api`) || Host(`login.example.com`) && PathPrefix(`/locales`) || Host(`login.example.com`) && PathPrefix(`${PathPrefix}/locales`) || Host(`login.example.com`) && Path(`/jwks.json`) || Host(`login.example.com`) && Path(`${PathPrefix}/jwks.json`)'  # yamllint disable-line rule:line-length
       - 'traefik.http.routers.authelia_backend.entrypoints=https'
       - 'traefik.http.routers.authelia_backend.tls=true'
       - 'traefik.http.services.authelia_backend.loadbalancer.server.scheme=https'

--- a/internal/suites/example/compose/authelia/docker-compose.backend.dist.yml
+++ b/internal/suites/example/compose/authelia/docker-compose.backend.dist.yml
@@ -5,10 +5,10 @@ services:
     image: authelia:dist
     labels:
       # Traefik 1.x
-      - 'traefik.frontend.rule=Host:login.example.com;PathPrefix:/api'
+      - 'traefik.frontend.rule=Host:login.example.com;PathPrefix:/api,/locales'
       - 'traefik.protocol=https'
       # Traefik 2.x
-      - 'traefik.http.routers.authelia_backend.rule=Host(`login.example.com`) && PathPrefix(`/.well-known/openid-configuration`) || Host(`login.example.com`) && PathPrefix(`/api`) || Host(`login.example.com`) && PathPrefix(`${PathPrefix}/api/`)'  # yamllint disable-line rule:line-length
+      - 'traefik.http.routers.authelia_backend.rule=Host(`login.example.com`) && PathPrefix(`/.well-known`) || Host(`login.example.com`) && PathPrefix(`${PathPrefix}/.well-known`) || Host(`login.example.com`) && PathPrefix(`/api`) || Host(`login.example.com`) && PathPrefix(`${PathPrefix}/api`) || Host(`login.example.com`) && PathPrefix(`/locales`) || Host(`login.example.com`) && PathPrefix(`${PathPrefix}/locales`) || Host(`login.example.com`) && Path(`/jwks.json`) || Host(`login.example.com`) && Path(`${PathPrefix}/jwks.json`)'  # yamllint disable-line rule:line-length
       - 'traefik.http.routers.authelia_backend.entrypoints=https'
       - 'traefik.http.routers.authelia_backend.tls=true'
       - 'traefik.http.services.authelia_backend.loadbalancer.server.scheme=https'


### PR DESCRIPTION
This change includes missing routes for both the Traefik and Traefik2 suites, issues would have manifested running dev mode tests for these suites when attempting to load translations.