### PR TITLE
fix(authentication): erroneously escaped group base dn

### DIFF
--- a/internal/authentication/ldap_user_provider_startup.go
+++ b/internal/authentication/ldap_user_provider_startup.go
@@ -130,7 +130,7 @@ func (p *LDAPUserProvider) parseDynamicGroupsConfiguration() {
 	}
 
 	if p.config.AdditionalGroupsDN != "" {
-		p.groupsBaseDN = ldap.EscapeFilter(p.config.AdditionalGroupsDN + "," + p.config.BaseDN)
+		p.groupsBaseDN = p.config.AdditionalGroupsDN + "," + p.config.BaseDN
 	} else {
 		p.groupsBaseDN = p.config.BaseDN
 	}

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -120,10 +120,10 @@ func TestEscapeSpecialCharsInGroupsFilter(t *testing.T) {
 		Emails:      []string{"john.doe@authelia.com"},
 	}
 
-	filter, _ := ldapClient.resolveGroupsFilter("john", &profile)
+	filter := ldapClient.resolveGroupsFilter("john", &profile)
 	assert.Equal(t, "(|(member=cn=john \\28external\\29,dc=example,dc=com)(uid=john)(uid=john))", filter)
 
-	filter, _ = ldapClient.resolveGroupsFilter("john#=(abc,def)", &profile)
+	filter = ldapClient.resolveGroupsFilter("john#=(abc,def)", &profile)
 	assert.Equal(t, "(|(member=cn=john \\28external\\29,dc=example,dc=com)(uid=john)(uid=john\\#\\=\\28abc\\,def\\29))", filter)
 }
 


### PR DESCRIPTION
The BaseDN for groups was escaped improperly and failed on any BaseDN with special characters. This fixes the issue. Introduced in a3b14871baeca9ebfbaded981bebb6f9c36b0311 (v4.30.0).

Fixes #4274