### PR TITLE
fix(authentication): err when user/display name same ldap attribute

### DIFF
--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -339,14 +339,9 @@ func (p *LDAPUserProvider) getUserProfile(client LDAPClient, username string) (p
 	}
 
 	for _, attr := range searchResult.Entries[0].Attributes {
-		switch attr.Name {
-		case p.config.DisplayNameAttribute:
-			userProfile.DisplayName = attr.Values[0]
-		case p.config.MailAttribute:
-			userProfile.Emails = attr.Values
-		case p.config.UsernameAttribute:
-			attrs := len(attr.Values)
+		attrs := len(attr.Values)
 
+		if attr.Name == p.config.UsernameAttribute {
 			switch attrs {
 			case 1:
 				userProfile.Username = attr.Values[0]
@@ -357,6 +352,18 @@ func (p *LDAPUserProvider) getUserProfile(client LDAPClient, username string) (p
 				return nil, fmt.Errorf("user '%s' has %d values for for attribute '%s' but the attribute must be a single value attribute",
 					username, attrs, p.config.UsernameAttribute)
 			}
+		}
+
+		if attrs == 0 {
+			continue
+		}
+
+		if attr.Name == p.config.MailAttribute {
+			userProfile.Emails = attr.Values
+		}
+
+		if attr.Name == p.config.DisplayNameAttribute {
+			userProfile.DisplayName = attr.Values[0]
 		}
 	}
 

--- a/internal/authentication/ldap_user_provider_startup.go
+++ b/internal/authentication/ldap_user_provider_startup.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-ldap/ldap/v3"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/utils"
 )
 
 // StartupCheck implements the startup check provider interface.
@@ -88,10 +89,16 @@ func (p *LDAPUserProvider) parseDynamicUsersConfiguration() {
 
 	p.log.Tracef("Dynamically generated users filter is %s", p.config.UsersFilter)
 
-	p.usersAttributes = []string{
-		p.config.DisplayNameAttribute,
-		p.config.MailAttribute,
-		p.config.UsernameAttribute,
+	if !utils.IsStringInSlice(p.config.UsernameAttribute, p.usersAttributes) {
+		p.usersAttributes = append(p.usersAttributes, p.config.UsernameAttribute)
+	}
+
+	if !utils.IsStringInSlice(p.config.MailAttribute, p.usersAttributes) {
+		p.usersAttributes = append(p.usersAttributes, p.config.MailAttribute)
+	}
+
+	if !utils.IsStringInSlice(p.config.DisplayNameAttribute, p.usersAttributes) {
+		p.usersAttributes = append(p.usersAttributes, p.config.DisplayNameAttribute)
 	}
 
 	if p.config.AdditionalUsersDN != "" {


### PR DESCRIPTION
This fixes an issue when both the username and display name attributes are the same. If the username attribute is the same as the display name attribute previously we only set the display name profile value which is incorrect. We should set the username profile value instead and allow the display name to be blank.

Fixes #3359