### PR TITLE
fix(storage): postgresql default port incorrect

### DIFF
--- a/internal/storage/migrations/V0006.ConsentPreConfiguration.mysql.up.sql
+++ b/internal/storage/migrations/V0006.ConsentPreConfiguration.mysql.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE oauth2_consent_preconfiguration (
     scopes TEXT NOT NULL,
     audience TEXT NULL,
     PRIMARY KEY (id),
-    CONSTRAINT oauth2_consent_preconfiguration_subjct_fkey
+    CONSTRAINT oauth2_consent_preconfiguration_subject_fkey
         FOREIGN KEY(subject)
             REFERENCES user_opaque_identifier(identifier) ON UPDATE RESTRICT ON DELETE RESTRICT
 );

--- a/internal/storage/migrations/V0006.ConsentPreConfiguration.postgres.up.sql
+++ b/internal/storage/migrations/V0006.ConsentPreConfiguration.postgres.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE oauth2_consent_preconfiguration (
     scopes TEXT NOT NULL,
     audience TEXT NULL,
     PRIMARY KEY (id),
-    CONSTRAINT oauth2_consent_preconfiguration_subjct_fkey
+    CONSTRAINT oauth2_consent_preconfiguration_subject_fkey
         FOREIGN KEY(subject)
             REFERENCES user_opaque_identifier(identifier) ON UPDATE RESTRICT ON DELETE RESTRICT
 );

--- a/internal/storage/migrations/V0006.ConsentPreConfiguration.sqlite.up.sql
+++ b/internal/storage/migrations/V0006.ConsentPreConfiguration.sqlite.up.sql
@@ -8,7 +8,7 @@ CREATE TABLE oauth2_consent_preconfiguration (
     scopes TEXT NOT NULL,
     audience TEXT NULL,
     PRIMARY KEY (id),
-    CONSTRAINT oauth2_consent_preconfiguration_subjct_fkey
+    CONSTRAINT oauth2_consent_preconfiguration_subject_fkey
         FOREIGN KEY(subject)
             REFERENCES user_opaque_identifier(identifier) ON UPDATE RESTRICT ON DELETE RESTRICT
 );

--- a/internal/storage/sql_provider_backend_postgres.go
+++ b/internal/storage/sql_provider_backend_postgres.go
@@ -148,7 +148,7 @@ func dsnPostgreSQL(config *schema.PostgreSQLStorageConfiguration, globalCACertPo
 	}
 
 	if dsnConfig.Port == 0 && !path.IsAbs(dsnConfig.Host) {
-		dsnConfig.Port = 4321
+		dsnConfig.Port = 5432
 	}
 
 	return stdlib.RegisterConnConfig(dsnConfig)


### PR DESCRIPTION
This fixes a typo with the default port for PostgreSQL in 4.37.

Fixes #4249