### PR TITLE
 fix(handlers): authorization header assumptions

### DIFF
--- a/internal/handlers/handler_authz.go
+++ b/internal/handlers/handler_authz.go
@@ -75,9 +75,9 @@ func (authz *Authz) Handler(ctx *middlewares.AutheliaCtx) {
 	if err != nil {
 		authn.Object = object
 
-		ctx.Logger.WithError(err).Error("Error occurred while attempting to authenticate a request")
-
 		if strategy.HeaderStrategy() && !ruleHasSubject && required != authorization.Bypass {
+			ctx.Logger.WithError(err).Error("Error occurred while attempting to authenticate a request")
+
 			switch strategy {
 			case nil:
 				ctx.ReplyUnauthorized()
@@ -87,6 +87,8 @@ func (authz *Authz) Handler(ctx *middlewares.AutheliaCtx) {
 
 			return
 		}
+
+		ctx.Logger.WithError(err).Debug("Error occurred while attempting to authenticate a request but the matched rule was a bypass rule")
 	}
 
 	switch isAuthzResult(authn.Level, required, ruleHasSubject) {

--- a/internal/handlers/handler_authz_types.go
+++ b/internal/handlers/handler_authz_types.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"net/url"
 
 	oauthelia2 "authelia.com/provider/oauth2"
@@ -10,6 +12,7 @@ import (
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/model"
+	"github.com/authelia/authelia/v4/internal/oidc"
 	"github.com/authelia/authelia/v4/internal/session"
 )
 
@@ -166,3 +169,13 @@ func (i AuthzImplementation) String() string {
 		return ""
 	}
 }
+
+type AuthzBearerIntrospectionProvider interface {
+	GetFullClient(ctx context.Context, id string) (client oidc.Client, err error)
+	GetAudienceStrategy(ctx context.Context) (strategy oauthelia2.AudienceMatchingStrategy)
+	IntrospectToken(ctx context.Context, token string, tokenUse oauthelia2.TokenUse, session oauthelia2.Session, scope ...string) (oauthelia2.TokenUse, oauthelia2.AccessRequester, error)
+}
+
+var (
+	errTokenIntent = errors.New("the bearer token doesn't appear to be an authelia bearer token")
+)

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -639,16 +639,21 @@ func (ctx *AutheliaCtx) RecordAuthn(success, regulated bool, method string) {
 }
 
 // GetClock returns the clock. For use with interface fulfillment.
-func (ctx *AutheliaCtx) GetClock() clock.Provider {
+func (ctx *AutheliaCtx) GetClock() (clock clock.Provider) {
 	return ctx.Clock
 }
 
 // GetRandom returns the random provider. For use with interface fulfillment.
-func (ctx *AutheliaCtx) GetRandom() random.Provider {
+func (ctx *AutheliaCtx) GetRandom() (random random.Provider) {
 	return ctx.Providers.Random
 }
 
 // GetJWTWithTimeFuncOption returns the WithTimeFunc jwt.ParserOption. For use with interface fulfillment.
-func (ctx *AutheliaCtx) GetJWTWithTimeFuncOption() jwt.ParserOption {
+func (ctx *AutheliaCtx) GetJWTWithTimeFuncOption() (option jwt.ParserOption) {
 	return jwt.WithTimeFunc(ctx.Clock.Now)
+}
+
+// GetConfiguration returns the current configuration.
+func (ctx *AutheliaCtx) GetConfiguration() (config schema.Configuration) {
+	return ctx.Configuration
 }

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -17,6 +17,7 @@ import (
 	"github.com/authelia/authelia/v4/internal/clock"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/model"
+	"github.com/authelia/authelia/v4/internal/random"
 	"github.com/authelia/authelia/v4/internal/storage"
 )
 
@@ -157,8 +158,10 @@ type Context interface {
 
 	RootURL() (issuerURL *url.URL)
 	IssuerURL() (issuerURL *url.URL, err error)
-	GetClock() clock.Provider
-	GetJWTWithTimeFuncOption() jwt.ParserOption
+	GetClock() (clock clock.Provider)
+	GetRandom() (random random.Provider)
+	GetConfiguration() (config schema.Configuration)
+	GetJWTWithTimeFuncOption() (option jwt.ParserOption)
 }
 
 // ClientRequesterResponder is a oauthelia2.Requster or fosite.Responder with a GetClient method.

--- a/internal/oidc/types_test.go
+++ b/internal/oidc/types_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/authelia/authelia/v4/internal/clock"
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/oidc"
+	"github.com/authelia/authelia/v4/internal/random"
 )
 
 func TestNewSession(t *testing.T) {
@@ -112,6 +114,15 @@ type TestContext struct {
 	MockIssuerURL *url.URL
 	IssuerURLFunc func() (issuerURL *url.URL, err error)
 	Clock         clock.Provider
+	Config        schema.Configuration
+}
+
+func (m *TestContext) GetRandom() (r random.Provider) {
+	return random.NewMathematical()
+}
+
+func (m *TestContext) GetConfiguration() (config schema.Configuration) {
+	return m.Config
 }
 
 // IssuerURL returns the MockIssuerURL.

--- a/internal/oidc/util_blackbox_test.go
+++ b/internal/oidc/util_blackbox_test.go
@@ -98,11 +98,6 @@ func TestIsJWTProfileAccessToken(t *testing.T) {
 		expected bool
 	}{
 		{
-			"ShouldReturnFalseOnNilToken",
-			nil,
-			false,
-		},
-		{
 			"ShouldReturnFalseOnNilTokenHeader",
 			&fjwt.Token{Header: nil},
 			false,
@@ -131,7 +126,7 @@ func TestIsJWTProfileAccessToken(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, oidc.IsJWTProfileAccessToken(tc.have))
+			assert.Equal(t, tc.expected, oidc.IsJWTProfileAccessToken(tc.have.Header))
 		})
 	}
 }


### PR DESCRIPTION
This fixes an issue where bearer scheme authorization headers are assumed to be targeted to Authelia. This change ignores bearers which are not potentially Authelia Access Tokens and skips tem as a potential source. This also fixes a situation where unknown or unregistered schemes results in an error when the strategy should just be skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced authentication strategies to support multiple header strategies.
- **Refactor**
	- Improved error handling and authorization logic for increased security and efficiency.
	- Updated internal logic for verifying access tokens using OpenID Connect standards.
- **Tests**
	- Added and modified tests to ensure robustness and reliability of authentication mechanisms.
- **Documentation**
	- Expanded documentation within the code to clarify the purpose and usage of new methods and strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->