### PR TITLE
fix(configuration): rename token_lifespan in configuration example

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -268,7 +268,7 @@ identity_validation:
   ## Reset Password flow. Adjusts how the reset password flow operates.
   reset_password:
     ## Maximum allowed time before the JWT is generated and when the user uses it in the duration common syntax.
-    # token_lifespan: '5 minutes'
+    # jwt_lifespan: '5 minutes'
 
     ## The algorithm used for the Reset Password JWT.
     # jwt_algorithm: 'HS256'

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -268,7 +268,7 @@ identity_validation:
   ## Reset Password flow. Adjusts how the reset password flow operates.
   reset_password:
     ## Maximum allowed time before the JWT is generated and when the user uses it in the duration common syntax.
-    # token_lifespan: '5 minutes'
+    # jwt_lifespan: '5 minutes'
 
     ## The algorithm used for the Reset Password JWT.
     # jwt_algorithm: 'HS256'


### PR DESCRIPTION
This change ensures that our configuration templates align with the expected key names and documentation.

Fixes #6948.