### PR TITLE
ci(buildkite): localised node artifacts

### DIFF
--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set +u
+
+if [[ "${BUILDKITE_LABEL}" == ":docker: Build Image [coverage]" && "${BUILDKITE_AGENT_NAME}" =~ ^vega[0-9]+$ ]]; then
+  mv authelia-image-coverage.tar.zst authelia-image-coverage-vega.tar.zst
+  BUILDKITE_S3_ENDPOINT="${S3_ENDPOINT}" BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="${S3_BUCKET}" BUILDKITE_S3_ACCESS_URL="${S3_ACCESS_URL}" BUILDKITE_S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" BUILDKITE_S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" buildkite-agent artifact upload authelia-image-coverage-vega.tar.zst
+fi

--- a/.buildkite/hooks/pre-artifact
+++ b/.buildkite/hooks/pre-artifact
@@ -21,7 +21,6 @@ if [[ "${BUILDKITE_LABEL}" == ":hammer_and_wrench: Unit Test" ]]; then
 fi
 
 if [[ "${BUILDKITE_LABEL}" == ":docker: Build Image [coverage]" ]]; then
-  # Saving image for docker push
   docker save "${DOCKER_IMAGE}" | zstdmt -T0 -12 > "authelia-image-coverage.tar.zst"
 fi
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -29,14 +29,20 @@ if [[ "${BUILDKITE_LABEL}" =~ ":debian: Build Package" ]]; then
 fi
 
 if [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
-  DEFAULT_ARCH=coverage
   echo "--- :docker: Extract and load build container"
   mkdir coverage
-  buildkite-agent artifact download "authelia-image-${DEFAULT_ARCH}*" .
-  if [[ "${SUITE}" == "Kubernetes" ]]; then
-    zstd -d authelia-image-coverage.tar.zst --stdout > ./internal/suites/example/kube/authelia-image-${DEFAULT_ARCH}.tar
+
+  if [[ "${BUILDKITE_AGENT_NAME}" =~ ^vega[0-9]+$ ]]; then
+    BUILDKITE_S3_ENDPOINT="${S3_ENDPOINT}" BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="${S3_BUCKET}" BUILDKITE_S3_ACCESS_URL="${S3_ACCESS_URL}" BUILDKITE_S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" BUILDKITE_S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" buildkite-agent artifact download "authelia-image-coverage-vega*" .
+    mv authelia-image-coverage-vega.tar.zst authelia-image-coverage.tar.zst
   else
-    zstdcat "authelia-image-${DEFAULT_ARCH}.tar.zst" | docker load
+    buildkite-agent artifact download "authelia-image-coverage.*" .
+  fi
+
+  if [[ "${SUITE}" == "Kubernetes" ]]; then
+    zstd -d authelia-image-coverage.tar.zst --stdout > ./internal/suites/example/kube/authelia-image-coverage.tar
+  else
+    zstdcat "authelia-image-coverage.tar.zst" | docker load
   fi
 
   if [[ "${BUILD_DUO}" == "true" ]] && [[ "${SUITE}" == "DuoPush" ]]; then
@@ -55,13 +61,13 @@ if [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
 fi
 
 if [[ "${BUILDKITE_LABEL}" == ":docker: Build and Deploy" ]]; then
-  echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+  echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 fi
 
 if [[ "${BUILDKITE_LABEL}" == ":docker: Deploy Manifest" ]]; then
   echo "--- :go: :react: :swagger: Extract pre-built binary"
   buildkite-agent artifact download "authelia-linux-*-musl.tar.gz" .
-  for archive in authelia-linux-*-musl.tar.gz; do tar xzf ${archive} --wildcards "authelia-linux-*"; done
+  for archive in authelia-linux-*-musl.tar.gz; do tar xzf "${archive}" --wildcards "authelia-linux-*"; done
 fi
 
 if [[ "${BUILDKITE_LABEL}" == ":github: Deploy Artifacts" ]]; then


### PR DESCRIPTION
This change ensures that vega Buildkite nodes will upload artifacts to a local MinIO instance and also retrieve artifacts from this location if the same constraint is met.