### PR TITLE
refactor(commands): include rfc3986 charset

### DIFF
--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate.md
@@ -43,8 +43,8 @@ authelia crypto hash generate --help
       --password string            manually supply the password rather than using the terminal prompt
       --random                     uses a randomly generated password
       --random.characters string   sets the explicit characters for the random string
-      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', and 'numeric-hex' (default "alphanumeric")
-      --random.length int          when using a randomly generated password it configures the length (default 72)
+      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', 'numeric-hex', and 'rfc3986' (default "alphanumeric")
+      --random.length int          sets the character length for the random string (default 72)
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_argon2.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_argon2.md
@@ -53,8 +53,8 @@ authelia crypto hash generate argon2 --help
       --password string            manually supply the password rather than using the terminal prompt
       --random                     uses a randomly generated password
       --random.characters string   sets the explicit characters for the random string
-      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', and 'numeric-hex' (default "alphanumeric")
-      --random.length int          when using a randomly generated password it configures the length (default 72)
+      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', 'numeric-hex', and 'rfc3986' (default "alphanumeric")
+      --random.length int          sets the character length for the random string (default 72)
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_bcrypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_bcrypt.md
@@ -48,8 +48,8 @@ authelia crypto hash generate bcrypt --help
       --password string            manually supply the password rather than using the terminal prompt
       --random                     uses a randomly generated password
       --random.characters string   sets the explicit characters for the random string
-      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', and 'numeric-hex' (default "alphanumeric")
-      --random.length int          when using a randomly generated password it configures the length (default 72)
+      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', 'numeric-hex', and 'rfc3986' (default "alphanumeric")
+      --random.length int          sets the character length for the random string (default 72)
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
@@ -49,8 +49,8 @@ authelia crypto hash generate pbkdf2 --help
       --password string            manually supply the password rather than using the terminal prompt
       --random                     uses a randomly generated password
       --random.characters string   sets the explicit characters for the random string
-      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', and 'numeric-hex' (default "alphanumeric")
-      --random.length int          when using a randomly generated password it configures the length (default 72)
+      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', 'numeric-hex', and 'rfc3986' (default "alphanumeric")
+      --random.length int          sets the character length for the random string (default 72)
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_scrypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_scrypt.md
@@ -51,8 +51,8 @@ authelia crypto hash generate scrypt --help
       --password string            manually supply the password rather than using the terminal prompt
       --random                     uses a randomly generated password
       --random.characters string   sets the explicit characters for the random string
-      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', and 'numeric-hex' (default "alphanumeric")
-      --random.length int          when using a randomly generated password it configures the length (default 72)
+      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', 'numeric-hex', and 'rfc3986' (default "alphanumeric")
+      --random.length int          sets the character length for the random string (default 72)
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_sha2crypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_sha2crypt.md
@@ -49,8 +49,8 @@ authelia crypto hash generate sha2crypt --help
       --password string            manually supply the password rather than using the terminal prompt
       --random                     uses a randomly generated password
       --random.characters string   sets the explicit characters for the random string
-      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', and 'numeric-hex' (default "alphanumeric")
-      --random.length int          when using a randomly generated password it configures the length (default 72)
+      --random.charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', 'numeric-hex', and 'rfc3986' (default "alphanumeric")
+      --random.length int          sets the character length for the random string (default 72)
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_rand.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_rand.md
@@ -43,10 +43,10 @@ authelia crypto rand --characters 0123456789ABCDEF
 ### Options
 
 ```
-      --characters string   Sets the explicit characters for the random string
-  -c, --charset string      Sets the charset for the random string, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', and 'numeric-hex' (default "alphanumeric")
+      --characters string   sets the explicit characters for the random string
+  -c, --charset string      sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', 'numeric-hex', and 'rfc3986' (default "alphanumeric")
   -h, --help                help for rand
-  -n, --length int          Sets the length of the random output (default 72)
+  -n, --length int          sets the character length for the random string (default 72)
 ```
 
 ### SEE ALSO

--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -547,9 +547,13 @@ const (
 	cmdFlagNameSHA512           = "sha512"
 	cmdFlagNameConfig           = "config"
 
-	cmdFlagNameCharSet    = "charset"
-	cmdFlagNameCharacters = "characters"
-	cmdFlagNameLength     = "length"
+	cmdFlagNameCharSet     = "charset"
+	cmdFlagValueCharSet    = "alphanumeric"
+	cmdFlagUsageCharset    = "sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', 'numeric-hex', and 'rfc3986'"
+	cmdFlagNameCharacters  = "characters"
+	cmdFlagUsageCharacters = "sets the explicit characters for the random string"
+	cmdFlagNameLength      = "length"
+	cmdFlagUsageLength     = "sets the character length for the random string"
 )
 
 const (

--- a/internal/commands/crypto.go
+++ b/internal/commands/crypto.go
@@ -60,9 +60,9 @@ func newCryptoRandCmd() (cmd *cobra.Command) {
 		DisableAutoGenTag: true,
 	}
 
-	cmd.Flags().StringP(cmdFlagNameCharSet, "c", "alphanumeric", "Sets the charset for the random string, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', and 'numeric-hex'")
-	cmd.Flags().String(cmdFlagNameCharacters, "", "Sets the explicit characters for the random string")
-	cmd.Flags().IntP(cmdFlagNameLength, "n", 72, "Sets the length of the random output")
+	cmd.Flags().StringP(cmdFlagNameCharSet, "c", cmdFlagValueCharSet, cmdFlagUsageCharset)
+	cmd.Flags().String(cmdFlagNameCharacters, "", cmdFlagUsageCharacters)
+	cmd.Flags().IntP(cmdFlagNameLength, "n", 72, cmdFlagUsageLength)
 
 	return cmd
 }

--- a/internal/commands/crypto_hash.go
+++ b/internal/commands/crypto_hash.go
@@ -497,9 +497,9 @@ func cmdFlagPassword(cmd *cobra.Command, noConfirm bool) {
 
 func cmdFlagRandomPassword(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool(cmdFlagNameRandom, false, "uses a randomly generated password")
-	cmd.PersistentFlags().Int(cmdFlagNameRandomLength, 72, "when using a randomly generated password it configures the length")
-	cmd.PersistentFlags().String(cmdFlagNameRandomCharSet, "alphanumeric", "sets the charset for the random password, options are 'ascii', 'alphanumeric', 'alphabetic', 'numeric', and 'numeric-hex'")
-	cmd.PersistentFlags().String(cmdFlagNameRandomCharacters, "", "sets the explicit characters for the random string")
+	cmd.PersistentFlags().String(cmdFlagNameRandomCharSet, cmdFlagValueCharSet, cmdFlagUsageCharset)
+	cmd.PersistentFlags().String(cmdFlagNameRandomCharacters, "", cmdFlagUsageCharacters)
+	cmd.PersistentFlags().Int(cmdFlagNameRandomLength, 72, cmdFlagUsageLength)
 }
 
 func cmdFlagIterations(cmd *cobra.Command, value int) {

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -34,6 +34,7 @@ func configFilterExisting(configs []string) (finalConfigs []string) {
 	return finalConfigs
 }
 
+//nolint:gocyclo
 func flagsGetRandomCharacters(flags *pflag.FlagSet, flagNameLength, flagNameCharSet, flagNameCharacters string) (r string, err error) {
 	var (
 		n       int

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -67,14 +67,28 @@ func flagsGetRandomCharacters(flags *pflag.FlagSet, flagNameLength, flagNameChar
 			charset = utils.CharSetASCII
 		case "alphanumeric":
 			charset = utils.CharSetAlphaNumeric
+		case "alphanumeric-lower":
+			charset = utils.CharSetAlphabeticLower + utils.CharSetNumeric
+		case "alphanumeric-upper":
+			charset = utils.CharSetAlphabeticUpper + utils.CharSetNumeric
 		case "alphabetic":
 			charset = utils.CharSetAlphabetic
+		case "alphabetic-lower":
+			charset = utils.CharSetAlphabeticLower
+		case "alphabetic-upper":
+			charset = utils.CharSetAlphabeticUpper
 		case "numeric-hex":
 			charset = utils.CharSetNumericHex
 		case "numeric":
 			charset = utils.CharSetNumeric
+		case "rfc3986":
+			charset = utils.CharSetRFC3986Unreserved
+		case "rfc3986-lower":
+			charset = utils.CharSetAlphabeticLower + utils.CharSetNumeric + utils.CharSetSymbolicRFC3986Unreserved
+		case "rfc3986-upper":
+			charset = utils.CharSetAlphabeticUpper + utils.CharSetNumeric + utils.CharSetSymbolicRFC3986Unreserved
 		default:
-			return "", fmt.Errorf("flag '--%s' with value '%s' is invalid, must be one of 'ascii', 'alphanumeric', 'alphabetic', 'numeric', or 'numeric-hex'", flagNameCharSet, c)
+			return "", fmt.Errorf("flag '--%s' with value '%s' is invalid, must be one of 'ascii', 'alphanumeric', 'alphabetic', 'numeric', 'numeric-hex', or 'rfc3986'", flagNameCharSet, c)
 		}
 	case useCharacters:
 		if charset, err = flags.GetString(flagNameCharacters); err != nil {

--- a/internal/utils/const.go
+++ b/internal/utils/const.go
@@ -111,8 +111,14 @@ const (
 )
 
 const (
+	// CharSetAlphabeticLower are literally just valid alphabetic lowercase printable ASCII chars.
+	CharSetAlphabeticLower = "abcdefghijklmnopqrstuvwxyz"
+
+	// CharSetAlphabeticUpper are literally just valid alphabetic uppercase printable ASCII chars.
+	CharSetAlphabeticUpper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
 	// CharSetAlphabetic are literally just valid alphabetic printable ASCII chars.
-	CharSetAlphabetic = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	CharSetAlphabetic = CharSetAlphabeticLower + CharSetAlphabeticUpper
 
 	// CharSetNumeric are literally just valid numeric chars.
 	CharSetNumeric = "0123456789"
@@ -123,11 +129,19 @@ const (
 	// CharSetSymbolic are literally just valid symbolic printable ASCII chars.
 	CharSetSymbolic = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 
+	// CharSetSymbolicRFC3986Unreserved are RFC3986 unreserved symbol characters.
+	// See https://www.rfc-editor.org/rfc/rfc3986#section-2.3.
+	CharSetSymbolicRFC3986Unreserved = "-._~"
+
 	// CharSetAlphaNumeric are literally just valid alphanumeric printable ASCII chars.
 	CharSetAlphaNumeric = CharSetAlphabetic + CharSetNumeric
 
 	// CharSetASCII are literally just valid printable ASCII chars.
 	CharSetASCII = CharSetAlphabetic + CharSetNumeric + CharSetSymbolic
+
+	// CharSetRFC3986Unreserved are RFC3986 unreserved characters.
+	// See https://www.rfc-editor.org/rfc/rfc3986#section-2.3.
+	CharSetRFC3986Unreserved = CharSetAlphabetic + CharSetSymbolicRFC3986Unreserved
 )
 
 var htmlEscaper = strings.NewReplacer(


### PR DESCRIPTION
This includes the RFC3986 unreserved charset as an option, and allows the '-upper' and '-lower' suffix for alphabetic inclusive charsets.