### PR TITLE
docs: Note importance of name in gitea config

### DIFF
--- a/docs/content/en/integration/openid-connect/gitea/index.md
+++ b/docs/content/en/integration/openid-connect/gitea/index.md
@@ -35,7 +35,7 @@ This example makes the following assumptions:
 * __Authentication Name (Gitea):__ `authelia`:
     * This option determines the redirect URI in the format of
       `https://gitea.example.com/user/oauth2/<Authentication Name>/callback`.
-      This means if you change this value  you need to update the redirect URI.
+      This means if you change this value you need to update the redirect URI.
 
 ## Configuration
 

--- a/docs/content/en/integration/openid-connect/gitea/index.md
+++ b/docs/content/en/integration/openid-connect/gitea/index.md
@@ -32,6 +32,10 @@ This example makes the following assumptions:
 * __Authelia Root URL:__ `https://auth.example.com`
 * __Client ID:__ `gitea`
 * __Client Secret:__ `insecure_secret`
+* __Authentication Name (Gitea):__ `authelia`:
+    * This option determines the redirect URI in the format of
+      `https://gitea.example.com/user/oauth2/<Authentication Name>/callback`.
+      This means if you change this value  you need to update the redirect URI.
 
 ## Configuration
 


### PR DESCRIPTION
Make the non-obvious relationship between the Gitea `Authentication Name` and the path of the redirect URI explicit.