### PR TITLE
build(bootstrap): add pnpm install to bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,4 +38,7 @@ then
   return
 fi
 
+# install husky and other dependences
+(cd web && pnpm install)
+
 authelia-scripts bootstrap

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,7 +38,4 @@ then
   return
 fi
 
-# install husky and other dependences
-(cd web && pnpm install)
-
 authelia-scripts bootstrap

--- a/cmd/authelia-scripts/cmd/bootstrap.go
+++ b/cmd/authelia-scripts/cmd/bootstrap.go
@@ -54,6 +54,7 @@ func cmdBootstrapRun(_ *cobra.Command, _ []string) {
 
 	createTemporaryDirectory()
 	createPNPMDirectory()
+	pnpmInstall()
 
 	bootstrapPrintln("Preparing /etc/hosts to serve subdomains of example.com...")
 	prepareHostsFile()
@@ -154,6 +155,17 @@ func createPNPMDirectory() {
 			panic(err)
 		}
 	}
+}
+
+func pnpmInstall() {
+	bootstrapPrintln("Installing web dependences ")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	shell(fmt.Sprintf("cd %s/web && pnpm install", cwd))
 }
 
 func bootstrapPrintln(args ...interface{}) {


### PR DESCRIPTION
In fresh clones, husky hooks are not installed until a pnpm install are executed.
this PR adds pnpm install to bootstrap.go