### PR TITLE
refactor(web): native vite env replacement

### DIFF
--- a/internal/suites/example/compose/authelia/docker-compose.frontend.dev.yml
+++ b/internal/suites/example/compose/authelia/docker-compose.frontend.dev.yml
@@ -24,7 +24,7 @@ services:
       - 'traefik.http.routers.authelia_frontend.entrypoints=https'
       - 'traefik.http.routers.authelia_frontend.tls=true'
     environment:
-      - VITE_PUBLIC_URL=${PathPrefix}
+      - VITE_BASEPATH=${PathPrefix}
     networks:
       - authelianet
 ...

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,9 +1,9 @@
-VITE_LOGO_OVERRIDE={{ .LogoOverride }}
-VITE_PUBLIC_URL={{ .Base }}
+VITE_BASEPATH={{ .Base }}
 VITE_DUO_SELF_ENROLLMENT={{ .DuoSelfEnrollment }}
+VITE_LOGO_OVERRIDE={{ .LogoOverride }}
+VITE_PRIVACY_POLICY_ACCEPT={{ .PrivacyPolicyAccept }}
+VITE_PRIVACY_POLICY_URL={{ .PrivacyPolicyURL }}
 VITE_REMEMBER_ME={{ .RememberMe }}
 VITE_RESET_PASSWORD={{ .ResetPassword }}
 VITE_RESET_PASSWORD_CUSTOM_URL={{ .ResetPasswordCustomURL }}
-VITE_PRIVACY_POLICY_URL={{ .PrivacyPolicyURL }}
-VITE_PRIVACY_POLICY_ACCEPT={{ .PrivacyPolicyAccept }}
 VITE_THEME={{ .Theme }}

--- a/web/index.html
+++ b/web/index.html
@@ -13,14 +13,14 @@
 </head>
 
 <body
-    data-basepath="%VITE_PUBLIC_URL%"
+    data-basepath="%VITE_BASEPATH%"
     data-duoselfenrollment="%VITE_DUO_SELF_ENROLLMENT%"
     data-logooverride="%VITE_LOGO_OVERRIDE%"
+    data-privacypolicyaccept="%VITE_PRIVACY_POLICY_ACCEPT%"
+    data-privacypolicyurl="%VITE_PRIVACY_POLICY_URL%"
     data-rememberme="%VITE_REMEMBER_ME%"
     data-resetpassword="%VITE_RESET_PASSWORD%"
     data-resetpasswordcustomurl="%VITE_RESET_PASSWORD_CUSTOM_URL%"
-    data-privacypolicyurl="%VITE_PRIVACY_POLICY_URL%"
-    data-privacypolicyaccept="%VITE_PRIVACY_POLICY_ACCEPT%"
     data-theme="%VITE_THEME%"
 >
   <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import eslintPlugin from "vite-plugin-eslint";
 import istanbul from "vite-plugin-istanbul";
 import svgr from "vite-plugin-svgr";
@@ -7,20 +7,8 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 // @ts-ignore
 export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, ".");
     const isCoverage = process.env.VITE_COVERAGE === "true";
     const sourcemap = isCoverage ? "inline" : undefined;
-
-    const htmlPlugin = () => {
-        return {
-            name: "html-transform",
-            transformIndexHtml(html: string) {
-                return html.replace(/%(.*?)%/g, function (match, p1) {
-                    return env[p1];
-                });
-            },
-        };
-    };
 
     const istanbulPlugin = isCoverage
         ? istanbul({
@@ -58,6 +46,6 @@ export default defineConfig(({ mode }) => {
             port: 3000,
             open: false,
         },
-        plugins: [eslintPlugin({ cache: false }), htmlPlugin(), istanbulPlugin, react(), svgr(), tsconfigPaths()],
+        plugins: [eslintPlugin({ cache: false }), istanbulPlugin, react(), svgr(), tsconfigPaths()],
     };
 });


### PR DESCRIPTION
#5073 introduced native env replacement within Vite therefore we can remove our html-transform hook.