### PR TITLE
fix(server): invalid base url

### DIFF
--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -68,17 +68,11 @@ func ServeTemplatedFile(t templates.Template, opts *TemplatedFileOptions) middle
 			provider   *session.Session
 		)
 
-		if provider, err = ctx.GetSessionProvider(); err == nil {
-			if provider.Config.AutheliaURL != nil {
-				baseURL = provider.Config.AutheliaURL.String()
-			} else {
-				baseURL = ctx.RootURLSlash().String()
-			}
+		baseURL = ctx.RootURLSlash().String()
 
+		if provider, err = ctx.GetSessionProvider(); err == nil {
 			domain = provider.Config.Domain
 			rememberMe = strconv.FormatBool(!provider.Config.DisableRememberMe)
-		} else {
-			baseURL = ctx.RootURLSlash().String()
 		}
 
 		data := &bytes.Buffer{}


### PR DESCRIPTION
This fixes an issue where the Base URL is not properly formed for the purposes of static asset acquisition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic for retrieving provider information and optimized the assignment of `baseURL` in server templates for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->