### PR TITLE
fix(configuration): misleading warning about logs_file

### DIFF
--- a/internal/configuration/deprecation.go
+++ b/internal/configuration/deprecation.go
@@ -59,7 +59,7 @@ var deprecations = map[string]Deprecation{
 	},
 	"host": {
 		Version: model.SemanticVersion{Major: 4, Minor: 30},
-		Key:     "logs_file",
+		Key:     "host",
 		NewKey:  "server.host",
 		AutoMap: true,
 		MapFunc: nil,


### PR DESCRIPTION
When `host` is set at the top level of configuration, we get as a result a misleading warn about its deprecation :

level=warning msg="Configuration: configuration key 'logs_file' is deprecated in 4.30.0 and has been replaced by 'server.host': this has been automatically mapped for you but you will need to adjust your configuration to remove this message"