### PR TITLE
fix(server): header inconsistencies

### DIFF
--- a/internal/middlewares/headers.go
+++ b/internal/middlewares/headers.go
@@ -22,6 +22,15 @@ func SecurityHeadersRelaxed(next fasthttp.RequestHandler) fasthttp.RequestHandle
 	}
 }
 
+// The SecurityHeadersBase middleware adds several modern recommended security headers with relaxed values.
+func SecurityHeadersBase(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		SetBaseSecurityHeaders(ctx)
+
+		next(ctx)
+	}
+}
+
 // The SetStandardSecurityHeaders function adds several modern recommended security headers with safe values.
 func SetStandardSecurityHeaders(ctx *fasthttp.RequestCtx) {
 	SetBaseSecurityHeaders(ctx)

--- a/internal/server/asset.go
+++ b/internal/server/asset.go
@@ -59,7 +59,7 @@ func newPublicHTMLEmbeddedHandler() fasthttp.RequestHandler {
 			return
 		}
 
-		middlewares.SetStandardSecurityHeaders(ctx)
+		middlewares.SetBaseSecurityHeaders(ctx)
 
 		contentType := mime.TypeByExtension(path.Ext(p))
 		if len(contentType) == 0 {
@@ -191,7 +191,7 @@ func newLocalesEmbeddedHandler() (handler fasthttp.RequestHandler) {
 			data = []byte("{}")
 		}
 
-		middlewares.SetStandardSecurityHeaders(ctx)
+		middlewares.SetBaseSecurityHeaders(ctx)
 		middlewares.SetContentTypeApplicationJSON(ctx)
 
 		switch {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -125,7 +125,8 @@ func handleRouter(config *schema.Configuration, providers middlewares.Providers)
 	handlerPublicHTML := newPublicHTMLEmbeddedHandler()
 	handlerLocales := newLocalesEmbeddedHandler()
 
-	bridge := middlewares.NewBridgeBuilder(*config, providers).Build()
+	bridge := middlewares.NewBridgeBuilder(*config, providers).
+		WithPreMiddlewares(middlewares.SecurityHeadersBase).Build()
 
 	bridgeSwagger := middlewares.NewBridgeBuilder(*config, providers).
 		WithPreMiddlewares(middlewares.SecurityHeadersRelaxed).Build()
@@ -181,16 +182,16 @@ func handleRouter(config *schema.Configuration, providers middlewares.Providers)
 	}
 
 	middlewareAPI := middlewares.NewBridgeBuilder(*config, providers).
-		WithPreMiddlewares(middlewares.SecurityHeadersNoStore, middlewares.SecurityHeadersCSPNone).
+		WithPreMiddlewares(middlewares.SecurityHeadersBase, middlewares.SecurityHeadersNoStore, middlewares.SecurityHeadersCSPNone).
 		Build()
 
 	middleware1FA := middlewares.NewBridgeBuilder(*config, providers).
-		WithPreMiddlewares(middlewares.SecurityHeadersNoStore, middlewares.SecurityHeadersCSPNone).
+		WithPreMiddlewares(middlewares.SecurityHeadersBase, middlewares.SecurityHeadersNoStore, middlewares.SecurityHeadersCSPNone).
 		WithPostMiddlewares(middlewares.Require1FA).
 		Build()
 
 	middlewareElevated1FA := middlewares.NewBridgeBuilder(*config, providers).
-		WithPreMiddlewares(middlewares.SecurityHeadersNoStore, middlewares.SecurityHeadersCSPNone).
+		WithPreMiddlewares(middlewares.SecurityHeadersBase, middlewares.SecurityHeadersNoStore, middlewares.SecurityHeadersCSPNone).
 		WithPostMiddlewares(middlewares.RequireElevated).
 		Build()
 
@@ -335,7 +336,7 @@ func handleRouter(config *schema.Configuration, providers middlewares.Providers)
 
 	if providers.OpenIDConnect != nil {
 		bridgeOIDC := middlewares.NewBridgeBuilder(*config, providers).WithPreMiddlewares(
-			middlewares.SecurityHeadersCSPNoneOpenIDConnect, middlewares.SecurityHeadersNoStore,
+			middlewares.SecurityHeadersBase, middlewares.SecurityHeadersCSPNoneOpenIDConnect, middlewares.SecurityHeadersNoStore,
 		).Build()
 
 		r.GET("/api/oidc/consent", bridgeOIDC(handlers.OpenIDConnectConsentGET))

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -39,7 +39,7 @@ func ServeTemplatedFile(t templates.Template, opts *TemplatedFileOptions) middle
 			}
 		}
 
-		middlewares.SetStandardSecurityHeaders(ctx.RequestCtx)
+		middlewares.SetBaseSecurityHeaders(ctx.RequestCtx)
 
 		switch ext {
 		case extHTML:

--- a/internal/suites/example/compose/nginx/portal/nginx.conf
+++ b/internal/suites/example/compose/nginx/portal/nginx.conf
@@ -115,6 +115,9 @@ http {
             add_header X-Frame-Options "DENY";
             add_header Permissions-Policy "accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), sync-xhr=(), xr-spatial-tracking=(), interest-cohort=()";
             add_header X-DNS-Prefetch-Control "off";
+            add_header Cross-Origin-Opener-Policy "same-origin";
+            add_header Cross-Origin-Embedder-Policy "require-corp";
+            add_header Cross-Origin-Resource-Policy "same-origin";
 
             proxy_pass        $frontend_endpoint;
         }
@@ -165,6 +168,9 @@ http {
         add_header X-Frame-Options "DENY";
         add_header Permissions-Policy "accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), sync-xhr=(), xr-spatial-tracking=(), interest-cohort=()";
         add_header X-DNS-Prefetch-Control "off";
+        add_header Cross-Origin-Opener-Policy "same-origin";
+        add_header Cross-Origin-Embedder-Policy "require-corp";
+        add_header Cross-Origin-Resource-Policy "same-origin";
 
         error_page 497 301 =307 https://$host:$server_port$request_uri;
 
@@ -336,6 +342,9 @@ http {
         add_header X-Frame-Options "DENY";
         add_header Permissions-Policy "accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), sync-xhr=(), xr-spatial-tracking=(), interest-cohort=()";
         add_header X-DNS-Prefetch-Control "off";
+        add_header Cross-Origin-Opener-Policy "same-origin";
+        add_header Cross-Origin-Embedder-Policy "require-corp";
+        add_header Cross-Origin-Resource-Policy "same-origin";
 
         error_page 497 301 =307 https://$host:$server_port$request_uri;
 


### PR DESCRIPTION
There were some header inconsistencies introduced by 427ed6c98aa6c24606166eb45306866bc679f912. This fixes that issue in a partial reversion of the changes.

Fixes #6882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in a function signature within test files.

- **New Features**
	- Introduced a new middleware function, `SecurityHeadersBase`, for setting base security headers.
	- Added new security headers (`Cross-Origin-Opener-Policy`, `Cross-Origin-Embedder-Policy`, `Cross-Origin-Resource-Policy`) in nginx configuration for enhanced security.

- **Refactor**
	- Updated functions in `asset.go` and `template.go` to use the new `SecurityHeadersBase` middleware.
	- Adjusted security headers configuration by adding `SecurityHeadersBase` to pre-middlewares in various `NewBridgeBuilder` calls in `handlers.go`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->