### PR TITLE
docs: add sql supported version info

### DIFF
--- a/docs/configuration/storage/mariadb.md
+++ b/docs/configuration/storage/mariadb.md
@@ -10,6 +10,20 @@ nav_order: 1
 
 The MySQL storage provider also serves as a MariaDB provider.
 
+## Version support
+
+We recommend using the latest version of MariaDB that is officially supported by the MariaDB developers. We also suggest
+checking out [PostgreSQL](postgres.md) as an alternative.
+
+The oldest version of MariaDB that has been tested is 10.6. If using 10.6 you may be required to adjust the 
+`explicit_defaults_for_timestamp` setting. This will be evident when the container starts with an error similar to
+`Error 1067: Invalid default value for 'exp'`. You can adjust this setting in the mysql.cnf file like so:
+
+```cnf
+[mysqld]
+explicit_defaults_for_timestamp = 1
+```
+
 ## Configuration
 
 ```yaml

--- a/docs/configuration/storage/mysql.md
+++ b/docs/configuration/storage/mysql.md
@@ -10,6 +10,20 @@ nav_order: 2
 
 The MySQL storage provider.
 
+## Version support
+
+We recommend using the latest version of MySQL that is officially supported by the MySQL developers. We also suggest
+checking out [PostgreSQL](postgres.md) as an alternative.
+
+The oldest version of MySQL that has been tested is 5.7. If using 5.7 you may be required to adjust the
+`explicit_defaults_for_timestamp` setting. This will be evident when the container starts with an error similar to
+`Error 1067: Invalid default value for 'exp'`. You can adjust this setting in the mysql.cnf file like so:
+
+```cnf
+[mysqld]
+explicit_defaults_for_timestamp = 1
+```
+
 ## Configuration
 
 ```yaml

--- a/docs/configuration/storage/postgres.md
+++ b/docs/configuration/storage/postgres.md
@@ -10,6 +10,19 @@ nav_order: 3
 
 The PostgreSQL storage provider.
 
+## Version support
+
+See [PostgreSQL support](https://www.postgresql.org/support/versioning/) for the versions supported by PostgreSQL. We
+recommend the _current minor_ version of one of the versions supported by PostgreSQL.
+
+The versions of PostgreSQL that should be supported by Authelia are:
+- 14
+- 13
+- 12
+- 11
+- 10
+- 9.6
+
 ## Configuration
 
 ```yaml

--- a/docs/configuration/storage/sqlite.md
+++ b/docs/configuration/storage/sqlite.md
@@ -14,7 +14,7 @@ instances of Authelia since the database will be a local file.
 
 Use of this storage provider leaves Authelia [stateful](../../features/statelessness.md). It's important in highly
 available scenarios to use one of the other providers, and we highly recommend it in production environments, but this
-requires you setup an external database.
+requires you setup an external database such as [PostgreSQL](postgres.md).
 
 ## Configuration
 

--- a/docs/deployment/supported-proxies/caddy.md
+++ b/docs/deployment/supported-proxies/caddy.md
@@ -6,6 +6,8 @@ grand_parent: Deployment
 nav_order: 1
 ---
 
+# Caddy
+
 [Caddy] is a reverse proxy supported by **Authelia**. 
 
 _**Important:** Caddy officially supports the forward auth flow in version 2.5.1 and greater. You must be using this 


### PR DESCRIPTION
This adds supported version / configuration info to primarily MySQL/MariaDB.

Closes #2822