### PR TITLE
fix(commands): crypto hash gen missing no args

### DIFF
--- a/internal/commands/crypto_hash.go
+++ b/internal/commands/crypto_hash.go
@@ -61,6 +61,7 @@ func newCryptoHashGenerateCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 		Short:   cmdAutheliaCryptoHashGenerateShort,
 		Long:    cmdAutheliaCryptoHashGenerateLong,
 		Example: cmdAutheliaCryptoHashGenerateExample,
+		Args:    cobra.NoArgs,
 		PreRunE: ctx.ChainRunE(
 			ctx.ConfigSetDefaultsRunE(defaults),
 			ctx.CryptoHashGenerateMapFlagsRunE,


### PR DESCRIPTION
This fixes an issue where the authelia crypto hash generate command does not automatically error when used with arguments leading to some confusing output.