### PR TITLE
add gettext to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH="/app:${PATH}" \
     X_AUTHELIA_CONFIG="/config/configuration.yml"
 
 RUN \
-	apk --no-cache add ca-certificates su-exec tzdata
+	apk --no-cache add ca-certificates gettext su-exec tzdata
 
 COPY LICENSE .healthcheck.env entrypoint.sh healthcheck.sh ./
 


### PR DESCRIPTION
simply need the `envsubst` to get the `AUTHELIA_IDENTITY_PROVIDERS_OIDC_CLIENTS_X_SECRET` environment variable to insert into the config.

Honestly didnt want to build my own image since it's just one package.

Hopefully this PR is ok

Thank you for the support!

**EDIT**

just to add, was looking to do something like [this](https://github.com/authelia/authelia/issues/3249) but looks like i need to render the config from env variables.