### PR TITLE
fix(handlers): bypass fails with authorization header

### DIFF
--- a/internal/handlers/handler_authz_authn.go
+++ b/internal/handlers/handler_authz_authn.go
@@ -146,6 +146,11 @@ func (s *CookieSessionAuthnStrategy) CanHandleUnauthorized() (handle bool) {
 	return false
 }
 
+// HeaderStrategy returns true if this AuthnStrategy is header based.
+func (s *CookieSessionAuthnStrategy) HeaderStrategy() (header bool) {
+	return false
+}
+
 // HandleUnauthorized is the Unauthorized handler for the cookie AuthnStrategy.
 func (s *CookieSessionAuthnStrategy) HandleUnauthorized(_ *middlewares.AutheliaCtx, _ *Authn, _ *url.URL) {
 }
@@ -260,6 +265,11 @@ func (s *HeaderAuthnStrategy) CanHandleUnauthorized() (handle bool) {
 	return s.handleAuthenticate
 }
 
+// HeaderStrategy returns true if this AuthnStrategy is header based.
+func (s *HeaderAuthnStrategy) HeaderStrategy() (header bool) {
+	return true
+}
+
 // HandleUnauthorized is the Unauthorized handler for the header AuthnStrategy.
 func (s *HeaderAuthnStrategy) HandleUnauthorized(ctx *middlewares.AutheliaCtx, authn *Authn, _ *url.URL) {
 	ctx.Logger.Debugf("Responding %d %s", s.statusAuthenticate, s.headerAuthenticate)
@@ -345,6 +355,11 @@ func (s *HeaderLegacyAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session
 
 // CanHandleUnauthorized returns true if this AuthnStrategy should handle Unauthorized requests.
 func (s *HeaderLegacyAuthnStrategy) CanHandleUnauthorized() (handle bool) {
+	return true
+}
+
+// HeaderStrategy returns true if this AuthnStrategy is header based.
+func (s *HeaderLegacyAuthnStrategy) HeaderStrategy() (header bool) {
 	return true
 }
 

--- a/internal/handlers/handler_authz_types.go
+++ b/internal/handlers/handler_authz_types.go
@@ -106,6 +106,7 @@ type AuthzBuilder struct {
 type AuthnStrategy interface {
 	Get(ctx *middlewares.AutheliaCtx, provider *session.Session, object *authorization.Object) (authn *Authn, err error)
 	CanHandleUnauthorized() (handle bool)
+	HeaderStrategy() (is bool)
 	HandleUnauthorized(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL)
 }
 


### PR DESCRIPTION
This fixes an issue where the failure to perform authorization via a header causes the bypass rule to fail to process the request. This just logs the error and continues as normal.

Fixes #6914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Restructured error handling and authorization logic to enhance system reliability.
- **New Features**
	- Introduced a method to identify header-based authentication strategies, improving authentication flexibility.
- **Tests**
	- Added new test scenarios to ensure robust handling of authentication bypass errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->