### PR TITLE
fix(configuration): illogical refresh interval default

### DIFF
--- a/cmd/authelia-scripts/cmd/gen.go
+++ b/cmd/authelia-scripts/cmd/gen.go
@@ -7,5 +7,5 @@
 package cmd
 
 const (
-	versionSwaggerUI = "5.10.0"
+	versionSwaggerUI = "5.10.1"
 )

--- a/docs/content/en/configuration/first-factor/introduction.md
+++ b/docs/content/en/configuration/first-factor/introduction.md
@@ -41,8 +41,15 @@ This section describes the individual configuration options.
 
 {{< confkey type="string,integer" syntax="duration" default="5 minutes" required="no">}}
 
-This setting controls the interval at which details are refreshed from the backend. Particularly useful for
-[LDAP](#ldap).
+_**Note:** when using the [File Provider](#file) this value has a default value of `always` as the cost in this
+scenario is basically not measurable, users can however override this setting by setting an explicit value._
+
+This setting controls the interval at which details are refreshed from the backend. The details refreshed in order of
+importance are the groups, email address, and display name. This is particularly useful for the [File Provider](#file)
+when [watch](file.md#watch) is enabled or generally with the [LDAP Provider](#ldap).
+
+In addition to the duration values this option accepts `always` and `disable` as values; where `always` will always
+refresh this value, and `disable` will never refresh the profile.
 
 ### password_reset
 

--- a/docs/data/configkeys.json
+++ b/docs/data/configkeys.json
@@ -145,6 +145,16 @@
         "env": "AUTHELIA_AUTHENTICATION_BACKEND_REFRESH_INTERVAL"
     },
     {
+        "path": "authentication_backend.refresh_interval",
+        "secret": false,
+        "env": "AUTHELIA_AUTHENTICATION_BACKEND_REFRESH_INTERVAL"
+    },
+    {
+        "path": "authentication_backend.refresh_interval",
+        "secret": false,
+        "env": "AUTHELIA_AUTHENTICATION_BACKEND_REFRESH_INTERVAL"
+    },
+    {
         "path": "authentication_backend.file.path",
         "secret": false,
         "env": "AUTHELIA_AUTHENTICATION_BACKEND_FILE_PATH"

--- a/docs/static/schemas/latest/json-schema/configuration.json
+++ b/docs/static/schemas/latest/json-schema/configuration.json
@@ -329,7 +329,7 @@
           "description": "Allows configuration of the password reset behaviour"
         },
         "refresh_interval": {
-          "type": "string",
+          "$ref": "#/$defs/RefreshIntervalDuration",
           "title": "Refresh Interval",
           "description": "How frequently the user details are refreshed from the backend"
         },
@@ -2251,6 +2251,26 @@
       "additionalProperties": false,
       "type": "object",
       "description": "PrivacyPolicy is the privacy policy configuration."
+    },
+    "RefreshIntervalDuration": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "always",
+            "never"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d+\\s*(y|M|w|d|h|m|s|ms|((year|month|week|day|hour|minute|second|millisecond)s?))(\\s*\\d+\\s*(y|M|w|d|h|m|s|ms|((year|month|week|day|hour|minute|second|millisecond)s?)))*$"
+        },
+        {
+          "type": "integer",
+          "description": "The duration in seconds"
+        }
+      ],
+      "default": "5 minutes"
     },
     "Regulation": {
       "properties": {

--- a/docs/static/schemas/v4.38/json-schema/configuration.json
+++ b/docs/static/schemas/v4.38/json-schema/configuration.json
@@ -329,7 +329,7 @@
           "description": "Allows configuration of the password reset behaviour"
         },
         "refresh_interval": {
-          "type": "string",
+          "$ref": "#/$defs/RefreshIntervalDuration",
           "title": "Refresh Interval",
           "description": "How frequently the user details are refreshed from the backend"
         },
@@ -2251,6 +2251,26 @@
       "additionalProperties": false,
       "type": "object",
       "description": "PrivacyPolicy is the privacy policy configuration."
+    },
+    "RefreshIntervalDuration": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "always",
+            "never"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^\\d+\\s*(y|M|w|d|h|m|s|ms|((year|month|week|day|hour|minute|second|millisecond)s?))(\\s*\\d+\\s*(y|M|w|d|h|m|s|ms|((year|month|week|day|hour|minute|second|millisecond)s?)))*$"
+        },
+        {
+          "type": "integer",
+          "description": "The duration in seconds"
+        }
+      ],
+      "default": "5 minutes"
     },
     "Regulation": {
       "properties": {

--- a/internal/configuration/decode_hooks_test.go
+++ b/internal/configuration/decode_hooks_test.go
@@ -559,6 +559,277 @@ func TestToTimeDurationHookFuncPointer(t *testing.T) {
 	}
 }
 
+func TestToRefreshIntervalDurationHookFunc(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		have   any
+		want   any
+		err    string
+		decode bool
+	}{
+		{
+			desc:   "ShouldDecodeFourtyFiveSeconds",
+			have:   "45s",
+			want:   schema.NewRefreshIntervalDuration(time.Second * 45),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeOneMinute",
+			have:   "1m",
+			want:   schema.NewRefreshIntervalDuration(time.Minute),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeTwoHours",
+			have:   "2h",
+			want:   schema.NewRefreshIntervalDuration(time.Hour * 2),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeThreeDays",
+			have:   "3d",
+			want:   schema.NewRefreshIntervalDuration(time.Hour * 24 * 3),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeFourWeeks",
+			have:   "4w",
+			want:   schema.NewRefreshIntervalDuration(time.Hour * 24 * 7 * 4),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeFiveMonths",
+			have:   "5M",
+			want:   schema.NewRefreshIntervalDuration(time.Hour * 24 * 30 * 5),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeSixYears",
+			have:   "6y",
+			want:   schema.NewRefreshIntervalDuration(time.Hour * 24 * 365 * 6),
+			decode: true,
+		},
+		{
+			desc:   "ShouldNotDecodeInvalidString",
+			have:   "abc",
+			want:   schema.RefreshIntervalDuration{},
+			err:    "could not decode 'abc' to a schema.RefreshIntervalDuration: could not parse 'abc' as a duration",
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeIntToSeconds",
+			have:   60,
+			want:   schema.NewRefreshIntervalDuration(time.Second * 60),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeInt8ToSeconds",
+			have:   int8(90),
+			want:   schema.NewRefreshIntervalDuration(time.Second * 90),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeInt16ToSeconds",
+			have:   int16(90),
+			want:   schema.NewRefreshIntervalDuration(time.Second * 90),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeInt32ToSeconds",
+			have:   int32(90),
+			want:   schema.NewRefreshIntervalDuration(time.Second * 90),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeFloat64ToSeconds",
+			have:   float64(90),
+			want:   schema.NewRefreshIntervalDuration(time.Second * 90),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeFloat64ToSeconds",
+			have:   math.MaxFloat64,
+			want:   schema.NewRefreshIntervalDuration(time.Duration(math.MaxInt64)),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeInt64ToSeconds",
+			have:   int64(120),
+			want:   schema.NewRefreshIntervalDuration(time.Second * 120),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeTimeDuration",
+			have:   time.Second * 30,
+			want:   schema.NewRefreshIntervalDuration(time.Second * 30),
+			decode: true,
+		},
+		{
+			desc:   "ShouldNotDecodeToString",
+			have:   int64(30),
+			want:   "",
+			decode: false,
+		},
+		{
+			desc:   "ShouldDecodeFromIntZero",
+			have:   0,
+			want:   schema.NewRefreshIntervalDuration(time.Duration(0)),
+			decode: true,
+		},
+		{
+			desc:   "ShouldSkipParsingBoolean",
+			have:   true,
+			want:   schema.RefreshIntervalDuration{},
+			decode: false,
+		},
+		{
+			desc: "ShouldNotDecodeFromBool",
+			have: true,
+			want: true,
+		},
+	}
+
+	hook := configuration.ToRefreshIntervalDurationHookFunc()
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+			switch {
+			case !tc.decode:
+				assert.NoError(t, err)
+				assert.Equal(t, tc.have, result)
+			case tc.err == "":
+				assert.NoError(t, err)
+				require.Equal(t, tc.want, result)
+			default:
+				assert.EqualError(t, err, tc.err)
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
+func TestTestToRefreshIntervalDurationHookFuncPointer(t *testing.T) {
+	testCases := []struct {
+		desc   string
+		have   any
+		want   any
+		err    string
+		decode bool
+	}{
+		{
+			desc:   "ShouldDecodeFourtyFiveSeconds",
+			have:   "45s",
+			want:   testRefreshIntervalDurationPtr(time.Second * 45),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeOneMinute",
+			have:   "1m",
+			want:   testRefreshIntervalDurationPtr(time.Minute),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeTwoHours",
+			have:   "2h",
+			want:   testRefreshIntervalDurationPtr(time.Hour * 2),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeThreeDays",
+			have:   "3d",
+			want:   testRefreshIntervalDurationPtr(time.Hour * 24 * 3),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeFourWeeks",
+			have:   "4w",
+			want:   testRefreshIntervalDurationPtr(time.Hour * 24 * 7 * 4),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeFiveMonths",
+			have:   "5M",
+			want:   testRefreshIntervalDurationPtr(time.Hour * 24 * 30 * 5),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeSixYears",
+			have:   "6y",
+			want:   testRefreshIntervalDurationPtr(time.Hour * 24 * 365 * 6),
+			decode: true,
+		},
+		{
+			desc:   "ShouldNotDecodeInvalidString",
+			have:   "abc",
+			want:   testRefreshIntervalDurationPtr(time.Duration(0)),
+			err:    "could not decode 'abc' to a *schema.RefreshIntervalDuration: could not parse 'abc' as a duration",
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeIntToSeconds",
+			have:   60,
+			want:   testRefreshIntervalDurationPtr(time.Second * 60),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeInt32ToSeconds",
+			have:   int32(90),
+			want:   testRefreshIntervalDurationPtr(time.Second * 90),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeInt64ToSeconds",
+			have:   int64(120),
+			want:   testRefreshIntervalDurationPtr(time.Second * 120),
+			decode: true,
+		},
+		{
+			desc:   "ShouldDecodeTimeDuration",
+			have:   time.Second * 30,
+			want:   testRefreshIntervalDurationPtr(time.Second * 30),
+			decode: true,
+		},
+		{
+			desc:   "ShouldNotDecodeToString",
+			have:   int64(30),
+			want:   &testString,
+			decode: false,
+		},
+		{
+			desc:   "ShouldDecodeFromIntZero",
+			have:   0,
+			want:   testRefreshIntervalDurationPtr(time.Duration(0)),
+			decode: true,
+		},
+		{
+			desc:   "ShouldNotDecodeFromBool",
+			have:   true,
+			want:   &testTrue,
+			decode: false,
+		},
+	}
+
+	hook := configuration.ToRefreshIntervalDurationHookFunc()
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+			switch {
+			case !tc.decode:
+				assert.NoError(t, err)
+				assert.Equal(t, tc.have, result)
+			case tc.err == "":
+				assert.NoError(t, err)
+				require.Equal(t, tc.want, result)
+			default:
+				assert.EqualError(t, err, tc.err)
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
 func TestStringToRegexpFunc(t *testing.T) {
 	testCases := []struct {
 		desc     string
@@ -1799,6 +2070,12 @@ func testInt32Ptr(i int32) *int32 {
 
 func testTimeDurationPtr(t time.Duration) *time.Duration {
 	return &t
+}
+
+func testRefreshIntervalDurationPtr(t time.Duration) *schema.RefreshIntervalDuration {
+	x := schema.NewRefreshIntervalDuration(t)
+
+	return &x
 }
 
 var (

--- a/internal/configuration/provider.go
+++ b/internal/configuration/provider.go
@@ -69,6 +69,7 @@ func unmarshal(ko *koanf.Koanf, val *schema.StructValidator, path string, o any)
 				StringToTLSVersionHookFunc(),
 				StringToPasswordDigestHookFunc(),
 				ToTimeDurationHookFunc(),
+				ToRefreshIntervalDurationHookFunc(),
 			),
 			Metadata:         nil,
 			Result:           o,

--- a/internal/configuration/schema/authentication.go
+++ b/internal/configuration/schema/authentication.go
@@ -10,7 +10,7 @@ import (
 type AuthenticationBackend struct {
 	PasswordReset AuthenticationBackendPasswordReset `koanf:"password_reset" json:"password_reset" jsonschema:"title=Password Reset" jsonschema_description:"Allows configuration of the password reset behaviour"`
 
-	RefreshInterval string `koanf:"refresh_interval" json:"refresh_interval" jsonschema:"title=Refresh Interval" jsonschema_description:"How frequently the user details are refreshed from the backend"`
+	RefreshInterval RefreshIntervalDuration `koanf:"refresh_interval" json:"refresh_interval" jsonschema:"default=5 minutes,title=Refresh Interval" jsonschema_description:"How frequently the user details are refreshed from the backend"`
 
 	// The file authentication backend configuration.
 	File *AuthenticationBackendFile `koanf:"file" json:"file" jsonschema:"title=File Backend" jsonschema_description:"The file authentication backend configuration"`
@@ -139,6 +139,10 @@ type AuthenticationBackendLDAPAttributes struct {
 	Mail              string `koanf:"mail" json:"mail" jsonschema:"title=Attribute: User Mail" jsonschema_description:"The directory server attribute which contains the mail address for all users and groups"`
 	MemberOf          string `koanf:"member_of" jsonschema:"title=Attribute: Member Of" jsonschema_description:"The directory server attribute which contains the objects that an object is a member of"`
 	GroupName         string `koanf:"group_name" json:"group_name" jsonschema:"title=Attribute: Group Name" jsonschema_description:"The directory server attribute which contains the group name for all groups"`
+}
+
+var DefaultAuthenticationBackendConfig = AuthenticationBackend{
+	RefreshInterval: NewRefreshIntervalDuration(time.Minute * 5),
 }
 
 // DefaultPasswordConfig represents the default configuration related to Argon2id hashing.

--- a/internal/configuration/schema/const.go
+++ b/internal/configuration/schema/const.go
@@ -44,18 +44,15 @@ const (
 // ErrTLSVersionNotSupported returned when an unknown TLS version supplied.
 var ErrTLSVersionNotSupported = errors.New("supplied tls version isn't supported")
 
-// ProfileRefreshDisabled represents a Value for refresh_interval that disables the check entirely.
-const ProfileRefreshDisabled = "disable"
-
 const (
 	// ProfileRefreshAlways represents a value for refresh_interval that's the same as 0ms.
 	ProfileRefreshAlways = "always"
 
-	// RefreshIntervalDefault represents the default value of refresh_interval.
-	RefreshIntervalDefault = "5m"
+	// ProfileRefreshDisabled represents a Value for refresh_interval that disables the check entirely.
+	ProfileRefreshDisabled = "disable"
 
-	// RefreshIntervalAlways represents the duration value refresh interval should have if set to always.
-	RefreshIntervalAlways = 0 * time.Millisecond
+	// RefreshIntervalDefault represents the default value of refresh_interval.
+	RefreshIntervalDefault = time.Minute * 5
 )
 
 const (

--- a/internal/configuration/schema/keys.go
+++ b/internal/configuration/schema/keys.go
@@ -115,6 +115,8 @@ var Keys = []string{
 	"authentication_backend.password_reset.disable",
 	"authentication_backend.password_reset.custom_url",
 	"authentication_backend.refresh_interval",
+	"authentication_backend.refresh_interval",
+	"authentication_backend.refresh_interval",
 	"authentication_backend.file.path",
 	"authentication_backend.file.watch",
 	"authentication_backend.file.password.algorithm",

--- a/internal/configuration/test_resources/config.durations.yml
+++ b/internal/configuration/test_resources/config.durations.yml
@@ -34,6 +34,7 @@ duo_api:
   integration_key: 'ABCDEF'
 
 authentication_backend:
+  refresh_interval: '5m'
   ldap:
     address: 'ldap://127.0.0.1'
     tls:

--- a/internal/configuration/test_resources/config.no-refresh.yml
+++ b/internal/configuration/test_resources/config.no-refresh.yml
@@ -3,6 +3,25 @@ default_redirection_url: 'https://home.example.com:8080/'
 
 server:
   address: 'tcp://127.0.0.1:9091'
+  endpoints:
+    authz:
+      forward-auth:
+        implementation: 'ForwardAuth'
+        authn_strategies:
+          - name: 'HeaderProxyAuthorization'
+          - name: 'CookieSession'
+      ext-authz:
+        implementation: 'ExtAuthz'
+        authn_strategies:
+          - name: 'HeaderProxyAuthorization'
+          - name: 'CookieSession'
+      auth-request:
+        implementation: 'AuthRequest'
+        authn_strategies:
+          - name: 'HeaderAuthRequestProxyAuthorization'
+          - name: 'CookieSession'
+      legacy:
+        implementation: 'Legacy'
 
 log:
   level: 'debug'
@@ -15,20 +34,47 @@ duo_api:
   integration_key: 'ABCDEF'
 
 authentication_backend:
-  refresh_interval: 'always'
   ldap:
     address: 'ldap://127.0.0.1'
+    tls:
+      private_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEA6z1LOg1ZCqb0lytXWZ+MRBpMHEXOoTOLYgfZXt1IYyE3Z758
+        cyalk0NYQhY5cZDsXPYWPvAHiPMUxutWkoxFwby56S+AbIMa3/Is+ILrHRJs8Exn
+        ZkpyrYFxPX12app2kErdmAkHSx0Z5/kuXiz96PHs8S8/ZbyZolLHzdfLtSzjvRm5
+        Zue5iFzsf19NJz5CIBfv8g5lRwtE8wNJoRSpn1xq7fqfuA0weDNFPzjlNWRLy6aa
+        rK7qJexRkmkCs4sLgyl+9NODYJpvmN8E1yhyC27E0joI6rBFVW7Ihv+cSPCdDzGp
+        EWe81x3AeqAa3mjVqkiq4u4Z2i8JDgBaPboqJwIDAQABAoIBAAFdLZ58jVOefDSU
+        L8F5R1rtvBs93GDa56f926jNJ6pLewLC+/2+757W+SAI+PRLntM7Kg3bXm/Q2QH+
+        Q1Y+MflZmspbWCdI61L5GIGoYKyeers59i+FpvySj5GHtLQRiTZ0+Kv1AXHSDWBm
+        9XneUOqU3IbZe0ifu1RRno72/VtjkGXbW8Mkkw+ohyGbIeTx/0/JQ6sSNZTT3Vk7
+        8i4IXptq3HSF0/vqZuah8rShoeNq72pD1YLM9YPdL5by1QkDLnqATDiCpLBTCaNV
+        I8sqYEun+HYbQzBj8ZACG2JVZpEEidONWQHw5BPWO95DSZYrVnEkuCqeH+u5vYt7
+        CHuJ3AECgYEA+W3v5z+j91w1VPHS0VB3SCDMouycAMIUnJPAbt+0LPP0scUFsBGE
+        hPAKddC54pmMZRQ2KIwBKiyWfCrJ8Xz8Yogn7fJgmwTHidJBr2WQpIEkNGlK3Dzi
+        jXL2sh0yC7sHvn0DqiQ79l/e7yRbSnv2wrTJEczOOH2haD7/tBRyCYECgYEA8W+q
+        E9YyGvEltnPFaOxofNZ8LHVcZSsQI5b6fc0iE7fjxFqeXPXEwGSOTwqQLQRiHn9b
+        CfPmIG4Vhyq0otVmlPvUnfBZ2OK+tl5X2/mQFO3ROMdvpi0KYa994uqfJdSTaqLn
+        jjoKFB906UFHnDQDLZUNiV1WwnkTglgLc+xrd6cCgYEAqqthyv6NyBTM3Tm2gcio
+        Ra9Dtntl51LlXZnvwy3IkDXBCd6BHM9vuLKyxZiziGx+Vy90O1xI872cnot8sINQ
+        Am+dur/tAEVN72zxyv0Y8qb2yfH96iKy9gxi5s75TnOEQgAygLnYWaWR2lorKRUX
+        bHTdXBOiS58S0UzCFEslGIECgYBqkO4SKWYeTDhoKvuEj2yjRYyzlu28XeCWxOo1
+        otiauX0YSyNBRt2cSgYiTzhKFng0m+QUJYp63/wymB/5C5Zmxi0XtWIDADpLhqLj
+        HmmBQ2Mo26alQ5YkffBju0mZyhVzaQop1eZi8WuKFV1FThPlB7hc3E0SM5zv2Grd
+        tQnOWwKBgQC40yZY0PcjuILhy+sIc0Wvh7LUA7taSdTye149kRvbvsCDN7Jh75lM
+        USjhLXY0Nld2zBm9r8wMb81mXH29uvD+tDqqsICvyuKlA/tyzXR+QTr7dCVKVwu0
+        1YjCJ36UpTsLre2f8nOSLtNmRfDPtbOE2mkOoO9dD9UU0XZwnvn9xw==
+        -----END RSA PRIVATE KEY-----
     base_dn: 'dc=example,dc=com'
     additional_users_dn: 'ou=users'
     users_filter: '(&({username_attribute}={input})(objectCategory=person)(objectClass=user))'
     additional_groups_dn: 'ou=groups'
     groups_filter: '(&(member={dn})(objectClass=groupOfNames))'
-
     user: 'cn=admin,dc=example,dc=com'
     attributes:
-      mail: 'mail'
-      group_name: 'cn'
       username: 'uid'
+      group_name: 'cn'
+      mail: 'mail'
 
 access_control:
   default_policy: 'deny'
@@ -99,11 +145,12 @@ session:
   name: 'authelia_session'
   expiration: '1h'  # 1 hour
   inactivity: '5m'  # 5 minutes
-  remember_me: -1
   domain: 'example.com'
   redis:
     host: '127.0.0.1'
     port: 6379
+    high_availability:
+      sentinel_name: 'test'
 
 regulation:
   max_retries: 3
@@ -111,8 +158,8 @@ regulation:
   ban_time: '5m'
 
 storage:
-  postgres:
-    address: 'tcp://127.0.0.1:5432'
+  mysql:
+    address: 'tcp://127.0.0.1:3306'
     database: 'authelia'
     username: 'authelia'
 
@@ -120,6 +167,6 @@ notifier:
   smtp:
     address: 'smtp://127.0.0.1:1025'
     username: 'test'
-    sender: 'Admin <admin@example.com>'
+    sender: 'admin@example.com'
     disable_require_tls: true
 ...

--- a/internal/configuration/test_resources/config.yml
+++ b/internal/configuration/test_resources/config.yml
@@ -34,6 +34,7 @@ duo_api:
   integration_key: 'ABCDEF'
 
 authentication_backend:
+  refresh_interval: 'disable'
   ldap:
     address: 'ldap://127.0.0.1'
     tls:

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -20,12 +20,11 @@ func ValidateAuthenticationBackend(config *schema.AuthenticationBackend, validat
 		validator.Push(fmt.Errorf(errFmtAuthBackendNotConfigured))
 	}
 
-	if config.RefreshInterval == "" {
-		config.RefreshInterval = schema.RefreshIntervalDefault
-	} else {
-		_, err := utils.ParseDurationString(config.RefreshInterval)
-		if err != nil && config.RefreshInterval != schema.ProfileRefreshDisabled && config.RefreshInterval != schema.ProfileRefreshAlways {
-			validator.Push(fmt.Errorf(errFmtAuthBackendRefreshInterval, config.RefreshInterval, err))
+	if !config.RefreshInterval.Valid() {
+		if config.File != nil && config.File.Watch {
+			config.RefreshInterval = schema.NewRefreshIntervalDurationAlways()
+		} else {
+			config.RefreshInterval = schema.NewRefreshIntervalDuration(schema.RefreshIntervalDefault)
 		}
 	}
 

--- a/internal/handlers/handler_authz_builder.go
+++ b/internal/handlers/handler_authz_builder.go
@@ -1,18 +1,15 @@
 package handlers
 
 import (
-	"time"
-
 	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
-	"github.com/authelia/authelia/v4/internal/utils"
 )
 
 // NewAuthzBuilder creates a new AuthzBuilder.
 func NewAuthzBuilder() *AuthzBuilder {
 	return &AuthzBuilder{
-		config: AuthzConfig{RefreshInterval: time.Second * -1},
+		config: AuthzConfig{RefreshInterval: schema.NewRefreshIntervalDurationAlways()},
 	}
 }
 
@@ -62,19 +59,8 @@ func (b *AuthzBuilder) WithConfig(config *schema.Configuration) *AuthzBuilder {
 		return b
 	}
 
-	var refreshInterval time.Duration
-
-	switch config.AuthenticationBackend.RefreshInterval {
-	case schema.ProfileRefreshDisabled:
-		refreshInterval = time.Second * -1
-	case schema.ProfileRefreshAlways:
-		refreshInterval = time.Second * 0
-	default:
-		refreshInterval, _ = utils.ParseDurationString(config.AuthenticationBackend.RefreshInterval)
-	}
-
 	b.config = AuthzConfig{
-		RefreshInterval: refreshInterval,
+		RefreshInterval: config.AuthenticationBackend.RefreshInterval,
 	}
 
 	return b

--- a/internal/handlers/handler_authz_builder_test.go
+++ b/internal/handlers/handler_authz_builder_test.go
@@ -14,31 +14,31 @@ func TestAuthzBuilder_WithConfig(t *testing.T) {
 
 	builder.WithConfig(&schema.Configuration{
 		AuthenticationBackend: schema.AuthenticationBackend{
-			RefreshInterval: "always",
+			RefreshInterval: schema.NewRefreshIntervalDurationAlways(),
 		},
 	})
 
-	assert.Equal(t, time.Second*0, builder.config.RefreshInterval)
+	assert.Equal(t, schema.NewRefreshIntervalDurationAlways(), builder.config.RefreshInterval)
 
 	builder.WithConfig(&schema.Configuration{
 		AuthenticationBackend: schema.AuthenticationBackend{
-			RefreshInterval: "disable",
+			RefreshInterval: schema.NewRefreshIntervalDurationNever(),
 		},
 	})
 
-	assert.Equal(t, time.Second*-1, builder.config.RefreshInterval)
+	assert.Equal(t, schema.NewRefreshIntervalDurationNever(), builder.config.RefreshInterval)
 
 	builder.WithConfig(&schema.Configuration{
 		AuthenticationBackend: schema.AuthenticationBackend{
-			RefreshInterval: "1m",
+			RefreshInterval: schema.NewRefreshIntervalDuration(time.Minute),
 		},
 	})
 
-	assert.Equal(t, time.Minute, builder.config.RefreshInterval)
+	assert.Equal(t, schema.NewRefreshIntervalDuration(time.Minute), builder.config.RefreshInterval)
 
 	builder.WithConfig(nil)
 
-	assert.Equal(t, time.Minute, builder.config.RefreshInterval)
+	assert.Equal(t, schema.NewRefreshIntervalDuration(time.Minute), builder.config.RefreshInterval)
 }
 
 func TestAuthzBuilder_WithEndpointConfig(t *testing.T) {

--- a/internal/handlers/handler_authz_test.go
+++ b/internal/handlers/handler_authz_test.go
@@ -279,13 +279,15 @@ func (s *AuthzSuite) TestShouldNotFailOnMissingEmail() {
 		s.T().Skip()
 	}
 
-	authz := s.Builder().Build()
-
 	mock := mocks.NewMockAutheliaCtx(s.T())
 
 	defer mock.Close()
 
+	mock.Ctx.Clock = &mock.Clock
+
 	mock.Clock.Set(time.Now())
+
+	authz := s.Builder().WithConfig(&mock.Ctx.Configuration).Build()
 
 	s.ConfigureMockSessionProviderWithAutomaticAutheliaURLs(mock)
 
@@ -675,7 +677,7 @@ func (s *AuthzSuite) TestShouldDestroySessionWhenInactiveForTooLong() {
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(testInactivity),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(testInactivity)),
 	)
 
 	authz := builder.Build()
@@ -725,7 +727,7 @@ func (s *AuthzSuite) TestShouldNotDestroySessionWhenInactiveForTooLongRememberMe
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(testInactivity),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(testInactivity)),
 	)
 
 	authz := builder.Build()
@@ -775,7 +777,7 @@ func (s *AuthzSuite) TestShouldNotDestroySessionWhenNotInactiveForTooLong() {
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(testInactivity),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(testInactivity)),
 	)
 
 	authz := builder.Build()
@@ -826,7 +828,7 @@ func (s *AuthzSuite) TestShouldUpdateInactivityTimestampEvenWhenHittingForbidden
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(testInactivity),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(testInactivity)),
 	)
 
 	authz := builder.Build()
@@ -877,7 +879,7 @@ func (s *AuthzSuite) TestShouldNotRefreshUserDetailsFromBackendWhenRefreshDisabl
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(-1 * time.Second),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDurationNever()),
 	)
 
 	authz := builder.Build()
@@ -900,7 +902,7 @@ func (s *AuthzSuite) TestShouldNotRefreshUserDetailsFromBackendWhenRefreshDisabl
 	mock.Clock.Set(time.Now())
 
 	mock.Ctx.Clock = &mock.Clock
-	mock.Ctx.Configuration.AuthenticationBackend.RefreshInterval = schema.ProfileRefreshDisabled
+	mock.Ctx.Configuration.AuthenticationBackend.RefreshInterval = schema.NewRefreshIntervalDurationNever()
 	mock.Ctx.Configuration.Session.Cookies[0].Inactivity = testInactivity
 
 	s.ConfigureMockSessionProviderWithAutomaticAutheliaURLs(mock)
@@ -970,7 +972,7 @@ func (s *AuthzSuite) TestShouldDestroySessionWhenUserDoesNotExist() {
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(5 * time.Minute),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(5 * time.Minute)),
 	)
 
 	authz := builder.Build()
@@ -1058,7 +1060,7 @@ func (s *AuthzSuite) TestShouldUpdateRemovedUserGroupsFromBackendAndDeny() {
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(5 * time.Minute),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(5 * time.Minute)),
 	)
 
 	authz := builder.Build()
@@ -1144,7 +1146,7 @@ func (s *AuthzSuite) TestShouldUpdateAddedUserGroupsFromBackendAndDeny() {
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(5 * time.Minute),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(5 * time.Minute)),
 	)
 
 	authz := builder.Build()
@@ -1229,7 +1231,7 @@ func (s *AuthzSuite) TestShouldCheckValidSessionUsernameHeaderAndReturn200() {
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(testInactivity),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(testInactivity)),
 	)
 
 	authz := builder.Build()
@@ -1282,7 +1284,7 @@ func (s *AuthzSuite) TestShouldCheckInvalidSessionUsernameHeaderAndReturn401AndD
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(testInactivity),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(5 * time.Minute)),
 	)
 
 	authz := builder.Build()
@@ -1353,7 +1355,7 @@ func (s *AuthzSuite) TestShouldNotRedirectRequestsForBypassACLWhenInactiveForToo
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(testInactivity),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(testInactivity)),
 	)
 
 	authz := builder.Build()
@@ -1431,7 +1433,7 @@ func (s *AuthzSuite) TestShouldFailToParsePortalURL() {
 	builder := s.Builder()
 
 	builder = builder.WithStrategies(
-		NewCookieSessionAuthnStrategy(testInactivity),
+		NewCookieSessionAuthnStrategy(schema.NewRefreshIntervalDuration(testInactivity)),
 	)
 
 	authz := builder.Build()

--- a/internal/handlers/handler_authz_types.go
+++ b/internal/handlers/handler_authz_types.go
@@ -2,10 +2,10 @@ package handlers
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/session"
 )
@@ -75,7 +75,7 @@ type Authn struct {
 
 // AuthzConfig represents the configuration elements of the Authz type.
 type AuthzConfig struct {
-	RefreshInterval time.Duration
+	RefreshInterval schema.RefreshIntervalDuration
 
 	// StatusCodeBadRequest is sent for configuration issues prior to performing authorization checks. It's set by the
 	// builder.

--- a/internal/mocks/authelia_ctx.go
+++ b/internal/mocks/authelia_ctx.go
@@ -74,6 +74,7 @@ func NewMockAutheliaCtx(t *testing.T) *MockAutheliaCtx {
 		},
 	}
 
+	config.AuthenticationBackend.RefreshInterval = schema.NewRefreshIntervalDuration(schema.RefreshIntervalDefault)
 	config.AccessControl = schema.AccessControl{
 		DefaultPolicy: "deny",
 		Rules: []schema.AccessControlRule{


### PR DESCRIPTION
When using the file provider with watch enabled, the refresh interval should just be set to always by default as the cost is minimal.