### PR TITLE
fix(handlers): legacy authz failure on nginx

### DIFF
--- a/internal/handlers/handler_authz.go
+++ b/internal/handlers/handler_authz.go
@@ -112,7 +112,7 @@ func (authz *Authz) getAutheliaURL(ctx *middlewares.AutheliaCtx, provider *sessi
 		return nil, err
 	}
 
-	if autheliaURL != nil {
+	if autheliaURL != nil || authz.legacy {
 		return autheliaURL, nil
 	}
 


### PR DESCRIPTION
Since nginx doesn't do portal URL detection we have to skip returning an error on the legacy authz implementation when the portal URL isn't detected.