### PR TITLE
feat: provide webauthn device description from frontend on registration

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -1021,23 +1021,28 @@ components:
           type: string
           format: byte
     webauthn.CredentialAttestationResponse:
-      allOf:
-        - $ref: '#/components/schemas/webauthn.PublicKeyCredential'
-        - type: object
-          properties:
-            clientExtensionResults:
-              type: object
+      type: object
+      properties:
+        credential:
+          allOf:
+            - $ref: '#/components/schemas/webauthn.PublicKeyCredential'
+            - type: object
               properties:
-                appidExclude:
-                  type: boolean
-            response:
-              allOf:
-                - $ref: '#/components/schemas/webauthn.AuthenticatorResponse'
-                - type: object
+                clientExtensionResults:
+                  type: object
                   properties:
-                    attestationObject:
-                      type: string
-                      format: byte
+                    appidExclude:
+                      type: boolean
+                response:
+                  allOf:
+                    - $ref: '#/components/schemas/webauthn.AuthenticatorResponse'
+                    - type: object
+                      properties:
+                        attestationObject:
+                          type: string
+                          format: byte
+        description:
+          type: string
     webauthn.CredentialAssertionResponse:
       allOf:
         - $ref: '#/components/schemas/webauthn.PublicKeyCredential'

--- a/web/src/services/Webauthn.ts
+++ b/web/src/services/Webauthn.ts
@@ -314,10 +314,14 @@ export async function getAssertionPublicKeyCredentialResult(
 
 async function postAttestationPublicKeyCredentialResult(
     credential: AttestationPublicKeyCredential,
+    description: string,
 ): Promise<AxiosResponse<OptionalDataServiceResponse<any>>> {
     const credentialJSON = encodeAttestationPublicKeyCredential(credential);
-
-    return axios.post<OptionalDataServiceResponse<any>>(WebauthnAttestationPath, credentialJSON);
+    const postBody = {
+        credential: credentialJSON,
+        description: description,
+    };
+    return axios.post<OptionalDataServiceResponse<any>>(WebauthnAttestationPath, postBody);
 }
 
 export async function postAssertionPublicKeyCredentialResult(
@@ -327,11 +331,10 @@ export async function postAssertionPublicKeyCredentialResult(
     workflowID?: string,
 ): Promise<AxiosResponse<ServiceResponse<SignInResponse>>> {
     const credentialJSON = encodeAssertionPublicKeyCredential(credential, targetURL, workflow, workflowID);
-
     return axios.post<ServiceResponse<SignInResponse>>(WebauthnAssertionPath, credentialJSON);
 }
 
-export async function performAttestationCeremony(token: string): Promise<AttestationResult> {
+export async function performAttestationCeremony(token: string, description: string): Promise<AttestationResult> {
     const attestationCreationOpts = await getAttestationCreationOptions(token);
 
     if (attestationCreationOpts.status !== 200 || attestationCreationOpts.options == null) {
@@ -350,7 +353,7 @@ export async function performAttestationCeremony(token: string): Promise<Attesta
         return AttestationResult.Failure;
     }
 
-    const response = await postAttestationPublicKeyCredentialResult(attestationResult.credential);
+    const response = await postAttestationPublicKeyCredentialResult(attestationResult.credential, description);
 
     if (response.data.status === "OK" && (response.status === 200 || response.status === 201)) {
         return AttestationResult.Success;

--- a/web/src/views/DeviceRegistration/RegisterWebauthn.tsx
+++ b/web/src/views/DeviceRegistration/RegisterWebauthn.tsx
@@ -12,6 +12,8 @@ import { FirstFactorPath } from "@services/Api";
 import { performAttestationCeremony } from "@services/Webauthn";
 import { extractIdentityToken } from "@utils/IdentityToken";
 
+const description = "Primary";
+
 const RegisterWebauthn = function () {
     const styles = useStyles();
     const navigate = useNavigate();
@@ -32,7 +34,7 @@ const RegisterWebauthn = function () {
         try {
             setRegistrationInProgress(true);
 
-            const result = await performAttestationCeremony(processToken);
+            const result = await performAttestationCeremony(processToken, description);
 
             setRegistrationInProgress(false);
 


### PR DESCRIPTION
WebAuthn devices are currently registered with the constant name `Primary`. In preparing for multiple WebAuthn device support, this value will eventually need to be a user-entered name.

This PR provides the first step by moving the constant `Primary` from the backend to the frontend. This updates the WebAuthn attestation API endpoint to accept the description string value from the client request.

This is part of the work for https://github.com/authelia/authelia/issues/4366.