### PR TITLE
refactor(suites): utilise pki certs in haproxy suite

### DIFF
--- a/internal/suites/example/compose/haproxy/Dockerfile
+++ b/internal/suites/example/compose/haproxy/Dockerfile
@@ -3,10 +3,6 @@ USER root
 
 RUN \
 apk add --no-cache \
-  curl \
-  lua-json4 \
-  openssl && \
-openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=AU/ST=Victoria/L=Melbourne/O=Authelia/CN=*.example.com" -keyout haproxy.key -out haproxy.crt && \
-cat haproxy.key haproxy.crt > /usr/local/etc/haproxy/haproxy.pem
+  lua-json4
 
 USER haproxy

--- a/internal/suites/example/compose/haproxy/docker-compose.yml
+++ b/internal/suites/example/compose/haproxy/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./example/compose/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
       - ./example/compose/haproxy/http.lua:/usr/local/etc/haproxy/haproxy-lua-http/http.lua
       - ./example/compose/haproxy/auth-request.lua:/usr/local/etc/haproxy/auth-request.lua
+      - ./common/pki:/pki
     networks:
       authelianet:
         # Set the IP to be able to query on port 8080

--- a/internal/suites/example/compose/haproxy/haproxy.cfg
+++ b/internal/suites/example/compose/haproxy/haproxy.cfg
@@ -2,10 +2,14 @@ global
     lua-prepend-path /usr/local/etc/haproxy/?/http.lua
     lua-load /usr/local/etc/haproxy/auth-request.lua
     log stdout format raw local0 debug
+	maxconn 2000
 
 defaults
     default-server init-addr none
     mode http
+	timeout connect 5000ms
+	timeout client 50000ms
+	timeout server 50000ms
     log global
     option forwardfor
     option httplog
@@ -16,7 +20,7 @@ resolvers docker
     nameserver ip 127.0.0.11:53
 
 frontend fe_api
-    bind *:8081 ssl crt /usr/local/etc/haproxy/haproxy.pem
+    bind *:8081 ssl crt /pki/private.chain.pem
 
     stats enable
     stats uri /api
@@ -24,7 +28,7 @@ frontend fe_api
     stats admin if LOCALHOST
 
 frontend fe_http
-    bind *:8080 ssl crt /usr/local/etc/haproxy/haproxy.pem
+    bind *:8080 ssl crt /pki/private.chain.pem
 
     acl api-path path_beg -i /api
 	acl devworkflow-path path -i -m end /devworkflow


### PR DESCRIPTION
This utilises the certs provided within the pki section of the repo for the HAProxy suite.