### PR TITLE
fix(oidc): insufficient debug logs on some endpoints

### DIFF
--- a/internal/handlers/handler_oauth_introspection.go
+++ b/internal/handlers/handler_oauth_introspection.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/ory/fosite"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
@@ -14,16 +15,25 @@ import (
 // https://datatracker.ietf.org/doc/html/rfc7662
 func OAuthIntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, req *http.Request) {
 	var (
+		requestID uuid.UUID
 		responder fosite.IntrospectionResponder
 		err       error
 	)
 
+	if requestID, err = uuid.NewRandom(); err != nil {
+		ctx.Providers.OpenIDConnect.WriteIntrospectionError(ctx, rw, fosite.ErrServerError)
+
+		return
+	}
+
 	oidcSession := oidc.NewSession()
+
+	ctx.Logger.Debugf("Introspection Request with id '%s' is being processed", requestID)
 
 	if responder, err = ctx.Providers.OpenIDConnect.NewIntrospectionRequest(ctx, req, oidcSession); err != nil {
 		rfc := fosite.ErrorToRFC6749Error(err)
 
-		ctx.Logger.Errorf("Introspection Request failed with error: %s", rfc.WithExposeDebug(true).GetDescription())
+		ctx.Logger.Errorf("Introspection Request with id '%s' failed with error: %s", requestID, rfc.WithExposeDebug(true).GetDescription())
 
 		ctx.Providers.OpenIDConnect.WriteIntrospectionError(ctx, rw, err)
 
@@ -32,7 +42,9 @@ func OAuthIntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 
 	requester := responder.GetAccessRequester()
 
-	ctx.Logger.Tracef("Introspection Request yeilded a %s (active: %t) requested at %s created with request id '%s' on client with id '%s'", responder.GetTokenUse(), responder.IsActive(), requester.GetRequestedAt().String(), requester.GetID(), requester.GetClient().GetID())
+	ctx.Logger.Tracef("Introspection Request with id '%s' yeilded a %s (active: %t) requested at %s created with request id '%s' on client with id '%s'", requestID, responder.GetTokenUse(), responder.IsActive(), requester.GetRequestedAt().String(), requester.GetID(), requester.GetClient().GetID())
 
 	ctx.Providers.OpenIDConnect.WriteIntrospectionResponse(ctx, rw, responder)
+
+	ctx.Logger.Debugf("Introspection Request with id '%s' was processed successfully", requestID)
 }

--- a/internal/handlers/handler_oauth_revocation.go
+++ b/internal/handlers/handler_oauth_revocation.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/ory/fosite"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
@@ -12,13 +13,26 @@ import (
 //
 // https://datatracker.ietf.org/doc/html/rfc7009
 func OAuthRevocationPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, req *http.Request) {
-	var err error
+	var (
+		requestID uuid.UUID
+		err       error
+	)
+
+	if requestID, err = uuid.NewRandom(); err != nil {
+		ctx.Providers.OpenIDConnect.WriteRevocationResponse(ctx, rw, fosite.ErrServerError)
+
+		return
+	}
+
+	ctx.Logger.Debugf("Revocation Request with id '%s' is being processed", requestID)
 
 	if err = ctx.Providers.OpenIDConnect.NewRevocationRequest(ctx, req); err != nil {
 		rfc := fosite.ErrorToRFC6749Error(err)
 
-		ctx.Logger.Errorf("Revocation Request failed with error: %s", rfc.WithExposeDebug(true).GetDescription())
+		ctx.Logger.Errorf("Revocation Request with id '%s' failed with error: %s", requestID, rfc.WithExposeDebug(true).GetDescription())
 	}
 
 	ctx.Providers.OpenIDConnect.WriteRevocationResponse(ctx, rw, err)
+
+	ctx.Logger.Debugf("Revocation Request with id '%s' was successfully processed", requestID)
 }

--- a/internal/handlers/handler_oidc_userinfo.go
+++ b/internal/handlers/handler_oidc_userinfo.go
@@ -21,19 +21,28 @@ import (
 // https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
 func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, req *http.Request) {
 	var (
+		requestID uuid.UUID
 		tokenType fosite.TokenType
 		requester fosite.AccessRequester
 		client    oidc.Client
 		err       error
 	)
 
+	if requestID, err = uuid.NewRandom(); err != nil {
+		ctx.Providers.OpenIDConnect.WriteError(rw, req, fosite.ErrServerError)
+
+		return
+	}
+
 	oidcSession := oidc.NewSession()
+
+	ctx.Logger.Debugf("UserInfo Request with id '%s' is being processed", requestID)
 
 	if tokenType, requester, err = ctx.Providers.OpenIDConnect.IntrospectToken(
 		req.Context(), fosite.AccessTokenFromRequest(req), fosite.AccessToken, oidcSession); err != nil {
 		rfc := fosite.ErrorToRFC6749Error(err)
 
-		ctx.Logger.Errorf("UserInfo Request failed with error: %s", rfc.WithExposeDebug(true).GetDescription())
+		ctx.Logger.Errorf("UserInfo Request with id '%s' failed with error: %s", requestID, rfc.WithExposeDebug(true).GetDescription())
 
 		if rfc.StatusCode() == http.StatusUnauthorized {
 			rw.Header().Set(fasthttp.HeaderWWWAuthenticate, fmt.Sprintf(`Bearer error="%s",error_description="%s"`, rfc.ErrorField, rfc.GetDescription()))
@@ -47,7 +56,7 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 	clientID := requester.GetClient().GetID()
 
 	if tokenType != fosite.AccessToken {
-		ctx.Logger.Errorf("UserInfo Request with id '%s' on client with id '%s' failed with error: bearer authorization failed as the token is not an access token", requester.GetID(), client.GetID())
+		ctx.Logger.Errorf("UserInfo Request with id '%s' on client with id '%s' failed with error: bearer authorization failed as the token is not an access token", requestID, client.GetID())
 
 		errStr := "Only access tokens are allowed in the authorization header."
 		rw.Header().Set(fasthttp.HeaderWWWAuthenticate, fmt.Sprintf(`Bearer error="invalid_token",error_description="%s"`, errStr))
@@ -59,7 +68,7 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 	if client, err = ctx.Providers.OpenIDConnect.GetFullClient(ctx, clientID); err != nil {
 		rfc := fosite.ErrorToRFC6749Error(err)
 
-		ctx.Logger.Errorf("UserInfo Request with id '%s' on client with id '%s' failed to retrieve client configuration with error: %s", requester.GetID(), client.GetID(), rfc.WithExposeDebug(true).GetDescription())
+		ctx.Logger.Errorf("UserInfo Request with id '%s' on client with id '%s' failed to retrieve client configuration with error: %s", requestID, client.GetID(), rfc.WithExposeDebug(true).GetDescription())
 
 		ctx.Providers.OpenIDConnect.WriteError(rw, req, errors.WithStack(rfc))
 
@@ -97,10 +106,12 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 
 	var token string
 
-	ctx.Logger.Tracef("UserInfo Response with id '%s' on client with id '%s' is being sent with the following claims: %+v", requester.GetID(), clientID, claims)
+	ctx.Logger.Tracef("UserInfo Response with id '%s' on client with id '%s' is being sent with the following claims: %+v", requestID, clientID, claims)
 
 	switch alg := client.GetUserinfoSigningAlg(); alg {
 	case oidc.SigningAlgNone, "":
+		ctx.Logger.Debugf("UserInfo Request with id '%s' on client with id '%s' is being returned unsigned as per the registered client configuration", requestID, client.GetID())
+
 		ctx.Providers.OpenIDConnect.Write(rw, req, claims)
 	default:
 		var jwk *oidc.JWK
@@ -110,6 +121,8 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 
 			return
 		}
+
+		ctx.Logger.Debugf("UserInfo Request with id '%s' on client with id '%s' is being returned signed as per the registered client configuration with key id '%s' using the '%s' algorithm", requestID, client.GetID(), jwk.KeyID(), jwk.JWK().Algorithm)
 
 		var jti uuid.UUID
 
@@ -137,4 +150,6 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 		rw.Header().Set(fasthttp.HeaderContentType, "application/jwt")
 		_, _ = rw.Write([]byte(token))
 	}
+
+	ctx.Logger.Debugf("UserInfo Request with id '%s' on client with id '%s' was successfully processed", requestID, client.GetID())
 }


### PR DESCRIPTION
This fixes an issue where on the userinfo, introspection, and revocation endpoints there are not sufficient logs at the debug level to see the flow of a the request.