### PR TITLE
ci(buildkite): additional localised node artifacts

### DIFF
--- a/.buildkite/hooks/post-artifact
+++ b/.buildkite/hooks/post-artifact
@@ -5,4 +5,7 @@ set +u
 if [[ "${BUILDKITE_LABEL}" == ":docker: Build Image [coverage]" && "${BUILDKITE_AGENT_NAME}" =~ ^vega[0-9]+$ ]]; then
   mv authelia-image-coverage.tar.zst authelia-image-coverage-vega.tar.zst
   BUILDKITE_S3_ENDPOINT="${S3_ENDPOINT}" BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="${S3_BUCKET}" BUILDKITE_S3_ACCESS_URL="${S3_ACCESS_URL}" BUILDKITE_S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" BUILDKITE_S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" buildkite-agent artifact upload authelia-image-coverage-vega.tar.zst
+elif [[ "${BUILDKITE_LABEL}" == ":docker: Build Image [coverage]" && "${BUILDKITE_AGENT_NAME}" =~ ^aquilla[0-9]+$ ]]; then
+  mv authelia-image-coverage.tar.zst authelia-image-coverage-aquilla.tar.zst
+  BUILDKITE_S3_ENDPOINT="${S3_ENDPOINT}" BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="${S3_BUCKET}" BUILDKITE_S3_ACCESS_URL="${S3_ACCESS_URL}" BUILDKITE_S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" BUILDKITE_S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" buildkite-agent artifact upload authelia-image-coverage-aquilla.tar.zst
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -35,6 +35,9 @@ if [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
   if [[ "${BUILDKITE_AGENT_NAME}" =~ ^vega[0-9]+$ ]]; then
     BUILDKITE_S3_ENDPOINT="${S3_ENDPOINT}" BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="${S3_BUCKET}" BUILDKITE_S3_ACCESS_URL="${S3_ACCESS_URL}" BUILDKITE_S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" BUILDKITE_S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" buildkite-agent artifact download "authelia-image-coverage-vega*" .
     mv authelia-image-coverage-vega.tar.zst authelia-image-coverage.tar.zst
+  elif [[ "${BUILDKITE_AGENT_NAME}" =~ ^aquilla[0-9]+$ ]]; then
+    BUILDKITE_S3_ENDPOINT="${S3_ENDPOINT}" BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="${S3_BUCKET}" BUILDKITE_S3_ACCESS_URL="${S3_ACCESS_URL}" BUILDKITE_S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" BUILDKITE_S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" buildkite-agent artifact download "authelia-image-coverage-aquilla*" .
+    mv authelia-image-coverage-aquilla.tar.zst authelia-image-coverage.tar.zst
   else
     buildkite-agent artifact download "authelia-image-coverage.*" .
   fi


### PR DESCRIPTION
This change ensures that aquilla Buildkite nodes will upload artifacts to a local MinIO instance and also retrieve artifacts from this location if the same constraint is met.