### PR TITLE
fix(authorization): final slash in url matches ignored

### DIFF
--- a/internal/authorization/authorizer_test.go
+++ b/internal/authorization/authorizer_test.go
@@ -669,11 +669,16 @@ func (s *AuthorizerSuite) TestShouldCheckResourceMatching() {
 			Policy:    twoFactor,
 			Resources: createSliceRegexRule(s.T(), []string{"^/a/longer/rule/.*$"}),
 		}).
+		WithRule(schema.ACLRule{
+			Domains:   []string{"resource.example.com"},
+			Policy:    twoFactor,
+			Resources: createSliceRegexRule(s.T(), []string{"^/an/exact/path/$"}),
+		}).
 		Build()
 
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/", "GET", Bypass)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/abc", "GET", Bypass)
-	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/", "GET", Denied)
+	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/", "GET", Bypass)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/one_factor/abc", "GET", OneFactor)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/xyz/embedded/abc", "GET", Bypass)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/a/longer/rule/abc", "GET", TwoFactor)
@@ -697,6 +702,7 @@ func (s *AuthorizerSuite) TestShouldCheckResourceMatching() {
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/%2E%2E%2fa/longer/rule/abc", "GET", TwoFactor)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/%2E%2E%2F/a/longer/rule/abc", "GET", TwoFactor)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/%2E%2E%2Fa/longer/rule/abc", "GET", TwoFactor)
+	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/%2E%2E%2Fan/exact/path/", "GET", TwoFactor)
 }
 
 // This test assures that rules without domains (not allowed by schema validator at this time) will pass validation correctly.

--- a/internal/authorization/authorizer_test.go
+++ b/internal/authorization/authorizer_test.go
@@ -684,6 +684,7 @@ func (s *AuthorizerSuite) TestShouldCheckResourceMatching() {
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/a/longer/rule/abc", "GET", TwoFactor)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/case/abc", "GET", Bypass)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/case/ABC", "GET", Denied)
+	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/an/exact/path/", "GET", TwoFactor)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/../a/longer/rule/abc", "GET", TwoFactor)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/..//a/longer/rule/abc", "GET", TwoFactor)
 	tester.CheckAuthorizations(s.T(), John, "https://resource.example.com/bypass/..%2f/a/longer/rule/abc", "GET", TwoFactor)

--- a/internal/utils/const.go
+++ b/internal/utils/const.go
@@ -88,11 +88,6 @@ var (
 	reDurationStandard    = regexp.MustCompile(`(?P<Duration>[1-9]\d*?)(?P<Unit>[^\d\s]+)`)
 )
 
-var (
-	slashForward = []byte("/")
-	questionMark = []byte("?")
-)
-
 // Duration unit types.
 const (
 	DurationUnitDays   = "d"

--- a/internal/utils/const.go
+++ b/internal/utils/const.go
@@ -88,6 +88,11 @@ var (
 	reDurationStandard    = regexp.MustCompile(`(?P<Duration>[1-9]\d*?)(?P<Unit>[^\d\s]+)`)
 )
 
+var (
+	slashForward = []byte("/")
+	questionMark = []byte("?")
+)
+
 // Duration unit types.
 const (
 	DurationUnitDays   = "d"

--- a/internal/utils/url.go
+++ b/internal/utils/url.go
@@ -3,15 +3,24 @@ package utils
 import (
 	"net/url"
 	"path"
+	"strings"
 )
 
 // URLPathFullClean returns a URL path with the query parameters appended (full path) with the path portion parsed
 // through path.Clean given a *url.URL.
-func URLPathFullClean(u *url.URL) (p string) {
-	switch len(u.RawQuery) {
-	case 0:
-		return path.Clean(u.Path)
-	default:
-		return path.Clean(u.Path) + "?" + u.RawQuery
+func URLPathFullClean(u *url.URL) string {
+	b := strings.Builder{}
+
+	b.WriteString(path.Clean(u.Path))
+
+	if len(u.Path) != 1 && u.Path[len(u.Path)-1] == '/' {
+		b.Write(slashForward)
 	}
+
+	if u.RawQuery != "" {
+		b.Write(questionMark)
+		b.WriteString(u.RawQuery)
+	}
+
+	return b.String()
 }

--- a/internal/utils/url.go
+++ b/internal/utils/url.go
@@ -3,24 +3,27 @@ package utils
 import (
 	"net/url"
 	"path"
-	"strings"
 )
 
 // URLPathFullClean returns a URL path with the query parameters appended (full path) with the path portion parsed
 // through path.Clean given a *url.URL.
-func URLPathFullClean(u *url.URL) string {
-	b := strings.Builder{}
+func URLPathFullClean(u *url.URL) (output string) {
+	lengthPath := len(u.Path)
+	lengthQuery := len(u.RawQuery)
+	appendForwardSlash := lengthPath > 1 && u.Path[lengthPath-1] == '/'
 
-	b.WriteString(path.Clean(u.Path))
-
-	if len(u.Path) > 1 && u.Path[len(u.Path)-1] == '/' {
-		b.Write(slashForward)
+	switch {
+	case lengthPath == 1 && lengthQuery == 0:
+		return u.Path
+	case lengthPath == 1:
+		return path.Clean(u.Path) + "?" + u.RawQuery
+	case lengthQuery != 0 && appendForwardSlash:
+		return path.Clean(u.Path) + "/?" + u.RawQuery
+	case lengthQuery != 0:
+		return path.Clean(u.Path) + "?" + u.RawQuery
+	case appendForwardSlash:
+		return path.Clean(u.Path) + "/"
+	default:
+		return path.Clean(u.Path)
 	}
-
-	if u.RawQuery != "" {
-		b.Write(questionMark)
-		b.WriteString(u.RawQuery)
-	}
-
-	return b.String()
 }

--- a/internal/utils/url.go
+++ b/internal/utils/url.go
@@ -13,7 +13,7 @@ func URLPathFullClean(u *url.URL) string {
 
 	b.WriteString(path.Clean(u.Path))
 
-	if len(u.Path) != 1 && u.Path[len(u.Path)-1] == '/' {
+	if len(u.Path) > 1 && u.Path[len(u.Path)-1] == '/' {
 		b.Write(slashForward)
 	}
 

--- a/internal/utils/url_test.go
+++ b/internal/utils/url_test.go
@@ -14,13 +14,17 @@ func TestURLPathFullClean(t *testing.T) {
 		have     string
 		expected string
 	}{
+		{"ShouldReturnFullPathSingleSlash", "https://example.com/", "/"},
+		{"ShouldReturnFullPathSingleSlashWithQuery", "https://example.com/?query=1&alt=2", "/?query=1&alt=2"},
 		{"ShouldReturnFullPathNormal", "https://example.com/test", "/test"},
-		{"ShouldReturnFullPathWithQuery", "https://example.com/test?query=1", "/test?query=1"},
-		{"ShouldReturnCleanedPath", "https://example.com/five/../test?query=1", "/test?query=1"},
-		{"ShouldReturnCleanedPathEscaped", "https://example.com/five/..%2ftest?query=1", "/test?query=1"},
-		{"ShouldReturnCleanedPathEscapedExtra", "https://example.com/five/..%2ftest?query=1", "/test?query=1"},
-		{"ShouldReturnCleanedPathEscapedExtraSurrounding", "https://example.com/five/%2f..%2f/test?query=1", "/test?query=1"},
-		{"ShouldReturnCleanedPathEscapedPeriods", "https://example.com/five/%2f%2e%2e%2f/test?query=1", "/test?query=1"},
+		{"ShouldReturnFullPathNormalWithSlashSuffix", "https://example.com/test/", "/test/"},
+		{"ShouldReturnFullPathNormalWithSlashSuffixAndQuery", "https://example.com/test/?query=1&alt=2", "/test/?query=1&alt=2"},
+		{"ShouldReturnFullPathWithQuery", "https://example.com/test?query=1&alt=2", "/test?query=1&alt=2"},
+		{"ShouldReturnCleanedPath", "https://example.com/five/../test?query=1&alt=2", "/test?query=1&alt=2"},
+		{"ShouldReturnCleanedPathEscaped", "https://example.com/five/..%2ftest?query=1&alt=2", "/test?query=1&alt=2"},
+		{"ShouldReturnCleanedPathEscapedExtra", "https://example.com/five/..%2ftest?query=1&alt=2", "/test?query=1&alt=2"},
+		{"ShouldReturnCleanedPathEscapedExtraSurrounding", "https://example.com/five/%2f..%2f/test?query=1&alt=2", "/test?query=1&alt=2"},
+		{"ShouldReturnCleanedPathEscapedPeriods", "https://example.com/five/%2f%2e%2e%2f/test?query=1&alt=2", "/test?query=1&alt=2"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This fixes an issue with the URL matching machinery which ignores the final slash of a URL. Introduced in 664d65d7fb4cd77f66629dc42c0a2c4a3ccc36a4.

Fixes #3692