### PR TITLE
test(suites): add 403 forbidden test in 1fa suite

### DIFF
--- a/cmd/authelia-scripts/cmd/bootstrap.go
+++ b/cmd/authelia-scripts/cmd/bootstrap.go
@@ -78,6 +78,7 @@ var hostEntries = []HostEntry{
 	{Domain: "login.example.com", IP: "192.168.240.100"},
 	{Domain: "admin.example.com", IP: "192.168.240.100"},
 	{Domain: "singlefactor.example.com", IP: "192.168.240.100"},
+	{Domain: "deny.example.com", IP: "192.168.240.100"},
 	{Domain: "dev.example.com", IP: "192.168.240.100"},
 	{Domain: "home.example.com", IP: "192.168.240.100"},
 	{Domain: "mx1.mail.example.com", IP: "192.168.240.100"},
@@ -193,7 +194,7 @@ func pnpmInstall() {
 		panic(err)
 	}
 
-	shell(fmt.Sprintf("cd %s/web && pnpm install", cwd))
+	shell(fmt.Sprintf("cd %s/web && pnpm install --force", cwd))
 }
 
 func bootstrapPrintln(args ...any) {

--- a/docs/content/en/integration/proxies/haproxy.md
+++ b/docs/content/en/integration/proxies/haproxy.md
@@ -221,7 +221,8 @@ frontend fe_http
     http-request set-header X-Forwarded-URI    %[path]%[var(req.questionmark)]%[query]
 
     # Protect endpoints with haproxy-auth-request and Authelia
-    http-request lua.auth-intercept be_authelia /api/authz/forward-auth HEAD * authorization,proxy-authorization,remote_user,remote-user,remote-groups,remote-name,remote-email - if protected-frontends
+    http-request lua.auth-intercept be_authelia /api/authz/forward-auth HEAD * authorization,proxy-authorization,remote-user,remote-groups,remote-name,remote-email - if protected-frontends
+    http-request deny if protected-frontends !{ var(txn.auth_response_successful) -m bool } { var(txn.auth_response_code) -m int 403 }
     http-request redirect location %[var(txn.auth_response_location)] if protected-frontends !{ var(txn.auth_response_successful) -m bool }
 
     # Authelia backend route
@@ -297,7 +298,8 @@ frontend fe_http
     http-request set-header X-Forwarded-URI    %[path]%[var(req.questionmark)]%[query]
 
     # Protect endpoints with haproxy-auth-request and Authelia
-    http-request lua.auth-intercept be_authelia_proxy /api/authz/forward-auth HEAD * authorization,proxy-authorization,remote_user,remote-user,remote-groups,remote-name,remote-email - if protected-frontends
+    http-request lua.auth-intercept be_authelia_proxy /api/authz/forward-auth HEAD * authorization,proxy-authorization,remote-user,remote-groups,remote-name,remote-email - if protected-frontends
+    http-request deny if protected-frontends !{ var(txn.auth_response_successful) -m bool } { var(txn.auth_response_code) -m int 403 }
     http-request redirect location %[var(txn.auth_response_location)] if protected-frontends !{ var(txn.auth_response_successful) -m bool }
 
     # Authelia backend route

--- a/internal/suites/ActiveDirectory/configuration.yml
+++ b/internal/suites/ActiveDirectory/configuration.yml
@@ -49,7 +49,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/ActiveDirectory/configuration.yml
+++ b/internal/suites/ActiveDirectory/configuration.yml
@@ -49,7 +49,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/ActiveDirectory/configuration.yml
+++ b/internal/suites/ActiveDirectory/configuration.yml
@@ -51,6 +51,8 @@ access_control:
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/Caddy/configuration.yml
+++ b/internal/suites/Caddy/configuration.yml
@@ -39,10 +39,12 @@ storage:
     path: /config/db.sqlite
 
 access_control:
-  default_policy: bypass
+  default_policy: deny
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/Caddy/configuration.yml
+++ b/internal/suites/Caddy/configuration.yml
@@ -41,7 +41,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Caddy/configuration.yml
+++ b/internal/suites/Caddy/configuration.yml
@@ -41,7 +41,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Docker/configuration.yml
+++ b/internal/suites/Docker/configuration.yml
@@ -38,42 +38,17 @@ totp:
 
 access_control:
   default_policy: deny
-
   rules:
-    - domain: singlefactor.example.com
-      policy: one_factor
-
-    - domain: public.example.com
+    - domain: "public.example.com"
       policy: bypass
-
-    - domain: secure.example.com
+    - domain: "deny.example.com"
+      policy: deny
+    - domain: "admin.example.com"
       policy: two_factor
-
-    - domain: "*.example.com"
-      subject: "group:admins"
+    - domain: "secure.example.com"
       policy: two_factor
-
-    - domain: dev.example.com
-      resources:
-        - "^/users/john/.*$"
-      subject: "user:john"
-      policy: two_factor
-
-    - domain: dev.example.com
-      resources:
-        - "^/users/harry/.*$"
-      subject: "user:harry"
-      policy: two_factor
-
-    - domain: "*.mail.example.com"
-      subject: "user:bob"
-      policy: two_factor
-
-    - domain: dev.example.com
-      resources:
-        - "^/users/bob/.*$"
-      subject: "user:bob"
-      policy: two_factor
+    - domain: "singlefactor.example.com"
+      policy: one_factor
 
 regulation:
   # Set it to 0 to disable max_retries.

--- a/internal/suites/Docker/configuration.yml
+++ b/internal/suites/Docker/configuration.yml
@@ -39,7 +39,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Docker/configuration.yml
+++ b/internal/suites/Docker/configuration.yml
@@ -39,7 +39,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Envoy/configuration.yml
+++ b/internal/suites/Envoy/configuration.yml
@@ -42,7 +42,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Envoy/configuration.yml
+++ b/internal/suites/Envoy/configuration.yml
@@ -42,7 +42,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Envoy/configuration.yml
+++ b/internal/suites/Envoy/configuration.yml
@@ -40,12 +40,12 @@ storage:
     path: /config/db.sqlite
 
 access_control:
-  default_policy: bypass
+  default_policy: deny
   rules:
-    - domain: "login.example.com"
-      policy: bypass
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/HAProxy/configuration.yml
+++ b/internal/suites/HAProxy/configuration.yml
@@ -35,7 +35,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/HAProxy/configuration.yml
+++ b/internal/suites/HAProxy/configuration.yml
@@ -33,10 +33,12 @@ storage:
     path: /config/db.sqlite
 
 access_control:
-  default_policy: bypass
+  default_policy: deny
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/HAProxy/configuration.yml
+++ b/internal/suites/HAProxy/configuration.yml
@@ -35,7 +35,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/HighAvailability/configuration.yml
+++ b/internal/suites/HighAvailability/configuration.yml
@@ -39,7 +39,7 @@ access_control:
   default_policy: deny
   rules:
     # Rules applied to everyone
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/HighAvailability/configuration.yml
+++ b/internal/suites/HighAvailability/configuration.yml
@@ -37,11 +37,12 @@ authentication_backend:
 
 access_control:
   default_policy: deny
-
   rules:
     # Rules applied to everyone
     - domain: public.example.com
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: secure.example.com
       policy: two_factor
     - domain: singlefactor.example.com

--- a/internal/suites/HighAvailability/configuration.yml
+++ b/internal/suites/HighAvailability/configuration.yml
@@ -39,17 +39,17 @@ access_control:
   default_policy: deny
   rules:
     # Rules applied to everyone
-    - domain: public.example.com
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny
-    - domain: secure.example.com
+    - domain: "secure.example.com"
       policy: two_factor
-    - domain: singlefactor.example.com
+    - domain: "singlefactor.example.com"
       policy: one_factor
 
     # Rules applied to 'admins' group
-    - domain: mx2.mail.example.com
+    - domain: "mx2.mail.example.com"
       subject: "group:admins"
       policy: deny
 
@@ -63,14 +63,14 @@ access_control:
       policy: two_factor
 
     # Rules applied to 'dev' group
-    - domain: dev.example.com
+    - domain: "dev.example.com"
       resources:
         - "^/groups/dev/.*$"
       subject: "group:dev"
       policy: two_factor
 
     # Rules applied to user 'harry'
-    - domain: dev.example.com
+    - domain: "dev.example.com"
       resources:
         - "^/users/harry/.*$"
       subject: "user:harry"

--- a/internal/suites/LDAP/configuration.yml
+++ b/internal/suites/LDAP/configuration.yml
@@ -58,6 +58,8 @@ access_control:
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/LDAP/configuration.yml
+++ b/internal/suites/LDAP/configuration.yml
@@ -56,7 +56,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/LDAP/configuration.yml
+++ b/internal/suites/LDAP/configuration.yml
@@ -56,7 +56,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/MariaDB/configuration.yml
+++ b/internal/suites/MariaDB/configuration.yml
@@ -49,6 +49,8 @@ access_control:
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/MariaDB/configuration.yml
+++ b/internal/suites/MariaDB/configuration.yml
@@ -47,7 +47,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/MariaDB/configuration.yml
+++ b/internal/suites/MariaDB/configuration.yml
@@ -47,7 +47,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/MySQL/configuration.yml
+++ b/internal/suites/MySQL/configuration.yml
@@ -48,7 +48,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/MySQL/configuration.yml
+++ b/internal/suites/MySQL/configuration.yml
@@ -48,7 +48,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/MySQL/configuration.yml
+++ b/internal/suites/MySQL/configuration.yml
@@ -50,6 +50,8 @@ access_control:
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/PathPrefix/configuration.yml
+++ b/internal/suites/PathPrefix/configuration.yml
@@ -35,7 +35,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/PathPrefix/configuration.yml
+++ b/internal/suites/PathPrefix/configuration.yml
@@ -33,10 +33,12 @@ storage:
     path: /config/db.sqlite
 
 access_control:
-  default_policy: bypass
+  default_policy: deny
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/PathPrefix/configuration.yml
+++ b/internal/suites/PathPrefix/configuration.yml
@@ -35,7 +35,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Postgres/configuration.yml
+++ b/internal/suites/Postgres/configuration.yml
@@ -49,6 +49,8 @@ access_control:
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/Postgres/configuration.yml
+++ b/internal/suites/Postgres/configuration.yml
@@ -47,7 +47,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Postgres/configuration.yml
+++ b/internal/suites/Postgres/configuration.yml
@@ -47,7 +47,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Standalone/configuration.yml
+++ b/internal/suites/Standalone/configuration.yml
@@ -41,48 +41,19 @@ totp:
 
 access_control:
   default_policy: deny
-
   rules:
-    - domain: singlefactor.example.com
-      policy: one_factor
-
     - domain: public.example.com
       policy: bypass
-
     - domain: secure.example.com
       policy: bypass
       methods:
         - OPTIONS
-
+    - domain: "deny.example.com"
+      policy: deny
     - domain: secure.example.com
       policy: two_factor
-
-    - domain: "*.example.com"
-      subject: "group:admins"
-      policy: two_factor
-
-    - domain: dev.example.com
-      resources:
-        - "^/users/john/.*$"
-      subject: "user:john"
-      policy: two_factor
-
-    - domain: dev.example.com
-      resources:
-        - "^/users/harry/.*$"
-      subject: "user:harry"
-      policy: two_factor
-
-    - domain: "*.mail.example.com"
-      subject: "user:bob"
-      policy: two_factor
-
-    - domain: dev.example.com
-      resources:
-        - "^/users/bob/.*$"
-      subject: "user:bob"
-      policy: two_factor
-
+    - domain: singlefactor.example.com
+      policy: one_factor
 
 regulation:
   # Set it to 0 to disable max_retries.

--- a/internal/suites/Standalone/configuration.yml
+++ b/internal/suites/Standalone/configuration.yml
@@ -42,7 +42,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: public.example.com
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: secure.example.com
       policy: bypass

--- a/internal/suites/Standalone/configuration.yml
+++ b/internal/suites/Standalone/configuration.yml
@@ -42,7 +42,7 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: secure.example.com
       policy: bypass

--- a/internal/suites/Standalone/configuration.yml
+++ b/internal/suites/Standalone/configuration.yml
@@ -50,9 +50,11 @@ access_control:
         - OPTIONS
     - domain: "deny.example.com"
       policy: deny
-    - domain: secure.example.com
+    - domain: "admin.example.com"
       policy: two_factor
-    - domain: singlefactor.example.com
+    - domain: "secure.example.com"
+      policy: two_factor
+    - domain: "singlefactor.example.com"
       policy: one_factor
 
 regulation:

--- a/internal/suites/Traefik/configuration.yml
+++ b/internal/suites/Traefik/configuration.yml
@@ -34,10 +34,12 @@ storage:
     path: /config/db.sqlite
 
 access_control:
-  default_policy: bypass
+  default_policy: deny
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/Traefik/configuration.yml
+++ b/internal/suites/Traefik/configuration.yml
@@ -36,7 +36,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Traefik/configuration.yml
+++ b/internal/suites/Traefik/configuration.yml
@@ -36,7 +36,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Traefik2/configuration.yml
+++ b/internal/suites/Traefik2/configuration.yml
@@ -45,10 +45,12 @@ storage:
     path: /config/db.sqlite
 
 access_control:
-  default_policy: bypass
+  default_policy: deny
   rules:
     - domain: "public.example.com"
       policy: bypass
+    - domain: "deny.example.com"
+      policy: deny
     - domain: "admin.example.com"
       policy: two_factor
     - domain: "secure.example.com"

--- a/internal/suites/Traefik2/configuration.yml
+++ b/internal/suites/Traefik2/configuration.yml
@@ -47,7 +47,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: ["home.example.com","public.example.com"]
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/Traefik2/configuration.yml
+++ b/internal/suites/Traefik2/configuration.yml
@@ -47,7 +47,7 @@ storage:
 access_control:
   default_policy: deny
   rules:
-    - domain: "public.example.com"
+    - domain: ["home.example.com","public.example.com"]
       policy: bypass
     - domain: "deny.example.com"
       policy: deny

--- a/internal/suites/const.go
+++ b/internal/suites/const.go
@@ -58,6 +58,9 @@ var PublicBaseURL = fmt.Sprintf("https://public.%s", BaseDomain)
 // SecureBaseURL the base URL of the secure domain.
 var SecureBaseURL = fmt.Sprintf("https://secure.%s", BaseDomain)
 
+// DenyBaseURL the base URL of the dev domain.
+var DenyBaseURL = fmt.Sprintf("https://deny.%s", BaseDomain)
+
 // DevBaseURL the base URL of the dev domain.
 var DevBaseURL = fmt.Sprintf("https://dev.%s", BaseDomain)
 

--- a/internal/suites/example/compose/authelia/resources/entrypoint-frontend.sh
+++ b/internal/suites/example/compose/authelia/resources/entrypoint-frontend.sh
@@ -2,4 +2,4 @@
 
 set -x
 
-pnpm install --frozen-lockfile && pnpm start
+pnpm install --force --frozen-lockfile && pnpm start

--- a/internal/suites/example/compose/haproxy/docker-compose.yml
+++ b/internal/suites/example/compose/haproxy/docker-compose.yml
@@ -10,6 +10,5 @@ services:
       - ./common/pki:/pki
     networks:
       authelianet:
-        # Set the IP to be able to query on port 8080
         ipv4_address: 192.168.240.100
 ...

--- a/internal/suites/example/compose/haproxy/haproxy.cfg
+++ b/internal/suites/example/compose/haproxy/haproxy.cfg
@@ -37,8 +37,7 @@ frontend fe_http
 	acl locales-path path_beg -i /locales
 	acl wellknown-path path_beg -i /.well-known
     acl host-authelia-portal hdr(host) -i login.example.com:8080
-	acl host-home-frontend hdr(host) -i home.example.com:8080
-    acl protected-frontends hdr(host) -m reg -i ^(?i)(admin|deny|public|secure|singlefactor)\.example\.com
+    acl protected-frontends hdr(host) -m reg -i ^(?i)(admin|deny|home|public|secure|singlefactor)\.example\.com
 
     http-request set-var(req.scheme) str(https) if { ssl_fc }
     http-request set-var(req.scheme) str(http) if !{ ssl_fc }
@@ -60,7 +59,6 @@ frontend fe_http
     use_backend fe_authelia if host-authelia-portal !api-path
     use_backend be_httpbin if protected-frontends headers-path
     use_backend be_mail if { hdr(host) -i mail.example.com:8080 }
-	use_backend be_protected if host-home-frontend
     use_backend be_protected if protected-frontends
 
 backend be_auth_request

--- a/internal/suites/example/compose/haproxy/haproxy.cfg
+++ b/internal/suites/example/compose/haproxy/haproxy.cfg
@@ -52,8 +52,8 @@ frontend fe_http
     # be_auth_request is used to make HAProxy do the TLS termination since the Lua script
     # does not know how to handle it (see https://github.com/TimWolla/haproxy-auth-request/issues/12).
     http-request lua.auth-intercept be_auth_request /api/authz/forward-auth HEAD * authorization,proxy-authorization,remote-user,remote-groups,remote-name,remote-email - if protected-frontends
-	http-request deny if protected-frontends !{ var(txn.auth_response_successful) -m bool } { var(txn.auth_response_code) -m int 403 }
-	http-request redirect location %[var(txn.auth_response_location)] if protected-frontends !{ var(txn.auth_response_successful) -m bool }
+    http-request deny if protected-frontends !{ var(txn.auth_response_successful) -m bool } { var(txn.auth_response_code) -m int 403 }
+    http-request redirect location %[var(txn.auth_response_location)] if protected-frontends !{ var(txn.auth_response_successful) -m bool }
 
     use_backend be_authelia if host-authelia-portal api-path || devworkflow-path || jwks-path || locales-path || wellknown-path
     use_backend fe_authelia if host-authelia-portal !api-path

--- a/internal/suites/example/compose/haproxy/haproxy.cfg
+++ b/internal/suites/example/compose/haproxy/haproxy.cfg
@@ -37,7 +37,8 @@ frontend fe_http
 	acl locales-path path_beg -i /locales
 	acl wellknown-path path_beg -i /.well-known
     acl host-authelia-portal hdr(host) -i login.example.com:8080
-    acl protected-frontends hdr(host) -m reg -i ^(?i)(admin|home|public|secure|singlefactor)\.example\.com
+	acl host-home-frontend hdr(host) -i home.example.com:8080
+    acl protected-frontends hdr(host) -m reg -i ^(?i)(admin|deny|public|secure|singlefactor)\.example\.com
 
     http-request set-var(req.scheme) str(https) if { ssl_fc }
     http-request set-var(req.scheme) str(http) if !{ ssl_fc }
@@ -51,13 +52,15 @@ frontend fe_http
 
     # be_auth_request is used to make HAProxy do the TLS termination since the Lua script
     # does not know how to handle it (see https://github.com/TimWolla/haproxy-auth-request/issues/12).
-    http-request lua.auth-intercept be_auth_request /api/authz/forward-auth HEAD * authorization,proxy-authorization,remote_user,remote-user,remote-groups,remote-name,remote-email - if protected-frontends
-    http-request redirect location %[var(txn.auth_response_location)] if protected-frontends !{ var(txn.auth_response_successful) -m bool }
+    http-request lua.auth-intercept be_auth_request /api/authz/forward-auth HEAD * authorization,proxy-authorization,remote-user,remote-groups,remote-name,remote-email - if protected-frontends
+	http-request deny if protected-frontends !{ var(txn.auth_response_successful) -m bool } { var(txn.auth_response_code) -m int 403 }
+	http-request redirect location %[var(txn.auth_response_location)] if protected-frontends !{ var(txn.auth_response_successful) -m bool }
 
     use_backend be_authelia if host-authelia-portal api-path || devworkflow-path || jwks-path || locales-path || wellknown-path
     use_backend fe_authelia if host-authelia-portal !api-path
     use_backend be_httpbin if protected-frontends headers-path
     use_backend be_mail if { hdr(host) -i mail.example.com:8080 }
+	use_backend be_protected if host-home-frontend
     use_backend be_protected if protected-frontends
 
 backend be_auth_request
@@ -71,25 +74,14 @@ backend be_authelia
     server authelia-backend authelia-backend:9091 resolvers docker ssl verify none
 
 backend fe_authelia
-	option httpchk
-	http-check expect rstatus ^2
-
     server authelia-frontend authelia-frontend:3000 check resolvers docker
     server authelia-backend authelia-backend:9091 check backup resolvers docker ssl verify none
 
 backend be_httpbin
-    ## Pass the Set-Cookie response headers to the user.
-    acl set_cookie_exist var(req.auth_response_header.set_cookie) -m found
-    http-response set-header Set-Cookie %[var(req.auth_response_header.set_cookie)] if set_cookie_exist
-
     server httpbin-backend httpbin:8000 resolvers docker
 
 backend be_mail
     server smtp-backend smtp:1080 resolvers docker
 
 backend be_protected
-    ## Pass the Set-Cookie response headers to the user.
-    acl set_cookie_exist var(req.auth_response_header.set_cookie) -m found
-    http-response set-header Set-Cookie %[var(req.auth_response_header.set_cookie)] if set_cookie_exist
-
     server nginx-backend nginx-backend:80 resolvers docker

--- a/internal/suites/example/compose/haproxy/http.lua
+++ b/internal/suites/example/compose/haproxy/http.lua
@@ -752,9 +752,9 @@ M.base64 = {}
 --- URL safe base64 encoder
 --
 -- Padding ('=') is omited, as permited per RFC
---   https://datatracker.ietf.org/doc/html/rfc4648
+--   https://tools.ietf.org/html/rfc4648
 -- in order to follow JSON Web Signature RFC
---   https://datatracker.ietf.org/doc/html/rfc7515
+--   https://tools.ietf.org/html/rfc7515
 --
 -- @param s String (can be binary data) to encode
 -- @param enc Function which implements base64 encoder (e.g. HAProxy base64 fetch)

--- a/internal/suites/example/compose/nginx/backend/docker-compose.yml
+++ b/internal/suites/example/compose/nginx/backend/docker-compose.yml
@@ -5,14 +5,14 @@ services:
     image: nginx:alpine
     labels:
       # Traefik 1.x
-      - 'traefik.frontend.rule=Host:admin.example.com,deny.example.com,public.example.com,secure.example.com,singlefactor.example.com'  # yamllint disable-line rule:line-length
+      - 'traefik.frontend.rule=Host:admin.example.com,deny.example.com,home.example.com,public.example.com,secure.example.com,singlefactor.example.com'  # yamllint disable-line rule:line-length
       - 'traefik.frontend.auth.forward.address=https://authelia-backend:9091/api/authz/forward-auth'  # yamllint disable-line rule:line-length
       - 'traefik.frontend.auth.forward.tls.insecureSkipVerify=true'
       - 'traefik.frontend.auth.forward.trustForwardHeader=true'
       - 'traefik.frontend.auth.forward.authResponseHeaders=Authorization,Proxy-Authorization,Remote-User,Remote-Groups,Remote-Email,Remote-Name'
       # Traefik 2.x
       - 'traefik.enable=true'
-      - 'traefik.http.routers.protectedapps.rule=Host(`admin.example.com`,`deny.example.com`,`public.example.com`,`secure.example.com`,`singlefactor.example.com`)'  # yamllint disable-line rule:line-length
+      - 'traefik.http.routers.protectedapps.rule=Host(`admin.example.com`,`deny.example.com`,`home.example.com`,`public.example.com`,`secure.example.com`,`singlefactor.example.com`)'  # yamllint disable-line rule:line-length
       - 'traefik.http.routers.protectedapps.entrypoints=https'
       - 'traefik.http.routers.protectedapps.tls=true'
       - 'traefik.http.routers.protectedapps.middlewares=authelia@docker'

--- a/internal/suites/example/compose/nginx/backend/docker-compose.yml
+++ b/internal/suites/example/compose/nginx/backend/docker-compose.yml
@@ -5,14 +5,14 @@ services:
     image: nginx:alpine
     labels:
       # Traefik 1.x
-      - 'traefik.frontend.rule=Host:home.example.com,public.example.com,secure.example.com,admin.example.com,singlefactor.example.com'  # yamllint disable-line rule:line-length
+      - 'traefik.frontend.rule=Host:admin.example.com,deny.example.com,public.example.com,secure.example.com,singlefactor.example.com'  # yamllint disable-line rule:line-length
       - 'traefik.frontend.auth.forward.address=https://authelia-backend:9091/api/authz/forward-auth'  # yamllint disable-line rule:line-length
       - 'traefik.frontend.auth.forward.tls.insecureSkipVerify=true'
       - 'traefik.frontend.auth.forward.trustForwardHeader=true'
       - 'traefik.frontend.auth.forward.authResponseHeaders=Authorization,Proxy-Authorization,Remote-User,Remote-Groups,Remote-Email,Remote-Name'
       # Traefik 2.x
       - 'traefik.enable=true'
-      - 'traefik.http.routers.protectedapps.rule=Host(`home.example.com`,`public.example.com`,`secure.example.com`,`admin.example.com`,`singlefactor.example.com`)'  # yamllint disable-line rule:line-length
+      - 'traefik.http.routers.protectedapps.rule=Host(`admin.example.com`,`deny.example.com`,`public.example.com`,`secure.example.com`,`singlefactor.example.com`)'  # yamllint disable-line rule:line-length
       - 'traefik.http.routers.protectedapps.entrypoints=https'
       - 'traefik.http.routers.protectedapps.tls=true'
       - 'traefik.http.routers.protectedapps.middlewares=authelia@docker'

--- a/internal/suites/example/compose/nginx/backend/html/deny/secret.html
+++ b/internal/suites/example/compose/nginx/backend/html/deny/secret.html
@@ -1,0 +1,29 @@
+<html>
+
+<head>
+  <title>Secret</title>
+  <link rel="icon" href="/icon.png" type="image/png" />
+  <script>
+    window.onload = () =>{
+      /**
+       * this section renames example.com for the real hostname
+       * it's required for multi cookie domain suite
+       * */
+      const hostname = window.location.hostname
+      const protocol = window.location.protocol
+      const port = window.location.port
+      const domain = hostname.replace(/^\w+\.(.+)$/i, "$1")
+      const newDomain = `${domain}:${port}`
+      document.body.innerHTML = document.body.innerHTML.replace(/example.com:8080/ig, newDomain)
+    }
+
+  </script>
+
+</head>
+
+<body id="secret">
+  This is a very important secret!<br />
+  Go back to <a href="https://home.example.com:8080/">home page</a>.
+</body>
+
+</html>

--- a/internal/suites/example/compose/nginx/backend/html/home/index.html
+++ b/internal/suites/example/compose/nginx/backend/html/home/index.html
@@ -37,6 +37,9 @@
       singlefactor.example.com <a href="https://singlefactor.example.com:8080/secret.html"> / secret.html</a>
     </li>
     <li>
+      deny.example.com <a href="https://deny.example.com:8080/secret.html"> / secret.html</a>
+    </li>
+    <li>
       dev.example.com
       <ul>
         <li>Groups

--- a/internal/suites/example/compose/nginx/backend/nginx.conf
+++ b/internal/suites/example/compose/nginx/backend/nginx.conf
@@ -32,6 +32,12 @@ http {
 
     server {
         listen 80;
+        root /usr/share/nginx/html/deny;
+        server_name ~^deny\.example([0-9])*\.com$;
+    }
+
+    server {
+        listen 80;
         root /usr/share/nginx/html/dev;
         server_name ~^dev\.example([0-9])*\.com$;
     }

--- a/internal/suites/example/compose/nginx/portal/nginx.conf
+++ b/internal/suites/example/compose/nginx/portal/nginx.conf
@@ -145,7 +145,7 @@ http {
     # Example configuration of domains protected by Authelia.
     server {
         listen 8080 ssl;
-        server_name ~^(public|admin|secure|dev|singlefactor|mx[1-2])(\.mail)?\.(?<basedomain>example([0-9])*\.com)$;
+        server_name ~^(public|admin|secure|deny|dev|singlefactor|mx[1-2])(\.mail)?\.(?<basedomain>example([0-9])*\.com)$;
 
         resolver 127.0.0.11 ipv6=off;
         set $upstream_authelia https://authelia-backend:9091/api/authz/auth-request;

--- a/internal/suites/example/compose/traefik/docker-compose.yml
+++ b/internal/suites/example/compose/traefik/docker-compose.yml
@@ -21,6 +21,5 @@ services:
       - '--insecureSkipVerify=true'
     networks:
       authelianet:
-        # Set the IP to be able to query on port 8080
         ipv4_address: 192.168.240.100
 ...

--- a/internal/suites/example/compose/traefik2/docker-compose.yml
+++ b/internal/suites/example/compose/traefik2/docker-compose.yml
@@ -28,10 +28,5 @@ services:
       - '--serversTransport.insecureSkipVerify=true'
     networks:
       authelianet:
-        aliases:
-          - public.example.com
-          - secure.example.com
-          - login.example.com
-        # Set the IP to be able to query on port 8080
         ipv4_address: 192.168.240.100
 ...

--- a/internal/suites/example/compose/traefik2/docker-compose.yml
+++ b/internal/suites/example/compose/traefik2/docker-compose.yml
@@ -28,5 +28,7 @@ services:
       - '--serversTransport.insecureSkipVerify=true'
     networks:
       authelianet:
+        aliases:
+          - login.example.com
         ipv4_address: 192.168.240.100
 ...

--- a/internal/suites/example/kube/apps/nginx.yml
+++ b/internal/suites/example/kube/apps/nginx.yml
@@ -95,6 +95,16 @@ spec:
                 name: nginx-backend-service
                 port:
                   number: 80
+    - host: deny.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx-backend-service
+                port:
+                  number: 80
     - host: dev.example.com
       http:
         paths:

--- a/internal/suites/example/kube/authelia/configs/configuration.yml
+++ b/internal/suites/example/kube/authelia/configs/configuration.yml
@@ -35,56 +35,17 @@ authentication_backend:
 
 access_control:
   default_policy: deny
-
   rules:
-    # Rules applied to everyone
-    - domain: home.example.com
+    - domain: ["home.example.com", "public.example.com"]
       policy: bypass
-    - domain: public.example.com
-      policy: bypass
-    - domain: secure.example.com
-      policy: two_factor
-    - domain: singlefactor.example.com
-      policy: one_factor
-
-    # Rules applied to 'admins' group
-    - domain: "mx2.mail.example.com"
-      subject: "group:admins"
+    - domain: "deny.example.com"
       policy: deny
-    - domain: "*.example.com"
-      subject: "group:admins"
+    - domain: "admin.example.com"
       policy: two_factor
-
-    # Rules applied to 'dev' group
-    - domain: dev.example.com
-      resources:
-        - "^/groups/dev/.*$"
-      subject: "group:dev"
+    - domain: "secure.example.com"
       policy: two_factor
-
-    # Rules applied to user 'john'
-    - domain: dev.example.com
-      resources:
-        - "^/users/john/.*$"
-      subject: "user:john"
-      policy: two_factor
-
-    # Rules applied to user 'harry'
-    - domain: dev.example.com
-      resources:
-        - "^/users/harry/.*$"
-      subject: "user:harry"
-      policy: two_factor
-
-    # Rules applied to user 'bob'
-    - domain: "*.mail.example.com"
-      subject: "user:bob"
-      policy: two_factor
-    - domain: "dev.example.com"
-      resources:
-        - "^/users/bob/.*$"
-      subject: "user:bob"
-      policy: two_factor
+    - domain: "singlefactor.example.com"
+      policy: one_factor
 
 session:
   expiration: 3600  # 1 hour

--- a/internal/suites/scenario_one_factor_test.go
+++ b/internal/suites/scenario_one_factor_test.go
@@ -126,6 +126,7 @@ func (s *OneFactorSuite) TestShouldDenyAccessOnForbidden() {
 
 	targetURL := fmt.Sprintf("%s/secret.html", DenyBaseURL)
 	s.doVisit(s.T(), s.Context(ctx), targetURL)
+	s.verifyURLIs(s.T(), s.Context(ctx), targetURL)
 	s.verifyBodyContains(s.T(), s.Context(ctx), "403 Forbidden")
 }
 

--- a/internal/suites/scenario_one_factor_test.go
+++ b/internal/suites/scenario_one_factor_test.go
@@ -117,6 +117,18 @@ func (s *OneFactorSuite) TestShouldDenyAccessOnBadPassword() {
 	s.verifyNotificationDisplayed(s.T(), s.Context(ctx), "Incorrect username or password.")
 }
 
+func (s *OneFactorSuite) TestShouldDenyAccessOnForbidden() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer func() {
+		cancel()
+		s.collectScreenshot(ctx.Err(), s.Page)
+	}()
+
+	targetURL := fmt.Sprintf("%s/secret.html", DenyBaseURL)
+	s.doVisit(s.T(), s.Context(ctx), targetURL)
+	s.verifyBodyContains(s.T(), s.Context(ctx), "403 Forbidden")
+}
+
 func TestRunOneFactor(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping suite test in short mode")


### PR DESCRIPTION
This fixes an issue with the HAProxy integration whereupon receiving a 403 Forbidden that the proxy continues to attempt to redirect to Authelia. Configuration for other suites also have been standardized in this PR based on the new test.