### PR TITLE
Grafana OIDC doc updates

### DIFF
--- a/docs/content/en/integration/openid-connect/grafana/index.md
+++ b/docs/content/en/integration/openid-connect/grafana/index.md
@@ -73,6 +73,8 @@ Add the following Generic OAuth configuration to the [Grafana] configuration:
 ```ini
 [server]
 root_url = https://grafana.example.com
+[auth]
+oauth_allow_insecure_email_lookup = true
 [auth.generic_oauth]
 enabled = true
 name = Authelia
@@ -88,6 +90,7 @@ login_attribute_path = preferred_username
 groups_attribute_path = groups
 name_attribute_path = name
 use_pkce = true
+skip_org_role_sync = true
 ```
 
 #### Environment Variables


### PR DESCRIPTION
As per the issue [here](https://github.com/grafana/grafana/issues/74154), as of Grafana v10, Grafana no longer supports email lookups by default.

To mitigate this when using Authelia, we need to include a few additional options in the Grafana configuration. This PR is to simply update the configuration to make these requirements clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Documentation**
	- Updated the integration guide for OAuth in Grafana with new configuration options: `oauth_allow_insecure_email_lookup` and `skip_org_role_sync`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->