### PR TITLE
docs; update nextcloud

### DIFF
--- a/docs/content/integration/openid-connect/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/nextcloud/index.md
@@ -67,6 +67,8 @@ identity_providers:
           - 'email'
           - 'groups'
         userinfo_signed_response_alg: 'none'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
 ```
 
 ### Application
@@ -100,7 +102,6 @@ $CONFIG = array (
     'oidc_login_proxy_ldap' => false,
     'oidc_login_disable_registration' => true,
     'oidc_login_redir_fallback' => false,
-    'oidc_login_alt_login_page' => 'assets/login.php',
     'oidc_login_tls_verify' => true,
     'oidc_create_groups' => false,
     'oidc_login_webdav_enabled' => false,
@@ -109,6 +110,7 @@ $CONFIG = array (
     'oidc_login_min_time_between_jwks_requests' => 10,
     'oidc_login_well_known_caching_time' => 86400,
     'oidc_login_update_avatar' => false,
+    'oidc_login_code_challenge_method' => 'S256'
 );
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the OpenID Connect integration guide for Nextcloud to include PKCE (Proof Key for Code Exchange) requirements and configuration.
	- Added information about requiring PKCE, specifying the PKCE challenge method as 'S256', and new configuration options `require_pkce` and `pkce_challenge_method`.
	- Removed the `oidc_login_alt_login_page` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->