### PR TITLE
refactor: misc fixups and optimizations

### DIFF
--- a/cmd/authelia-scripts/cmd/gen.go
+++ b/cmd/authelia-scripts/cmd/gen.go
@@ -7,5 +7,5 @@
 package cmd
 
 const (
-	versionSwaggerUI = "5.11.9"
+	versionSwaggerUI = "5.11.10"
 )

--- a/docs/layouts/shortcodes/oidc-common.html
+++ b/docs/layouts/shortcodes/oidc-common.html
@@ -9,7 +9,7 @@
        value. We recommend following the [How Do I Generate Client a Client Identifier or Client Secret]({{ $faq }}#how-do-i-generate-a-client-identifier-or-client-secret) FAQ.
     3. This *__must__* only contain [RFC3986 Unreserved Characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3).
     4. This *__must__* be no more than 100 characters in length.
-2. The [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html) `secret` parameter:
+2. The [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html) `client_secret` parameter:
     1. The value used in this guide is merely for demonstration purposes and you *__should absolutely not__* use this in
        production and should instead utilize the
        [How Do I Generate Client a Client Identifier or Client Secret]({{ $faq }}#how-do-i-generate-a-client-identifier-or-client-secret) FAQ.

--- a/web/src/layouts/MinimalLayout.tsx
+++ b/web/src/layouts/MinimalLayout.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 
 import UserSvg from "@assets/images/user.svg?react";
 import AccountSettingsMenu from "@components/AccountSettingsMenu";
-import Brand from "@components/Brand";
 import PrivacyPolicyDrawer from "@components/PrivacyPolicyDrawer";
 import TypographyWithTooltip from "@components/TypographyWithTooltip";
 import { UserInfo } from "@models/UserInfo";
@@ -16,13 +15,10 @@ export interface Props {
     id?: string;
     children?: ReactNode;
     title?: string | null;
-    titleTooltip?: string | null;
-    subtitle?: string | null;
-    subtitleTooltip?: string | null;
     userInfo?: UserInfo;
 }
 
-const LoginLayout = function (props: Props) {
+const MinimalLayout = function (props: Props) {
     const { t: translate } = useTranslation();
 
     const styles = useStyles();
@@ -60,26 +56,12 @@ const LoginLayout = function (props: Props) {
                         </Grid>
                         {props.title ? (
                             <Grid item xs={12}>
-                                <TypographyWithTooltip
-                                    variant={"h5"}
-                                    value={props.title}
-                                    tooltip={props.titleTooltip !== null ? props.titleTooltip : undefined}
-                                />
-                            </Grid>
-                        ) : null}
-                        {props.subtitle ? (
-                            <Grid item xs={12}>
-                                <TypographyWithTooltip
-                                    variant={"h6"}
-                                    value={props.subtitle}
-                                    tooltip={props.subtitleTooltip !== null ? props.subtitleTooltip : undefined}
-                                />
+                                <TypographyWithTooltip variant={"h5"} value={props.title} />
                             </Grid>
                         ) : null}
                         <Grid item xs={12} className={styles.body}>
                             {props.children}
                         </Grid>
-                        <Brand />
                     </Grid>
                 </Container>
                 <PrivacyPolicyDrawer />
@@ -97,8 +79,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         paddingLeft: 32,
         paddingRight: 32,
     },
-    title: {},
-    subtitle: {},
     icon: {
         margin: theme.spacing(),
         width: "64px",
@@ -111,4 +91,4 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
 }));
 
-export default LoginLayout;
+export default MinimalLayout;

--- a/web/src/views/LoginPortal/AuthenticatedView/AuthenticatedView.tsx
+++ b/web/src/views/LoginPortal/AuthenticatedView/AuthenticatedView.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import { LogoutRoute as SignOutRoute } from "@constants/Routes";
-import LoginLayout from "@layouts/LoginLayout";
+import MinimalLayout from "@layouts/MinimalLayout";
 import { UserInfo } from "@models/UserInfo";
 import Authenticated from "@views/LoginPortal/Authenticated";
 
@@ -26,7 +26,7 @@ const AuthenticatedView = function (props: Props) {
     };
 
     return (
-        <LoginLayout
+        <MinimalLayout
             id="authenticated-stage"
             title={`${translate("Hi")} ${props.userInfo.display_name}`}
             userInfo={props.userInfo}
@@ -41,7 +41,7 @@ const AuthenticatedView = function (props: Props) {
                     <Authenticated />
                 </Grid>
             </Grid>
-        </LoginLayout>
+        </MinimalLayout>
     );
 };
 

--- a/web/src/views/LoginPortal/ConsentView/ConsentView.tsx
+++ b/web/src/views/LoginPortal/ConsentView/ConsentView.tsx
@@ -148,7 +148,6 @@ const ConsentView = function (props: Props) {
                 id="consent-stage"
                 title={`${translate("Hi")} ${userInfo?.display_name}`}
                 subtitle={translate("Consent Request")}
-                showBrand
             >
                 <Grid container>
                     <Grid item xs={12}>

--- a/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
+++ b/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
@@ -190,7 +190,7 @@ const FirstFactorForm = function (props: Props) {
     );
 
     return (
-        <LoginLayout id="first-factor-stage" title={translate("Sign in")} showBrand>
+        <LoginLayout id="first-factor-stage" title={translate("Sign in")}>
             <FormControl id={"form-login"}>
                 <Grid container spacing={2}>
                     <Grid item xs={12}>

--- a/web/src/views/LoginPortal/SecondFactor/SecondFactorForm.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/SecondFactorForm.tsx
@@ -83,7 +83,6 @@ const SecondFactorForm = function (props: Props) {
         <LoginLayout
             id="second-factor-stage"
             title={`${translate("Hi")} ${props.userInfo.display_name}`}
-            showBrand
             userInfo={props.userInfo}
         >
             {props.configuration.available_methods.size > 1 ? (

--- a/web/src/views/LoginPortal/SignOut/SignOut.tsx
+++ b/web/src/views/LoginPortal/SignOut/SignOut.tsx
@@ -11,7 +11,7 @@ import { useIsMountedRef } from "@hooks/Mounted";
 import { useNotifications } from "@hooks/NotificationsContext";
 import { useQueryParam } from "@hooks/QueryParam";
 import { useRedirector } from "@hooks/Redirector";
-import LoginLayout from "@layouts/LoginLayout";
+import MinimalLayout from "@layouts/MinimalLayout";
 import { signOut } from "@services/SignOut";
 
 export interface Props {}
@@ -57,9 +57,9 @@ const SignOut = function (props: Props) {
     }
 
     return (
-        <LoginLayout title={translate("Sign out")}>
+        <MinimalLayout title={translate("Sign out")}>
             <Typography className={styles.typo}>{translate("You're being signed out and redirected")}...</Typography>
-        </LoginLayout>
+        </MinimalLayout>
     );
 };
 

--- a/web/src/views/ResetPassword/ResetPasswordStep1.tsx
+++ b/web/src/views/ResetPassword/ResetPasswordStep1.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom";
 
 import { IndexRoute } from "@constants/Routes";
 import { useNotifications } from "@hooks/NotificationsContext";
-import LoginLayout from "@layouts/LoginLayout";
+import MinimalLayout from "@layouts/MinimalLayout";
 import { initiateResetPasswordProcess } from "@services/ResetPassword";
 
 const ResetPasswordStep1 = function () {
@@ -42,7 +42,7 @@ const ResetPasswordStep1 = function () {
     };
 
     return (
-        <LoginLayout title={translate("Reset password")} id="reset-password-step1-stage">
+        <MinimalLayout title={translate("Reset password")} id="reset-password-step1-stage">
             <FormControl id={"form-reset-password-username"}>
                 <Grid container className={styles.root} spacing={2}>
                     <Grid item xs={12}>
@@ -86,7 +86,7 @@ const ResetPasswordStep1 = function () {
                     </Grid>
                 </Grid>
             </FormControl>
-        </LoginLayout>
+        </MinimalLayout>
     );
 };
 

--- a/web/src/views/ResetPassword/ResetPasswordStep2.tsx
+++ b/web/src/views/ResetPassword/ResetPasswordStep2.tsx
@@ -13,7 +13,7 @@ import { IndexRoute } from "@constants/Routes";
 import { IdentityToken } from "@constants/SearchParams";
 import { useNotifications } from "@hooks/NotificationsContext";
 import { useQueryParam } from "@hooks/QueryParam";
-import LoginLayout from "@layouts/LoginLayout";
+import MinimalLayout from "@layouts/MinimalLayout";
 import { PasswordPolicyConfiguration, PasswordPolicyMode } from "@models/PasswordPolicy";
 import { getPasswordPolicyConfiguration } from "@services/PasswordPolicyConfiguration";
 import { completeResetPasswordProcess, resetPassword } from "@services/ResetPassword";
@@ -110,7 +110,7 @@ const ResetPasswordStep2 = function () {
     const handleCancelClick = () => navigate(IndexRoute);
 
     return (
-        <LoginLayout title={translate("Enter new password")} id="reset-password-step2-stage">
+        <MinimalLayout title={translate("Enter new password")} id="reset-password-step2-stage">
             <FormControl id={"form-reset-password"}>
                 <Grid container className={styles.root} spacing={2}>
                     <Grid item xs={12}>
@@ -191,7 +191,7 @@ const ResetPasswordStep2 = function () {
                     </Grid>
                 </Grid>
             </FormControl>
-        </LoginLayout>
+        </MinimalLayout>
     );
 };
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -69,6 +69,8 @@ export default defineConfig(({ mode }) => {
                                             switch (chunkInfo.name) {
                                                 case "LoginLayout":
                                                     return `static/js/${match[1]}.Login.[hash].js`;
+                                                case "MinimalLayout":
+                                                    return `static/js/${match[1]}.Minimal.[hash].js`;
                                                 default:
                                                     return `static/js/${match[1]}.[name].[hash].js`;
                                             }


### PR DESCRIPTION
Fixes a missed change to secret -> client_secret and allows lazy loading optimizations for the layouts. In addition layouts are not really intended to be parameterized as much as normal components like these are so it makes sense to remove a few elements to satisfy common use cases within the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `MinimalLayout` for a cleaner, minimalistic user interface across various pages.
	- Updated Swagger UI version to "5.11.10" for enhanced API documentation.
- **Bug Fixes**
	- Revised OpenID Connect 1.0 specification to rename `secret` parameter to `client_secret`.
- **Refactor**
	- Removed `showBrand` prop across multiple components, now unconditionally displaying the brand.
	- Transitioned various views (Login, Authenticated, Consent, First Factor, Second Factor, Sign Out, Reset Password Steps 1 & 2) to use `MinimalLayout` for a consistent look and feel.
- **Chores**
	- Updated chunk naming logic in `vite.config.ts` to support the new `MinimalLayout`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->