### PR TITLE
fix: handle null devices list get response properly

### DIFF
--- a/web/src/services/Client.ts
+++ b/web/src/services/Client.ts
@@ -19,16 +19,19 @@ export async function Post<T>(path: string, body?: any) {
     return res;
 }
 
-export async function Get<T = undefined>(path: string): Promise<T> {
+export async function GetWithOptionalResponse<T = undefined>(path: string): Promise<T | undefined> {
     const res = await axios.get<ServiceResponse<T>>(path);
 
     if (res.status !== 200 || hasServiceError(res).errored) {
         throw new Error(`Failed GET from ${path}. Code: ${res.status}.`);
     }
+    return toData<T>(res);
+}
 
-    const d = toData<T>(res);
-    if (!d) {
+export async function Get<T = undefined>(path: string): Promise<T> {
+    const res = await GetWithOptionalResponse<T>(path);
+    if (!res) {
         throw new Error("unexpected type of response");
     }
-    return d;
+    return res;
 }

--- a/web/src/services/UserWebauthnDevices.ts
+++ b/web/src/services/UserWebauthnDevices.ts
@@ -1,8 +1,8 @@
 import { WebauthnDevice } from "@models/Webauthn";
 import { WebauthnDevicesPath } from "@services/Api";
-import { Get } from "@services/Client";
+import { GetWithOptionalResponse } from "@services/Client";
 
 // getWebauthnDevices returns the list of webauthn devices for the authenticated user.
 export async function getWebauthnDevices(): Promise<WebauthnDevice[]> {
-    return Get<WebauthnDevice[]>(WebauthnDevicesPath);
+    return (await GetWithOptionalResponse<WebauthnDevice[]>(WebauthnDevicesPath)) || [];
 }


### PR DESCRIPTION
When a user opens the webauthn devices settings page without any devices configured (e.g. on initial enrollment), the UI loading bar stays indefinitely. This is due to the user devices endpoint returning `null` instead of an empty list, which the UI does not handle gracefully. This change adds a `GetWithOptionalResponse` function in the UI to handle this case, similar to the existing `PostWithOptionalResponse` method in the same file.