### PR TITLE
test: add example single line filter

### DIFF
--- a/docs/content/en/configuration/methods/files.md
+++ b/docs/content/en/configuration/methods/files.md
@@ -163,6 +163,10 @@ Filters can either be used on their own, in combination, or not at all. The filt
 defined. You can preview the output of the YAML files when processed via the filters using the
 [authelia config template](../../reference/cli/authelia/authelia_config_template.md) command.
 
+_**Important Note:** the filters are applied in order and thus if the output of one filter outputs a string that
+contains syntax for a subsequent filter it will be filtered. It is therefore suggested the template filter is the only
+filter and if it isn't that it's last._
+
 Examples:
 
 ```bash

--- a/docs/content/en/reference/guides/templating.md
+++ b/docs/content/en/reference/guides/templating.md
@@ -96,8 +96,26 @@ The following is a list of special functions and their syntax.
 
 #### iterate
 
-Input is a single uint. Returns a slice of uints from 0 to the provided uint.
+This template function takes a single input and is a positive integer. Returns a slice of uints from 0 to the provided
+input.
 
 #### fileContent
 
-Input is a path. Returns the content of a file.
+This template function takes a single input and is a string which should be a path. Returns the content of a file.
+
+Example:
+
+```yaml
+example: |
+  {{- fileContent "/absolute/path/to/file" | nindent 2 }}
+```
+
+#### secret
+
+Overload for [fileContent](#filecontent) except that tailing newlines will be removed.
+
+Example:
+
+```yaml
+example: '{{ secret "/absolute/path/to/file" }}'
+```

--- a/internal/configuration/koanf_provider_filtered_file.go
+++ b/internal/configuration/koanf_provider_filtered_file.go
@@ -60,8 +60,8 @@ type BytesFilter func(in []byte) (out []byte, err error)
 // NewFileFiltersDefault returns the default list of BytesFilter.
 func NewFileFiltersDefault() []BytesFilter {
 	return []BytesFilter{
-		NewTemplateFileFilter(),
 		NewExpandEnvFileFilter(),
+		NewTemplateFileFilter(),
 	}
 }
 

--- a/internal/configuration/provider_test.go
+++ b/internal/configuration/provider_test.go
@@ -119,7 +119,6 @@ func TestShouldValidateConfigurationWithFilters(t *testing.T) {
 
 	t.Setenv("ABC_CLIENT_SECRET", "$plaintext$example-abc")
 	t.Setenv("XYZ_CLIENT_SECRET", "$plaintext$example-xyz")
-	t.Setenv("ANOTHER_CLIENT_SECRET", "$plaintext$example-123")
 	t.Setenv("SERVICES_SERVER", "10.10.10.10")
 	t.Setenv("ROOT_DOMAIN", "example.org")
 
@@ -134,10 +133,11 @@ func TestShouldValidateConfigurationWithFilters(t *testing.T) {
 	assert.Equal(t, "smtp://10.10.10.10:1025", config.Notifier.SMTP.Address.String())
 	assert.Equal(t, "10.10.10.10", config.Session.Redis.Host)
 
-	require.Len(t, config.IdentityProviders.OIDC.Clients, 3)
+	require.Len(t, config.IdentityProviders.OIDC.Clients, 4)
 	assert.Equal(t, "$plaintext$example-abc", config.IdentityProviders.OIDC.Clients[0].Secret.String())
 	assert.Equal(t, "$plaintext$example-xyz", config.IdentityProviders.OIDC.Clients[1].Secret.String())
-	assert.Equal(t, "$plaintext$example-123", config.IdentityProviders.OIDC.Clients[2].Secret.String())
+	assert.Equal(t, "$plaintext$example_secret value", config.IdentityProviders.OIDC.Clients[2].Secret.String())
+	assert.Equal(t, "$plaintext$abc", config.IdentityProviders.OIDC.Clients[3].Secret.String())
 }
 
 func TestShouldNotIgnoreInvalidEnvs(t *testing.T) {

--- a/internal/configuration/test_resources/config.filtered.yml
+++ b/internal/configuration/test_resources/config.filtered.yml
@@ -19,7 +19,7 @@ authentication_backend:
     address: 'ldap://{{ env "SERVICES_SERVER" }}'
     tls:
       private_key: |
-        {{- fileContent "./test_resources/example_filter_rsa_private_key" | nindent 8 }}
+        {{- secret "./test_resources/example_filter_rsa_private_key" | nindent 8 }}
     base_dn: dc=example,dc=com
     additional_users_dn: ou=users
     users_filter: (&({username_attribute}={input})(objectCategory=person)(objectClass=user))
@@ -161,6 +161,9 @@ identity_providers:
         secret: '$XYZ_CLIENT_SECRET'
         consent_mode: explicit
       - id: '123'
-        secret: $ANOTHER_CLIENT_SECRET
+        secret: {{ secret "./test_resources/example_secret" }}
+        consent_mode: explicit
+      - id: '456'
+        secret: '{{ secret "./test_resources/example_password_secret" }}'
         consent_mode: explicit
 ...

--- a/internal/configuration/test_resources/config.filtered.yml
+++ b/internal/configuration/test_resources/config.filtered.yml
@@ -161,7 +161,7 @@ identity_providers:
         secret: '$XYZ_CLIENT_SECRET'
         consent_mode: explicit
       - id: '123'
-        secret: {{ secret "./test_resources/example_secret" }}
+        secret: '{{ secret "./test_resources/example_secret" }}'
         consent_mode: explicit
       - id: '456'
         secret: '{{ secret "./test_resources/example_password_secret" }}'

--- a/internal/configuration/test_resources/example_password_secret
+++ b/internal/configuration/test_resources/example_password_secret
@@ -1,0 +1,3 @@
+$plaintext$abc
+
+

--- a/internal/templates/funcs.go
+++ b/internal/templates/funcs.go
@@ -27,6 +27,7 @@ func FuncMap() map[string]any {
 	return map[string]any{
 		"iterate":     FuncIterate,
 		"fileContent": FuncFileContent,
+		"secret":      FuncSecret,
 		"env":         FuncGetEnv,
 		"expandenv":   FuncExpandEnv,
 		"split":       FuncStringSplit,
@@ -420,4 +421,13 @@ func FuncFileContent(path string) (data string, err error) {
 	}
 
 	return string(raw), nil
+}
+
+// FuncSecret returns the file content stripping the newlines from the end of the content.
+func FuncSecret(path string) (data string, err error) {
+	if data, err = FuncFileContent(path); err != nil {
+		return "", err
+	}
+
+	return strings.TrimRight(data, "\n"), nil
 }


### PR DESCRIPTION
This shows an example of using a template filter to include a single line secret.