### PR TITLE
docs: fix ip addresses

### DIFF
--- a/docs/content/en/integration/proxies/caddy.md
+++ b/docs/content/en/integration/proxies/caddy.md
@@ -59,7 +59,7 @@ In the example we have a commented `trusted_proxies` directive which shows an ex
 to the trusted proxy list in [Caddy]:
 
 * 10.0.0.0/8
-* 172.16.0.0/16
+* 172.16.0.0/12
 * 192.168.0.0/16
 * fc00::/7
 
@@ -84,7 +84,7 @@ support to ensure the basic example covers your use case in a secure way.
 ##     https://www.authelia.com/integration/proxies/caddy/#forwarded-header-trust#trusted-proxies
 (trusted_proxy_list) {
        ## Uncomment & adjust the following line to configure specific ranges which should be considered as trustworthy.
-       # trusted_proxies 10.0.0.0/8 172.16.0.0/16 192.168.0.0/16 fc00::/7
+       # trusted_proxies 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 fc00::/7
 }
 
 # Authelia Portal.
@@ -123,7 +123,7 @@ nextcloud.example.com {
 ##     https://www.authelia.com/integration/proxies/caddy/#forwarded-header-trust#trusted-proxies
 (trusted_proxy_list) {
        ## Uncomment & adjust the following line to configure specific ranges which should be considered as trustworthy.
-       # trusted_proxies 10.0.0.0/8 172.16.0.0/16 192.168.0.0/16 fc00::/7
+       # trusted_proxies 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 fc00::/7
 }
 
 example.com {
@@ -168,7 +168,7 @@ preferred in *most* situations. If you are unsure of what you're doing please do
 ##     https://www.authelia.com/integration/proxies/caddy/#forwarded-header-trust#trusted-proxies
 (trusted_proxy_list) {
        ## Uncomment & adjust the following line to configure specific ranges which should be considered as trustworthy.
-       # trusted_proxies 10.0.0.0/8 172.16.0.0/16 192.168.0.0/16 fc00::/7
+       # trusted_proxies 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 fc00::/7
 }
 
 # Authelia Portal.

--- a/docs/content/en/integration/proxies/haproxy.md
+++ b/docs/content/en/integration/proxies/haproxy.md
@@ -62,7 +62,7 @@ line in the main configuration which shows an example of not trusting any proxie
 the following networks to the trusted proxy list in [HAProxy]:
 
 * 10.0.0.0/8
-* 172.16.0.0/16
+* 172.16.0.0/12
 * 192.168.0.0/16
 * fc00::/7
 

--- a/docs/content/en/integration/proxies/traefik.md
+++ b/docs/content/en/integration/proxies/traefik.md
@@ -55,7 +55,7 @@ In the example we have four commented lines which configure `trustedIPs` which s
 networks to the trusted proxy list in [Traefik]:
 
 * 10.0.0.0/8
-* 172.16.0.0/16
+* 172.16.0.0/12
 * 192.168.0.0/16
 * fc00::/7
 
@@ -109,15 +109,15 @@ services:
       - '--entryPoints.http.http.redirections.entryPoint.to=https'
       - '--entryPoints.http.http.redirections.entryPoint.scheme=https'
       ## Please see the Forwarded Header Trust section of the Authelia Traefik Integration documentation.
-      # - '--entryPoints.http.forwardedHeaders.trustedIPs=10.0.0.0/8,172.16.0.0/16,192.168.0.0/16,fc00::/7'
-      # - '--entryPoints.http.proxyProtocol.trustedIPs=10.0.0.0/8,172.16.0.0/16,192.168.0.0/16,fc00::/7'
+      # - '--entryPoints.http.forwardedHeaders.trustedIPs=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7'
+      # - '--entryPoints.http.proxyProtocol.trustedIPs=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7'
       - '--entryPoints.http.forwardedHeaders.insecure=false'
       - '--entryPoints.http.proxyProtocol.insecure=false'
       - '--entryPoints.https=true'
       - '--entryPoints.https.address=:8443/tcp'
       ## Please see the Forwarded Header Trust section of the Authelia Traefik Integration documentation.
-      # - '--entryPoints.https.forwardedHeaders.trustedIPs=10.0.0.0/8,172.16.0.0/16,192.168.0.0/16,fc00::/7'
-      # - '--entryPoints.https.proxyProtocol.trustedIPs=10.0.0.0/8,172.16.0.0/16,192.168.0.0/16,fc00::/7'
+      # - '--entryPoints.https.forwardedHeaders.trustedIPs=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7'
+      # - '--entryPoints.https.proxyProtocol.trustedIPs=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7'
       - '--entryPoints.https.forwardedHeaders.insecure=false'
       - '--entryPoints.https.proxyProtocol.insecure=false'
     networks:

--- a/docs/content/en/integration/proxies/traefikv1.md
+++ b/docs/content/en/integration/proxies/traefikv1.md
@@ -45,7 +45,7 @@ In the example we have four commented lines which configure `TrustedIPs` which s
 networks to the trusted proxy list in [Traefik]:
 
 * 10.0.0.0/8
-* 172.16.0.0/16
+* 172.16.0.0/12
 * 192.168.0.0/16
 * fc00::/7
 
@@ -105,8 +105,8 @@ services:
       - '--entryPoints=Name:http Address::80'
       - '--entryPoints=Name:https Address::443 TLS'
       ## See the Forwarded Header Trust section. Comment the above two lines, then uncomment and customize the next two lines to configure the TrustedIPs.
-      # - '--entryPoints=Name:http Address::80 ForwardedHeaders.TrustedIPs:10.0.0.0/8,172.16.0.0/16,192.168.0.0/16,fc00::/7 ProxyProtocol.TrustedIPs:10.0.0.0/8,172.16.0.0/16,192.168.0.0/16,fc00::/7'
-      # - '--entryPoints=Name:https Address::443 TLS ForwardedHeaders.TrustedIPs:10.0.0.0/8,172.16.0.0/16,192.168.0.0/16,fc00::/7 ProxyProtocol.TrustedIPs:10.0.0.0/8,172.16.0.0/16,192.168.0.0/16,fc00::/7'
+      # - '--entryPoints=Name:http Address::80 ForwardedHeaders.TrustedIPs:10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7 ProxyProtocol.TrustedIPs:10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7'
+      # - '--entryPoints=Name:https Address::443 TLS ForwardedHeaders.TrustedIPs:10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7 ProxyProtocol.TrustedIPs:10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7'
       - '--entryPoints=Name:api Address::8081'
   authelia:
     image: authelia/authelia


### PR DESCRIPTION
This PR fixes some IP address ranges which I assume were meant to be a list of all [private IP address ranges](https://en.wikipedia.org/wiki/Private_network#Private_IPv4_addresses) but were specifying 172.16.0.0/16 instead of 172.16.0.0/12.