### PR TITLE
feat(oidc): signed discovery

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -1301,6 +1301,18 @@ notifier:
     ## for security reasons.
     # enforce_pkce: 'public_clients_only'
 
+    ## SECURITY NOTICE: It's not recommended changing this option. We encourage you to read the documentation and fully
+    ## understanding it before enabling this option.
+    # enable_jwt_access_token_stateless_introspection: false
+
+    ## The signing algorithm used for signing the discovery and metadata responses. An issuer JWK with a matching
+    ## algorithm must be available when configured. Most clients completely ignore this and it has a performance cost.
+    # discovery_signed_response_alg: 'none'
+
+    ## The signing key id used for signing the discovery and metadata responses. An issuer JWK with a matching key id
+    ## must be available when configured. Most clients completely ignore this and it has a performance cost.
+    # discovery_signed_response_key_id: ''
+
     ## Authorization Policies which can be utilized by clients. The 'policy_name' is an arbitrary value that you pick
     ## which is utilized as the value for the 'authorization_policy' on the client.
     # authorization_policies:

--- a/docs/content/en/configuration/identity-providers/openid-connect/provider.md
+++ b/docs/content/en/configuration/identity-providers/openid-connect/provider.md
@@ -203,7 +203,6 @@ identity_providers:
           -----END CERTIFICATE-----
 ```
 
-
 #### key_id
 
 {{< confkey type="string" default="<thumbprint of public key>" required="no" >}}
@@ -343,6 +342,43 @@ strongly discouraged unless you have a very specific use case.
 A client with an [access_token_signed_response_alg](clients.md#access_token_signed_response_alg) or
 [access_token_signed_response_key_id](clients.md#access_token_signed_response_key_id) must be configured for this option to
 be enabled.
+
+### discovery_signed_response_alg
+
+{{< confkey type="string" default="none" required="no" >}}
+
+_**Important Note:** Many clients do not support this option and it has a performance cost. It's therefore recommended
+unless you have a specific need that you do not enable this option._
+
+_**Note:** This value is completely ignored if the
+[discovery_signed_response_key_id](#discovery_signed_response_key_id) is defined._
+
+The algorithm used to sign the [OAuth 2.0 Authorization Server Metadata] and [OpenID Connect Discovery 1.0] responses.
+Per the specifications this Signed JSON Web Token is stored in the `signed_metadata` value using the compact encoding.
+
+See the response object section of the
+[integration guide](../../../integration/openid-connect/introduction.md#response-object) for more information including
+the algorithm column for supported values.
+
+With the exclusion of `none` which excludes the `signed_metadata` value, the algorithm chosen must have a key
+configured in the [jwks](#jwks) section to be considered valid.
+
+See the response object section of the [integration guide](../../../integration/openid-connect/introduction.md#response-object)
+for more information including the algorithm column for supported values.
+
+### discovery_signed_response_key_id
+
+{{< confkey type="string" required="no" >}}
+
+_**Important Note:** Many clients do not support this option and it has a performance cost. It's therefore recommended
+unless you have a specific need that you do not enable this option._
+
+_**Note:** This value automatically configures the [discovery_signed_response_alg](#discovery_signed_response_alg)
+value with the algorithm of the specified key._
+
+The algorithm used to sign the [OAuth 2.0 Authorization Server Metadata] and [OpenID Connect Discovery 1.0] responses.
+The value of this must one of those provided or calculated in the [jwks](#jwks). Per the specifications this Signed JSON
+Web Token is stored in the `signed_metadata` value using the compact encoding.
 
 ### pushed_authorizations
 
@@ -524,7 +560,7 @@ identity_providers:
 
 ### cors
 
-Some [OpenID Connect 1.0] Endpoints need to allow cross-origin resource sharing, however some are optional. This section allows
+Some [OpenID Connect 1.0] Endpoints need to allow cross-origin resource sharing; however, some are optional. This section allows
 you to configure the optional parts. We reply with CORS headers when the request includes the Origin header.
 
 #### endpoints
@@ -592,6 +628,8 @@ To integrate Authelia's [OpenID Connect 1.0] implementation with a relying party
 
 [token lifespan]: https://docs.apigee.com/api-platform/antipatterns/oauth-long-expiration
 [OpenID Connect 1.0]: https://openid.net/connect/
+[OAuth 2.0 Authorization Server Metadata]: https://oauth.net/2/authorization-server-metadata/
+[OpenID Connect Discovery 1.0]: https://openid.net/specs/openid-connect-discovery-1_0.html
 [Token Endpoint]: https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
 [JWT]: https://datatracker.ietf.org/doc/html/rfc7519
 [RFC6234]: https://datatracker.ietf.org/doc/html/rfc6234

--- a/docs/content/en/configuration/identity-providers/openid-connect/provider.md
+++ b/docs/content/en/configuration/identity-providers/openid-connect/provider.md
@@ -74,6 +74,9 @@ identity_providers:
     minimum_parameter_entropy: 8
     enforce_pkce: 'public_clients_only'
     enable_pkce_plain_challenge: false
+    enable_jwt_access_token_stateless_introspection: false
+    discovery_signed_response_alg: 'none'
+    discovery_signed_response_key_id: ''
     pushed_authorizations:
       enforce: false
       context_lifespan: '5m'

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -1301,6 +1301,18 @@ notifier:
     ## for security reasons.
     # enforce_pkce: 'public_clients_only'
 
+    ## SECURITY NOTICE: It's not recommended changing this option. We encourage you to read the documentation and fully
+    ## understanding it before enabling this option.
+    # enable_jwt_access_token_stateless_introspection: false
+
+    ## The signing algorithm used for signing the discovery and metadata responses. An issuer JWK with a matching
+    ## algorithm must be available when configured. Most clients completely ignore this and it has a performance cost.
+    # discovery_signed_response_alg: 'none'
+
+    ## The signing key id used for signing the discovery and metadata responses. An issuer JWK with a matching key id
+    ## must be available when configured. Most clients completely ignore this and it has a performance cost.
+    # discovery_signed_response_key_id: ''
+
     ## Authorization Policies which can be utilized by clients. The 'policy_name' is an arbitrary value that you pick
     ## which is utilized as the value for the 'authorization_policy' on the client.
     # authorization_policies:

--- a/internal/configuration/schema/identity_providers.go
+++ b/internal/configuration/schema/identity_providers.go
@@ -24,6 +24,9 @@ type IdentityProvidersOpenIDConnect struct {
 
 	EnableJWTAccessTokenStatelessIntrospection bool `koanf:"enable_jwt_access_token_stateless_introspection" json:"enable_jwt_access_token_stateless_introspection" jsonschema:"title=Enable JWT Access Token Stateless Introspection" jsonschema_description:"Allows the use of stateless introspection of JWT Access Tokens which is not recommended."`
 
+	DiscoverySignedResponseAlg   string `koanf:"discovery_signed_response_alg" json:"discovery_signed_response_alg" jsonschema:"default=none,enum=none,enum=RS256,enum=RS384,enum=RS512,enum=ES256,enum=ES384,enum=ES512,enum=PS256,enum=PS384,enum=PS512,title=Discovery Response Signing Algorithm" jsonschema_description:"The Algorithm this provider uses to sign the Discovery and Metadata Document responses."`
+	DiscoverySignedResponseKeyID string `koanf:"discovery_signed_response_key_id" json:"discovery_signed_response_key_id" jsonschema:"title=Discovery Response Signing Key ID" jsonschema_description:"The Key ID this provider uses to sign the Discovery and Metadata Document responses (overrides the 'discovery_signed_response_alg')."`
+
 	PAR  IdentityProvidersOpenIDConnectPAR  `koanf:"pushed_authorizations" json:"pushed_authorizations" jsonschema:"title=Pushed Authorizations" jsonschema_description:"Configuration options for Pushed Authorization Requests."`
 	CORS IdentityProvidersOpenIDConnectCORS `koanf:"cors" json:"cors" jsonschema:"title=CORS" jsonschema_description:"Configuration options for Cross-Origin Request Sharing."`
 

--- a/internal/configuration/schema/identity_providers.go
+++ b/internal/configuration/schema/identity_providers.go
@@ -16,9 +16,6 @@ type IdentityProvidersOpenIDConnect struct {
 	HMACSecret  string `koanf:"hmac_secret" json:"hmac_secret" jsonschema:"title=HMAC Secret" jsonschema_description:"The HMAC Secret used to sign Access Tokens."`
 	JSONWebKeys []JWK  `koanf:"jwks" json:"jwks" jsonschema:"title=Issuer JSON Web Keys" jsonschema_description:"The JWK's which are to be used to sign various objects like ID Tokens."`
 
-	IssuerCertificateChain X509CertificateChain `koanf:"issuer_certificate_chain" json:"issuer_certificate_chain" jsonschema:"title=Issuer Certificate Chain,deprecated" jsonschema_description:"The Issuer Certificate Chain with an RSA Public Key used to sign ID Tokens."`
-	IssuerPrivateKey       *rsa.PrivateKey      `koanf:"issuer_private_key" json:"issuer_private_key" jsonschema:"title=Issuer Private Key,deprecated" jsonschema_description:"The Issuer Private Key with an RSA Private Key used to sign ID Tokens."`
-
 	EnableClientDebugMessages bool `koanf:"enable_client_debug_messages" json:"enable_client_debug_messages" jsonschema:"default=false,title=Enable Client Debug Messages" jsonschema_description:"Enables additional debug messages for clients."`
 	MinimumParameterEntropy   int  `koanf:"minimum_parameter_entropy" json:"minimum_parameter_entropy" jsonschema:"default=8,minimum=-1,title=Minimum Parameter Entropy" jsonschema_description:"The minimum entropy of the nonce parameter."`
 
@@ -36,6 +33,9 @@ type IdentityProvidersOpenIDConnect struct {
 	Lifespans             IdentityProvidersOpenIDConnectLifespans         `koanf:"lifespans" json:"lifespans" jsonschema:"title=Lifespans" jsonschema_description:"Token lifespans configuration."`
 
 	Discovery IdentityProvidersOpenIDConnectDiscovery `json:"-"` // MetaData value. Not configurable by users.
+
+	IssuerCertificateChain X509CertificateChain `koanf:"issuer_certificate_chain" json:"issuer_certificate_chain" jsonschema:"title=Issuer Certificate Chain,deprecated" jsonschema_description:"The Issuer Certificate Chain with an RSA Public Key used to sign ID Tokens."`
+	IssuerPrivateKey       *rsa.PrivateKey      `koanf:"issuer_private_key" json:"issuer_private_key" jsonschema:"title=Issuer Private Key,deprecated" jsonschema_description:"The Issuer Private Key with an RSA Private Key used to sign ID Tokens."`
 }
 
 // IdentityProvidersOpenIDConnectPolicy configuration for OpenID Connect 1.0 authorization policies.

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -55,6 +55,11 @@ const (
 	schemeHTTPS = "https"
 )
 
+// General fmt consts.
+const (
+	errFmtMustBeOneOf = "'%s' must be one of %s but it's configured as '%s'"
+)
+
 // Notifier Error constants.
 const (
 	errFmtNotifierMultipleConfigured = "notifier: please ensure only one of the 'smtp' or 'filesystem' notifier is configured"
@@ -179,6 +184,8 @@ const (
 	errFmtOIDCProviderPrivateKeysKeyCertificateMismatch  = "identity_providers: oidc: jwks: key #%d with key id '%s': option 'certificate_chain' does not appear to contain the public key for the private key provided by option 'key'"
 	errFmtOIDCProviderPrivateKeysCertificateChainInvalid = "identity_providers: oidc: jwks: key #%d with key id '%s': option 'certificate_chain' produced an error during validation of the chain: %w"
 	errFmtOIDCProviderPrivateKeysNoRS256                 = "identity_providers: oidc: jwks: keys: must at least have one key supporting the '%s' algorithm but only has %s"
+	errFmtOIDCProviderInvalidValue                       = "identity_providers: oidc: option " +
+		errFmtMustBeOneOf
 
 	errFmtOIDCCORSInvalidOrigin                    = "identity_providers: oidc: cors: option 'allowed_origins' contains an invalid value '%s' as it has a %s: origins must only be scheme, hostname, and an optional port"
 	errFmtOIDCCORSInvalidOriginWildcard            = "identity_providers: oidc: cors: option 'allowed_origins' contains the wildcard origin '*' with more than one origin but the wildcard origin must be defined by itself"
@@ -236,7 +243,7 @@ const (
 		"%s however when utilizing the 'client_credentials' value for the 'grant_types' the values %s are not allowed"
 	errFmtOIDCClientInvalidEntryDuplicates = errFmtOIDCClientOption + "'%s' must have unique values but the values %s are duplicated"
 	errFmtOIDCClientInvalidValue           = errFmtOIDCClientOption +
-		"'%s' must be one of %s but it's configured as '%s'"
+		errFmtMustBeOneOf
 	errFmtOIDCClientInvalidLifespan = errFmtOIDCClientOption +
 		"'lifespan' must not be configured when no custom lifespans are configured but it's configured as '%s'"
 	errFmtOIDCClientInvalidTokenEndpointAuthMethod = errFmtOIDCClientOption +
@@ -508,6 +515,8 @@ const (
 	attrOIDCGrantTypes            = "grant_types"
 	attrOIDCRedirectURIs          = "redirect_uris"
 	attrOIDCTokenAuthMethod       = "token_endpoint_auth_method"
+	attrOIDCDiscoSigAlg           = "discovery_signed_response_alg"
+	attrOIDCDiscoSigKID           = "discovery_signed_response_key_id"
 	attrOIDCUsrSigAlg             = "userinfo_signed_response_alg"
 	attrOIDCUsrSigKID             = "userinfo_signed_response_key_id"
 	attrOIDCIntrospectionSigAlg   = "introspection_signed_response_alg"

--- a/internal/handlers/handler_oidc_wellknown.go
+++ b/internal/handlers/handler_oidc_wellknown.go
@@ -36,26 +36,28 @@ func OpenIDConnectConfigurationWellKnownGET(ctx *middlewares.AutheliaCtx) {
 		OpenIDConnectWellKnownConfiguration: ctx.Providers.OpenIDConnect.GetOpenIDConnectWellKnownConfiguration(issuer.String()),
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, &oidc.OpenIDConnectWellKnownClaims{
-		OpenIDConnectWellKnownSignedConfiguration: metadata,
-		RegisteredClaims: jwt.RegisteredClaims{
-			ID:        uuid.New().String(),
-			Issuer:    issuer.String(),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
-		},
-	})
+	if ctx.Configuration.IdentityProviders.OIDC.DiscoverySignedResponseKeyID != "" {
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, &oidc.OpenIDConnectWellKnownClaims{
+			OpenIDConnectWellKnownSignedConfiguration: metadata,
+			RegisteredClaims: jwt.RegisteredClaims{
+				ID:        uuid.New().String(),
+				Issuer:    issuer.String(),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		})
 
-	kid := ctx.Providers.OpenIDConnect.KeyManager.GetKeyID(ctx, "", oidc.SigningAlgRSAUsingSHA256)
+		kid := ctx.Providers.OpenIDConnect.KeyManager.GetKeyID(ctx, ctx.Configuration.IdentityProviders.OIDC.DiscoverySignedResponseKeyID, ctx.Configuration.IdentityProviders.OIDC.DiscoverySignedResponseAlg)
 
-	token.Header[oidc.JWTHeaderKeyIdentifier] = kid
+		token.Header[oidc.JWTHeaderKeyIdentifier] = kid
 
-	if metadata.SignedMetadata, err = token.SignedString(ctx.Providers.OpenIDConnect.KeyManager.Get(ctx, kid, oidc.SigningAlgRSAUsingSHA256).PrivateJWK().Key); err != nil {
-		ctx.Logger.WithError(err).Errorf("Error occurred signing metadata")
+		if metadata.SignedMetadata, err = token.SignedString(ctx.Providers.OpenIDConnect.KeyManager.Get(ctx, kid, ctx.Configuration.IdentityProviders.OIDC.DiscoverySignedResponseAlg).PrivateJWK().Key); err != nil {
+			ctx.Logger.WithError(err).Errorf("Error occurred signing metadata")
 
-		ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
+			ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
 
-		return
+			return
+		}
 	}
 
 	if err = ctx.ReplyJSON(metadata, fasthttp.StatusOK); err != nil {
@@ -91,26 +93,28 @@ func OAuthAuthorizationServerWellKnownGET(ctx *middlewares.AutheliaCtx) {
 		OAuth2WellKnownConfiguration: ctx.Providers.OpenIDConnect.GetOAuth2WellKnownConfiguration(issuer.String()),
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, &oidc.OAuth2WellKnownClaims{
-		OAuth2WellKnownSignedConfiguration: metadata,
-		RegisteredClaims: jwt.RegisteredClaims{
-			ID:        uuid.New().String(),
-			Issuer:    issuer.String(),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
-		},
-	})
+	if ctx.Configuration.IdentityProviders.OIDC.DiscoverySignedResponseKeyID != "" {
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, &oidc.OAuth2WellKnownClaims{
+			OAuth2WellKnownSignedConfiguration: metadata,
+			RegisteredClaims: jwt.RegisteredClaims{
+				ID:        uuid.New().String(),
+				Issuer:    issuer.String(),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		})
 
-	kid := ctx.Providers.OpenIDConnect.KeyManager.GetKeyID(ctx, "", oidc.SigningAlgRSAUsingSHA256)
+		kid := ctx.Providers.OpenIDConnect.KeyManager.GetKeyID(ctx, ctx.Configuration.IdentityProviders.OIDC.DiscoverySignedResponseKeyID, ctx.Configuration.IdentityProviders.OIDC.DiscoverySignedResponseAlg)
 
-	token.Header[oidc.JWTHeaderKeyIdentifier] = kid
+		token.Header[oidc.JWTHeaderKeyIdentifier] = kid
 
-	if metadata.SignedMetadata, err = token.SignedString(ctx.Providers.OpenIDConnect.KeyManager.Get(ctx, kid, oidc.SigningAlgRSAUsingSHA256).PrivateJWK().Key); err != nil {
-		ctx.Logger.WithError(err).Errorf("Error occurred signing metadata")
+		if metadata.SignedMetadata, err = token.SignedString(ctx.Providers.OpenIDConnect.KeyManager.Get(ctx, kid, ctx.Configuration.IdentityProviders.OIDC.DiscoverySignedResponseAlg).PrivateJWK().Key); err != nil {
+			ctx.Logger.WithError(err).Errorf("Error occurred signing metadata")
 
-		ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
+			ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
 
-		return
+			return
+		}
 	}
 
 	if err = ctx.ReplyJSON(metadata, fasthttp.StatusOK); err != nil {

--- a/internal/handlers/handler_oidc_wellknown.go
+++ b/internal/handlers/handler_oidc_wellknown.go
@@ -2,10 +2,14 @@ package handlers
 
 import (
 	"net/url"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
+	"github.com/authelia/authelia/v4/internal/oidc"
 )
 
 // OpenIDConnectConfigurationWellKnownGET handles requests to a .well-known endpoint (RFC5785) which returns the
@@ -28,7 +32,33 @@ func OpenIDConnectConfigurationWellKnownGET(ctx *middlewares.AutheliaCtx) {
 		return
 	}
 
-	if err = ctx.ReplyJSON(ctx.Providers.OpenIDConnect.GetOpenIDConnectWellKnownConfiguration(issuer.String()), fasthttp.StatusOK); err != nil {
+	metadata := oidc.OpenIDConnectWellKnownSignedConfiguration{
+		OpenIDConnectWellKnownConfiguration: ctx.Providers.OpenIDConnect.GetOpenIDConnectWellKnownConfiguration(issuer.String()),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, &oidc.OpenIDConnectWellKnownClaims{
+		OpenIDConnectWellKnownSignedConfiguration: metadata,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        uuid.New().String(),
+			Issuer:    issuer.String(),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	})
+
+	kid := ctx.Providers.OpenIDConnect.KeyManager.GetKeyID(ctx, "", oidc.SigningAlgRSAUsingSHA256)
+
+	token.Header[oidc.JWTHeaderKeyIdentifier] = kid
+
+	if metadata.SignedMetadata, err = token.SignedString(ctx.Providers.OpenIDConnect.KeyManager.Get(ctx, kid, oidc.SigningAlgRSAUsingSHA256).PrivateJWK().Key); err != nil {
+		ctx.Logger.WithError(err).Errorf("Error occurred signing metadata")
+
+		ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
+
+		return
+	}
+
+	if err = ctx.ReplyJSON(metadata, fasthttp.StatusOK); err != nil {
 		ctx.Logger.WithError(err).Error("Error occurred encoding JSON response")
 
 		ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
@@ -57,7 +87,33 @@ func OAuthAuthorizationServerWellKnownGET(ctx *middlewares.AutheliaCtx) {
 		return
 	}
 
-	if err = ctx.ReplyJSON(ctx.Providers.OpenIDConnect.GetOAuth2WellKnownConfiguration(issuer.String()), fasthttp.StatusOK); err != nil {
+	metadata := oidc.OAuth2WellKnownSignedConfiguration{
+		OAuth2WellKnownConfiguration: ctx.Providers.OpenIDConnect.GetOAuth2WellKnownConfiguration(issuer.String()),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, &oidc.OAuth2WellKnownClaims{
+		OAuth2WellKnownSignedConfiguration: metadata,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        uuid.New().String(),
+			Issuer:    issuer.String(),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	})
+
+	kid := ctx.Providers.OpenIDConnect.KeyManager.GetKeyID(ctx, "", oidc.SigningAlgRSAUsingSHA256)
+
+	token.Header[oidc.JWTHeaderKeyIdentifier] = kid
+
+	if metadata.SignedMetadata, err = token.SignedString(ctx.Providers.OpenIDConnect.KeyManager.Get(ctx, kid, oidc.SigningAlgRSAUsingSHA256).PrivateJWK().Key); err != nil {
+		ctx.Logger.WithError(err).Errorf("Error occurred signing metadata")
+
+		ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
+
+		return
+	}
+
+	if err = ctx.ReplyJSON(metadata, fasthttp.StatusOK); err != nil {
 		ctx.Logger.WithError(err).Error("Error occurred encoding JSON response")
 
 		ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)

--- a/internal/oidc/discovery_test.go
+++ b/internal/oidc/discovery_test.go
@@ -393,7 +393,6 @@ func TestNewOpenIDConnectWellKnownConfiguration_Copy(t *testing.T) {
 				ServiceDocumentation:                       "",
 				OPPolicyURI:                                "",
 				OPTOSURI:                                   "",
-				SignedMetadata:                             "",
 			},
 			OAuth2DiscoveryOptions: oidc.OAuth2DiscoveryOptions{
 				IntrospectionEndpoint:                              "",
@@ -491,7 +490,7 @@ func TestNewOpenIDConnectWellKnownConfiguration_Copy(t *testing.T) {
 			FederationRegistrationEndpoint:                 "",
 			ClientRegistrationTypesSupported:               nil,
 			RequestAuthenticationMethodsSupported:          nil,
-			RequestAuthenticationSigningAlgValuesSupproted: nil,
+			RequestAuthenticationSigningAlgValuesSupported: nil,
 		},
 	}
 

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -348,12 +348,6 @@ type CommonDiscoveryOptions struct {
 		Client if it is given.
 	*/
 	OPTOSURI string `json:"op_tos_uri,omitempty"`
-
-	/*
-			A JWT containing metadata values about the authorization server as claims. This is a string value consisting of
-		    the entire signed JWT. A "signed_metadata" metadata value SHOULD NOT appear as a claim in the JWT.
-	*/
-	SignedMetadata string `json:"signed_metadata,omitempty"`
 }
 
 // OAuth2DiscoveryOptions represents the discovery options specific to OAuth 2.0.
@@ -392,6 +386,18 @@ type OAuth2DiscoveryOptions struct {
 	IntrospectionEndpointAuthMethodsSupported []string `json:"introspection_endpoint_auth_methods_supported,omitempty"`
 
 	/*
+		OPTIONAL. JSON array containing a list of the JWS signing algorithms ("alg" values) supported by the
+		introspection endpoint for the signature on the JWT [JWT] used to authenticate the client at the introspection
+		endpoint for the "private_key_jwt" and "client_secret_jwt" authentication methods. This metadata entry MUST be
+		present if either of these authentication methods are specified in the
+		"introspection_endpoint_auth_methods_supported" entry. No default algorithms are implied if this entry is omitted.
+		The value "none" MUST NOT be used.
+		See Also:
+			JWT: https://datatracker.ietf.org/doc/html/rfc7519
+	*/
+	IntrospectionEndpointAuthSigningAlgValuesSupported []string `json:"introspection_endpoint_auth_signing_alg_values_supported,omitempty"`
+
+	/*
 		OPTIONAL. JSON array containing a list of client authentication methods supported by this revocation endpoint.
 		The valid client authentication method values are those registered in the IANA "OAuth Token Endpoint
 		Authentication Methods" registry [IANA.OAuth.Parameters]. If omitted, the default is "client_secret_basic" --
@@ -412,18 +418,6 @@ type OAuth2DiscoveryOptions struct {
 			JWT: https://datatracker.ietf.org/doc/html/rfc7519
 	*/
 	RevocationEndpointAuthSigningAlgValuesSupported []string `json:"revocation_endpoint_auth_signing_alg_values_supported,omitempty"`
-
-	/*
-		OPTIONAL. JSON array containing a list of the JWS signing algorithms ("alg" values) supported by the
-		introspection endpoint for the signature on the JWT [JWT] used to authenticate the client at the introspection
-		endpoint for the "private_key_jwt" and "client_secret_jwt" authentication methods. This metadata entry MUST be
-		present if either of these authentication methods are specified in the
-		"introspection_endpoint_auth_methods_supported" entry. No default algorithms are implied if this entry is omitted.
-		The value "none" MUST NOT be used.
-		See Also:
-			JWT: https://datatracker.ietf.org/doc/html/rfc7519
-	*/
-	IntrospectionEndpointAuthSigningAlgValuesSupported []string `json:"introspection_endpoint_auth_signing_alg_values_supported,omitempty"`
 
 	/*
 		OPTIONAL. JSON array containing a list of PKCE [RFC7636] code challenge methods supported by this authorization
@@ -449,13 +443,13 @@ type OAuth2JWTIntrospectionResponseDiscoveryOptions struct {
 		JWA [RFC7518] supported by the introspection endpoint to encrypt the content encryption key for introspection
 		responses (content key encryption).
 	*/
-	IntrospectionEncryptionAlgValuesSupported []string `json:"introspection_encryption_alg_values_supported"`
+	IntrospectionEncryptionAlgValuesSupported []string `json:"introspection_encryption_alg_values_supported,omitempty"`
 
 	/*
 		OPTIONAL.  JSON array containing a list of the JWE [RFC7516] encryption algorithms ("enc" values) as defined in
 		JWA [RFC7518] supported by the introspection endpoint to encrypt the response (content encryption).
 	*/
-	IntrospectionEncryptionEncValuesSupported []string `json:"introspection_encryption_enc_values_supported"`
+	IntrospectionEncryptionEncValuesSupported []string `json:"introspection_encryption_enc_values_supported,omitempty"`
 }
 
 type OAuth2DeviceAuthorizationGrantDiscoveryOptions struct {
@@ -534,14 +528,6 @@ type OAuth2PushedAuthorizationDiscoveryOptions struct {
 // OpenIDConnectDiscoveryOptions represents the discovery options specific to OpenID Connect.
 type OpenIDConnectDiscoveryOptions struct {
 	/*
-		RECOMMENDED. URL of the OP's UserInfo Endpoint [OpenID.Core]. This URL MUST use the https scheme and MAY contain
-		port, path, and query parameter components.
-		See Also:
-			OpenID.Core: https://openid.net/specs/openid-connect-core-1_0.html
-	*/
-	UserinfoEndpoint string `json:"userinfo_endpoint,omitempty"`
-
-	/*
 		REQUIRED. JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP for the ID
 		Token to encode the Claims in a JWT [JWT]. The algorithm RS256 MUST be included. The value none MAY be supported,
 		but MUST NOT be used unless the Response Type used returns no ID Token from the Authorization Endpoint (such as
@@ -550,6 +536,32 @@ type OpenIDConnectDiscoveryOptions struct {
 			JWT: https://datatracker.ietf.org/doc/html/rfc7519
 	*/
 	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported,omitempty"`
+
+	/*
+		OPTIONAL. JSON array containing a list of the JWE encryption algorithms (alg values) supported by the OP for the
+		ID Token to encode the Claims in a JWT [JWT].
+		See Also:
+			JWE: https://datatracker.ietf.org/doc/html/rfc7516
+			JWT: https://datatracker.ietf.org/doc/html/rfc7519
+	*/
+	IDTokenEncryptionAlgValuesSupported []string `json:"id_token_encryption_alg_values_supported,omitempty"`
+
+	/*
+		OPTIONAL. JSON array containing a list of the JWE encryption algorithms (enc values) supported by the OP for the
+		ID Token to encode the Claims in a JWT [JWT].
+		See Also:
+			JWE: https://datatracker.ietf.org/doc/html/rfc7516
+			JWT: https://datatracker.ietf.org/doc/html/rfc7519
+	*/
+	IDTokenEncryptionEncValuesSupported []string `json:"id_token_encryption_enc_values_supported,omitempty"`
+
+	/*
+		RECOMMENDED. URL of the OP's UserInfo Endpoint [OpenID.Core]. This URL MUST use the https scheme and MAY contain
+		port, path, and query parameter components.
+		See Also:
+			OpenID.Core: https://openid.net/specs/openid-connect-core-1_0.html
+	*/
+	UserinfoEndpoint string `json:"userinfo_endpoint,omitempty"`
 
 	/*
 		OPTIONAL. JSON array containing a list of the JWS [JWS] signing algorithms (alg values) [JWA] supported by the
@@ -562,23 +574,6 @@ type OpenIDConnectDiscoveryOptions struct {
 	UserinfoSigningAlgValuesSupported []string `json:"userinfo_signing_alg_values_supported,omitempty"`
 
 	/*
-		OPTIONAL. JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP for Request
-		Objects, which are described in Section 6.1 of OpenID Connect Core 1.0 [OpenID.Core]. These algorithms are used
-		both when the Request Object is passed by value (using the request parameter) and when it is passed by reference
-		(using the request_uri parameter). Servers SHOULD support none and RS256.
-	*/
-	RequestObjectSigningAlgValuesSupported []string `json:"request_object_signing_alg_values_supported,omitempty"`
-
-	/*
-		OPTIONAL. JSON array containing a list of the JWE encryption algorithms (alg values) supported by the OP for the
-		ID Token to encode the Claims in a JWT [JWT].
-		See Also:
-			JWE: https://datatracker.ietf.org/doc/html/rfc7516
-			JWT: https://datatracker.ietf.org/doc/html/rfc7519
-	*/
-	IDTokenEncryptionAlgValuesSupported []string `json:"id_token_encryption_alg_values_supported,omitempty"`
-
-	/*
 		OPTIONAL. JSON array containing a list of the JWE [JWE] encryption algorithms (alg values) [JWA] supported by
 		the UserInfo Endpoint to encode the Claims in a JWT [JWT].
 		See Also:
@@ -589,24 +584,6 @@ type OpenIDConnectDiscoveryOptions struct {
 	UserinfoEncryptionAlgValuesSupported []string `json:"userinfo_encryption_alg_values_supported,omitempty"`
 
 	/*
-		OPTIONAL. JSON array containing a list of the JWE encryption algorithms (alg values) supported by the OP for
-		Request Objects. These algorithms are used both when the Request Object is passed by value and when it is passed
-		by reference.
-		See Also:
-			JWE: https://datatracker.ietf.org/doc/html/rfc7516
-	*/
-	RequestObjectEncryptionAlgValuesSupported []string `json:"request_object_encryption_alg_values_supported,omitempty"`
-
-	/*
-		OPTIONAL. JSON array containing a list of the JWE encryption algorithms (enc values) supported by the OP for the
-		ID Token to encode the Claims in a JWT [JWT].
-		See Also:
-			JWE: https://datatracker.ietf.org/doc/html/rfc7516
-			JWT: https://datatracker.ietf.org/doc/html/rfc7519
-	*/
-	IDTokenEncryptionEncValuesSupported []string `json:"id_token_encryption_enc_values_supported,omitempty"`
-
-	/*
 		OPTIONAL. JSON array containing a list of the JWE encryption algorithms (enc values) [JWA] supported by the
 		UserInfo Endpoint to encode the Claims in a JWT [JWT].
 		See Also:
@@ -615,6 +592,23 @@ type OpenIDConnectDiscoveryOptions struct {
 			JWT: https://datatracker.ietf.org/doc/html/rfc7519
 	*/
 	UserinfoEncryptionEncValuesSupported []string `json:"userinfo_encryption_enc_values_supported,omitempty"`
+
+	/*
+		OPTIONAL. JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP for Request
+		Objects, which are described in Section 6.1 of OpenID Connect Core 1.0 [OpenID.Core]. These algorithms are used
+		both when the Request Object is passed by value (using the request parameter) and when it is passed by reference
+		(using the request_uri parameter). Servers SHOULD support none and RS256.
+	*/
+	RequestObjectSigningAlgValuesSupported []string `json:"request_object_signing_alg_values_supported,omitempty"`
+
+	/*
+		OPTIONAL. JSON array containing a list of the JWE encryption algorithms (alg values) supported by the OP for
+		Request Objects. These algorithms are used both when the Request Object is passed by value and when it is passed
+		by reference.
+		See Also:
+			JWE: https://datatracker.ietf.org/doc/html/rfc7516
+	*/
+	RequestObjectEncryptionAlgValuesSupported []string `json:"request_object_encryption_alg_values_supported,omitempty"`
 
 	/*
 		OPTIONAL. JSON array containing a list of the JWE encryption algorithms (enc values) supported by the OP for
@@ -890,7 +884,7 @@ type OpenIDFederationDiscoveryOptions struct {
 		authentication methods are specified in the request_authentication_methods_supported entry. No default
 		algorithms are implied if this entry is omitted. Servers SHOULD support RS256. The value none MUST NOT be used.
 	*/
-	RequestAuthenticationSigningAlgValuesSupproted []string `json:"request_authentication_signing_alg_values_supported,omitempty"`
+	RequestAuthenticationSigningAlgValuesSupported []string `json:"request_authentication_signing_alg_values_supported,omitempty"`
 }
 
 // OAuth2WellKnownConfiguration represents the well known discovery document specific to OAuth 2.0.
@@ -903,6 +897,22 @@ type OAuth2WellKnownConfiguration struct {
 	*OAuth2JWTIntrospectionResponseDiscoveryOptions
 	*OAuth2JWTSecuredAuthorizationRequestDiscoveryOptions
 	*OAuth2PushedAuthorizationDiscoveryOptions
+}
+
+type OAuth2WellKnownSignedConfiguration struct {
+	OAuth2WellKnownConfiguration
+
+	/*
+			A JWT containing metadata values about the authorization server as claims. This is a string value consisting of
+		    the entire signed JWT. A "signed_metadata" metadata value SHOULD NOT appear as a claim in the JWT.
+	*/
+	SignedMetadata string `json:"signed_metadata,omitempty"`
+}
+
+type OAuth2WellKnownClaims struct {
+	OAuth2WellKnownSignedConfiguration
+
+	jwt.RegisteredClaims
 }
 
 // OpenIDConnectWellKnownConfiguration represents the well known discovery document specific to OpenID Connect.
@@ -918,4 +928,20 @@ type OpenIDConnectWellKnownConfiguration struct {
 	*OpenIDConnectClientInitiatedBackChannelAuthFlowDiscoveryOptions
 	*OpenIDConnectJWTSecuredAuthorizationResponseModeDiscoveryOptions
 	*OpenIDFederationDiscoveryOptions
+}
+
+type OpenIDConnectWellKnownSignedConfiguration struct {
+	OpenIDConnectWellKnownConfiguration
+
+	/*
+			A JWT containing metadata values about the authorization server as claims. This is a string value consisting of
+		    the entire signed JWT. A "signed_metadata" metadata value SHOULD NOT appear as a claim in the JWT.
+	*/
+	SignedMetadata string `json:"signed_metadata,omitempty"`
+}
+
+type OpenIDConnectWellKnownClaims struct {
+	OpenIDConnectWellKnownSignedConfiguration
+
+	jwt.RegisteredClaims
 }


### PR DESCRIPTION
Adds the signed metadata JWT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added new configuration options `discovery_signed_response_alg` and `discovery_signed_response_key_id` for signing responses in OpenID Connect.
	- Introduced JWT tokens with specific claims for enhanced security in well-known configurations.
- **Refactor**
	- Improved OpenID Connect and OAuth2 discovery configurations for enhanced security and compatibility.
- **Bug Fixes**
	- Fixed a typo in the OpenID Connect discovery configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->