### PR TITLE
docs: expand on existing bundle info

### DIFF
--- a/examples/compose/local/README.md
+++ b/examples/compose/local/README.md
@@ -1,4 +1,4 @@
 # Usage
 
 Please see the documentation covering the [Bundles](https://www.authelia.com/integration/deployment/docker/#bundles)
-and the [lite](https://www.authelia.com/integration/deployment/docker/#lite) bundle for usage instructions.
+and the [local](https://www.authelia.com/integration/deployment/docker/#local) bundle for usage instructions.


### PR DESCRIPTION
There was a missing readme and missing context to the readme for the example bundles. This resolves this.