### PR TITLE
refactor(oidc): true nil error reporter

### DIFF
--- a/internal/oidc/provider.go
+++ b/internal/oidc/provider.go
@@ -20,7 +20,7 @@ func NewOpenIDConnectProvider(config *schema.IdentityProvidersOpenIDConnect, sto
 	signer := NewKeyManager(config)
 
 	provider = &OpenIDConnectProvider{
-		JSONWriter: herodot.NewJSONWriter(nil),
+		JSONWriter: herodot.NewJSONWriter(&NilErrorReporter{}),
 		Store:      NewStore(config, store),
 		KeyManager: signer,
 		Config:     NewConfig(config, signer, templates),

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -193,6 +194,11 @@ type IDTokenSessionContainer interface {
 	IDTokenHeaders() *fjwt.Headers
 	IDTokenClaims() *fjwt.IDTokenClaims
 }
+
+// NilErrorReporter is a true nil herodot.ErrorReporter.
+type NilErrorReporter struct{}
+
+func (*NilErrorReporter) ReportError(r *http.Request, code int, err error, args ...interface{}) {}
 
 // ConsentGetResponseBody schema of the response body of the consent GET endpoint.
 type ConsentGetResponseBody struct {


### PR DESCRIPTION
This accounts for an upstream change which prints errors detected by herodot.