### PR TITLE
docs: assign custom doc heading anchor to avoid HTML id collision

### DIFF
--- a/docs/content/en/configuration/first-factor/file.md
+++ b/docs/content/en/configuration/first-factor/file.md
@@ -68,7 +68,7 @@ The path to the file with the user details list. Supported file types are:
 
 Enables reloading the database by watching it for changes.
 
-### search
+### search {#file-search}
 
 Username searching functionality options.
 


### PR DESCRIPTION
Take the one heading in the documentation which causes an HTML id collision with ids that Hugo uses natively and change it to avoid the collision.

Use Hugo's [heading ids](https://gohugo.io/content-management/cross-references/#heading-ids) feature to change the anchor for the `search` heading from `#search` to `#file-search`

The only other potential collisions are with the ids "suggestions", "announcement" and "mode" (which aren't present as headings in any doc page). The "search" id only exists in the file.md doc page.
There are no intra page links in the documentation to this anchor tag that would need to be updated.

Fixes #6069