### PR TITLE
fix(configuration): regression in redis default port

### DIFF
--- a/internal/configuration/validator/session.go
+++ b/internal/configuration/validator/session.go
@@ -250,9 +250,11 @@ func validateRedis(config *schema.Session, validator *schema.StructValidator) {
 
 	validateRedisCommon(config, validator)
 
-	if config.Redis.Port == 0 {
+	abs := path.IsAbs(config.Redis.Host)
+
+	if !abs && config.Redis.Port == 0 {
 		config.Redis.Port = schema.DefaultRedisConfiguration.Port
-	} else if !path.IsAbs(config.Redis.Host) && (config.Redis.Port < 1 || config.Redis.Port > 65535) {
+	} else if !abs && (config.Redis.Port < 1 || config.Redis.Port > 65535) {
 		validator.Push(fmt.Errorf(errFmtSessionRedisPortRange, config.Redis.Port))
 	}
 

--- a/internal/configuration/validator/session_test.go
+++ b/internal/configuration/validator/session_test.go
@@ -298,6 +298,27 @@ func TestShouldHandleRedisConfigSuccessfully(t *testing.T) {
 	assert.Equal(t, 8, config.Session.Redis.MaximumActiveConnections)
 }
 
+func TestShouldHandleRedisSocketConfigSuccessfully(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+
+	// Set redis config because password must be set only when redis is used.
+	config.Session.Redis = &schema.SessionRedis{
+		Host:     "/path/to/socket.sock",
+		Port:     0,
+		Password: "password",
+	}
+
+	ValidateSession(&config, validator)
+
+	assert.Len(t, validator.Warnings(), 0)
+	assert.Len(t, validator.Errors(), 0)
+
+	assert.Equal(t, 8, config.Session.Redis.MaximumActiveConnections)
+	assert.Equal(t, 0, config.Session.Redis.Port)
+	assert.Equal(t, "/path/to/socket.sock", config.Session.Redis.Host)
+}
+
 func TestShouldRaiseErrorWithInvalidRedisPortLow(t *testing.T) {
 	validator := schema.NewStructValidator()
 	config := newDefaultSessionConfig()


### PR DESCRIPTION
This fixes an issue introduced in 5edd5fcf69d8f17a6731e0f1b5cf8f8591823e56 which prevented a redis socket from being used. The redis port zero value is used to determine if we should attempt to utilize a unix socket but the contribution always sets it as default regardless.