### PR TITLE
fix(notification): smtp auth not configured

### DIFF
--- a/internal/notification/smtp_auth.go
+++ b/internal/notification/smtp_auth.go
@@ -1,0 +1,81 @@
+package notification
+
+import (
+	"fmt"
+	"net/smtp"
+	"strings"
+
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/utils"
+	gomail "github.com/wneessen/go-mail"
+	"github.com/wneessen/go-mail/auth"
+)
+
+// NewOpportunisticSMTPAuth is an opportunistic smtp.Auth implementation.
+func NewOpportunisticSMTPAuth(config *schema.SMTPNotifierConfiguration) *OpportunisticSMTPAuth {
+	return &OpportunisticSMTPAuth{
+		username: config.Username,
+		password: config.Password,
+		host:     config.Host,
+	}
+}
+
+// OpportunisticSMTPAuth is an opportunistic smtp.Auth implementation.
+type OpportunisticSMTPAuth struct {
+	username, password, host string
+
+	satPreference []gomail.SMTPAuthType
+	sa            smtp.Auth
+}
+
+// Start begins an authentication with a server.
+// It returns the name of the authentication protocol
+// and optionally data to include in the initial AUTH message
+// sent to the server.
+// If it returns a non-nil error, the SMTP client aborts
+// the authentication attempt and closes the connection.
+func (a *OpportunisticSMTPAuth) Start(server *smtp.ServerInfo) (proto string, toServer []byte, err error) {
+	for _, pref := range a.satPreference {
+		if utils.IsStringInSlice(string(pref), server.Auth) {
+			switch pref {
+			case gomail.SMTPAuthPlain:
+				a.sa = smtp.PlainAuth("", a.username, a.password, a.host)
+			case gomail.SMTPAuthLogin:
+				a.sa = auth.LoginAuth(a.username, a.password, a.host)
+			case gomail.SMTPAuthCramMD5:
+				a.sa = smtp.CRAMMD5Auth(a.username, a.password)
+			}
+
+			break
+		}
+	}
+
+	if a.sa == nil {
+		for _, sa := range server.Auth {
+			switch gomail.SMTPAuthType(sa) {
+			case gomail.SMTPAuthPlain:
+				a.sa = smtp.PlainAuth("", a.username, a.password, a.host)
+			case gomail.SMTPAuthLogin:
+				a.sa = auth.LoginAuth(a.username, a.password, a.host)
+			case gomail.SMTPAuthCramMD5:
+				a.sa = smtp.CRAMMD5Auth(a.username, a.password)
+			}
+		}
+	}
+
+	if a.sa == nil {
+		return "", nil, fmt.Errorf("unsupported SMTP AUTH types: %s", strings.Join(server.Auth, ", "))
+	}
+
+	return a.sa.Start(server)
+}
+
+// Next continues the authentication. The server has just sent
+// the fromServer data. If more is true, the server expects a
+// response, which Next should return as toServer; otherwise
+// Next should return toServer == nil.
+// If Next returns a non-nil error, the SMTP client aborts
+// the authentication attempt and closes the connection.
+func (a *OpportunisticSMTPAuth) Next(fromServer []byte, more bool) (toServer []byte, err error) {
+	return a.sa.Next(fromServer, more)
+}

--- a/internal/notification/smtp_auth.go
+++ b/internal/notification/smtp_auth.go
@@ -14,6 +14,10 @@ import (
 
 // NewOpportunisticSMTPAuth is an opportunistic smtp.Auth implementation.
 func NewOpportunisticSMTPAuth(config *schema.SMTPNotifierConfiguration) *OpportunisticSMTPAuth {
+	if config.Username == "" && config.Password == "" {
+		return nil
+	}
+
 	return &OpportunisticSMTPAuth{
 		username: config.Username,
 		password: config.Password,

--- a/internal/notification/smtp_auth.go
+++ b/internal/notification/smtp_auth.go
@@ -5,10 +5,11 @@ import (
 	"net/smtp"
 	"strings"
 
-	"github.com/authelia/authelia/v4/internal/configuration/schema"
-	"github.com/authelia/authelia/v4/internal/utils"
 	gomail "github.com/wneessen/go-mail"
 	"github.com/wneessen/go-mail/auth"
+
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/utils"
 )
 
 // NewOpportunisticSMTPAuth is an opportunistic smtp.Auth implementation.

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -125,7 +125,9 @@ func (n *SMTPNotifier) Send(ctx context.Context, recipient mail.Address, subject
 		return fmt.Errorf("notifier: smtp: failed to establish client: %w", err)
 	}
 
-	client.SetSMTPAuthCustom(NewOpportunisticSMTPAuth(n.config))
+	if auth := NewOpportunisticSMTPAuth(n.config); auth != nil {
+		client.SetSMTPAuthCustom(auth)
+	}
 
 	if err = client.DialWithContext(ctx); err != nil {
 		return fmt.Errorf("notifier: smtp: failed to dial connection: %w", err)


### PR DESCRIPTION
This fixes an issue introduced by the pending migration to the new SMTP library in 0bb657e11cfa6b9f16cd28340291b121fa1579bc where the auth mechanism is never defined. This only affects commits that are yet to be versioned.