### PR TITLE
fix: add toolbar below appbar in settings page to avoid content overlap

### DIFF
--- a/web/src/views/Settings/SettingsView.tsx
+++ b/web/src/views/Settings/SettingsView.tsx
@@ -102,6 +102,7 @@ export default function SettingsView(props: Props) {
                 </Box>
             </Drawer>
             <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+                <Toolbar variant="dense" />
                 <Grid container spacing={2}>
                     <Grid item xs={12}>
                         <Typography>{translate("Manage your security keys")}</Typography>


### PR DESCRIPTION
Before:

![Screenshot from 2022-11-13 21:26:50](https://user-images.githubusercontent.com/2831985/201582143-23f1e979-46dc-4eb5-9faf-4f71981c7e98.png)

After:

![Screenshot from 2022-11-13 21:26:28](https://user-images.githubusercontent.com/2831985/201582195-2013b5a9-cef9-47b4-a3b9-955de014bb06.png)

