### PR TITLE
ci: remove container read-only mounts

### DIFF
--- a/cmd/authelia-gen/cmd_docs_date.go
+++ b/cmd/authelia-gen/cmd_docs_date.go
@@ -175,9 +175,11 @@ func replaceDates(path string, date time.Time, dateGit *time.Time) {
 			switch {
 			case scanner.Text() == delimiterLineFrontMatter:
 				buf.Write(scanner.Bytes())
+
 				frontmatter++
 			case frontmatter != 0 && strings.HasPrefix(scanner.Text(), "date: "):
 				buf.WriteString(dateGitLine)
+
 				found++
 			default:
 				buf.Write(scanner.Bytes())

--- a/cmd/authelia-scripts/cmd/bootstrap.go
+++ b/cmd/authelia-scripts/cmd/bootstrap.go
@@ -235,6 +235,7 @@ func prepareHostsFile() {
 				} else {
 					lines[i] = entry.IP + " " + entry.Domain
 					modified = true
+
 					break
 				}
 			}

--- a/cmd/authelia-scripts/cmd/suites.go
+++ b/cmd/authelia-scripts/cmd/suites.go
@@ -139,6 +139,7 @@ func cmdSuitesTeardownRun(_ *cobra.Command, args []string) {
 		if runningSuite == "" {
 			log.Fatal(ErrNoRunningSuite)
 		}
+
 		suiteName = runningSuite
 	}
 
@@ -167,11 +168,13 @@ func cmdSuitesTestRun(_ *cobra.Command, args []string) {
 	} else {
 		if runningSuite != "" {
 			fmt.Println(txtRunningSuite + runningSuite + ") detected. Run tests of that suite")
+
 			if err := runSuiteTests(runningSuite, false); err != nil {
 				log.Fatal(err)
 			}
 		} else {
 			fmt.Println("No suite provided therefore all suites will be tested")
+
 			if err := runAllSuites(); err != nil {
 				log.Fatal(err)
 			}

--- a/docs/content/en/integration/proxies/envoy.md
+++ b/docs/content/en/integration/proxies/envoy.md
@@ -109,8 +109,8 @@ services:
       - '80:8080'
       - '443:8443'
     volumes:
-      - '${PWD}/data/envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro'
-      - '${PWD}/data/certificates:/certificates:ro'
+      - '${PWD}/data/envoy/envoy.yaml:/etc/envoy/envoy.yaml'
+      - '${PWD}/data/certificates:/certificates'
   authelia:
     container_name: 'authelia'
     image: 'authelia/authelia'

--- a/docs/content/en/integration/proxies/nginx-proxy-manager/index.md
+++ b/docs/content/en/integration/proxies/nginx-proxy-manager/index.md
@@ -92,7 +92,7 @@ services:
     volumes:
       - '${PWD}/data/nginx-proxy-manager/data:/data'
       - '${PWD}/data/nginx-proxy-manager/letsencrypt:/etc/letsencrypt'
-      - '${PWD}/data/nginx/snippets:/snippets:ro'
+      - '${PWD}/data/nginx/snippets:/snippets'
     environment:
       TZ: 'Australia/Melbourne'
   authelia:

--- a/docs/content/en/integration/proxies/nginx.md
+++ b/docs/content/en/integration/proxies/nginx.md
@@ -127,8 +127,8 @@ services:
       - '80:80'
       - '443:443'
     volumes:
-      - ${PWD}/data/nginx/snippets:/config/nginx/snippets:ro
-      - ${PWD}/data/nginx/site-confs:/config/nginx/site-confs:ro
+      - '${PWD}/data/nginx/snippets:/config/nginx/snippets'
+      - '${PWD}/data/nginx/site-confs:/config/nginx/site-confs'
     environment:
       TZ: 'Australia/Melbourne'
       DOCKER_MODS: 'linuxserver/mods:nginx-proxy-confs'

--- a/docs/content/en/integration/proxies/swag.md
+++ b/docs/content/en/integration/proxies/swag.md
@@ -156,7 +156,7 @@ services:
     volumes:
       - '${PWD}/data/swag:/config'
       ## Uncomment the line below if you want to use the Authelia configuration snippets.
-      #- ${PWD}/data/nginx/snippets:/snippets:ro
+      #- '${PWD}/data/nginx/snippets:/snippets'
     environment:
       PUID: '1000'
       PGID: '1000'

--- a/internal/authentication/file_user_provider_test.go
+++ b/internal/authentication/file_user_provider_test.go
@@ -151,6 +151,7 @@ func TestShouldReloadDatabase(t *testing.T) {
 			actual, theError := provider.Reload()
 
 			assert.Equal(t, tc.expected, actual)
+
 			if tc.err == "" {
 				assert.NoError(t, theError)
 			} else {
@@ -311,6 +312,7 @@ func TestShouldUpdatePasswordHashingAlgorithmToArgon2id(t *testing.T) {
 		require.True(t, ok)
 
 		assert.True(t, strings.HasPrefix(db.Users["harry"].Password.Encode(), "$6$"))
+
 		err := provider.UpdatePassword("harry", "newpassword")
 		assert.NoError(t, err)
 
@@ -341,6 +343,7 @@ func TestShouldUpdatePasswordHashingAlgorithmToSHA512(t *testing.T) {
 		require.True(t, ok)
 
 		assert.True(t, strings.HasPrefix(db.Users["john"].Password.Encode(), "$argon2id$"))
+
 		err := provider.UpdatePassword("john", "newpassword")
 		assert.NoError(t, err)
 

--- a/internal/configuration/decode_hooks_test.go
+++ b/internal/configuration/decode_hooks_test.go
@@ -66,6 +66,7 @@ func TestStringToMailAddressHookFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -127,6 +128,7 @@ func TestStringToMailAddressHookFuncPointer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -200,6 +202,7 @@ func TestStringToURLHookFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -273,6 +276,7 @@ func TestStringToURLHookFuncPointer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -423,6 +427,7 @@ func TestToTimeDurationHookFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -544,6 +549,7 @@ func TestToTimeDurationHookFuncPointer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -694,6 +700,7 @@ func TestToRefreshIntervalDurationHookFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -815,6 +822,7 @@ func TestTestToRefreshIntervalDurationHookFuncPointer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -903,6 +911,7 @@ func TestStringToRegexpFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -911,9 +920,9 @@ func TestStringToRegexpFunc(t *testing.T) {
 				assert.NoError(t, err)
 				require.Equal(t, tc.want, result)
 
-				pattern := result.(regexp.Regexp)
-
 				var names []string
+
+				pattern := result.(regexp.Regexp)
 				for _, name := range pattern.SubexpNames() {
 					if name != "" {
 						names = append(names, name)
@@ -1016,6 +1025,7 @@ func TestStringToRegexpFuncPointers(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -1030,6 +1040,7 @@ func TestStringToRegexpFuncPointers(t *testing.T) {
 					assert.Nil(t, pattern)
 				} else {
 					var names []string
+
 					for _, name := range pattern.SubexpNames() {
 						if name != "" {
 							names = append(names, name)
@@ -1382,6 +1393,7 @@ func TestStringToPrivateKeyHookFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -1470,6 +1482,7 @@ func TestStringToX509CertificateHookFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			result, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.want), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -1941,6 +1954,7 @@ func TestStringToX509CertificateChainHookFunc(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			actual, err := hook(reflect.TypeOf(tc.have), reflect.TypeOf(tc.expected), tc.have)
+
 			switch {
 			case !tc.decode:
 				assert.NoError(t, err)
@@ -1956,6 +1970,7 @@ func TestStringToX509CertificateChainHookFunc(t *testing.T) {
 				switch chain := actual.(type) {
 				case *schema.X509CertificateChain:
 					require.NotNil(t, chain)
+
 					if tc.verr == "" {
 						assert.NoError(t, chain.Validate())
 					} else {
@@ -1963,6 +1978,7 @@ func TestStringToX509CertificateChainHookFunc(t *testing.T) {
 					}
 				case schema.X509CertificateChain:
 					require.NotNil(t, chain)
+
 					if tc.verr == "" {
 						assert.NoError(t, chain.Validate())
 					} else {

--- a/internal/configuration/schema/types_address_test.go
+++ b/internal/configuration/schema/types_address_test.go
@@ -596,6 +596,7 @@ func TestAddress_Dial(t *testing.T) {
 
 			} else {
 				assert.Nil(t, conn)
+
 				if tc.err != "" {
 					assert.EqualError(t, err, tc.err)
 				} else {

--- a/internal/configuration/schema/types_test.go
+++ b/internal/configuration/schema/types_test.go
@@ -214,6 +214,7 @@ func TestNewX509CertificateChain(t *testing.T) {
 					assert.NotNil(t, actual.Leaf())
 					assert.NotNil(t, actual.CertificatesRaw())
 				}
+
 				assert.NoError(t, err)
 			default:
 				assert.Nil(t, actual)

--- a/internal/configuration/validator/identity_providers_test.go
+++ b/internal/configuration/validator/identity_providers_test.go
@@ -439,6 +439,7 @@ func TestShouldRaiseErrorWhenOIDCServerClientBadValues(t *testing.T) {
 			errs := validator.Errors()
 
 			require.Len(t, errs, len(tc.errors))
+
 			for i, errStr := range tc.errors {
 				t.Run(fmt.Sprintf("Error%d", i+1), func(t *testing.T) {
 					assert.EqualError(t, errs[i], errStr)
@@ -2590,6 +2591,7 @@ func TestValidateOIDCClients(t *testing.T) {
 
 			t.Run("Warnings", func(t *testing.T) {
 				require.Len(t, validator.Warnings(), len(tc.serrs))
+
 				for i, err := range tc.serrs {
 					assert.EqualError(t, validator.Warnings()[i], err)
 				}
@@ -2597,6 +2599,7 @@ func TestValidateOIDCClients(t *testing.T) {
 
 			t.Run("Errors", func(t *testing.T) {
 				require.Len(t, validator.Errors(), len(tc.errs))
+
 				for i, err := range tc.errs {
 					t.Run(fmt.Sprintf("Error%d", i+1), func(t *testing.T) {
 						assert.EqualError(t, validator.Errors()[i], err)

--- a/internal/configuration/validator/session_test.go
+++ b/internal/configuration/validator/session_test.go
@@ -213,6 +213,7 @@ func TestShouldSetDefaultSessionDomainsValues(t *testing.T) {
 
 			warns := validator.Warnings()
 			require.Len(t, warns, len(tc.warns))
+
 			for i, err := range warns {
 				assert.EqualError(t, err, tc.warns[i])
 			}

--- a/internal/handlers/handler_authz_impl_authrequest_test.go
+++ b/internal/handlers/handler_authz_impl_authrequest_test.go
@@ -63,6 +63,7 @@ func (s *AuthRequestAuthzSuite) TestShouldHandleAllMethodsDeny() {
 					query.Set(queryArgRD, pairURI.TargetURI.String())
 					query.Set(queryArgRM, method)
 					expected.RawQuery = query.Encode()
+
 					assert.Equal(t, fasthttp.StatusUnauthorized, mock.Ctx.Response.StatusCode())
 					assert.Equal(t, expected.String(), string(mock.Ctx.Response.Header.Peek(fasthttp.HeaderLocation)))
 				})

--- a/internal/middlewares/authelia_context_test.go
+++ b/internal/middlewares/authelia_context_test.go
@@ -294,11 +294,13 @@ func TestAutheliaCtx_IssuerURL(t *testing.T) {
 				require.NotNil(t, actual)
 
 				assert.Equal(t, tc.expected, actual.String())
+
 				if len(tc.expectedProto) == 0 {
 					assert.Equal(t, tc.proto, actual.Scheme)
 				} else {
 					assert.Equal(t, tc.expectedProto, actual.Scheme)
 				}
+
 				assert.Equal(t, tc.host, actual.Host)
 				assert.Equal(t, tc.base, actual.Path)
 			} else {
@@ -329,6 +331,7 @@ func TestShouldCallNextWithAutheliaCtx(t *testing.T) {
 	middleware(func(actx *middlewares.AutheliaCtx) {
 		// Authelia context wraps the request.
 		assert.Equal(t, ctx, actx.RequestCtx)
+
 		nextCalled = true
 	})(ctx)
 

--- a/internal/middlewares/http_to_authelia_handler_adaptor.go
+++ b/internal/middlewares/http_to_authelia_handler_adaptor.go
@@ -87,6 +87,7 @@ func NewHTTPToAutheliaHandlerAdaptor(h AutheliaHandlerFunc) RequestHandler {
 		ctx.Request.Header.VisitAll(func(k, v []byte) {
 			sk := string(k)
 			sv := string(v)
+
 			switch sk {
 			case "Transfer-Encoding":
 				r.TransferEncoding = append(r.TransferEncoding, sv)

--- a/internal/middlewares/password_policy_test.go
+++ b/internal/middlewares/password_policy_test.go
@@ -134,6 +134,7 @@ func TestPasswordPolicyProvider_Validate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			require.Equal(t, len(tc.have), len(tc.expected))
+
 			for i := 0; i < len(tc.have); i++ {
 				provider := NewPasswordPolicyProvider(tc.config)
 				t.Run(tc.have[i], func(t *testing.T) {

--- a/internal/oidc/flow_client_credentials_test.go
+++ b/internal/oidc/flow_client_credentials_test.go
@@ -229,6 +229,7 @@ func TestClientCredentialsGrantHandler_PopulateTokenEndpointResponse(t *testing.
 			strategy := mocks.NewMockAccessTokenStrategy(ctrl)
 			request := fosite.NewAccessRequest(new(fosite.DefaultSession))
 			response := fosite.NewAccessResponse()
+
 			defer ctrl.Finish()
 
 			handler := oidc.ClientCredentialsGrantHandler{

--- a/internal/oidc/flow_refresh_test.go
+++ b/internal/oidc/flow_refresh_test.go
@@ -666,6 +666,7 @@ func TestRefreshTokenGrantHandler_HandleTokenEndpointRequest(t *testing.T) {
 			err := handler.HandleTokenEndpointRequest(context.TODO(), requester)
 			if tc.err != nil {
 				assert.Equal(t, tc.err.Error(), err.Error())
+
 				if tc.rexpected != nil {
 					assert.Regexp(t, tc.rexpected, oidc.ErrorToDebugRFC6749Error(err))
 				} else {

--- a/internal/oidc/types_test.go
+++ b/internal/oidc/types_test.go
@@ -193,6 +193,7 @@ func TestPopulateClientCredentialsFlowSessionWithAccessRequest(t *testing.T) {
 			err := oidc.PopulateClientCredentialsFlowSessionWithAccessRequest(tc.ctx, tc.request, tc.have, nil)
 
 			assert.Equal(t, "", tc.have.GetSubject())
+
 			if len(tc.err) == 0 {
 				assert.NoError(t, err)
 				assert.EqualValues(t, tc.expected, tc.have)

--- a/internal/suites/ActiveDirectory/docker-compose.yml
+++ b/internal/suites/ActiveDirectory/docker-compose.yml
@@ -3,6 +3,6 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './ActiveDirectory/configuration.yml:/config/configuration.yml:ro'
-      - './common/pki:/pki:ro'
+      - './ActiveDirectory/configuration.yml:/config/configuration.yml'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/BypassAll/docker-compose.yml
+++ b/internal/suites/BypassAll/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './BypassAll/configuration.yml:/config/configuration.yml:ro'
+      - './BypassAll/configuration.yml:/config/configuration.yml'
       - './BypassAll/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/CLI/docker-compose.yml
+++ b/internal/suites/CLI/docker-compose.yml
@@ -3,10 +3,10 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './CLI/configuration.yml:/config/configuration.yml:ro'
-      - './CLI/storage.yml:/config/configuration.storage.yml:ro'
+      - './CLI/configuration.yml:/config/configuration.yml'
+      - './CLI/storage.yml:/config/configuration.storage.yml'
       - './CLI/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
       - '/tmp:/tmp'
     user: ${USER_ID}:${GROUP_ID}
 ...

--- a/internal/suites/Caddy/docker-compose.yml
+++ b/internal/suites/Caddy/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './Caddy/configuration.yml:/config/configuration.yml:ro'
+      - './Caddy/configuration.yml:/config/configuration.yml'
       - './Caddy/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/Docker/docker-compose.yml
+++ b/internal/suites/Docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './Docker/configuration.yml:/config/configuration.yml:ro'
+      - './Docker/configuration.yml:/config/configuration.yml'
       - './Docker/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/DuoPush/docker-compose.yml
+++ b/internal/suites/DuoPush/docker-compose.yml
@@ -3,9 +3,9 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './DuoPush/configuration.yml:/config/configuration.yml:ro'
+      - './DuoPush/configuration.yml:/config/configuration.yml'
       - './DuoPush/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
       - '/tmp:/tmp'
     user: ${USER_ID}:${GROUP_ID}
 ...

--- a/internal/suites/Envoy/docker-compose.yml
+++ b/internal/suites/Envoy/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './Envoy/configuration.yml:/config/configuration.yml:ro'
+      - './Envoy/configuration.yml:/config/configuration.yml'
       - './Envoy/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/HAProxy/docker-compose.yml
+++ b/internal/suites/HAProxy/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './HAProxy/configuration.yml:/config/configuration.yml:ro'
+      - './HAProxy/configuration.yml:/config/configuration.yml'
       - './HAProxy/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/HighAvailability/docker-compose.yml
+++ b/internal/suites/HighAvailability/docker-compose.yml
@@ -3,6 +3,6 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './HighAvailability/configuration.yml:/config/configuration.yml:ro'
-      - './common/pki:/pki:ro'
+      - './HighAvailability/configuration.yml:/config/configuration.yml'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/LDAP/docker-compose.yml
+++ b/internal/suites/LDAP/docker-compose.yml
@@ -3,6 +3,6 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './LDAP/configuration.yml:/config/configuration.yml:ro'
-      - './common/pki:/pki:ro'
+      - './LDAP/configuration.yml:/config/configuration.yml'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/MariaDB/docker-compose.yml
+++ b/internal/suites/MariaDB/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './MariaDB/configuration.yml:/config/configuration.yml:ro'
+      - './MariaDB/configuration.yml:/config/configuration.yml'
       - './MariaDB/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/MultiCookieDomain/docker-compose.yml
+++ b/internal/suites/MultiCookieDomain/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './MultiCookieDomain/configuration.yml:/config/configuration.yml:ro'
+      - './MultiCookieDomain/configuration.yml:/config/configuration.yml'
       - './MultiCookieDomain/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/MySQL/docker-compose.yml
+++ b/internal/suites/MySQL/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './MySQL/configuration.yml:/config/configuration.yml:ro'
+      - './MySQL/configuration.yml:/config/configuration.yml'
       - './MySQL/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/NetworkACL/docker-compose.yml
+++ b/internal/suites/NetworkACL/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './NetworkACL/configuration.yml:/config/configuration.yml:ro'
+      - './NetworkACL/configuration.yml:/config/configuration.yml'
       - './NetworkACL/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/OIDC/docker-compose.yml
+++ b/internal/suites/OIDC/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       AUTHELIA_IDENTITY_PROVIDERS_OIDC_ISSUER_CERTIFICATE_CHAIN_FILE: /pki/public.oidc.chain.pem
       AUTHELIA_IDENTITY_PROVIDERS_OIDC_ISSUER_PRIVATE_KEY_FILE: /pki/private.oidc.pem
     volumes:
-      - './OIDC/configuration.yml:/config/configuration.yml:ro'
+      - './OIDC/configuration.yml:/config/configuration.yml'
       - './OIDC/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/OIDCTraefik/docker-compose.yml
+++ b/internal/suites/OIDCTraefik/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       AUTHELIA_IDENTITY_PROVIDERS_OIDC_ISSUER_CERTIFICATE_CHAIN_FILE: /pki/public.oidc.chain.pem
       AUTHELIA_IDENTITY_PROVIDERS_OIDC_ISSUER_PRIVATE_KEY_FILE: /pki/private.oidc.pem
     volumes:
-      - './OIDCTraefik/configuration.yml:/config/configuration.yml:ro'
+      - './OIDCTraefik/configuration.yml:/config/configuration.yml'
       - './OIDCTraefik/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/OneFactorOnly/docker-compose.yml
+++ b/internal/suites/OneFactorOnly/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './OneFactorOnly/configuration.yml:/config/configuration.yml:ro'
+      - './OneFactorOnly/configuration.yml:/config/configuration.yml'
       - './OneFactorOnly/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/PathPrefix/docker-compose.yml
+++ b/internal/suites/PathPrefix/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './PathPrefix/configuration.yml:/config/configuration.yml:ro'
+      - './PathPrefix/configuration.yml:/config/configuration.yml'
       - './PathPrefix/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/Postgres/docker-compose.yml
+++ b/internal/suites/Postgres/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './Postgres/configuration.yml:/config/configuration.yml:ro'
+      - './Postgres/configuration.yml:/config/configuration.yml'
       - './Postgres/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/ShortTimeouts/docker-compose.yml
+++ b/internal/suites/ShortTimeouts/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './ShortTimeouts/configuration.yml:/config/configuration.yml:ro'
+      - './ShortTimeouts/configuration.yml:/config/configuration.yml'
       - './ShortTimeouts/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/Standalone/docker-compose.yml
+++ b/internal/suites/Standalone/docker-compose.yml
@@ -6,9 +6,9 @@ services:
       - AUTHELIA_JWT_SECRET_FILE=/tmp/authelia/StandaloneSuite/jwt
       - AUTHELIA_SESSION_SECRET_FILE=/tmp/authelia/StandaloneSuite/session
     volumes:
-      - './Standalone/configuration.yml:/config/configuration.yml:ro'
+      - './Standalone/configuration.yml:/config/configuration.yml'
       - './Standalone/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
       - '/tmp:/tmp'
     user: ${USER_ID}:${GROUP_ID}
 ...

--- a/internal/suites/Traefik/docker-compose.yml
+++ b/internal/suites/Traefik/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './Traefik/configuration.yml:/config/configuration.yml:ro'
+      - './Traefik/configuration.yml:/config/configuration.yml'
       - './Traefik/users.yml:/config/users.yml'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/Traefik2/docker-compose.yml
+++ b/internal/suites/Traefik2/docker-compose.yml
@@ -3,9 +3,9 @@ version: '3'
 services:
   authelia-backend:
     volumes:
-      - './Traefik2/configuration.yml:/config/configuration.yml:ro'
+      - './Traefik2/configuration.yml:/config/configuration.yml'
       - './Traefik2/users.yml:/config/users.yml'
       - './Traefik2/favicon.ico:/config/assets/favicon.ico'
       - './Traefik2/logo.png:/config/assets/logo.png'
-      - './common/pki:/pki:ro'
+      - './common/pki:/pki'
 ...

--- a/internal/suites/environment.go
+++ b/internal/suites/environment.go
@@ -25,11 +25,13 @@ func waitUntilServiceLogDetected(
 		if err != nil {
 			return false, err
 		}
+
 		for _, pattern := range logPatterns {
 			if strings.Contains(logs, pattern) {
 				return true, nil
 			}
 		}
+
 		return false, nil
 	})
 

--- a/internal/suites/example/compose/haproxy/docker-compose.yml
+++ b/internal/suites/example/compose/haproxy/docker-compose.yml
@@ -4,10 +4,10 @@ services:
   haproxy:
     image: authelia/integration-haproxy
     volumes:
-      - ./example/compose/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
-      - ./example/compose/haproxy/http.lua:/usr/local/etc/haproxy/haproxy-lua-http/http.lua
-      - ./example/compose/haproxy/auth-request.lua:/usr/local/etc/haproxy/auth-request.lua
-      - ./common/pki:/pki
+      - './example/compose/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg'
+      - './example/compose/haproxy/http.lua:/usr/local/etc/haproxy/haproxy-lua-http/http.lua'
+      - './example/compose/haproxy/auth-request.lua:/usr/local/etc/haproxy/auth-request.lua'
+      - './common/pki:/pki'
     networks:
       authelianet:
         ipv4_address: 192.168.240.100

--- a/internal/suites/kubernetes.go
+++ b/internal/suites/kubernetes.go
@@ -74,6 +74,7 @@ func (k Kubectl) WaitPodsReady(namespace string, timeout time.Duration) error {
 		lines := strings.Split(string(output), "\n")
 
 		nonEmptyLines := make([]string, 0)
+
 		for _, line := range lines {
 			if line != "" {
 				nonEmptyLines = append(nonEmptyLines, line)

--- a/internal/suites/scenario_oidc_test.go
+++ b/internal/suites/scenario_oidc_test.go
@@ -139,6 +139,7 @@ func (s *OIDCScenario) TestShouldAuthorizeAccessToOIDCApp() {
 			}
 
 			assert.NoError(t, err)
+
 			switch expected := tc.expected.(type) {
 			case *regexp.Regexp:
 				assert.Regexp(t, expected, actual)

--- a/internal/utils/crypto_test.go
+++ b/internal/utils/crypto_test.go
@@ -424,6 +424,7 @@ func TestX509ParseKeyUsage(t *testing.T) {
 
 				assert.Equal(t, tc.expected, actual)
 			}
+
 			for _, have := range tc.have {
 				t.Run(strings.Join(have, ","), func(t *testing.T) {
 					actual := X509ParseKeyUsage(have, tc.ca)
@@ -462,6 +463,7 @@ func TestX509ParseExtendedKeyUsage(t *testing.T) {
 
 				assert.Equal(t, tc.expected, actual)
 			}
+
 			for _, have := range tc.have {
 				t.Run(strings.Join(have, ","), func(t *testing.T) {
 					actual := X509ParseExtendedKeyUsage(have, tc.ca)

--- a/internal/utils/exec_test.go
+++ b/internal/utils/exec_test.go
@@ -50,6 +50,7 @@ func TestShouldRunFuncUntilNoError(t *testing.T) {
 		if counter < 3 {
 			return errors.New("not ready")
 		}
+
 		return nil
 	})
 	assert.NoError(t, err, "")
@@ -63,6 +64,7 @@ func TestShouldFailAfterMaxAttemps(t *testing.T) {
 		if counter < 4 {
 			return errors.New("not ready")
 		}
+
 		return nil
 	})
 	assert.ErrorContains(t, err, "not ready")


### PR DESCRIPTION
This PR removes all references to read-only mounts. Docker Engine to v25+ results in a change for recursive mounts which causes errors in CI per [this note](https://docs.docker.com/engine/release-notes/25.0/#2500). Also updated code with linting suggestions per new version of golangci-lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated integration guides for proxies including Envoy, Nginx Proxy Manager, Nginx, and SWAG.
- **Tests**
	- Enhanced testing across various internal components to improve reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->