### PR TITLE
feat(configuration): load config from directory

### DIFF
--- a/docs/content/en/configuration/methods/files.md
+++ b/docs/content/en/configuration/methods/files.md
@@ -12,6 +12,20 @@ weight: 101200
 toc: true
 ---
 
+## Loading Behaviour
+
+There are several options which affect the loading of files:
+
+|   Name    |            Argument             |                                  Description                                  |
+|:---------:|:-------------------------------:|:-----------------------------------------------------------------------------:|
+|   Files   |        `--config`, `-c`         |                  A list of configuration file paths to load                   |
+| Directory |      `--config.directory`       | The path of a directory path where all files with known extensions are loaded |
+|  Filters  | `--config.experimental.filters` |  A list of filters applied to every file from the Files or Directory options  |
+
+All of these options can be used in combination. For example you can run
+`authelia --config /opt/authelia/example.yml --config.directory /etc/authelia` which will load
+`/opt/authelia/example.yml` and `/etc/authelia/*.yml`/`/etc/authelia/*.yaml`.
+
 ## Formats
 
 The only supported configuration file format is [YAML](#yaml).
@@ -163,6 +177,10 @@ The name used to enable this filter is `template`.
 
 This filter uses the [Go template engine](https://pkg.go.dev/text/template) to render the configuration files. It uses
 similar syntax to Jinja2 templates with different function names.
+
+Comprehensive examples are beyond what we support and people wishing to use this should consult the official
+[Go template engine](https://pkg.go.dev/text/template) documentation for syntax instructions. We also log the generated
+output at each filter stage as a base64 string when trace logging is enabled.
 
 #### Functions
 

--- a/docs/content/en/configuration/methods/files.md
+++ b/docs/content/en/configuration/methods/files.md
@@ -16,15 +16,13 @@ toc: true
 
 There are several options which affect the loading of files:
 
-|   Name    |            Argument             |                                  Description                                  |
-|:---------:|:-------------------------------:|:-----------------------------------------------------------------------------:|
-|   Files   |        `--config`, `-c`         |                  A list of configuration file paths to load                   |
-| Directory |      `--config.directory`       | The path of a directory path where all files with known extensions are loaded |
-|  Filters  | `--config.experimental.filters` |  A list of filters applied to every file from the Files or Directory options  |
+|       Name        |            Argument             |                                    Description                                     |
+|:-----------------:|:-------------------------------:|:----------------------------------------------------------------------------------:|
+| Files/Directories |        `--config`, `-c`         | A list of file or directory (non-recursive) paths to load configuration files from |
+|      Filters      | `--config.experimental.filters` |   A list of filters applied to every file from the Files or Directories options    |
 
-All of these options can be used in combination. For example you can run
-`authelia --config /opt/authelia/example.yml --config.directory /etc/authelia` which will load
-`/opt/authelia/example.yml` and `/etc/authelia/*.yml`/`/etc/authelia/*.yaml`.
+__*Note:* when specifying directories and files, the individual files specified must not be within any of the
+directories specified.__
 
 ## Formats
 

--- a/docs/content/en/reference/cli/authelia/authelia.md
+++ b/docs/content/en/reference/cli/authelia/authelia.md
@@ -41,9 +41,8 @@ authelia --config /etc/authelia/config/
 ### Options
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
   -h, --help                                  help for authelia
 ```
 

--- a/docs/content/en/reference/cli/authelia/authelia.md
+++ b/docs/content/en/reference/cli/authelia/authelia.md
@@ -24,7 +24,8 @@ An open-source authentication and authorization server providing
 two-factor authentication and single sign-on (SSO) for your
 applications via a web portal.
 
-Documentation is available at: https://www.authelia.com/
+General documentation is available at: https://www.authelia.com/
+CLI documentation is available at: https://www.authelia.com/reference/cli/authelia/authelia/
 
 ```
 authelia [flags]
@@ -42,7 +43,7 @@ authelia --config /etc/authelia/config/
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
   -h, --help                                  help for authelia
 ```
 

--- a/docs/content/en/reference/cli/authelia/authelia.md
+++ b/docs/content/en/reference/cli/authelia/authelia.md
@@ -42,7 +42,8 @@ authelia --config /etc/authelia/config/
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
   -h, --help                                  help for authelia
 ```
 

--- a/docs/content/en/reference/cli/authelia/authelia_access-control.md
+++ b/docs/content/en/reference/cli/authelia/authelia_access-control.md
@@ -36,7 +36,7 @@ authelia access-control --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_access-control.md
+++ b/docs/content/en/reference/cli/authelia/authelia_access-control.md
@@ -35,9 +35,8 @@ authelia access-control --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_access-control.md
+++ b/docs/content/en/reference/cli/authelia/authelia_access-control.md
@@ -36,7 +36,8 @@ authelia access-control --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_access-control_check-policy.md
+++ b/docs/content/en/reference/cli/authelia/authelia_access-control_check-policy.md
@@ -65,9 +65,8 @@ authelia access-control check-policy --config config.yml --url https://example.c
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_access-control_check-policy.md
+++ b/docs/content/en/reference/cli/authelia/authelia_access-control_check-policy.md
@@ -66,7 +66,7 @@ authelia access-control check-policy --config config.yml --url https://example.c
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_access-control_check-policy.md
+++ b/docs/content/en/reference/cli/authelia/authelia_access-control_check-policy.md
@@ -66,7 +66,8 @@ authelia access-control check-policy --config config.yml --url https://example.c
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_build-info.md
+++ b/docs/content/en/reference/cli/authelia/authelia_build-info.md
@@ -49,7 +49,7 @@ authelia build-info
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_build-info.md
+++ b/docs/content/en/reference/cli/authelia/authelia_build-info.md
@@ -49,7 +49,8 @@ authelia build-info
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_build-info.md
+++ b/docs/content/en/reference/cli/authelia/authelia_build-info.md
@@ -48,9 +48,8 @@ authelia build-info
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto.md
@@ -38,7 +38,8 @@ authelia crypto --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto.md
@@ -37,9 +37,8 @@ authelia crypto --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto.md
@@ -38,7 +38,7 @@ authelia crypto --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate.md
@@ -38,7 +38,7 @@ authelia crypto certificate --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate.md
@@ -37,9 +37,8 @@ authelia crypto certificate --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate.md
@@ -38,7 +38,8 @@ authelia crypto certificate --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa.md
@@ -37,9 +37,8 @@ authelia crypto certificate ecdsa --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa.md
@@ -38,7 +38,7 @@ authelia crypto certificate ecdsa --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa.md
@@ -38,7 +38,8 @@ authelia crypto certificate ecdsa --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_generate.md
@@ -62,9 +62,8 @@ authelia crypto certificate ecdsa generate --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_generate.md
@@ -63,7 +63,8 @@ authelia crypto certificate ecdsa generate --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_generate.md
@@ -63,7 +63,7 @@ authelia crypto certificate ecdsa generate --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_request.md
@@ -58,7 +58,7 @@ authelia crypto certificate ecdsa request --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_request.md
@@ -57,9 +57,8 @@ authelia crypto certificate ecdsa request --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_request.md
@@ -58,7 +58,8 @@ authelia crypto certificate ecdsa request --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519.md
@@ -38,7 +38,7 @@ authelia crypto certificate ed25519 --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519.md
@@ -38,7 +38,8 @@ authelia crypto certificate ed25519 --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519.md
@@ -37,9 +37,8 @@ authelia crypto certificate ed25519 --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_generate.md
@@ -62,7 +62,7 @@ authelia crypto certificate ed25519 request --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_generate.md
@@ -62,7 +62,8 @@ authelia crypto certificate ed25519 request --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_generate.md
@@ -61,9 +61,8 @@ authelia crypto certificate ed25519 request --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_request.md
@@ -57,7 +57,7 @@ authelia crypto certificate ed25519 request --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_request.md
@@ -56,9 +56,8 @@ authelia crypto certificate ed25519 request --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_request.md
@@ -57,7 +57,8 @@ authelia crypto certificate ed25519 request --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa.md
@@ -38,7 +38,8 @@ authelia crypto certificate rsa --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa.md
@@ -38,7 +38,7 @@ authelia crypto certificate rsa --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa.md
@@ -37,9 +37,8 @@ authelia crypto certificate rsa --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_generate.md
@@ -63,7 +63,8 @@ authelia crypto certificate rsa generate --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_generate.md
@@ -63,7 +63,7 @@ authelia crypto certificate rsa generate --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_generate.md
@@ -62,9 +62,8 @@ authelia crypto certificate rsa generate --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_request.md
@@ -58,7 +58,7 @@ authelia crypto certificate rsa request --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_request.md
@@ -58,7 +58,8 @@ authelia crypto certificate rsa request --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_request.md
@@ -57,9 +57,8 @@ authelia crypto certificate rsa request --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash.md
@@ -38,7 +38,7 @@ authelia crypto hash --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash.md
@@ -38,7 +38,8 @@ authelia crypto hash --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash.md
@@ -37,9 +37,8 @@ authelia crypto hash --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate.md
@@ -49,9 +49,8 @@ authelia crypto hash generate --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate.md
@@ -50,7 +50,7 @@ authelia crypto hash generate --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate.md
@@ -50,7 +50,8 @@ authelia crypto hash generate --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_argon2.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_argon2.md
@@ -49,7 +49,7 @@ authelia crypto hash generate argon2 --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_argon2.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_argon2.md
@@ -49,7 +49,8 @@ authelia crypto hash generate argon2 --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_argon2.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_argon2.md
@@ -48,9 +48,8 @@ authelia crypto hash generate argon2 --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_bcrypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_bcrypt.md
@@ -44,7 +44,7 @@ authelia crypto hash generate bcrypt --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_bcrypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_bcrypt.md
@@ -43,9 +43,8 @@ authelia crypto hash generate bcrypt --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_bcrypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_bcrypt.md
@@ -44,7 +44,8 @@ authelia crypto hash generate bcrypt --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
@@ -45,7 +45,7 @@ authelia crypto hash generate pbkdf2 --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
@@ -44,9 +44,8 @@ authelia crypto hash generate pbkdf2 --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
@@ -45,7 +45,8 @@ authelia crypto hash generate pbkdf2 --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_scrypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_scrypt.md
@@ -46,9 +46,8 @@ authelia crypto hash generate scrypt --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_scrypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_scrypt.md
@@ -47,7 +47,8 @@ authelia crypto hash generate scrypt --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_scrypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_scrypt.md
@@ -47,7 +47,7 @@ authelia crypto hash generate scrypt --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_sha2crypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_sha2crypt.md
@@ -44,9 +44,8 @@ authelia crypto hash generate sha2crypt --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_sha2crypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_sha2crypt.md
@@ -45,7 +45,8 @@ authelia crypto hash generate sha2crypt --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_sha2crypt.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_generate_sha2crypt.md
@@ -45,7 +45,7 @@ authelia crypto hash generate sha2crypt --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --no-confirm                            skip the password confirmation prompt
       --password string                       manually supply the password rather than using the terminal prompt
       --random                                uses a randomly generated password

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_validate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_validate.md
@@ -44,7 +44,8 @@ authelia crypto hash validate '$5$rounds=500000$WFjMpdCQxIkbNl0k$M0qZaZoK8Gwdh8C
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_validate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_validate.md
@@ -44,7 +44,7 @@ authelia crypto hash validate '$5$rounds=500000$WFjMpdCQxIkbNl0k$M0qZaZoK8Gwdh8C
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_hash_validate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_hash_validate.md
@@ -43,9 +43,8 @@ authelia crypto hash validate '$5$rounds=500000$WFjMpdCQxIkbNl0k$M0qZaZoK8Gwdh8C
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair.md
@@ -38,7 +38,7 @@ authelia crypto pair --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair.md
@@ -37,9 +37,8 @@ authelia crypto pair --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair.md
@@ -38,7 +38,8 @@ authelia crypto pair --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa.md
@@ -41,9 +41,8 @@ authelia crypto pair ecdsa --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa.md
@@ -42,7 +42,7 @@ authelia crypto pair ecdsa --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa.md
@@ -42,7 +42,8 @@ authelia crypto pair ecdsa --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa_generate.md
@@ -47,7 +47,8 @@ authelia crypto pair ecdsa generate --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa_generate.md
@@ -47,7 +47,7 @@ authelia crypto pair ecdsa generate --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ecdsa_generate.md
@@ -46,9 +46,8 @@ authelia crypto pair ecdsa generate --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519.md
@@ -42,7 +42,7 @@ authelia crypto pair ed25519 --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519.md
@@ -42,7 +42,8 @@ authelia crypto pair ed25519 --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519.md
@@ -41,9 +41,8 @@ authelia crypto pair ed25519 --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519_generate.md
@@ -46,7 +46,7 @@ authelia crypto pair ed25519 generate --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519_generate.md
@@ -46,7 +46,8 @@ authelia crypto pair ed25519 generate --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_ed25519_generate.md
@@ -45,9 +45,8 @@ authelia crypto pair ed25519 generate --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa.md
@@ -41,9 +41,8 @@ authelia crypto pair rsa --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa.md
@@ -42,7 +42,7 @@ authelia crypto pair rsa --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa.md
@@ -42,7 +42,8 @@ authelia crypto pair rsa --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa_generate.md
@@ -47,7 +47,7 @@ authelia crypto pair rsa generate --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa_generate.md
@@ -46,9 +46,8 @@ authelia crypto pair rsa generate --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_pair_rsa_generate.md
@@ -47,7 +47,8 @@ authelia crypto pair rsa generate --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_rand.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_rand.md
@@ -52,9 +52,8 @@ authelia crypto rand --characters 0123456789ABCDEF
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_rand.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_rand.md
@@ -53,7 +53,7 @@ authelia crypto rand --characters 0123456789ABCDEF
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_rand.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_rand.md
@@ -53,7 +53,8 @@ authelia crypto rand --characters 0123456789ABCDEF
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_storage.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage.md
@@ -57,7 +57,8 @@ authelia storage --help
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_storage.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage.md
@@ -56,9 +56,8 @@ authelia storage --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_storage.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage.md
@@ -57,7 +57,7 @@ authelia storage --help
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_storage_encryption.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_encryption.md
@@ -38,7 +38,8 @@ authelia storage encryption --help
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_encryption.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_encryption.md
@@ -38,7 +38,7 @@ authelia storage encryption --help
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_encryption.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_encryption.md
@@ -37,9 +37,8 @@ authelia storage encryption --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_encryption_change-key.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_encryption_change-key.md
@@ -43,9 +43,8 @@ authelia storage encryption change-key --encryption-key b3453fde-ecc2-4a1f-9422-
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_encryption_change-key.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_encryption_change-key.md
@@ -44,7 +44,7 @@ authelia storage encryption change-key --encryption-key b3453fde-ecc2-4a1f-9422-
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_encryption_change-key.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_encryption_change-key.md
@@ -44,7 +44,8 @@ authelia storage encryption change-key --encryption-key b3453fde-ecc2-4a1f-9422-
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_encryption_check.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_encryption_check.md
@@ -46,7 +46,8 @@ authelia storage encryption check --verbose --encryption-key b3453fde-ecc2-4a1f-
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_encryption_check.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_encryption_check.md
@@ -45,9 +45,8 @@ authelia storage encryption check --verbose --encryption-key b3453fde-ecc2-4a1f-
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_encryption_check.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_encryption_check.md
@@ -46,7 +46,7 @@ authelia storage encryption check --verbose --encryption-key b3453fde-ecc2-4a1f-
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate.md
@@ -37,9 +37,8 @@ authelia storage migrate --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate.md
@@ -38,7 +38,7 @@ authelia storage migrate --help
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate.md
@@ -38,7 +38,8 @@ authelia storage migrate --help
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_down.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_down.md
@@ -46,9 +46,8 @@ authelia storage migrate down --target 20 --encryption-key b3453fde-ecc2-4a1f-94
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_down.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_down.md
@@ -47,7 +47,7 @@ authelia storage migrate down --target 20 --encryption-key b3453fde-ecc2-4a1f-94
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_down.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_down.md
@@ -47,7 +47,8 @@ authelia storage migrate down --target 20 --encryption-key b3453fde-ecc2-4a1f-94
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_history.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_history.md
@@ -44,7 +44,8 @@ authelia storage migrate history --encryption-key b3453fde-ecc2-4a1f-9422-2707dd
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_history.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_history.md
@@ -44,7 +44,7 @@ authelia storage migrate history --encryption-key b3453fde-ecc2-4a1f-9422-2707dd
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_history.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_history.md
@@ -43,9 +43,8 @@ authelia storage migrate history --encryption-key b3453fde-ecc2-4a1f-9422-2707dd
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-down.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-down.md
@@ -45,7 +45,8 @@ authelia storage migrate list-down --encryption-key b3453fde-ecc2-4a1f-9422-2707
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-down.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-down.md
@@ -44,9 +44,8 @@ authelia storage migrate list-down --encryption-key b3453fde-ecc2-4a1f-9422-2707
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-down.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-down.md
@@ -45,7 +45,7 @@ authelia storage migrate list-down --encryption-key b3453fde-ecc2-4a1f-9422-2707
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-up.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-up.md
@@ -44,9 +44,8 @@ authelia storage migrate list-up --encryption-key b3453fde-ecc2-4a1f-9422-2707dd
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-up.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-up.md
@@ -45,7 +45,8 @@ authelia storage migrate list-up --encryption-key b3453fde-ecc2-4a1f-9422-2707dd
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-up.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_list-up.md
@@ -45,7 +45,7 @@ authelia storage migrate list-up --encryption-key b3453fde-ecc2-4a1f-9422-2707dd
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_up.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_up.md
@@ -46,9 +46,8 @@ authelia storage migrate up --encryption-key b3453fde-ecc2-4a1f-9422-2707ddbed49
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_up.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_up.md
@@ -47,7 +47,8 @@ authelia storage migrate up --encryption-key b3453fde-ecc2-4a1f-9422-2707ddbed49
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_migrate_up.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_migrate_up.md
@@ -47,7 +47,7 @@ authelia storage migrate up --encryption-key b3453fde-ecc2-4a1f-9422-2707ddbed49
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_schema-info.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_schema-info.md
@@ -44,7 +44,7 @@ authelia storage schema-info --encryption-key b3453fde-ecc2-4a1f-9422-2707ddbed4
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_schema-info.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_schema-info.md
@@ -43,9 +43,8 @@ authelia storage schema-info --encryption-key b3453fde-ecc2-4a1f-9422-2707ddbed4
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_schema-info.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_schema-info.md
@@ -44,7 +44,8 @@ authelia storage schema-info --encryption-key b3453fde-ecc2-4a1f-9422-2707ddbed4
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user.md
@@ -38,7 +38,8 @@ authelia storage user --help
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user.md
@@ -37,9 +37,8 @@ authelia storage user --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user.md
@@ -38,7 +38,7 @@ authelia storage user --help
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers.md
@@ -37,9 +37,8 @@ authelia storage user identifiers --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers.md
@@ -38,7 +38,8 @@ authelia storage user identifiers --help
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers.md
@@ -38,7 +38,7 @@ authelia storage user identifiers --help
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_add.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_add.md
@@ -46,9 +46,8 @@ authelia storage user identifiers add john --identifier f0919359-9d15-4e15-bcba-
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_add.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_add.md
@@ -47,7 +47,7 @@ authelia storage user identifiers add john --identifier f0919359-9d15-4e15-bcba-
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_add.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_add.md
@@ -47,7 +47,8 @@ authelia storage user identifiers add john --identifier f0919359-9d15-4e15-bcba-
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_export.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_export.md
@@ -46,7 +46,7 @@ authelia storage user identifiers export --file export.yaml --encryption-key b34
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_export.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_export.md
@@ -46,7 +46,8 @@ authelia storage user identifiers export --file export.yaml --encryption-key b34
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_export.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_export.md
@@ -45,9 +45,8 @@ authelia storage user identifiers export --file export.yaml --encryption-key b34
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_generate.md
@@ -48,9 +48,8 @@ authelia storage user identifiers generate --users john,mary --services openid -
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_generate.md
@@ -49,7 +49,7 @@ authelia storage user identifiers generate --users john,mary --services openid -
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_generate.md
@@ -49,7 +49,8 @@ authelia storage user identifiers generate --users john,mary --services openid -
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_import.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_import.md
@@ -48,9 +48,8 @@ authelia storage user identifiers import --file export.yaml --encryption-key b34
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_import.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_import.md
@@ -49,7 +49,8 @@ authelia storage user identifiers import --file export.yaml --encryption-key b34
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_import.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_identifiers_import.md
@@ -49,7 +49,7 @@ authelia storage user identifiers import --file export.yaml --encryption-key b34
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp.md
@@ -38,7 +38,7 @@ authelia storage user totp --help
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp.md
@@ -37,9 +37,8 @@ authelia storage user totp --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp.md
@@ -38,7 +38,8 @@ authelia storage user totp --help
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_delete.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_delete.md
@@ -44,7 +44,7 @@ authelia storage user totp delete john --encryption-key b3453fde-ecc2-4a1f-9422-
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_delete.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_delete.md
@@ -43,9 +43,8 @@ authelia storage user totp delete john --encryption-key b3453fde-ecc2-4a1f-9422-
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_delete.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_delete.md
@@ -44,7 +44,8 @@ authelia storage user totp delete john --encryption-key b3453fde-ecc2-4a1f-9422-
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_export.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_export.md
@@ -47,7 +47,8 @@ authelia storage user totp export --format png --dir ./totp-qr --encryption-key 
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_export.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_export.md
@@ -46,9 +46,8 @@ authelia storage user totp export --format png --dir ./totp-qr --encryption-key 
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_export.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_export.md
@@ -47,7 +47,7 @@ authelia storage user totp export --format png --dir ./totp-qr --encryption-key 
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_generate.md
@@ -56,7 +56,7 @@ authelia storage user totp generate john --algorithm SHA512 --config config.yml 
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_generate.md
@@ -55,9 +55,8 @@ authelia storage user totp generate john --algorithm SHA512 --config config.yml 
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_totp_generate.md
@@ -56,7 +56,8 @@ authelia storage user totp generate john --algorithm SHA512 --config config.yml 
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn.md
@@ -37,9 +37,8 @@ authelia storage user webauthn --help
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn.md
@@ -38,7 +38,7 @@ authelia storage user webauthn --help
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn.md
@@ -38,7 +38,8 @@ authelia storage user webauthn --help
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_delete.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_delete.md
@@ -53,7 +53,7 @@ authelia storage user webauthn delete --kid abc123 --encryption-key b3453fde-ecc
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_delete.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_delete.md
@@ -52,9 +52,8 @@ authelia storage user webauthn delete --kid abc123 --encryption-key b3453fde-ecc
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_delete.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_delete.md
@@ -53,7 +53,8 @@ authelia storage user webauthn delete --kid abc123 --encryption-key b3453fde-ecc
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_list.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_list.md
@@ -46,9 +46,8 @@ authelia storage user webauthn list john --encryption-key b3453fde-ecc2-4a1f-942
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.directory string                configuration directory to load configuration files from
-      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                         configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_list.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_list.md
@@ -47,7 +47,8 @@ authelia storage user webauthn list john --encryption-key b3453fde-ecc2-4a1f-942
 
 ```
   -c, --config strings                         configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings    applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string                configuration directory to load configuration files from
+      --config.experimental.filters strings    list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_list.md
+++ b/docs/content/en/reference/cli/authelia/authelia_storage_user_webauthn_list.md
@@ -47,7 +47,7 @@ authelia storage user webauthn list john --encryption-key b3453fde-ecc2-4a1f-942
 
 ```
   -c, --config strings                         configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings    list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings    list of filters to apply to all configuration files, for more information: authelia --help authelia filters
       --encryption-key string                  the storage encryption key to use
       --mysql.database string                  the MySQL database name (default "authelia")
       --mysql.host string                      the MySQL hostname

--- a/docs/content/en/reference/cli/authelia/authelia_validate-config.md
+++ b/docs/content/en/reference/cli/authelia/authelia_validate-config.md
@@ -44,7 +44,7 @@ authelia validate-config --config config.yml
 
 ```
   -c, --config strings                        configuration files or directories to load (default [configuration.yml])
-      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information: authelia --help authelia filters
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_validate-config.md
+++ b/docs/content/en/reference/cli/authelia/authelia_validate-config.md
@@ -43,9 +43,8 @@ authelia validate-config --config config.yml
 ### Options inherited from parent commands
 
 ```
-  -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.directory string               configuration directory to load configuration files from
-      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
+  -c, --config strings                        configuration files or directories to load (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/docs/content/en/reference/cli/authelia/authelia_validate-config.md
+++ b/docs/content/en/reference/cli/authelia/authelia_validate-config.md
@@ -44,7 +44,8 @@ authelia validate-config --config config.yml
 
 ```
   -c, --config strings                        configuration files to load (default [configuration.yml])
-      --config.experimental.filters strings   applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'
+      --config.directory string               configuration directory to load configuration files from
+      --config.experimental.filters strings   list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'
 ```
 
 ### SEE ALSO

--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -533,7 +533,12 @@ const (
 	cmdFlagNameSaltSize         = "salt-size"
 	cmdFlagNameProfile          = "profile"
 
+	cmdConfigDefaultContainer = "/config/configuration.yml"
+	cmdConfigDefaultDaemon    = "/etc/authelia/configuration.yml"
+
 	cmdFlagNameConfig = "config"
+
+	cmdFlagNameConfigDirectory = "config.directory"
 
 	cmdFlagNameConfigExpFilters = "config.experimental.filters"
 

--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -13,7 +13,8 @@ An open-source authentication and authorization server providing
 two-factor authentication and single sign-on (SSO) for your
 applications via a web portal.
 
-Documentation is available at: https://www.authelia.com/`
+General documentation is available at: https://www.authelia.com/
+CLI documentation is available at: https://www.authelia.com/reference/cli/authelia/authelia/`
 
 	cmdAutheliaExample = `authelia --config /etc/authelia/config.yml --config /etc/authelia/access-control.yml
 authelia --config /etc/authelia/config.yml,/etc/authelia/access-control.yml
@@ -628,4 +629,30 @@ const (
 
 var (
 	validIdentifierServices = []string{identifierServiceOpenIDConnect}
+)
+
+const (
+	helpTopicConfigFilters = `Configuration Filters are an experimental system for templating configuration files.
+
+Using the --config.experimental.filters flag users can define multiple filters to apply to all configuration files that
+are loaded by Authelia. These filters are applied after loading the file data from the filesystem, but before they are
+parsed by the relevant file format parser.
+
+The filters are processed in the order specified, and the content of each configuration file is logged as a base64 raw
+string when the log level is set to trace.
+
+The following filters are available:
+
+	expand-env:
+
+		This filter expands environment variables in place where specified in the configuration. For example the string
+		${DOMAIN_NAME} will be replaced with the value from the DOMAIN_NAME environment variable or an empty string.
+
+	template:
+
+		This filter uses the go template system to filter the file. In addition to the standard functions, several
+		custom functions exist to facilitate this process. The 'env' function takes a single string does similar to the
+		'expand-env' filter for example.
+
+		For a full list of functions see: https://www.authelia.com/configuration/methods/files/#functions`
 )

--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -538,8 +538,6 @@ const (
 
 	cmdFlagNameConfig = "config"
 
-	cmdFlagNameConfigDirectory = "config.directory"
-
 	cmdFlagNameConfigExpFilters = "config.experimental.filters"
 
 	cmdFlagNameCharSet     = "charset"

--- a/internal/commands/context.go
+++ b/internal/commands/context.go
@@ -272,22 +272,17 @@ func (ctx *CmdCtx) ConfigValidateSectionPasswordRunE(cmd *cobra.Command, _ []str
 // ConfigEnsureExistsRunE logs the warnings and errors detected during the validations that have ran.
 func (ctx *CmdCtx) ConfigEnsureExistsRunE(cmd *cobra.Command, _ []string) (err error) {
 	var (
-		configs   []string
-		directory string
-		created   bool
-		result    XEnvCLIResult
+		configs []string
+		created bool
+		result  XEnvCLIResult
 	)
 
 	if configs, result, err = loadXEnvCLIStringSliceValue(cmd, "", cmdFlagNameConfig); err != nil {
 		return err
 	}
 
-	if directory, _, err = loadXEnvCLIStringValue(cmd, "", cmdFlagNameConfigDirectory); err != nil {
-		return err
-	}
-
 	switch {
-	case result == XEnvCLIResultCLIExplicit, directory != "":
+	case result == XEnvCLIResultCLIExplicit:
 		return nil
 	case result == XEnvCLIResultEnvironment && len(configs) == 1:
 		switch configs[0] {
@@ -313,13 +308,12 @@ func (ctx *CmdCtx) ConfigEnsureExistsRunE(cmd *cobra.Command, _ []string) (err e
 // ConfigLoadRunE loads the configuration into the CmdCtx.
 func (ctx *CmdCtx) ConfigLoadRunE(cmd *cobra.Command, _ []string) (err error) {
 	var (
-		configs   []string
-		directory string
+		configs []string
 
 		filters []configuration.FileFilter
 	)
 
-	if configs, directory, filters, err = loadXEnvCLIConfigValues(cmd); err != nil {
+	if configs, filters, err = loadXEnvCLIConfigValues(cmd); err != nil {
 		return err
 	}
 
@@ -333,7 +327,6 @@ func (ctx *CmdCtx) ConfigLoadRunE(cmd *cobra.Command, _ []string) (err error) {
 		ctx.config,
 		configuration.NewDefaultSourcesWithDefaults(
 			configs,
-			directory,
 			filters,
 			configuration.DefaultEnvPrefix,
 			configuration.DefaultEnvDelimiter,

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -46,8 +46,9 @@ func NewRootCmd() (cmd *cobra.Command) {
 	}
 
 	cmd.PersistentFlags().StringSliceP(cmdFlagNameConfig, "c", []string{"configuration.yml"}, "configuration files to load")
+	cmd.PersistentFlags().String(cmdFlagNameConfigDirectory, "", "configuration directory to load configuration files from")
 
-	cmd.PersistentFlags().StringSlice(cmdFlagNameConfigExpFilters, nil, "applies filters in order to the configuration file before the YAML parser, options are 'template', 'expand-env'")
+	cmd.PersistentFlags().StringSlice(cmdFlagNameConfigExpFilters, nil, "list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'")
 
 	cmd.AddCommand(
 		newAccessControlCommand(ctx),

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -45,10 +45,9 @@ func NewRootCmd() (cmd *cobra.Command) {
 		DisableAutoGenTag: true,
 	}
 
-	cmd.PersistentFlags().StringSliceP(cmdFlagNameConfig, "c", []string{"configuration.yml"}, "configuration files to load")
-	cmd.PersistentFlags().String(cmdFlagNameConfigDirectory, "", "configuration directory to load configuration files from")
+	cmd.PersistentFlags().StringSliceP(cmdFlagNameConfig, "c", []string{"configuration.yml"}, "configuration files or directories to load")
 
-	cmd.PersistentFlags().StringSlice(cmdFlagNameConfigExpFilters, nil, "list of filters to apply to all configuration files between loading them from disk and parsing their content, options are 'template', 'expand-env'")
+	cmd.PersistentFlags().StringSlice(cmdFlagNameConfigExpFilters, nil, "list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'")
 
 	cmd.AddCommand(
 		newAccessControlCommand(ctx),

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -47,7 +47,7 @@ func NewRootCmd() (cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringSliceP(cmdFlagNameConfig, "c", []string{"configuration.yml"}, "configuration files or directories to load")
 
-	cmd.PersistentFlags().StringSlice(cmdFlagNameConfigExpFilters, nil, "list of filters to apply to all configuration files, the filters are applied after loading them from disk and before parsing their content, options are 'template', 'expand-env'")
+	cmd.PersistentFlags().StringSlice(cmdFlagNameConfigExpFilters, nil, "list of filters to apply to all configuration files, for more information: authelia --help authelia filters")
 
 	cmd.AddCommand(
 		newAccessControlCommand(ctx),
@@ -55,6 +55,8 @@ func NewRootCmd() (cmd *cobra.Command) {
 		newCryptoCmd(ctx),
 		newStorageCmd(ctx),
 		newValidateConfigCmd(ctx),
+
+		newHelpTopic("filters", "Help for the config filters", helpTopicConfigFilters),
 	)
 
 	return cmd
@@ -88,6 +90,8 @@ func (ctx *CmdCtx) RootRunE(_ *cobra.Command, _ []string) (err error) {
 	}
 
 	doStartupChecks(ctx)
+
+	ctx.cconfig = nil
 
 	runServices(ctx)
 

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -284,11 +284,13 @@ func loadXNormalizedPaths(paths []string) ([]string, error) {
 			dirs = append(dirs, path)
 		case err == nil:
 			configs = append(configs, path)
-			files = append(dirs, path)
+			files = append(files, path)
 		default:
 			if os.IsNotExist(err) {
 				configs = append(configs, path)
 				files = append(files, path)
+
+				continue
 			}
 
 			return nil, fmt.Errorf("error occurred stating file at path '%s': %w", path, err)

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -275,7 +275,7 @@ func loadXNormalizedPaths(originalConfigs []string, originalDirectory string) ([
 		err       error
 	)
 
-	if strings.HasSuffix(originalDirectory, "/") || strings.HasSuffix(originalDirectory, "/") {
+	if strings.HasSuffix(originalDirectory, "/") {
 		directory = filepath.Dir(originalDirectory)
 	} else {
 		directory = originalDirectory

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -340,28 +340,20 @@ func loadXEnvCLIStringSliceValue(cmd *cobra.Command, envKey, flagName string) (v
 	}
 }
 
-func loadXEnvCLIStringValue(cmd *cobra.Command, envKey, flagName string) (value string, result XEnvCLIResult, err error) { //nolint:unparam
-	if cmd.Flags().Changed(flagName) {
-		value, err = cmd.Flags().GetString(flagName)
-
-		return value, XEnvCLIResultCLIExplicit, err
+func newHelpTopic(topic, short, body string) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:   topic,
+		Short: short,
 	}
 
-	var (
-		env string
-		ok  bool
-	)
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		_ = cmd.Parent().Help()
 
-	if envKey != "" {
-		env, ok = os.LookupEnv(envKey)
-	}
+		fmt.Println()
+		fmt.Printf("Help Topic: %s\n\n", topic)
+		fmt.Print(body)
+		fmt.Print("\n\n")
+	})
 
-	switch {
-	case ok && env != "":
-		return env, XEnvCLIResultEnvironment, nil
-	default:
-		value, err = cmd.Flags().GetString(flagName)
-
-		return value, XEnvCLIResultCLIImplicit, err
-	}
+	return cmd
 }

--- a/internal/commands/util_test.go
+++ b/internal/commands/util_test.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadXNormalizedPaths(t *testing.T) {
+	testCases := []struct {
+		name, expectErr                string
+		haveConfigs, expectConfigs     []string
+		haveDirectory, expectDirectory string
+	}{
+		{
+			name:        "ShouldNormalizeDirectory",
+			expectErr:   "",
+			haveConfigs: []string{"/abc/123.yml"}, expectConfigs: []string{"/abc/123.yml"},
+			haveDirectory: "/etc/authelia/", expectDirectory: "/etc/authelia",
+		},
+		{
+			name:        "ShouldErrOnConfigInDirectory",
+			expectErr:   "failed to load config directory '/etc/authelia': the file '/etc/authelia/123.yml' is in that directory which is not supported",
+			haveConfigs: []string{"/etc/authelia/123.yml"}, expectConfigs: nil,
+			haveDirectory: "/etc/authelia/", expectDirectory: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualConfigs, actualDirectory, actualErr := loadXNormalizedPaths(tc.haveConfigs, tc.haveDirectory)
+
+			assert.Equal(t, tc.expectConfigs, actualConfigs)
+			assert.Equal(t, tc.expectDirectory, actualDirectory)
+
+			if tc.expectErr != "" {
+				assert.EqualError(t, actualErr, tc.expectErr)
+			} else {
+				assert.Nil(t, actualErr)
+			}
+		})
+	}
+}

--- a/internal/commands/util_test.go
+++ b/internal/commands/util_test.go
@@ -1,42 +1,110 @@
 package commands
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadXNormalizedPaths(t *testing.T) {
+	root := t.TempDir()
+
+	configdir := filepath.Join(root, "config")
+	otherdir := filepath.Join(root, "other")
+
+	require.NoError(t, os.Mkdir(configdir, 0700))
+	require.NoError(t, os.Mkdir(otherdir, 0700))
+
+	var (
+		info os.FileInfo
+		file *os.File
+		err  error
+	)
+
+	ayml := filepath.Join(configdir, "a.yml")
+	byml := filepath.Join(configdir, "b.yml")
+	cyml := filepath.Join(otherdir, "c.yml")
+
+	file, err = os.Create(ayml)
+
+	require.NoError(t, err)
+
+	require.NoError(t, file.Close())
+
+	file, err = os.Create(byml)
+
+	require.NoError(t, err)
+
+	require.NoError(t, file.Close())
+
+	file, err = os.Create(cyml)
+
+	require.NoError(t, err)
+
+	require.NoError(t, file.Close())
+
+	info, err = os.Stat(configdir)
+
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+
+	info, err = os.Stat(otherdir)
+
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+
+	info, err = os.Stat(ayml)
+
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+
+	info, err = os.Stat(byml)
+
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+
+	info, err = os.Stat(cyml)
+
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+
 	testCases := []struct {
-		name, expectErr                string
-		haveConfigs, expectConfigs     []string
-		haveDirectory, expectDirectory string
+		name           string
+		have, expected []string
+		expectedErr    string
 	}{
-		{
-			name:        "ShouldNormalizeDirectory",
-			expectErr:   "",
-			haveConfigs: []string{"/abc/123.yml"}, expectConfigs: []string{"/abc/123.yml"},
-			haveDirectory: "/etc/authelia/", expectDirectory: "/etc/authelia",
+		{"ShouldAllowFiles",
+			[]string{ayml},
+			[]string{ayml}, "",
 		},
-		{
-			name:        "ShouldErrOnConfigInDirectory",
-			expectErr:   "failed to load config directory '/etc/authelia': the file '/etc/authelia/123.yml' is in that directory which is not supported",
-			haveConfigs: []string{"/etc/authelia/123.yml"}, expectConfigs: nil,
-			haveDirectory: "/etc/authelia/", expectDirectory: "",
+		{"ShouldAllowDirectories",
+			[]string{configdir},
+			[]string{configdir}, "",
+		},
+		{"ShouldAllowFilesDirectories",
+			[]string{ayml, otherdir},
+			[]string{ayml, otherdir}, "",
+		},
+		{"ShouldRaiseErrOnOverlappingFilesDirectories",
+			[]string{ayml, configdir},
+			nil, fmt.Sprintf("failed to load config directory '%s': the config file '%s' is in that directory which is not supported", configdir, ayml),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualConfigs, actualDirectory, actualErr := loadXNormalizedPaths(tc.haveConfigs, tc.haveDirectory)
+			actual, actualErr := loadXNormalizedPaths(tc.have)
 
-			assert.Equal(t, tc.expectConfigs, actualConfigs)
-			assert.Equal(t, tc.expectDirectory, actualDirectory)
+			assert.Equal(t, tc.expected, actual)
 
-			if tc.expectErr != "" {
-				assert.EqualError(t, actualErr, tc.expectErr)
+			if tc.expectedErr == "" {
+				assert.NoError(t, actualErr)
 			} else {
-				assert.Nil(t, actualErr)
+				assert.EqualError(t, actualErr, tc.expectedErr)
 			}
 		})
 	}

--- a/internal/configuration/provider_test.go
+++ b/internal/configuration/provider_test.go
@@ -81,7 +81,7 @@ func TestShouldHaveNotifier(t *testing.T) {
 	testSetEnv(t, "AUTHENTICATION_BACKEND_LDAP_PASSWORD", "abc")
 
 	val := schema.NewStructValidator()
-	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	assert.Len(t, val.Errors(), 0)
@@ -98,7 +98,7 @@ func TestShouldValidateConfigurationWithEnv(t *testing.T) {
 	testSetEnv(t, "AUTHENTICATION_BACKEND_LDAP_PASSWORD", "abc")
 
 	val := schema.NewStructValidator()
-	_, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	assert.Len(t, val.Errors(), 0)
@@ -117,7 +117,7 @@ func TestShouldValidateConfigurationWithFilters(t *testing.T) {
 	_ = os.Setenv("ROOT_DOMAIN", "example.org")
 
 	val := schema.NewStructValidator()
-	_, config, err := Load(val, NewDefaultSourcesFiltered([]string{"./test_resources/config.filtered.yml"}, NewFileFiltersDefault(), DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, config, err := Load(val, NewDefaultSourcesFiltered([]string{"./test_resources/config.filtered.yml"}, "", NewFileFiltersDefault(), DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	require.Len(t, val.Errors(), 0)
@@ -139,7 +139,7 @@ func TestShouldNotIgnoreInvalidEnvs(t *testing.T) {
 	testSetEnv(t, "AUTHENTICATION_BACKEND_LDAP_URL", "an env authentication backend ldap password")
 
 	val := schema.NewStructValidator()
-	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -162,7 +162,7 @@ func TestShouldValidateAndRaiseErrorsOnNormalConfigurationAndSecret(t *testing.T
 	testSetEnv(t, "STORAGE_ENCRYPTION_KEY", "a_very_bad_encryption_key")
 
 	val := schema.NewStructValidator()
-	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	require.Len(t, val.Errors(), 1)
@@ -191,7 +191,7 @@ func TestShouldRaiseIOErrOnUnreadableFile(t *testing.T) {
 	cfg := filepath.Join(dir, "myconf.yml")
 
 	val := schema.NewStructValidator()
-	_, _, err := Load(val, NewYAMLFileSource(cfg))
+	_, _, err := Load(val, NewFileSource(cfg))
 
 	assert.NoError(t, err)
 	require.Len(t, val.Errors(), 1)
@@ -209,7 +209,7 @@ func TestShouldValidateConfigurationWithEnvSecrets(t *testing.T) {
 	testSetEnv(t, "STORAGE_ENCRYPTION_KEY_FILE", "./test_resources/example_secret")
 
 	val := schema.NewStructValidator()
-	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	assert.Len(t, val.Errors(), 0)
@@ -226,7 +226,7 @@ func TestShouldLoadURLList(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -244,7 +244,7 @@ func TestShouldConfigureConsent(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -266,7 +266,7 @@ func TestShouldValidateAndRaiseErrorsOnBadConfiguration(t *testing.T) {
 	testSetEnv(t, "AUTHENTICATION_BACKEND_LDAP_PASSWORD", "abc")
 
 	val := schema.NewStructValidator()
-	keys, c, err := Load(val, NewDefaultSources([]string{"./test_resources/config_bad_keys.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, c, err := Load(val, NewDefaultSources([]string{"./test_resources/config_bad_keys.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -285,7 +285,7 @@ func TestShouldRaiseErrOnInvalidNotifierSMTPSender(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config_smtp_sender_invalid.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config_smtp_sender_invalid.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -301,7 +301,7 @@ func TestShouldHandleErrInvalidatorWhenSMTPSenderBlank(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_smtp_sender_blank.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_smtp_sender_blank.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -325,7 +325,7 @@ func TestShouldDecodeSMTPSenderWithoutName(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -342,7 +342,7 @@ func TestShouldDecodeSMTPSenderWithName(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_alt.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_alt.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -360,7 +360,7 @@ func TestShouldParseRegex(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_domain_regex.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_domain_regex.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -392,7 +392,7 @@ func TestShouldErrOnParseInvalidRegex(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config_domain_bad_regex.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config_domain_bad_regex.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -417,7 +417,7 @@ func TestShouldNotReadConfigurationOnFSAccessDenied(t *testing.T) {
 	assert.NoError(t, testCreateFile(filepath.Join(dir, "config.yml"), "port: 9091\n", 0000))
 
 	val := schema.NewStructValidator()
-	_, _, err := Load(val, NewYAMLFileSource(cfg))
+	_, _, err := Load(val, NewFileSource(cfg))
 
 	assert.NoError(t, err)
 	require.Len(t, val.Errors(), 1)
@@ -431,7 +431,7 @@ func TestShouldNotLoadDirectoryConfiguration(t *testing.T) {
 	dir := t.TempDir()
 
 	val := schema.NewStructValidator()
-	_, _, err := Load(val, NewYAMLFileSource(dir))
+	_, _, err := Load(val, NewFileSource(dir))
 
 	assert.NoError(t, err)
 	require.Len(t, val.Errors(), 1)

--- a/internal/configuration/provider_test.go
+++ b/internal/configuration/provider_test.go
@@ -196,7 +196,7 @@ func TestShouldRaiseIOErrOnUnreadableFile(t *testing.T) {
 	assert.NoError(t, err)
 	require.Len(t, val.Errors(), 1)
 	assert.Len(t, val.Warnings(), 0)
-	assert.EqualError(t, val.Errors()[0], fmt.Sprintf("failed to load configuration from yaml file(%s) source: open %s: permission denied", cfg, cfg))
+	assert.EqualError(t, val.Errors()[0], fmt.Sprintf("failed to load configuration from file path(%s) source: open %s: permission denied", cfg, cfg))
 }
 
 func TestShouldValidateConfigurationWithEnvSecrets(t *testing.T) {
@@ -422,7 +422,7 @@ func TestShouldNotReadConfigurationOnFSAccessDenied(t *testing.T) {
 	assert.NoError(t, err)
 	require.Len(t, val.Errors(), 1)
 
-	assert.EqualError(t, val.Errors()[0], fmt.Sprintf("failed to load configuration from yaml file(%s) source: open %s: permission denied", cfg, cfg))
+	assert.EqualError(t, val.Errors()[0], fmt.Sprintf("failed to load configuration from file path(%s) source: open %s: permission denied", cfg, cfg))
 }
 
 func TestShouldLoadDirectoryConfiguration(t *testing.T) {

--- a/internal/configuration/provider_test.go
+++ b/internal/configuration/provider_test.go
@@ -81,7 +81,7 @@ func TestShouldHaveNotifier(t *testing.T) {
 	testSetEnv(t, "AUTHENTICATION_BACKEND_LDAP_PASSWORD", "abc")
 
 	val := schema.NewStructValidator()
-	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	assert.Len(t, val.Errors(), 0)
@@ -98,7 +98,7 @@ func TestShouldValidateConfigurationWithEnv(t *testing.T) {
 	testSetEnv(t, "AUTHENTICATION_BACKEND_LDAP_PASSWORD", "abc")
 
 	val := schema.NewStructValidator()
-	_, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	assert.Len(t, val.Errors(), 0)
@@ -117,7 +117,7 @@ func TestShouldValidateConfigurationWithFilters(t *testing.T) {
 	_ = os.Setenv("ROOT_DOMAIN", "example.org")
 
 	val := schema.NewStructValidator()
-	_, config, err := Load(val, NewDefaultSourcesFiltered([]string{"./test_resources/config.filtered.yml"}, "", NewFileFiltersDefault(), DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, config, err := Load(val, NewDefaultSourcesFiltered([]string{"./test_resources/config.filtered.yml"}, NewFileFiltersDefault(), DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	require.Len(t, val.Errors(), 0)
@@ -139,7 +139,7 @@ func TestShouldNotIgnoreInvalidEnvs(t *testing.T) {
 	testSetEnv(t, "AUTHENTICATION_BACKEND_LDAP_URL", "an env authentication backend ldap password")
 
 	val := schema.NewStructValidator()
-	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -162,7 +162,7 @@ func TestShouldValidateAndRaiseErrorsOnNormalConfigurationAndSecret(t *testing.T
 	testSetEnv(t, "STORAGE_ENCRYPTION_KEY", "a_very_bad_encryption_key")
 
 	val := schema.NewStructValidator()
-	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	require.Len(t, val.Errors(), 1)
@@ -209,7 +209,7 @@ func TestShouldValidateConfigurationWithEnvSecrets(t *testing.T) {
 	testSetEnv(t, "STORAGE_ENCRYPTION_KEY_FILE", "./test_resources/example_secret")
 
 	val := schema.NewStructValidator()
-	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	_, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 	assert.Len(t, val.Errors(), 0)
@@ -226,7 +226,7 @@ func TestShouldLoadURLList(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -244,7 +244,7 @@ func TestShouldConfigureConsent(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -266,7 +266,7 @@ func TestShouldValidateAndRaiseErrorsOnBadConfiguration(t *testing.T) {
 	testSetEnv(t, "AUTHENTICATION_BACKEND_LDAP_PASSWORD", "abc")
 
 	val := schema.NewStructValidator()
-	keys, c, err := Load(val, NewDefaultSources([]string{"./test_resources/config_bad_keys.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, c, err := Load(val, NewDefaultSources([]string{"./test_resources/config_bad_keys.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -285,7 +285,7 @@ func TestShouldRaiseErrOnInvalidNotifierSMTPSender(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config_smtp_sender_invalid.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config_smtp_sender_invalid.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -301,7 +301,7 @@ func TestShouldHandleErrInvalidatorWhenSMTPSenderBlank(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_smtp_sender_blank.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_smtp_sender_blank.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -325,7 +325,7 @@ func TestShouldDecodeSMTPSenderWithoutName(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -342,7 +342,7 @@ func TestShouldDecodeSMTPSenderWithName(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_alt.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_alt.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -360,7 +360,7 @@ func TestShouldParseRegex(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_domain_regex.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_domain_regex.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -392,7 +392,7 @@ func TestShouldErrOnParseInvalidRegex(t *testing.T) {
 	testReset()
 
 	val := schema.NewStructValidator()
-	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config_domain_bad_regex.yml"}, "", DefaultEnvPrefix, DefaultEnvDelimiter)...)
+	keys, _, err := Load(val, NewDefaultSources([]string{"./test_resources/config_domain_bad_regex.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
 
 	assert.NoError(t, err)
 
@@ -425,7 +425,7 @@ func TestShouldNotReadConfigurationOnFSAccessDenied(t *testing.T) {
 	assert.EqualError(t, val.Errors()[0], fmt.Sprintf("failed to load configuration from yaml file(%s) source: open %s: permission denied", cfg, cfg))
 }
 
-func TestShouldNotLoadDirectoryConfiguration(t *testing.T) {
+func TestShouldLoadDirectoryConfiguration(t *testing.T) {
 	testReset()
 
 	dir := t.TempDir()
@@ -434,11 +434,8 @@ func TestShouldNotLoadDirectoryConfiguration(t *testing.T) {
 	_, _, err := Load(val, NewFileSource(dir))
 
 	assert.NoError(t, err)
-	require.Len(t, val.Errors(), 1)
+	assert.Len(t, val.Errors(), 0)
 	assert.Len(t, val.Warnings(), 0)
-
-	expectedErr := fmt.Sprintf(utils.GetExpectedErrTxt("yamlisdir"), dir)
-	assert.EqualError(t, val.Errors()[0], fmt.Sprintf("failed to load configuration from yaml file(%s) source: %s", dir, expectedErr))
 }
 
 func testSetEnv(t *testing.T, key, value string) {

--- a/internal/configuration/sources.go
+++ b/internal/configuration/sources.go
@@ -59,7 +59,7 @@ func NewFilteredFileSources(paths []string, filters []FileFilter) (sources []*Fi
 
 // Name of the Source.
 func (s *FileSource) Name() (name string) {
-	return fmt.Sprintf("yaml file(%s)", s.path)
+	return fmt.Sprintf("file path(%s)", s.path)
 }
 
 // Merge the FileSource koanf.Koanf into the provided one.
@@ -76,7 +76,7 @@ func (s *FileSource) Load(val *schema.StructValidator) (err error) {
 	var info os.FileInfo
 
 	if info, err = os.Stat(s.path); err != nil {
-		return fmt.Errorf("invalid file path source configuration: failed to stat '%s': %w", s.path, err)
+		return err
 	}
 
 	if info.IsDir() {

--- a/internal/configuration/types.go
+++ b/internal/configuration/types.go
@@ -14,11 +14,12 @@ type Source interface {
 	Load(val *schema.StructValidator) (err error)
 }
 
-// YAMLFileSource is a YAML file configuration.Source.
-type YAMLFileSource struct {
-	koanf   *koanf.Koanf
-	path    string
-	filters []FileFilter
+// FileSource is a file configuration.Source.
+type FileSource struct {
+	koanf     *koanf.Koanf
+	path      string
+	directory bool
+	filters   []FileFilter
 }
 
 // EnvironmentSource is a configuration configuration.Source which loads values from the environment.

--- a/internal/configuration/types.go
+++ b/internal/configuration/types.go
@@ -16,10 +16,9 @@ type Source interface {
 
 // FileSource is a file configuration.Source.
 type FileSource struct {
-	koanf     *koanf.Koanf
-	path      string
-	directory bool
-	filters   []FileFilter
+	koanf   *koanf.Koanf
+	path    string
+	filters []FileFilter
 }
 
 // EnvironmentSource is a configuration configuration.Source which loads values from the environment.

--- a/internal/suites/suite_cli_test.go
+++ b/internal/suites/suite_cli_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/storage"
@@ -81,7 +81,7 @@ func (s *CLISuite) TestShouldValidateConfig() {
 func (s *CLISuite) TestShouldFailValidateConfig() {
 	output, err := s.Exec("authelia-backend", []string{"authelia", s.testArg, s.coverageArg, "validate-config", "--config=/config/invalid.yml"})
 	s.Assert().NoError(err)
-	s.Assert().Contains(output, "failed to load configuration from yaml file(/config/invalid.yml) source: open /config/invalid.yml: no such file or directory")
+	s.Assert().Contains(output, "failed to load configuration from file path(/config/invalid.yml) source: stat /config/invalid.yml: no such file or directory\n")
 }
 
 func (s *CLISuite) TestShouldHashPasswordArgon2() {


### PR DESCRIPTION
This allows specifying paths to a combination of files and directories with the `--config` option provided none of the specified file paths reside directly inside one of the specified directory paths. The directory paths are not recursive, and load `.yml` and `.yaml` files at this time.