### PR TITLE
fix(server): handled errors not logged correctly

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,8 +17,8 @@ import (
 // CreateServer Create Authelia's internal webserver with the given configuration and providers.
 func CreateServer(config schema.Configuration, providers middlewares.Providers) (*fasthttp.Server, net.Listener) {
 	server := &fasthttp.Server{
-		ErrorHandler:          handlerError(),
-		Handler:               getHandler(config, providers),
+		ErrorHandler:          handleError(),
+		Handler:               handleRouter(config, providers),
 		NoDefaultServerHeader: true,
 		ReadBufferSize:        config.Server.ReadBufferSize,
 		WriteBufferSize:       config.Server.WriteBufferSize,


### PR DESCRIPTION
This fixes an issue where errors handled by the ErrorHandler were not correctly logged. It also ensures the errors are logged with fields to make them easy to diagnose.

Fixes #3506