### PR TITLE
fix(web): fix base64 decoding

### DIFF
--- a/web/src/utils/Base64.ts
+++ b/web/src/utils/Base64.ts
@@ -205,5 +205,5 @@ export function getBytesFromBase64(str: string): Uint8Array {
         result[j + 2] = buffer & 0xff;
     }
 
-    return result.subarray(0, result.length - missingOctets);
+    return result.slice(0, result.length - missingOctets);
 }


### PR DESCRIPTION
Replacing subarray to slice in order to avoid challenge wrong encoding.

Fixes #6635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the method of extracting portions of arrays in the app's internal processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->