### PR TITLE
fix(logging): include logs about logging config

### DIFF
--- a/internal/commands/context.go
+++ b/internal/commands/context.go
@@ -252,11 +252,12 @@ func (ctx *CmdCtx) LogConfigure(_ *cobra.Command, _ []string) (err error) {
 
 	config.KeepStdout = true
 
-	if err = logging.InitializeLogger(config, false); err != nil {
+	if err = logging.InitializeLogger(schema.Log{Level: ctx.config.Log.Level}, false); err != nil {
 		return fmt.Errorf("Cannot initialize logger: %w", err)
 	}
 
 	ctx.log.WithFields(map[string]any{"filters": ctx.cconfig.filters, "files": ctx.cconfig.files}).Debug("Loaded Configuration Sources")
+	ctx.log.WithFields(map[string]any{"level": ctx.config.Log.Level, "format": ctx.config.Log.Format, "file": ctx.config.Log.FilePath, "keep_stdout": ctx.config.Log.KeepStdout}).Debug("Logging Initialized")
 
 	return nil
 }


### PR DESCRIPTION
Similar to fdb62daf9ea895e4e719c15dcee640e1f0e16e10 / #6935, it makes it hard to debug some configurations when various log configurations exist so logging the configuration at startup as a debug log message will assist the developers in debugging this kind of setup. This fixes the absence of this log message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated logging initialization to use a new configuration schema and added debug logging for settings initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->