### PR TITLE
docs: add "token_endpoint_auth_method" option to DSM integration example

### DIFF
--- a/docs/content/integration/openid-connect/synology-dsm/index.md
+++ b/docs/content/integration/openid-connect/synology-dsm/index.md
@@ -67,6 +67,7 @@ identity_providers:
           - 'groups'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: client_secret_post
 ```
 
 ### Application


### PR DESCRIPTION
This fix OIDC SSO login to Synology DSM. Without this option, SSO login doesn't work and shows an error in Authelia's log :

`(...) The registered client with id 'synology-dsm' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'client_secret_post' (...)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the OpenID Connect integration guide for Synology DSM with new authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->