### PR TITLE
fix(suites): fix passive health checks for caddy suite

### DIFF
--- a/internal/suites/example/compose/caddy/Caddyfile
+++ b/internal/suites/example/compose/caddy/Caddyfile
@@ -40,7 +40,6 @@ login.example.com:8080 {
 			fail_duration 10s
 			max_fails 1
 			unhealthy_status 5xx
-			unhealthy_request_count 1
 		}
 	}
 }

--- a/internal/suites/example/compose/caddy/Dockerfile
+++ b/internal/suites/example/compose/caddy/Dockerfile
@@ -1,0 +1,7 @@
+FROM caddy:2.5.1-builder AS builder
+
+RUN xcaddy build fix-empty-copy-headers
+
+FROM caddy:2.5.1
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/internal/suites/example/compose/caddy/docker-compose.yml
+++ b/internal/suites/example/compose/caddy/docker-compose.yml
@@ -2,6 +2,7 @@
 version: '3'
 services:
   caddy:
+    # build: ./example/compose/caddy/ # used for debugging
     image: caddy:2.5.1-alpine
     volumes:
       - ./example/compose/caddy/Caddyfile:/etc/caddy/Caddyfile

--- a/internal/suites/example/compose/nginx/portal/nginx.conf
+++ b/internal/suites/example/compose/nginx/portal/nginx.conf
@@ -251,7 +251,7 @@ http {
         }
     }
 
-        # Example configuration of domains protected by Authelia.
+    # Example configuration of domains protected by Authelia.
     server {
         listen 8080 ssl;
         server_name     oidc.example.com

--- a/internal/suites/verify_body_contains.go
+++ b/internal/suites/verify_body_contains.go
@@ -1,29 +1,14 @@
 package suites
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/go-rod/rod"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func (rs *RodSession) verifyBodyContains(t *testing.T, page *rod.Page, pattern string) {
-	body, err := page.Element("body")
+	body, err := page.ElementR("body", pattern)
 	assert.NoError(t, err)
 	assert.NotNil(t, body)
-
-	text, err := body.Text()
-	assert.NoError(t, err)
-	assert.NotNil(t, text)
-
-	if strings.Contains(text, pattern) {
-		err = nil
-	} else {
-		err = fmt.Errorf("body does not contain pattern: %s", pattern)
-	}
-
-	require.NoError(t, err)
 }


### PR DESCRIPTION
This change fixes an issue that was incorrectly marking the primary load balancer target for the front end in dev mode as down.