### PR TITLE
refactor(cmd): restrict bootstrap pnpm tasks to dev environment

### DIFF
--- a/cmd/authelia-scripts/cmd/bootstrap.go
+++ b/cmd/authelia-scripts/cmd/bootstrap.go
@@ -53,8 +53,11 @@ func cmdBootstrapRun(_ *cobra.Command, _ []string) {
 	}
 
 	createTemporaryDirectory()
-	createPNPMDirectory()
-	pnpmInstall()
+
+	if os.Getenv("CI") != "true" {
+		createPNPMDirectory()
+		pnpmInstall()
+	}
 
 	bootstrapPrintln("Preparing /etc/hosts to serve subdomains of example.com...")
 	prepareHostsFile()


### PR DESCRIPTION
This change prevents installing the `node_modules` on CI nodes that do not require them.