### PR TITLE
ci(web): simplify import-alias configuration

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -9,10 +9,8 @@ module.exports = {
             typescript: {},
         },
     },
-    plugins: ["@limegrass/import-alias"],
-    extends: ["react-app", "plugin:import/errors", "plugin:import/warnings", "plugin:prettier/recommended", "prettier"],
+    extends: ["react-app", "plugin:@limegrass/import-alias/recommended", "plugin:import/errors", "plugin:import/warnings", "plugin:prettier/recommended", "prettier"],
     rules: {
-        "@limegrass/import-alias/import-alias": "error",
         "import/order": [
             "error",
             {


### PR DESCRIPTION
This change simplifies configuration to enable the`import-alias` ESLint plugin rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated code styling and linting configurations for improved code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->