### PR TITLE
docs: fix missing backtick in file authentication docs

### DIFF
--- a/docs/configuration/authentication/file.md
+++ b/docs/configuration/authentication/file.md
@@ -87,7 +87,7 @@ required: no
 {: .label .label-config .label-green }
 </div>
 
-Controls the hashing algorithm used for hashing new passwords. Value must be one of `argon2id` or `sha512.
+Controls the hashing algorithm used for hashing new passwords. Value must be one of `argon2id` or `sha512`.
 
 
 #### iterations


### PR DESCRIPTION
Was reading through the docs and realised there's a missing format character when mentioning the SHA512 algorithm under password (https://www.authelia.com/docs/configuration/authentication/file.html#algorithm).

<img width="742" alt="image" src="https://user-images.githubusercontent.com/19372079/167862375-a112c8bd-c05e-4e35-952b-82c7dc7befec.png">

This minor PR fixes the mentioned typo.