### PR TITLE
feat(storage): add unix socket support for mysql provider

### DIFF
--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -115,7 +115,8 @@ const (
 	errStrStorage                            = "storage: configuration for a 'local', 'mysql' or 'postgres' database must be provided"
 	errStrStorageEncryptionKeyMustBeProvided = "storage: option 'encryption_key' must is required"
 	errStrStorageEncryptionKeyTooShort       = "storage: option 'encryption_key' must be 20 characters or longer"
-	errFmtStorageUserPassMustBeProvided      = "storage: %s: option 'username' and 'password' are required" //nolint:gosec
+	errFmtStorageUserMustBeProvided          = "storage: %s: option 'username' is required"
+	errFmtStoragePassMustBeProvided          = "storage: %s: option 'password' is required" //nolint:gosec
 	errFmtStorageOptionMustBeProvided        = "storage: %s: option '%s' is required"
 	errFmtStoragePostgreSQLInvalidSSLMode    = "storage: postgres: ssl: option 'mode' must be one of '%s' but it is configured as '%s'"
 )

--- a/internal/configuration/validator/storage.go
+++ b/internal/configuration/validator/storage.go
@@ -40,8 +40,16 @@ func validateSQLConfiguration(config *schema.SQLStorageConfiguration, validator 
 		validator.Push(fmt.Errorf(errFmtStorageOptionMustBeProvided, provider, "host"))
 	}
 
-	if config.Username == "" || config.Password == "" {
-		validator.Push(fmt.Errorf(errFmtStorageUserPassMustBeProvided, provider))
+	if config.Username == "" {
+		validator.Push(fmt.Errorf(errFmtStorageUserMustBeProvided, provider))
+	}
+
+	if config.Password == "" && provider == "mysql" && config.Port > 0 {
+		validator.Push(fmt.Errorf(errFmtStoragePassMustBeProvided, provider))
+	}
+
+	if config.Password == "" && provider == "postgres" {
+		validator.Push(fmt.Errorf(errFmtStoragePassMustBeProvided, provider))
 	}
 
 	if config.Database == "" {

--- a/internal/configuration/validator/storage_test.go
+++ b/internal/configuration/validator/storage_test.go
@@ -55,14 +55,20 @@ func (suite *StorageSuite) TestShouldValidateLocalPathIsProvided() {
 	suite.Require().Len(suite.validator.Errors(), 0)
 }
 
+// MySQL over TCP.
 func (suite *StorageSuite) TestShouldValidateMySQLHostUsernamePasswordAndDatabaseAreProvided() {
-	suite.config.MySQL = &schema.MySQLStorageConfiguration{}
+	suite.config.MySQL = &schema.MySQLStorageConfiguration{
+		SQLStorageConfiguration: schema.SQLStorageConfiguration{
+			Port: 3306,
+		},
+	}
 	ValidateStorage(suite.config, suite.validator)
 
-	suite.Require().Len(suite.validator.Errors(), 3)
+	suite.Require().Len(suite.validator.Errors(), 4)
 	suite.Assert().EqualError(suite.validator.Errors()[0], "storage: mysql: option 'host' is required")
-	suite.Assert().EqualError(suite.validator.Errors()[1], "storage: mysql: option 'username' and 'password' are required")
-	suite.Assert().EqualError(suite.validator.Errors()[2], "storage: mysql: option 'database' is required")
+	suite.Assert().EqualError(suite.validator.Errors()[1], "storage: mysql: option 'username' is required")
+	suite.Assert().EqualError(suite.validator.Errors()[2], "storage: mysql: option 'password' is required")
+	suite.Assert().EqualError(suite.validator.Errors()[3], "storage: mysql: option 'database' is required")
 
 	suite.validator.Clear()
 	suite.config.MySQL = &schema.MySQLStorageConfiguration{
@@ -79,15 +85,40 @@ func (suite *StorageSuite) TestShouldValidateMySQLHostUsernamePasswordAndDatabas
 	suite.Require().Len(suite.validator.Errors(), 0)
 }
 
+// MySQL over unix socket.
+func (suite *StorageSuite) TestShouldValidateMySQLHostUsernameAndDatabaseAreProvided() {
+	suite.config.MySQL = &schema.MySQLStorageConfiguration{}
+	ValidateStorage(suite.config, suite.validator)
+
+	suite.Require().Len(suite.validator.Errors(), 3)
+	suite.Assert().EqualError(suite.validator.Errors()[0], "storage: mysql: option 'host' is required")
+	suite.Assert().EqualError(suite.validator.Errors()[1], "storage: mysql: option 'username' is required")
+	suite.Assert().EqualError(suite.validator.Errors()[2], "storage: mysql: option 'database' is required")
+
+	suite.validator.Clear()
+	suite.config.MySQL = &schema.MySQLStorageConfiguration{
+		SQLStorageConfiguration: schema.SQLStorageConfiguration{
+			Host:     "/run/mysqld/mysqld.sock",
+			Username: "myuser",
+			Database: "database",
+		},
+	}
+	ValidateStorage(suite.config, suite.validator)
+
+	suite.Require().Len(suite.validator.Warnings(), 0)
+	suite.Require().Len(suite.validator.Errors(), 0)
+}
+
 func (suite *StorageSuite) TestShouldValidatePostgreSQLHostUsernamePasswordAndDatabaseAreProvided() {
 	suite.config.PostgreSQL = &schema.PostgreSQLStorageConfiguration{}
 	suite.config.MySQL = nil
 	ValidateStorage(suite.config, suite.validator)
 
-	suite.Require().Len(suite.validator.Errors(), 3)
+	suite.Require().Len(suite.validator.Errors(), 4)
 	suite.Assert().EqualError(suite.validator.Errors()[0], "storage: postgres: option 'host' is required")
-	suite.Assert().EqualError(suite.validator.Errors()[1], "storage: postgres: option 'username' and 'password' are required")
-	suite.Assert().EqualError(suite.validator.Errors()[2], "storage: postgres: option 'database' is required")
+	suite.Assert().EqualError(suite.validator.Errors()[1], "storage: postgres: option 'username' is required")
+	suite.Assert().EqualError(suite.validator.Errors()[2], "storage: postgres: option 'password' is required")
+	suite.Assert().EqualError(suite.validator.Errors()[3], "storage: postgres: option 'database' is required")
 
 	suite.validator.Clear()
 	suite.config.PostgreSQL = &schema.PostgreSQLStorageConfiguration{

--- a/internal/storage/sql_provider_backend_mysql.go
+++ b/internal/storage/sql_provider_backend_mysql.go
@@ -30,7 +30,11 @@ func NewMySQLProvider(config *schema.Configuration) (provider *MySQLProvider) {
 }
 
 func dataSourceNameMySQL(config schema.MySQLStorageConfiguration) (dataSourceName string) {
-	dataSourceName = fmt.Sprintf("%s:%s", config.Username, config.Password)
+	dataSourceName = config.Username
+
+	if config.Password != "" {
+		dataSourceName += fmt.Sprintf(":%s", config.Password)
+	}
 
 	if dataSourceName != "" {
 		dataSourceName += "@"
@@ -39,11 +43,12 @@ func dataSourceNameMySQL(config schema.MySQLStorageConfiguration) (dataSourceNam
 	address := config.Host
 	if config.Port > 0 {
 		address += fmt.Sprintf(":%d", config.Port)
+		dataSourceName += "tcp"
+	} else {
+		dataSourceName += "unix"
 	}
 
-	dataSourceName += fmt.Sprintf("tcp(%s)/%s", address, config.Database)
-
-	dataSourceName += "?"
+	dataSourceName += fmt.Sprintf("(%s)/%s?", address, config.Database)
 	dataSourceName += fmt.Sprintf("timeout=%ds&multiStatements=true&parseTime=true", int32(config.Timeout/time.Second))
 
 	return dataSourceName


### PR DESCRIPTION
I would like to run Authelia as a SystemD service and connect to a local mysql database via an unix socket
(in a similar way this can be done with redis).