### PR TITLE
Fix issue for NGINX Proxy Manager error 444, add proxy_buffer_size

### DIFF
--- a/docs/content/en/integration/proxies/nginx.md
+++ b/docs/content/en/integration/proxies/nginx.md
@@ -403,6 +403,7 @@ location /authelia {
     proxy_http_version 1.1;
     proxy_cache_bypass $cookie_session;
     proxy_no_cache $cookie_session;
+    proxy_buffer_size 32k;
     proxy_buffers 4 32k;
     client_body_buffer_size 128k;
 
@@ -487,6 +488,7 @@ location /authelia-basic {
     proxy_http_version 1.1;
     proxy_cache_bypass $cookie_session;
     proxy_no_cache $cookie_session;
+    proxy_buffer_size 32k;
     proxy_buffers 4 32k;
     client_body_buffer_size 128k;
 


### PR DESCRIPTION
I ran into an 444 error while using NGINX Proxy Manager with the given [NGINX configuration](https://www.authelia.com/integration/proxies/nginx/).

After some research I've noticed an error in the nginx log inside the Docker container:
`2023/01/04 21:53:08 [emerg] 773#773: "proxy_busy_buffers_size" must be less than the size of all "proxy_buffers" minus one buffer in /etc/nginx/nginx.conf:84`

Probably this is due to the `proxy_buffers 4 32k;` setting in [authelia-location.conf](https://www.authelia.com/integration/proxies/nginx/#authelia-locationconf).

This can be fixed with ease, by providing the configuration `proxy_buffer_size 32k;` in [authelia-location.conf](https://www.authelia.com/integration/proxies/nginx/#authelia-locationconf).