### PR TITLE
fix(commands): missing pkcs8 option

### DIFF
--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_generate.md
@@ -56,6 +56,7 @@ authelia crypto certificate ecdsa generate --help
   -o, --organization strings            certificate organization (default [Authelia])
       --organizational-unit strings     certificate organizational unit
       --path.ca string                  source directory of the certificate authority files, if not provided the certificate will be self-signed
+      --pkcs8                           force PKCS #8 ASN.1 format
   -p, --postcode strings                certificate postcode
       --province strings                certificate province
       --sans strings                    subject alternative names

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ecdsa_request.md
@@ -48,6 +48,7 @@ authelia crypto certificate ecdsa request --help
       --not-before string             earliest date and time the certificate is considered valid in various formats (default is now)
   -o, --organization strings          certificate organization (default [Authelia])
       --organizational-unit strings   certificate organizational unit
+      --pkcs8                         force PKCS #8 ASN.1 format
   -p, --postcode strings              certificate postcode
       --province strings              certificate province
       --sans strings                  subject alternative names

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_generate.md
@@ -55,6 +55,7 @@ authelia crypto certificate ed25519 request --help
   -o, --organization strings            certificate organization (default [Authelia])
       --organizational-unit strings     certificate organizational unit
       --path.ca string                  source directory of the certificate authority files, if not provided the certificate will be self-signed
+      --pkcs8                           force PKCS #8 ASN.1 format
   -p, --postcode strings                certificate postcode
       --province strings                certificate province
       --sans strings                    subject alternative names

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_ed25519_request.md
@@ -47,6 +47,7 @@ authelia crypto certificate ed25519 request --help
       --not-before string             earliest date and time the certificate is considered valid in various formats (default is now)
   -o, --organization strings          certificate organization (default [Authelia])
       --organizational-unit strings   certificate organizational unit
+      --pkcs8                         force PKCS #8 ASN.1 format
   -p, --postcode strings              certificate postcode
       --province strings              certificate province
       --sans strings                  subject alternative names

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_generate.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_generate.md
@@ -56,6 +56,7 @@ authelia crypto certificate rsa generate --help
   -o, --organization strings            certificate organization (default [Authelia])
       --organizational-unit strings     certificate organizational unit
       --path.ca string                  source directory of the certificate authority files, if not provided the certificate will be self-signed
+      --pkcs8                           force PKCS #8 ASN.1 format
   -p, --postcode strings                certificate postcode
       --province strings                certificate province
       --sans strings                    subject alternative names

--- a/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_request.md
+++ b/docs/content/en/reference/cli/authelia/authelia_crypto_certificate_rsa_request.md
@@ -48,6 +48,7 @@ authelia crypto certificate rsa request --help
       --not-before string             earliest date and time the certificate is considered valid in various formats (default is now)
   -o, --organization strings          certificate organization (default [Authelia])
       --organizational-unit strings   certificate organizational unit
+      --pkcs8                         force PKCS #8 ASN.1 format
   -p, --postcode strings              certificate postcode
       --province strings              certificate province
       --sans strings                  subject alternative names

--- a/internal/commands/crypto_helper.go
+++ b/internal/commands/crypto_helper.go
@@ -59,10 +59,10 @@ func cmdFlagsCryptoCertificateRequest(cmd *cobra.Command) {
 
 func cmdFlagsCryptoPairGenerate(cmd *cobra.Command) {
 	cmd.Flags().String(cmdFlagNameFilePublicKey, "public.pem", "name of the file to export the public key data to")
-	cmd.Flags().Bool(cmdFlagNamePKCS8, false, "force PKCS #8 ASN.1 format")
 }
 
 func cmdFlagsCryptoPrivateKey(cmd *cobra.Command) {
+	cmd.Flags().Bool(cmdFlagNamePKCS8, false, "force PKCS #8 ASN.1 format")
 	cmd.Flags().String(cmdFlagNameFilePrivateKey, "private.pem", "name of the file to export the private key data to")
 	cmd.Flags().StringP(cmdFlagNameDirectory, "d", "", "directory where the generated keys, certificates, etc will be stored")
 }


### PR DESCRIPTION
Several crypto generate situations could not generate PKCS #8 ASN.1 DER format keys. Ths fixes this.