### PR TITLE
fix(configuration): deprecated secrets not mapped

### DIFF
--- a/internal/configuration/const.go
+++ b/internal/configuration/const.go
@@ -55,5 +55,5 @@ const (
 var (
 	secretSuffix          = []string{"key", "secret", "password", "token", "certificate_chain"}
 	secretExclusionPrefix = []string{"identity_providers.oidc.lifespans."}
-	secretExclusionExact  = []string{"server.tls.key"}
+	secretExclusionExact  = []string{"server.tls.key", "authentication_backend.disable_reset_password", "tls_key"}
 )

--- a/internal/configuration/helpers.go
+++ b/internal/configuration/helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
-func getEnvConfigMap(keys []string, prefix, delimiter string) (keyMap map[string]string, ignoredKeys []string) {
+func getEnvConfigMap(keys []string, prefix, delimiter string, ds map[string]Deprecation) (keyMap map[string]string, ignoredKeys []string) {
 	keyMap = make(map[string]string)
 
 	for _, key := range keys {
@@ -16,6 +16,12 @@ func getEnvConfigMap(keys []string, prefix, delimiter string) (keyMap map[string
 		}
 
 		// Secret envs should be ignored by the env parser.
+		if IsSecretKey(key) {
+			ignoredKeys = append(ignoredKeys, ToEnvironmentSecretKey(key, prefix, delimiter))
+		}
+	}
+
+	for key := range ds {
 		if IsSecretKey(key) {
 			ignoredKeys = append(ignoredKeys, ToEnvironmentSecretKey(key, prefix, delimiter))
 		}
@@ -32,10 +38,18 @@ func getEnvConfigMap(keys []string, prefix, delimiter string) (keyMap map[string
 	return keyMap, ignoredKeys
 }
 
-func getSecretConfigMap(keys []string, prefix, delimiter string) (keyMap map[string]string) {
+func getSecretConfigMap(keys []string, prefix, delimiter string, ds map[string]Deprecation) (keyMap map[string]string) {
 	keyMap = make(map[string]string)
 
 	for _, key := range keys {
+		if IsSecretKey(key) {
+			originalKey := strings.ToUpper(strings.ReplaceAll(key, constDelimiter, delimiter)) + constSecretSuffix
+
+			keyMap[prefix+originalKey] = key
+		}
+	}
+
+	for key := range ds {
 		if IsSecretKey(key) {
 			originalKey := strings.ToUpper(strings.ReplaceAll(key, constDelimiter, delimiter)) + constSecretSuffix
 

--- a/internal/configuration/helpers_test.go
+++ b/internal/configuration/helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
 )
 
 func TestIsSecretKey(t *testing.T) {
@@ -28,7 +30,7 @@ func TestGetEnvConfigMaps(t *testing.T) {
 		"mysecret.user_password",
 	}
 
-	keys, ignoredKeys := getEnvConfigMap(input, DefaultEnvPrefix, DefaultEnvDelimiter)
+	keys, ignoredKeys := getEnvConfigMap(input, DefaultEnvPrefix, DefaultEnvDelimiter, deprecations)
 
 	key, ok = keys[DefaultEnvPrefix+"MY_NON_SECRET_CONFIG_ITEM"]
 	assert.True(t, ok)
@@ -52,7 +54,7 @@ func TestGetEnvConfigMaps(t *testing.T) {
 	assert.Contains(t, ignoredKeys, DefaultEnvPrefix+"MYSECRET_USER_PASSWORD_FILE")
 }
 
-func TestGetSecretConfigMap(t *testing.T) {
+func TestGetSecretConfigMapMockInput(t *testing.T) {
 	var (
 		key string
 		ok  bool
@@ -65,7 +67,7 @@ func TestGetSecretConfigMap(t *testing.T) {
 		"mysecret.user_password",
 	}
 
-	keys := getSecretConfigMap(input, DefaultEnvPrefix, DefaultEnvDelimiter)
+	keys := getSecretConfigMap(input, DefaultEnvPrefix, DefaultEnvDelimiter, deprecations)
 
 	key, ok = keys[DefaultEnvPrefix+"MY_NON_SECRET_CONFIG_ITEM_FILE"]
 	assert.False(t, ok)
@@ -73,13 +75,27 @@ func TestGetSecretConfigMap(t *testing.T) {
 
 	key, ok = keys[DefaultEnvPrefix+"MYOTHER_CONFIGKEY_FILE"]
 	assert.True(t, ok)
-	assert.Equal(t, key, "myother.configkey")
+	assert.Equal(t, "myother.configkey", key)
 
 	key, ok = keys[DefaultEnvPrefix+"MYSECRET_PASSWORD_FILE"]
 	assert.True(t, ok)
-	assert.Equal(t, key, "mysecret.password")
+	assert.Equal(t, "mysecret.password", key)
 
 	key, ok = keys[DefaultEnvPrefix+"MYSECRET_USER_PASSWORD_FILE"]
 	assert.True(t, ok)
-	assert.Equal(t, key, "mysecret.user_password")
+	assert.Equal(t, "mysecret.user_password", key)
+}
+
+func TestGetSecretConfigMap(t *testing.T) {
+	keys := getSecretConfigMap(schema.Keys, DefaultEnvPrefix, DefaultEnvDelimiter, deprecations)
+
+	var (
+		key string
+		ok  bool
+	)
+
+	key, ok = keys[DefaultEnvPrefix+"JWT_SECRET_FILE"]
+
+	assert.True(t, ok)
+	assert.Equal(t, "jwt_secret", key)
 }

--- a/internal/configuration/sources.go
+++ b/internal/configuration/sources.go
@@ -253,7 +253,7 @@ func (s *EnvironmentSource) Merge(ko *koanf.Koanf, _ *schema.StructValidator) (e
 
 // Load the Source into the EnvironmentSource koanf.Koanf.
 func (s *EnvironmentSource) Load(_ *schema.StructValidator) (err error) {
-	keyMap, ignoredKeys := getEnvConfigMap(schema.Keys, s.prefix, s.delimiter)
+	keyMap, ignoredKeys := getEnvConfigMap(schema.Keys, s.prefix, s.delimiter, deprecations)
 
 	return s.koanf.Load(env.ProviderWithValue(s.prefix, constDelimiter, koanfEnvironmentCallback(keyMap, ignoredKeys, s.prefix, s.delimiter)), nil)
 }
@@ -287,7 +287,7 @@ func (s *SecretsSource) Merge(ko *koanf.Koanf, val *schema.StructValidator) (err
 
 // Load the Source into the SecretsSource koanf.Koanf.
 func (s *SecretsSource) Load(val *schema.StructValidator) (err error) {
-	keyMap := getSecretConfigMap(schema.Keys, s.prefix, s.delimiter)
+	keyMap := getSecretConfigMap(schema.Keys, s.prefix, s.delimiter, deprecations)
 
 	return s.koanf.Load(env.ProviderWithValue(s.prefix, constDelimiter, koanfEnvironmentSecretsCallback(keyMap, val)), nil)
 }


### PR DESCRIPTION
This fixes an issue where a deprecated configuration options when used as a secret are not mapped like the other configuration sources are.