### PR TITLE
fix(commands): internal services not cleaned up properly

### DIFF
--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -777,3 +777,12 @@ Layouts:
 const (
 	fmtLogServerListening = "Server is listening for %s connections on '%s' path '%s'"
 )
+
+const (
+	logFieldService = "service"
+	logFieldFile    = "file"
+	logFieldOP      = "op"
+
+	serviceTypeServer  = "server"
+	serviceTypeWatcher = "watcher"
+)

--- a/internal/commands/services.go
+++ b/internal/commands/services.go
@@ -191,7 +191,7 @@ func (service *FileWatcherService) Run() (err error) {
 		}
 	}()
 
-	service.log.WithField("file", filepath.Join(service.directory, service.file)).Info("Watching for file changes to the file")
+	service.log.WithField(logFieldFile, filepath.Join(service.directory, service.file)).Info("Watching file for changes")
 
 	for {
 		select {
@@ -219,7 +219,7 @@ func (service *FileWatcherService) Run() (err error) {
 				case reloaded:
 					log.Info("Reloaded successfully")
 				default:
-					log.Debug("Reload of was triggered but it was skipped")
+					log.Debug("Reload was triggered but it was skipped")
 				}
 			case event.Op&fsnotify.Remove == fsnotify.Remove:
 				log.Debug("File remove was detected")
@@ -229,7 +229,7 @@ func (service *FileWatcherService) Run() (err error) {
 				return nil
 			}
 
-			service.log.WithError(err).Error("Error while watching files")
+			service.log.WithError(err).Error("Error while watching file for changes")
 		}
 	}
 }

--- a/internal/suites/environment.go
+++ b/internal/suites/environment.go
@@ -42,7 +42,7 @@ func waitUntilAutheliaBackendIsReady(dockerEnvironment *DockerEnvironment) error
 		90*time.Second,
 		dockerEnvironment,
 		"authelia-backend",
-		[]string{"Startup Complete"})
+		[]string{"Startup complete"})
 }
 
 func waitUntilAutheliaFrontendIsReady(dockerEnvironment *DockerEnvironment) error {


### PR DESCRIPTION
This fixes a race condition which in some circumstances (seemed to only affect a deliberately under provisioned VM in testing, however it could still theoretically occur on any system) can cause the process to hang during a shutdown. While unrelated this also adds additional trace logging to the shutdown process to better capture each stage to better facilitate debugging in the future specifically when one particular service is taking time to stop.

Fixes #4963