### PR TITLE
ci: fix renovaterc

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -22,7 +22,7 @@
     "npm"
   ],
   "kubernetes": {
-    "fileMatch": ["kube/.+\\.yml$"],
+    "fileMatch": ["kube/.+\\.yml$"]
   },
   "labels": [
     "dependencies"


### PR DESCRIPTION
This fixes an issue with a trailing comma in the .renovaterc file.

Fixes #3293