### PR TITLE
docs(oidc): add freshrss oidc integration guide

### DIFF
--- a/docs/content/en/integration/openid-connect/freshrss/index.md
+++ b/docs/content/en/integration/openid-connect/freshrss/index.md
@@ -16,7 +16,7 @@ community: true
 ## Tested Versions
 
 * [Authelia]
-  * [v4.37.5](https://github.com/authelia/authelia/releases/tag/v4.37.5)
+  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
 * [Freshrss]
   * [1.23.1](https://github.com/FreshRSS/FreshRSS/releases/tag/1.23.1)
 
@@ -35,6 +35,10 @@ This example makes the following assumptions:
 * __Port:__ '443'
   * this is the port freshrss is served over (usually 80 for http and 443 for https) NOT the port of the docker container
 
+### Special Notes
+
+1. The FressRSS implementation seems to always include the port in the requested `redirect_uri`. As Authelia strictly conforms to the specifications this means the client registration **_MUST_** include the port for the requested `redirect_uri` to match.
+
 ## Configuration
 
 ### Authelia
@@ -49,18 +53,19 @@ identity_providers:
     ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
     ## See: https://www.authelia.com/c/oidc
     clients:
-    - id: freshrss
-      description: freshrss
+    - id: 'freshrss'
+      description: 'freshrss'
       secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
       public: false
-      authorization_policy: two_factor
+      authorization_policy: 'two_factor'
       redirect_uris:
-        - https://freshrss.example.com:443/i/oidc/ # IMPORTANT: you must add the port to the redirect uri
+        - 'https://freshrss.example.com:443/i/oidc/'
       scopes:
-        - openid
-        - groups
-        - email
-        - profile
+        - 'openid'
+        - 'groups'
+        - 'email'
+        - 'profile'
+      token_endpoint_auth_method: 'client_secret_post'
       userinfo_signed_response_alg: 'none'
 ```
 

--- a/docs/content/en/integration/openid-connect/freshrss/index.md
+++ b/docs/content/en/integration/openid-connect/freshrss/index.md
@@ -1,0 +1,91 @@
+---
+title: "freshrss"
+description: "Integrating Freshrss with the Authelia OpenID Connect 1.0 Provider."
+lead: ""
+date: 2024-02-14T20:29:13+11:00
+draft: false
+images: []
+menu:
+  integration:
+    parent: "openid-connect"
+weight: 620
+toc: true
+community: true
+---
+
+## Tested Versions
+
+* [Authelia]
+  * [v4.37.5](https://github.com/authelia/authelia/releases/tag/v4.37.5)
+* [Freshrss]
+  * [1.23.1](https://github.com/FreshRSS/FreshRSS/releases/tag/1.23.1)
+
+## Before You Begin
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://freshrss.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+* __Client ID:__ `freshrss`
+* __Client Secret:__ `insecure_secret`
+* __Port:__ '443'
+  * this is the port freshrss is served over (usually 80 for http and 443 for https) NOT the port of the docker container
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__
+[client configuration](../../../configuration/identity-providers/openid-connect/clients.md) for use with [freshrss](https://freshrss.github.io/FreshRSS/) which
+will operate with the above example:
+
+```yaml
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+    - id: freshrss
+      description: freshrss
+      secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+      public: false
+      authorization_policy: two_factor
+      redirect_uris:
+        - https://freshrss.example.com:443/i/oidc/ # IMPORTANT: you must add the port to the redirect uri
+      scopes:
+        - openid
+        - groups
+        - email
+        - profile
+      userinfo_signed_response_alg: 'none'
+```
+
+### Application
+
+1. To configure [freshrss](https://freshrss.github.io/FreshRSS/) to utilize Authelia as an [OpenID Connect 1.0](https://www.authelia.com/integration/openid-connect/introduction/) Provider, specify the following environment variables:
+
+```yaml
+environment:
+  OIDC_ENABLED: 1
+  OIDC_PROVIDER_METADATA_URL: https://auth.example.com/.well-known/openid-configuration
+  OIDC_CLIENT_ID: freshrss
+  OIDC_CLIENT_SECRET: insecure_secret
+  OIDC_CLIENT_CRYPTO_KEY: XXXXXXXXXX
+  OIDC_REMOTE_USER_CLAIM: preferred_username
+  OIDC_SCOPES: openid groups email profile
+  OIDC_X_FORWARDED_HEADERS: X-Forwarded-Host X-Forwarded-Port X-Forwarded-Proto
+```
+2. Open the newly created freshrss instance
+3. During initial config, select "HTTP" during the user creation
+
+## See Also
+
+- [freshrss OIDC documentation](https://freshrss.github.io/FreshRSS/en/admins/16_OpenID-Connect.html)
+
+[Authelia]: https://www.authelia.com
+[freshrss]: https://freshrss.github.io/FreshRSS/
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md

--- a/docs/content/en/integration/openid-connect/freshrss/index.md
+++ b/docs/content/en/integration/openid-connect/freshrss/index.md
@@ -65,7 +65,7 @@ identity_providers:
         - 'groups'
         - 'email'
         - 'profile'
-      token_endpoint_auth_method: 'client_secret_post'
+      token_endpoint_auth_method: 'client_secret_basic'
       userinfo_signed_response_alg: 'none'
 ```
 


### PR DESCRIPTION
Create integration guide for oidc authentication for freshrss and authelia

Document non-obvious behaviour that freshrss expects port in the redirect URI

Signed-off-by: darkpixelftw <darkpixelftw@outlook.com>