### PR TITLE
refactor(validator): remove redundant nil check

### DIFF
--- a/internal/configuration/validator/access_control.go
+++ b/internal/configuration/validator/access_control.go
@@ -62,12 +62,10 @@ func ValidateAccessControl(config *schema.Configuration, validator *schema.Struc
 		validator.Push(fmt.Errorf(errFmtAccessControlDefaultPolicyValue, strJoinOr(validACLRulePolicies), config.AccessControl.DefaultPolicy))
 	}
 
-	if config.AccessControl.Networks != nil {
-		for _, n := range config.AccessControl.Networks {
-			for _, networks := range n.Networks {
-				if !IsNetworkValid(networks) {
-					validator.Push(fmt.Errorf(errFmtAccessControlNetworkGroupIPCIDRInvalid, n.Name, networks))
-				}
+	for _, n := range config.AccessControl.Networks {
+		for _, networks := range n.Networks {
+			if !IsNetworkValid(networks) {
+				validator.Push(fmt.Errorf(errFmtAccessControlNetworkGroupIPCIDRInvalid, n.Name, networks))
 			}
 		}
 	}


### PR DESCRIPTION
From the Go docs:

> "For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/2TugLncT_ob
