### PR TITLE
Grafana Integration Doc Changes

### DIFF
--- a/docs/content/en/integration/openid-connect/grafana/index.md
+++ b/docs/content/en/integration/openid-connect/grafana/index.md
@@ -42,6 +42,8 @@ To configure [Grafana] to utilize Authelia as an [OpenID Connect] Provider:
 1. Add the following Generic OAuth configuration to the [Grafana] configuration:
 
 ```ruby
+[server]
+root_url = https://grafana.example.com
 [auth.generic_oauth]
 enabled = true
 name = Authelia


### PR DESCRIPTION
When integrating Grafana with Authelia I encountered a problem where Grafana wasn't passing Authelia the correct redirect uri resulting in the following error.

`The 'redirect_uri' parameter does not match any of the OAuth 2.0 Client's pre-registered redirect urls`

Making the following change to my grafana.ini config fixed the issue for me.