### PR TITLE
refactor(server): log tls handshake errors on non-TLS ports

### DIFF
--- a/internal/server/const.go
+++ b/internal/server/const.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"regexp"
+
 	"github.com/valyala/fasthttp"
 )
 
@@ -84,10 +86,15 @@ const (
 	errFmtMessageServerReadBuffer  = "Request from client exceeded the server read buffer. The read buffer can be adjusted by modifying the '%s.buffers.read' configuration value."
 	errMessageServerRequestTimeout = "Request timeout occurred while handling request from client."
 	errMessageServerNetwork        = "An unknown network error occurred while handling a request from client."
+	errFmtMessageServerTLSVersion  = "A %s connection handshake occurred on a non-TLS listener."
 	errMessageServerGeneric        = "An unknown error occurred while handling a request from client."
 )
 
 const (
 	tmplCSPSwaggerNonce = "default-src 'self'; img-src 'self' https://validator.swagger.io data:; object-src 'none'; script-src 'self' 'unsafe-inline' 'nonce-%s'; style-src 'self' 'nonce-%s'; base-uri 'self'"
 	tmplCSPSwagger      = "default-src 'self'; img-src 'self' https://validator.swagger.io data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self'; base-uri 'self'"
+)
+
+var (
+	reTLSRequestOnPlainTextSocketErr = regexp.MustCompile(`contents: \\x16\\x([a-fA-F0-9]{2})\\x([a-fA-F0-9]{2})`)
 )

--- a/internal/utils/crypto_test.go
+++ b/internal/utils/crypto_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"runtime"
 	"strings"
@@ -470,6 +471,78 @@ func TestX509ParseExtendedKeyUsage(t *testing.T) {
 
 					assert.Equal(t, tc.expected, actual)
 				})
+			}
+		})
+	}
+}
+
+func TestTLSVersionFromBytesString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     string
+		expected int
+		err      string
+	}{
+		{
+			"ShouldDecodeSSL3.0",
+			"0300",
+			tls.VersionSSL30, //nolint:staticcheck
+			"",
+		},
+		{
+			"ShouldDecodeTLS1.0",
+			"0301",
+			tls.VersionTLS10,
+			"",
+		},
+		{
+			"ShouldDecodeTLS1.1",
+			"0302",
+			tls.VersionTLS11,
+			"",
+		},
+		{
+			"ShouldDecodeTLS1.2",
+			"0303",
+			tls.VersionTLS12,
+			"",
+		},
+		{
+			"ShouldDecodeTLS1.3",
+			"0304",
+			tls.VersionTLS13,
+			"",
+		},
+		{
+			"ShouldNotDecodeUnknownVersion",
+			"ffff",
+			-1,
+			"tls version 0xffff is unknown",
+		},
+		{
+			"ShouldNotDecodeUnknownLength",
+			"ff",
+			-1,
+			"the input size was incorrect: should be 4 but was 2",
+		},
+		{
+			"ShouldNotDecodeUnknownCharacters",
+			"zzzz",
+			-1,
+			"failed to decode hex: encoding/hex: invalid byte: U+007A 'z'",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := TLSVersionFromBytesString(tc.have)
+
+			assert.Equal(t, tc.expected, actual)
+
+			if tc.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
 			}
 		})
 	}


### PR DESCRIPTION
This gives more helpful feedback when this scenario occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Improved error messaging for TLS handshake issues.
	- Enhanced TLS version handling and detection capabilities.
- **Tests**
	- Added tests for TLS version conversion functionality.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->