### PR TITLE
fix(oidc): pkce session generated needlessly

### DIFF
--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ory/fosite/handler/oauth2"
 	"github.com/ory/fosite/handler/openid"
 	"github.com/ory/fosite/handler/par"
-	"github.com/ory/fosite/handler/pkce"
 	"github.com/ory/fosite/i18n"
 	"github.com/ory/fosite/token/hmac"
 	"github.com/ory/fosite/token/jwt"
@@ -243,7 +242,7 @@ func (c *Config) LoadHandlers(store *Store, strategy jwt.Signer) {
 			RefreshTokenStrategy:   c.Strategy.Core,
 			TokenRevocationStorage: store,
 		},
-		&pkce.Handler{
+		&PKCEHandler{
 			AuthorizeCodeStrategy: c.Strategy.Core,
 			Storage:               store,
 			Config:                c,

--- a/internal/oidc/const.go
+++ b/internal/oidc/const.go
@@ -146,11 +146,13 @@ const (
 )
 
 const (
+	FormParameterAuthorizationCode   = "code"
 	FormParameterClientID            = "client_id"
 	FormParameterClientSecret        = "client_secret"
 	FormParameterRequestURI          = "request_uri"
 	FormParameterResponseMode        = "response_mode"
 	FormParameterCodeChallenge       = "code_challenge"
+	FormParameterCodeVerifier        = "code_verifier"
 	FormParameterCodeChallengeMethod = "code_challenge_method"
 	FormParameterClientAssertionType = "client_assertion_type"
 	FormParameterClientAssertion     = "client_assertion"

--- a/internal/oidc/const_test.go
+++ b/internal/oidc/const_test.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ory/fosite"
-
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/utils"
 )
@@ -115,24 +113,6 @@ func MustLoadRSAPrivateKey(bits string, extra ...string) *rsa.PrivateKey {
 	}
 
 	return key
-}
-
-type RFC6749ErrorTest struct {
-	*fosite.RFC6749Error
-}
-
-func (err *RFC6749ErrorTest) Error() string {
-	return err.WithExposeDebug(true).GetDescription()
-}
-
-func ErrorToRFC6749ErrorTest(err error) (rfc error) {
-	if err == nil {
-		return nil
-	}
-
-	ferr := fosite.ErrorToRFC6749Error(err)
-
-	return &RFC6749ErrorTest{ferr}
 }
 
 var (

--- a/internal/oidc/pkce.go
+++ b/internal/oidc/pkce.go
@@ -1,0 +1,265 @@
+package oidc
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"regexp"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/fosite/handler/pkce"
+	"github.com/ory/x/errorsx"
+	"github.com/pkg/errors"
+)
+
+var _ fosite.TokenEndpointHandler = (*PKCEHandler)(nil)
+
+// PKCEHandler is a fork of pkce.Handler with modifications to rectify bugs. It implements the
+// fosite.TokenEndpointHandler.
+type PKCEHandler struct {
+	AuthorizeCodeStrategy oauth2.AuthorizeCodeStrategy
+	Storage               pkce.PKCERequestStorage
+	Config                interface {
+		fosite.EnforcePKCEProvider
+		fosite.EnforcePKCEForPublicClientsProvider
+		fosite.EnablePKCEPlainChallengeMethodProvider
+	}
+}
+
+var (
+	rePKCEVerifier = regexp.MustCompile(`[^\w.\-~]`)
+)
+
+// HandleAuthorizeEndpointRequest implements fosite.TokenEndpointHandler partially.
+func (c *PKCEHandler) HandleAuthorizeEndpointRequest(ctx context.Context, requester fosite.AuthorizeRequester, responder fosite.AuthorizeResponder) error {
+	// This let's us define multiple response types, for example open id connect's id_token.
+	if !requester.GetResponseTypes().Has(FormParameterAuthorizationCode) {
+		return nil
+	}
+
+	challenge := requester.GetRequestForm().Get(FormParameterCodeChallenge)
+	method := requester.GetRequestForm().Get(FormParameterCodeChallengeMethod)
+	client := requester.GetClient()
+
+	if err := c.validate(ctx, challenge, method, client); err != nil {
+		return err
+	}
+
+	// We don't need a session if it's not enforced and the PKCE parameters are not provided by the client.
+	if challenge == "" && method == "" {
+		return nil
+	}
+
+	code := responder.GetCode()
+	if len(code) == 0 {
+		return errorsx.WithStack(fosite.ErrServerError.WithDebug("The PKCE handler must be loaded after the authorize code handler."))
+	}
+
+	signature := c.AuthorizeCodeStrategy.AuthorizeCodeSignature(ctx, code)
+	if err := c.Storage.CreatePKCERequestSession(ctx, signature, requester.Sanitize([]string{
+		FormParameterCodeChallenge,
+		FormParameterCodeChallengeMethod,
+	})); err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebugf("The recorded error is: %s.", err.Error()))
+	}
+
+	return nil
+}
+
+func (c *PKCEHandler) validate(ctx context.Context, challenge, method string, client fosite.Client) error {
+	if len(challenge) == 0 {
+		// If the server requires Proof Key for Code Exchange (PKCE) by OAuth
+		// clients and the client does not send the "code_challenge" in
+		// the request, the authorization endpoint MUST return the authorization
+		// error response with the "error" value set to "invalid_request".  The
+		// "error_description" or the response of "error_uri" SHOULD explain the
+		// nature of error, e.g., code challenge required.
+		return c.validateNoPKCE(ctx, client)
+	}
+
+	// If the server supporting PKCE does not support the requested
+	// transformation, the authorization endpoint MUST return the
+	// authorization error response with "error" value set to
+	// "invalid_request".  The "error_description" or the response of
+	// "error_uri" SHOULD explain the nature of error, e.g., transform
+	// algorithm not supported.
+	switch method {
+	case PKCEChallengeMethodSHA256:
+		break
+	case PKCEChallengeMethodPlain:
+		fallthrough
+	case "":
+		if !c.Config.GetEnablePKCEPlainChallengeMethod(ctx) {
+			return errorsx.WithStack(fosite.ErrInvalidRequest.
+				WithHint("Clients must use the 'S256' PKCE 'code_challenge_method' but the 'plain' method was requested.").
+				WithDebug("The server is configured in a way that enforces PKCE 'S256' as challenge method for clients."))
+		}
+	default:
+		return errorsx.WithStack(fosite.ErrInvalidRequest.
+			WithHint("The code_challenge_method is not supported, use S256 instead."))
+	}
+
+	return nil
+}
+
+func (c *PKCEHandler) validateNoPKCE(ctx context.Context, client fosite.Client) error {
+	var enforce bool
+
+	enforce = c.Config.GetEnforcePKCE(ctx)
+
+	if enforce {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.
+			WithHint("Clients must include a code_challenge when performing the authorize code flow, but it is missing.").
+			WithDebug("The server is configured in a way that enforces PKCE for clients."))
+	}
+
+	enforce = c.Config.GetEnforcePKCEForPublicClients(ctx)
+	public := client.IsPublic()
+
+	if enforce && public {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.
+			WithHint("This client must include a code_challenge when performing the authorize code flow, but it is missing.").
+			WithDebug("The server is configured in a way that enforces PKCE for this client."))
+	}
+
+	return nil
+}
+
+// HandleTokenEndpointRequest implements fosite.TokenEndpointHandler partially.
+//
+//nolint:gocyclo
+func (c *PKCEHandler) HandleTokenEndpointRequest(ctx context.Context, requester fosite.AccessRequester) error {
+	if !c.CanHandleTokenEndpointRequest(ctx, requester) {
+		return errorsx.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	// code_verifier
+	// REQUIRED.  Code verifier
+	//
+	// The "code_challenge_method" is bound to the Authorization Code when
+	// the Authorization Code is issued.  That is the method that the token
+	// endpoint MUST use to verify the "code_verifier".
+	verifier := requester.GetRequestForm().Get(FormParameterCodeVerifier)
+
+	code := requester.GetRequestForm().Get(FormParameterAuthorizationCode)
+	signature := c.AuthorizeCodeStrategy.AuthorizeCodeSignature(ctx, code)
+	pkceRequest, err := c.Storage.GetPKCERequestSession(ctx, signature, requester.GetSession())
+
+	nv := len(verifier)
+
+	if errors.Is(err, fosite.ErrNotFound) {
+		if nv == 0 {
+			return c.validateNoPKCE(ctx, requester.GetClient())
+		}
+
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint("Unable to find initial PKCE data tied to this request").WithWrap(err).WithDebugf("The recorded error is: %s.", err.Error()))
+	} else if err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebugf("The recorded error is: %s.", err.Error()))
+	}
+
+	if err = c.Storage.DeletePKCERequestSession(ctx, signature); err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebugf("The recorded error is: %s.", err.Error()))
+	}
+
+	challenge := pkceRequest.GetRequestForm().Get(FormParameterCodeChallenge)
+	method := pkceRequest.GetRequestForm().Get(FormParameterCodeChallengeMethod)
+	client := pkceRequest.GetClient()
+
+	if err = c.validate(ctx, challenge, method, client); err != nil {
+		return err
+	}
+
+	nc := len(challenge)
+
+	if !c.Config.GetEnforcePKCE(ctx) && nc == 0 && nv == 0 {
+		return nil
+	}
+
+	// NOTE: The code verifier SHOULD have enough entropy to make it
+	// 	impractical to guess the value.  It is RECOMMENDED that the output of
+	// 	a suitable random number generator be used to create a 32-octet
+	// 	sequence.  The octet sequence is then base64url-encoded to produce a
+	// 	43-octet URL safe string to use as the code verifier.
+
+	// Miscellaneous validations.
+	switch {
+	case nv < 43:
+		return errorsx.WithStack(fosite.ErrInvalidGrant.
+			WithHint("The PKCE code verifier must be at least 43 characters."))
+	case nv > 128:
+		return errorsx.WithStack(fosite.ErrInvalidGrant.
+			WithHint("The PKCE code verifier can not be longer than 128 characters."))
+	case rePKCEVerifier.MatchString(verifier):
+		return errorsx.WithStack(fosite.ErrInvalidGrant.
+			WithHint("The PKCE code verifier must only contain [a-Z], [0-9], '-', '.', '_', '~'."))
+	case nc == 0:
+		return errorsx.WithStack(fosite.ErrInvalidGrant.
+			WithHint("The PKCE code verifier was provided but the code challenge was absent from the authorization request."))
+	}
+
+	// Upon receipt of the request at the token endpoint, the server
+	// verifies it by calculating the code challenge from the received
+	// "code_verifier" and comparing it with the previously associated
+	// "code_challenge", after first transforming it according to the
+	// "code_challenge_method" method specified by the client.
+	//
+	// 	If the "code_challenge_method" from Section 4.3 was "S256", the
+	// received "code_verifier" is hashed by SHA-256, base64url-encoded, and
+	// then compared to the "code_challenge", i.e.:
+	//
+	// BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) == code_challenge
+	//
+	// If the "code_challenge_method" from Section 4.3 was "plain", they are
+	// compared directly, i.e.:
+	//
+	// code_verifier == code_challenge.
+	//
+	// 	If the values are equal, the token endpoint MUST continue processing
+	// as normal (as defined by OAuth 2.0 [RFC6749]).  If the values are not
+	// equal, an error response indicating "invalid_grant" as described in
+	// Section 5.2 of [RFC6749] MUST be returned.
+	switch method {
+	case PKCEChallengeMethodSHA256:
+		hash := sha256.New()
+		if _, err = hash.Write([]byte(verifier)); err != nil {
+			return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebugf("The recorded error is: %s.", err.Error()))
+		}
+
+		sum := hash.Sum([]byte{})
+
+		expected := make([]byte, base64.RawURLEncoding.EncodedLen(len(sum)))
+
+		base64.RawURLEncoding.Strict().Encode(expected, sum)
+
+		if subtle.ConstantTimeCompare(expected, []byte(challenge)) == 0 {
+			return errorsx.WithStack(fosite.ErrInvalidGrant.
+				WithHint("The PKCE code challenge did not match the code verifier."))
+		}
+	case PKCEChallengeMethodPlain:
+		fallthrough
+	default:
+		if subtle.ConstantTimeCompare([]byte(verifier), []byte(challenge)) == 0 {
+			return errorsx.WithStack(fosite.ErrInvalidGrant.
+				WithHint("The PKCE code challenge did not match the code verifier."))
+		}
+	}
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse implements fosite.TokenEndpointHandler partially.
+func (c *PKCEHandler) PopulateTokenEndpointResponse(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {
+	return nil
+}
+
+// CanSkipClientAuth implements fosite.TokenEndpointHandler partially.
+func (c *PKCEHandler) CanSkipClientAuth(ctx context.Context, requester fosite.AccessRequester) bool {
+	return false
+}
+
+// CanHandleTokenEndpointRequest implements fosite.TokenEndpointHandler partially.
+func (c *PKCEHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester fosite.AccessRequester) bool {
+	return requester.GetGrantTypes().ExactOne(GrantTypeAuthorizationCode)
+}

--- a/internal/oidc/pkce_test.go
+++ b/internal/oidc/pkce_test.go
@@ -1,0 +1,544 @@
+package oidc_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authelia/authelia/v4/internal/oidc"
+)
+
+func TestPKCEHandler_Misc(t *testing.T) {
+	store := storage.NewMemoryStore()
+	strategy := &MockCodeStrategy{}
+	config := &oidc.Config{}
+
+	handler := &oidc.PKCEHandler{Storage: store, AuthorizeCodeStrategy: strategy, Config: config}
+
+	assert.Nil(t, handler.PopulateTokenEndpointResponse(context.Background(), nil, nil))
+	assert.False(t, handler.CanSkipClientAuth(context.Background(), nil))
+}
+
+func TestPKCEHandler_CanHandleTokenEndpointRequest(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     fosite.AccessRequester
+		expected bool
+	}{
+		{
+			"ShouldHandleAuthorizeCode",
+			&fosite.AccessRequest{
+				GrantTypes: fosite.Arguments{oidc.GrantTypeAuthorizationCode},
+			},
+			true,
+		},
+		{
+			"ShouldNotHandleRefreshToken",
+			&fosite.AccessRequest{
+				GrantTypes: fosite.Arguments{oidc.GrantTypeRefreshToken},
+			},
+			false,
+		},
+		{
+			"ShouldNotHandleClientCredentials",
+			&fosite.AccessRequest{
+				GrantTypes: fosite.Arguments{oidc.GrantTypeClientCredentials},
+			},
+			false,
+		},
+		{
+			"ShouldNotHandleImplicit",
+			&fosite.AccessRequest{
+				GrantTypes: fosite.Arguments{oidc.GrantTypeImplicit},
+			},
+			false,
+		},
+	}
+
+	store := storage.NewMemoryStore()
+	strategy := &MockCodeStrategy{}
+	config := &oidc.Config{}
+
+	handler := &oidc.PKCEHandler{Storage: store, AuthorizeCodeStrategy: strategy, Config: config}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, handler.CanHandleTokenEndpointRequest(context.Background(), tc.have))
+		})
+	}
+}
+
+func TestPKCEHandler_HandleAuthorizeEndpointRequest(t *testing.T) {
+	store := storage.NewMemoryStore()
+	strategy := &MockCodeStrategy{}
+	config := &oidc.Config{}
+
+	client := &oidc.BaseClient{ID: "test"}
+
+	handler := &oidc.PKCEHandler{Storage: store, AuthorizeCodeStrategy: strategy, Config: config}
+
+	testCases := []struct {
+		name                                      string
+		types                                     fosite.Arguments
+		enforce, enforcePublicClients, allowPlain bool
+		method, challenge, code                   string
+		expected                                  string
+		client                                    *oidc.BaseClient
+	}{
+		{
+			"ShouldNotHandleBlankResponseModes",
+			fosite.Arguments{},
+			false,
+			false,
+			false,
+			oidc.PKCEChallengeMethodPlain,
+			"challenge",
+			"",
+			"",
+			client,
+		},
+		{
+			"ShouldHandleAuthorizeCodeFlow",
+			fosite.Arguments{oidc.ResponseTypeAuthorizationCodeFlow},
+			false,
+			false,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"challenge",
+			"abc123",
+			"",
+			client,
+		},
+		{
+			"ShouldErrorHandleAuthorizeCodeFlowWithoutCode",
+			fosite.Arguments{oidc.ResponseTypeAuthorizationCodeFlow},
+			false,
+			false,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"challenge",
+			"",
+			"The authorization server encountered an unexpected condition that prevented it from fulfilling the request. The PKCE handler must be loaded after the authorize code handler.",
+			client,
+		},
+		{
+			"ShouldErrorHandleAuthorizeCodeFlowWithoutChallengeMethodWhenEnforced",
+			fosite.Arguments{oidc.ResponseTypeAuthorizationCodeFlow},
+			true,
+			false,
+			true,
+			"",
+			"",
+			"abc123",
+			"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Clients must include a code_challenge when performing the authorize code flow, but it is missing. The server is configured in a way that enforces PKCE for clients.",
+			client,
+		},
+		{
+			"ShouldErrorHandleAuthorizeCodeFlowWithoutChallengeWhenEnforced",
+			fosite.Arguments{oidc.ResponseTypeAuthorizationCodeFlow},
+			true,
+			false,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"",
+			"abc123",
+			"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Clients must include a code_challenge when performing the authorize code flow, but it is missing. The server is configured in a way that enforces PKCE for clients.",
+			client,
+		},
+		{
+			"ShouldSkipNotEnforced",
+			fosite.Arguments{oidc.ResponseTypeAuthorizationCodeFlow},
+			false,
+			false,
+			true,
+			"",
+			"",
+			"abc123",
+			"",
+			client,
+		},
+		{
+			"ShouldErrorUnknownChallengeMethod",
+			fosite.Arguments{oidc.ResponseTypeAuthorizationCodeFlow},
+			true,
+			false,
+			true,
+			"abc",
+			"abc",
+			"abc123",
+			"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. The code_challenge_method is not supported, use S256 instead.",
+			client,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config.ProofKeyCodeExchange.Enforce = tc.enforce
+			config.ProofKeyCodeExchange.EnforcePublicClients = tc.enforcePublicClients
+			config.ProofKeyCodeExchange.AllowPlainChallengeMethod = tc.allowPlain
+
+			requester := fosite.NewAuthorizeRequest()
+
+			requester.Client = tc.client
+
+			if len(tc.method) > 0 {
+				requester.Form.Add(oidc.FormParameterCodeChallengeMethod, tc.method)
+			}
+
+			if len(tc.challenge) > 0 {
+				requester.Form.Add(oidc.FormParameterCodeChallenge, tc.challenge)
+			}
+
+			requester.ResponseTypes = tc.types
+
+			responder := fosite.NewAuthorizeResponse()
+
+			if len(tc.code) > 0 {
+				responder.AddParameter(oidc.FormParameterAuthorizationCode, tc.code)
+			}
+
+			err := handler.HandleAuthorizeEndpointRequest(context.Background(), requester, responder)
+
+			err = ErrorToRFC6749ErrorTest(err)
+
+			if len(tc.expected) == 0 {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.expected)
+			}
+		})
+	}
+}
+
+func TestPKCEHandler_HandleTokenEndpointRequest(t *testing.T) {
+	store := storage.NewMemoryStore()
+	strategy := &MockCodeStrategy{}
+	config := &oidc.Config{}
+
+	handler := &oidc.PKCEHandler{Storage: store, AuthorizeCodeStrategy: strategy, Config: config}
+
+	challenge := "GM6jKJIR6JxgxU5m5Y79WzudqoNmo7PogrhI1_F8eGw"
+	verifier := "Nt6MpT7QXtfme55cKv9b23KEAvSEHyjRVtQt5jcjUUmWU9bTzd"
+
+	clientConfidential := &oidc.BaseClient{
+		ID:     "test",
+		Public: false,
+	}
+
+	clientPublic := &oidc.BaseClient{
+		ID:     "test",
+		Public: true,
+	}
+
+	testCases := []struct {
+		name                                      string
+		grant                                     string
+		enforce, enforcePublicClients, allowPlain bool
+		method, challenge, verifier               string
+		code                                      string
+		expected                                  string
+		client                                    *oidc.BaseClient
+	}{
+		{
+			"ShouldFailNotAuthCode",
+			oidc.GrantTypeClientCredentials,
+			false,
+			false,
+			false,
+			oidc.PKCEChallengeMethodSHA256,
+			challenge,
+			verifier,
+			"code-0",
+			"The handler is not responsible for this request.",
+			clientConfidential,
+		},
+		{
+			"ShouldPassPlainWithConfidentialClientWhenEnforcedWhenAllowPlain",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			true,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"sW6e3dnNWdLMoT9rLrSMgC8xfVNuwnNdAShrGWbysqVoc8s3HK",
+			"sW6e3dnNWdLMoT9rLrSMgC8xfVNuwnNdAShrGWbysqVoc8s3HK",
+			"code-1",
+			"",
+			clientConfidential,
+		},
+		{
+			"ShouldFailWithConfidentialClientWithNotAllowPlainWhenPlainWhenEnforced",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			true,
+			false,
+			oidc.PKCEChallengeMethodPlain,
+			"sW6e3dnNWdLMoT9rLrSMgC8xfVNuwnNdAShrGWbysqVoc8s3HK",
+			"sW6e3dnNWdLMoT9rLrSMgC8xfVNuwnNdAShrGWbysqVoc8s3HK",
+			"code-2",
+			"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Clients must use the 'S256' PKCE 'code_challenge_method' but the 'plain' method was requested. The server is configured in a way that enforces PKCE 'S256' as challenge method for clients.",
+			clientConfidential,
+		},
+		{
+			"ShouldPassWithConfidentialClientWhenNotProvidedWhenNotEnforced",
+			oidc.GrantTypeAuthorizationCode,
+			false,
+			false,
+			false,
+			"",
+			"",
+			"",
+			"code-3",
+			"",
+			clientConfidential,
+		},
+		{
+			"ShouldPassWithPublicClientWhenNotProvidedWhenNotEnforced",
+			oidc.GrantTypeAuthorizationCode,
+			false,
+			false,
+			false,
+			"",
+			"",
+			"",
+			"code-4",
+			"",
+			clientPublic,
+		},
+		{
+			"ShouldFailWithPublicClientWhenNotProvidedWhenNotEnforcedWhenEnforcedForPublicClients",
+			oidc.GrantTypeAuthorizationCode,
+			false,
+			true,
+			false,
+			"",
+			"",
+			"",
+			"code-5",
+			"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. This client must include a code_challenge when performing the authorize code flow, but it is missing. The server is configured in a way that enforces PKCE for this client.",
+			clientPublic,
+		},
+		{
+			"ShouldPassS256WithConfidentialClientWhenEnforcedWhenAllowPlain",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			true,
+			true,
+			oidc.PKCEChallengeMethodSHA256,
+			challenge,
+			verifier,
+			"code-6",
+			"",
+			clientConfidential,
+		},
+		{
+			"ShouldPassS256WithConfidentialClientWhenEnforcedWhenNotAllowPlain",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			true,
+			false,
+			oidc.PKCEChallengeMethodSHA256,
+			challenge,
+			verifier,
+			"code-7",
+			"",
+			clientConfidential,
+		},
+		{
+			"ShouldFailS256WithConfidentialClientWhenEnforcedWhenAllowPlain",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			true,
+			true,
+			oidc.PKCEChallengeMethodSHA256,
+			challenge,
+			"jSfm3f5nS9eD4eYSHaeQxVBVKxXnfmbWAFQiiAdMAK98EhNifm",
+			"code-8",
+			"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. The PKCE code challenge did not match the code verifier.",
+			clientConfidential,
+		},
+		{
+			"ShouldFailS256WithConfidentialClientWhenVerifierTooShort",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			true,
+			true,
+			oidc.PKCEChallengeMethodSHA256,
+			challenge,
+			"aaaaaaaaaaaaa",
+			"code-9",
+			"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. The PKCE code verifier must be at least 43 characters.",
+			clientConfidential,
+		},
+		{
+			"ShouldFailPlainWithConfidentialClientWhenNotMatching",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			true,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"jqNhtkWBNbP9oz6BjA2ufPWxADqnHJcUNhS8VNzBWLd44ynFzi",
+			"uoPgkXQNCiiMzQ4aXeXdzBQaDArGNN9bke8gQWo7qZZ2djrcJZ",
+			"code-10",
+			"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. The PKCE code challenge did not match the code verifier.",
+			clientConfidential,
+		},
+		{
+			"ShouldPassNoPKCESessionWhenNotEnforced",
+			oidc.GrantTypeAuthorizationCode,
+			false,
+			false,
+			true,
+			"",
+			"",
+			"",
+			"code-11",
+			"",
+			clientConfidential,
+		},
+		{
+			"ShouldFailNoPKCESessionWhenEnforced",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			false,
+			true,
+			"",
+			"",
+			"",
+			"code-12",
+			"The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Clients must include a code_challenge when performing the authorize code flow, but it is missing. The server is configured in a way that enforces PKCE for clients.",
+			clientConfidential,
+		},
+		{
+			"ShouldFailLongVerifier",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			false,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"fUcMF5287hMEieVQcjvxViWUEUGD9NjG63hELzLtSyPiETpwCjuLuZYJCMJkeAMb3wg6WRHXRzj6KSScu48J7KRDJScEAZbRXjMjR79KQavdqHLVDpv4WQra7teJvGjJfUcMF5287hMEieVQcjvxViWUEUGD9NjG63hELzLtSyPiETpwCjuLuZYJCMJkeAMb3wg6WRHXRzj6KSScu48J7KRDJScEAZbRXjMjR79KQavdqHLVDpv4WQra7teJvGjJ",
+			"fUcMF5287hMEieVQcjvxViWUEUGD9NjG63hELzLtSyPiETpwCjuLuZYJCMJkeAMb3wg6WRHXRzj6KSScu48J7KRDJScEAZbRXjMjR79KQavdqHLVDpv4WQra7teJvGjJfUcMF5287hMEieVQcjvxViWUEUGD9NjG63hELzLtSyPiETpwCjuLuZYJCMJkeAMb3wg6WRHXRzj6KSScu48J7KRDJScEAZbRXjMjR79KQavdqHLVDpv4WQra7teJvGjJ",
+			"code-13",
+			"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. The PKCE code verifier can not be longer than 128 characters.",
+			clientConfidential,
+		},
+		{
+			"ShouldFailBadChars",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			false,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"U5katcVxpTd8jU5YpUD9xdoivT55zzMWdMiy2TDA4DH9FJ5bTK45Mhd@",
+			"U5katcVxpTd8jU5YpUD9xdoivT55zzMWdMiy2TDA4DH9FJ5bTK45Mhd@",
+			"code-14",
+			"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. The PKCE code verifier must only contain [a-Z], [0-9], '-', '.', '_', '~'.",
+			clientConfidential,
+		},
+		{
+			"ShouldFailNoChallenge",
+			oidc.GrantTypeAuthorizationCode,
+			false,
+			false,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"",
+			"U5katcVxpTd8jU5YpUD9xdoivT55zzMWdMiy2TDA4DH9FJ5bTK45Mhd",
+			"code-15",
+			"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. The PKCE code verifier was provided but the code challenge was absent from the authorization request.",
+			clientConfidential,
+		},
+		{
+			"ShouldFailNoPKCESessionWhenEnforcedNotFound",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			false,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"",
+			"abc123",
+			"",
+			"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. Unable to find initial PKCE data tied to this request The recorded error is: not_found.",
+			clientConfidential,
+		},
+		{
+			"ShouldFailInvalidCode",
+			oidc.GrantTypeAuthorizationCode,
+			true,
+			false,
+			true,
+			oidc.PKCEChallengeMethodPlain,
+			"WXNqfH6FCXcJH5oT9eqTM3HTdTh4b2aSvVe9KWkxcHCJJ3FaXF",
+			"WXNqfH6FCXcJH5oT9eqTM3HTdTh4b2aSvVe9KWkxcHCJJ3FaXF",
+			"BADCODE",
+			"The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. Unable to find initial PKCE data tied to this request The recorded error is: not_found.",
+			clientConfidential,
+		},
+		{
+			"ShouldPassNotEnforcedNoSession",
+			oidc.GrantTypeAuthorizationCode,
+			false,
+			false,
+			true,
+			"",
+			"",
+			"",
+			"",
+			"",
+			clientConfidential,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			config.ProofKeyCodeExchange.Enforce = tc.enforce
+			config.ProofKeyCodeExchange.EnforcePublicClients = tc.enforcePublicClients
+			config.ProofKeyCodeExchange.AllowPlainChallengeMethod = tc.allowPlain
+
+			if len(tc.code) > 0 {
+				strategy.signature = tc.code
+			} else {
+				strategy.signature = fmt.Sprintf("code-%d", i)
+			}
+
+			ar := fosite.NewAuthorizeRequest()
+
+			ar.Client = tc.client
+
+			if len(tc.challenge) != 0 {
+				ar.Form.Add(oidc.FormParameterCodeChallenge, tc.challenge)
+			}
+
+			if len(tc.method) != 0 {
+				ar.Form.Add(oidc.FormParameterCodeChallengeMethod, tc.method)
+			}
+
+			if len(tc.code) > 0 {
+				require.NoError(t, store.CreatePKCERequestSession(ctx, fmt.Sprintf("code-%d", i), ar))
+			}
+
+			r := fosite.NewAccessRequest(nil)
+			r.Client = tc.client
+			r.GrantTypes = fosite.Arguments{tc.grant}
+
+			if len(tc.verifier) != 0 {
+				r.Form.Add(oidc.FormParameterCodeVerifier, tc.verifier)
+			}
+
+			err := handler.HandleTokenEndpointRequest(context.Background(), r)
+			err = ErrorToRFC6749ErrorTest(err)
+
+			if len(tc.expected) == 0 {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This handles an issue where the PKCE sessions were generated needlessly which also resulted in an unexpected error in rare circumstances.