### PR TITLE
ci: fix docker tag manifest hashes

### DIFF
--- a/cmd/authelia-scripts/cmd/helpers_docker.go
+++ b/cmd/authelia-scripts/cmd/helpers_docker.go
@@ -42,8 +42,13 @@ func (d *Docker) Login(username, password, registry string) error {
 }
 
 // Manifest push a docker manifest to dockerhub.
-func (d *Docker) Manifest(tag1, tag2 string) error {
-	args := []string{"build", "-t", tag1, "-t", tag2}
+func (d *Docker) Manifest(tags []string) error {
+	args := []string{"build"}
+
+	for _, tag := range tags {
+		args = append(args, "-t", tag)
+	}
+
 	annotations := ""
 
 	buildMetaData, err := getBuild(ciBranch, os.Getenv("BUILDKITE_BUILD_NUMBER"), "")


### PR DESCRIPTION
#4071 introduced a regression where Docker manifest hashes did not match between the same semantic versions, this is due to the `org.opencontainers.image.created` label/annotation. We now perform a single build and push to remedy this issue.

Fixes #4353, Closes #4351.