### PR TITLE
fix(utils): fix suite setup timeout

### DIFF
--- a/internal/suites/environment.go
+++ b/internal/suites/environment.go
@@ -19,7 +19,7 @@ func waitUntilServiceLogDetected(
 	logPatterns []string) error {
 	log.Debug("Waiting for service " + service + " to be ready...")
 
-	err := utils.CheckUntil(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err := utils.CheckUntil(interval, timeout, func() (bool, error) {
 		logs, err := dockerEnvironment.Logs(service, []string{"--tail", "20"})
 
 		if err != nil {


### PR DESCRIPTION
After PR #4751 the suites times out if takes more of 60 seconds.
This PR honors the timeout configured at waitUntilAutheliaBackendIsReady (90s)