### PR TITLE
fix(logging): injected time format inconsistent

### DIFF
--- a/docs/content/en/configuration/miscellaneous/logging.md
+++ b/docs/content/en/configuration/miscellaneous/logging.md
@@ -75,7 +75,8 @@ level to `debug` or `trace` this will generate large amount of log entries. Admi
 they rotate and/or truncate the logs over time to prevent significant long-term disk usage.
 
 If you include the value `%d` in the filename it will replace this value with a date time indicative of the time
-the logger was initialized using `2006-02-01T150405Z` as the format.
+the logger was initialized using [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) as the format which is
+represented as `2006-01-02T15:04:05Z07:00` in go.
 
 #### File Path Examples
 

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -50,7 +50,7 @@ func InitializeLogger(config schema.LogConfiguration, log bool) error {
 	}
 
 	if config.FilePath != "" {
-		filePath := strings.ReplaceAll(config.FilePath, "%d", time.Now().Format("2006-02-01T150405Z"))
+		filePath := strings.ReplaceAll(config.FilePath, "%d", time.Now().Format(time.RFC3339))
 
 		f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 


### PR DESCRIPTION
This fixes an issue where the injected log time format is inconsistent with a normalized time format. This adjusts it to use a RFC3339 format.