### PR TITLE
Docs: spelling correction

### DIFF
--- a/docs/content/en/configuration/storage/postgres.md
+++ b/docs/content/en/configuration/storage/postgres.md
@@ -32,7 +32,7 @@ storage:
     username: authelia
     password: mypassword
     tls:
-      server_name: psotgres.example.com
+      server_name: postgres.example.com
       skip_verify: false
       minimum_version: TLS1.2
       maximum_version: TLS1.3


### PR DESCRIPTION
Corrected spelling of "postgres" in server config example.