### PR TITLE
fix(commands): config template empty feedback

### DIFF
--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -807,8 +807,24 @@ Layouts:
 )
 
 const (
-	fmtLogServerListening       = "Listening for %s connections on '%s' path '%s'"
-	fmtYAMLConfigTemplateHeader = "---\n##\n## The following the output of files passed through the enabled Authelia configuration filters.\n## File Source Path: %s##\n\n"
+	fmtLogServerListening = "Listening for %s connections on '%s' path '%s'"
+
+	fmtYAMLConfigTemplateHeader = `
+---
+##
+## Authelia rendered configuration file (file filters).
+##
+## Filters: %s
+##
+`
+
+	fmtYAMLConfigTemplateFileHeader = `
+---
+##
+## File Source Path: %s
+##
+
+`
 )
 
 const (

--- a/internal/configuration/const.go
+++ b/internal/configuration/const.go
@@ -23,6 +23,12 @@ const (
 	extYAML = ".yaml"
 )
 
+const (
+	filterField     = "filter"
+	filterTemplate  = "template"
+	filterExpandEnv = "expand-env"
+)
+
 var (
 	errNoValidator = errors.New("no validator provided")
 	errNoSources   = errors.New("no sources provided")

--- a/internal/configuration/sources.go
+++ b/internal/configuration/sources.go
@@ -181,6 +181,16 @@ func (s *FileSource) readFilesDirectory(path string) (files []*File, err error) 
 	return files, nil
 }
 
+func (s *FileSource) GetBytesFilterNames() (names []string) {
+	names = make([]string, len(s.filters))
+
+	for i, filter := range s.filters {
+		names[i] = filter.Name()
+	}
+
+	return names
+}
+
 // NewBytesSource returns a configuration.Source configured to load from a specified bytes.
 func NewBytesSource(data []byte) (source *BytesSource) {
 	return &BytesSource{
@@ -219,7 +229,7 @@ func (b *BytesSource) ReadBytes() (data []byte, err error) {
 	copy(data, b.data)
 
 	for _, filter := range b.filters {
-		if data, err = filter(data); err != nil {
+		if data, err = filter.Filter(data); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This makes the 'authelia config template' command give feedback about the absence of configuration file sources when previously it did not. In addition it refactors the header output to have more clarity when using multiple files, as well as the filters which are enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced configuration template support with improved formatting and filtering capabilities.
- **Refactor**
	- Refactored configuration filtering logic for better flexibility and readability.
- **Documentation**
	- Updated internal documentation to reflect changes in configuration and filtering mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->