### PR TITLE
fix:(web): otp autocomplete defaults to off

### DIFF
--- a/web/src/views/LoginPortal/SecondFactor/OTPDial.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/OTPDial.tsx
@@ -34,6 +34,7 @@ const OTPDial = function (props: Props) {
                     isDisabled={props.state === State.InProgress || props.state === State.Success}
                     isInputNum
                     hasErrored={props.state === State.Failure}
+                    autoComplete="one-time-code"
                     inputStyle={classnames(
                         styles.otpDigitInput,
                         props.state === State.Failure ? styles.inputError : "",


### PR DESCRIPTION
This sets the autocomplete value to `one-time-code` instead of using the default of `off`.

Fixes #4660