### PR TITLE
docs: add caddy to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   [![Matrix](https://img.shields.io/matrix/authelia-support:matrix.org?label=matrix&logo=matrix&style=flat-square&color=blue)](https://matrix.to/#/#support:authelia.com)
 
 **Authelia** is an open-source authentication and authorization server providing two-factor authentication and single 
-sign-on (SSO) for your applications via a web portal. It acts as a companion for reverse proxies like [nginx], [Traefik] 
+sign-on (SSO) for your applications via a web portal. It acts as a companion for reverse proxies like [nginx], [Traefik], [caddy] 
 or [HAProxy] to let them know whether requests should either be allowed or redirected to Authelia's portal for
 authentication.
 
@@ -83,7 +83,7 @@ If you want to know more about the roadmap, follow [Roadmap](https://www.autheli
 
 ## Proxy support
 
-Authelia works in combination with [nginx], [Traefik] or [HAProxy]. It can be deployed on bare metal with
+Authelia works in combination with [nginx], [Traefik], [caddy] or [HAProxy]. It can be deployed on bare metal with
 Docker or on top of [Kubernetes].
 
 <p align="center">
@@ -367,6 +367,7 @@ for providing us with free licenses to their great tools.
 [config.template.yml]: ./config.template.yml
 [nginx]: https://www.nginx.com/
 [Traefik]: https://traefik.io/
+[caddy]: https://caddyserver.com/
 [HAProxy]: https://www.haproxy.org/
 [Docker]: https://docker.com/
 [Kubernetes]: https://kubernetes.io/


### PR DESCRIPTION
A bit of a followup to #3307. This directly mentions caddy for easier `CTRL`+`F` skimming of the readme.