### PR TITLE
refactor(oidc): use exact scope matching

### DIFF
--- a/internal/oidc/flow_refresh.go
+++ b/internal/oidc/flow_refresh.go
@@ -106,7 +106,7 @@ func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Contex
 	originalScopes := originalRequest.GetGrantedScopes()
 
 	for _, scope := range request.GetRequestedScopes() {
-		if !strategy(originalScopes, scope) {
+		if !originalScopes.Has(scope) {
 			if client, ok := request.GetClient().(RefreshFlowScopeClient); ok && client.GetRefreshFlowIgnoreOriginalGrantedScopes(ctx) {
 				// Skips addressing point 2 of the text in RFC6749 Section 6 and instead just prevents the scope
 				// requested from being granted.


### PR DESCRIPTION
This ensures if we add custom scope strategies later then we don't accidentally give clients more scopes than the resource owner granted.