### PR TITLE
fix(notifier): mime parts in reverse order

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -16,7 +16,7 @@ body:
         1. Please ensure you do not report security vulnerabilities via this method. See our [Security Policy](https://www.authelia.com/security-policy).
         2. Please try to give as much information as possible for us to be able to reproduce the issue and provide a quick fix.
         3. Please ensure an issue does not already exist for this potential bug.
-        4. Please only provide specific versions. Latest is not a version.
+        4. Please only provide a released specific version or versions. Latest is not a version. Only released stable versions should be reported here; unreleased, untagged, or beta versions should have a report submitted via a [discussion](https://github.com/authelia/authelia/discussions/new/choose) instead.
         5. Please only report bugs with Authelia itself. Issues which match one of the following criteria should not be reported here but should be a [discussion](https://github.com/authelia/authelia/discussions/new/choose) instead:
             - Bugs with third-party software.
             - Mistakes in the documentation.

--- a/cmd/authelia-gen/templates/github_issue_template_bug_report.yml.tmpl
+++ b/cmd/authelia-gen/templates/github_issue_template_bug_report.yml.tmpl
@@ -16,7 +16,7 @@ body:
         1. Please ensure you do not report security vulnerabilities via this method. See our [Security Policy](https://www.authelia.com/security-policy).
         2. Please try to give as much information as possible for us to be able to reproduce the issue and provide a quick fix.
         3. Please ensure an issue does not already exist for this potential bug.
-        4. Please only provide specific versions. Latest is not a version.
+        4. Please only provide a released specific version or versions. Latest is not a version. Only released stable versions should be reported here; unreleased, untagged, or beta versions should have a report submitted via a [discussion](https://github.com/authelia/authelia/discussions/new/choose) instead.
         5. Please only report bugs with Authelia itself. Issues which match one of the following criteria should not be reported here but should be a [discussion](https://github.com/authelia/authelia/discussions/new/choose) instead:
             - Bugs with third-party software.
             - Mistakes in the documentation.

--- a/cmd/authelia-scripts/cmd/gen.go
+++ b/cmd/authelia-scripts/cmd/gen.go
@@ -7,5 +7,5 @@
 package cmd
 
 const (
-	versionSwaggerUI = "5.0.0"
+	versionSwaggerUI = "5.1.0"
 )

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -128,12 +128,12 @@ func (n *SMTPNotifier) Send(ctx context.Context, recipient mail.Address, subject
 			return fmt.Errorf("notifier: smtp: failed to set body: text template errored: %w", err)
 		}
 	default:
-		if err = msg.AddAlternativeHTMLTemplate(et.HTML, data); err != nil {
-			return fmt.Errorf("notifier: smtp: failed to set body: html template errored: %w", err)
-		}
-
 		if err = msg.AddAlternativeTextTemplate(et.Text, data); err != nil {
 			return fmt.Errorf("notifier: smtp: failed to set body: text template errored: %w", err)
+		}
+
+		if err = msg.AddAlternativeHTMLTemplate(et.HTML, data); err != nil {
+			return fmt.Errorf("notifier: smtp: failed to set body: html template errored: %w", err)
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue where the mime multipart parts were in the incorrect order. Only affects beta releases.

Fixes #5617