### PR TITLE
docs: Fix small typo example-two instead of example-three

### DIFF
--- a/docs/content/en/integration/openid-connect/oauth-2.0-bearer-token-usage.md
+++ b/docs/content/en/integration/openid-connect/oauth-2.0-bearer-token-usage.md
@@ -259,7 +259,7 @@ identity_providers:
 
 This example illustrates a method to configure a Client Credential flow for this purpose. This flow is useful for
 automations. It's important to note that for access control evaluation purposes this token will match a subject of
-`oauth2:client:example-two` i.e. the `oauth2:client:` prefix followed by the client id.
+`oauth2:client:example-three` i.e. the `oauth2:client:` prefix followed by the client id.
 
 ```yaml
 identity_providers:


### PR DESCRIPTION
Would make understanding things a bit more difficult. Small copy & paste error - the third example uses `example-three` obviously.