### PR TITLE
docs: Clarify that Chrome did not deprecate WebAuthn

### DIFF
--- a/docs/content/en/roadmap/active/webauthn.md
+++ b/docs/content/en/roadmap/active/webauthn.md
@@ -14,7 +14,7 @@ aliases:
   - /r/webauthn
 ---
 
-[WebAuthn] requires urgent implementation as it is being deprecated by Chrome. It is a modern evolution of the
+[WebAuthn] requires urgent implementation as [Chrome removed support of their U2F API since August 2022][chrome-removed-u2f]. It is a modern evolution of the
 [FIDO U2F] protocol and is very similar in many ways. It even includes a backwards compatability extension called
 the [FIDO AppID Extension] which allows a previously registered [FIDO U2F] device to be used with the protocol to
 authenticate.
@@ -64,6 +64,7 @@ registration.
 
 [FIDO U2F]: https://fidoalliance.org/specs/u2f-specs-master/fido-u2f-overview.html
 [WebAuthn]: https://www.w3.org/TR/webauthn-2/
+[chrome-removed-u2f]: https://developer.chrome.com/blog/deps-rems-95/#deprecate-u2f-api-cryptotoken
 [Passwordless Login]: https://www.w3.org/TR/webauthn-2/#client-side-discoverable-public-key-credential-source
 [Conveyancing Preference]: https://www.w3.org/TR/webauthn-2/#enum-attestation-convey
 [User Verification Requirement]: https://www.w3.org/TR/webauthn-2/#enum-userVerificationRequirement


### PR DESCRIPTION
Prevents communicating a misleading deprecation of WebAuthn, when it's actually referring to the (_now legacy_) U2F API that Chrome is dropping (_and has already removed_).

---

**Side-note:**

Your CI reacted to a minor update to docs and looks like it's running the whole suite of jobs that has nothing to do with docs.