### PR TITLE
fix(configuration): missing request_uris option

### DIFF
--- a/cmd/authelia-scripts/cmd/gen.go
+++ b/cmd/authelia-scripts/cmd/gen.go
@@ -7,5 +7,5 @@
 package cmd
 
 const (
-	versionSwaggerUI = "5.12.0"
+	versionSwaggerUI = "5.12.3"
 )

--- a/config.template.yml
+++ b/config.template.yml
@@ -1380,6 +1380,11 @@ notifier:
         # redirect_uris:
           # - 'https://oidc.example.com:8080/oauth2/callback'
 
+        ## Request URI's specifies a list of valid case-sensitive TLS-secured URIs for this client for use as
+        ## URIs to fetch Request Objects.
+        # request_uris:
+          # - 'https://oidc.example.com:8080/oidc/request-object.jwk'
+
         ## Audience this client is allowed to request.
         # audience: []
 

--- a/docs/content/configuration/identity-providers/openid-connect/clients.md
+++ b/docs/content/configuration/identity-providers/openid-connect/clients.md
@@ -36,6 +36,8 @@ identity_providers:
         public: false
         redirect_uris:
           - 'https://oidc.example.com:8080/oauth2/callback'
+        request_uris:
+          - 'https://oidc.example.com:8080/oidc/request-object.jwk'
         audience:
           - 'https://app.example.com'
         scopes:
@@ -200,6 +202,15 @@ their redirect URIs are as follows:
    attempt to authorize will fail and an error will be generated.
 2. The redirect URIs are case-sensitive.
 3. The URI must include a scheme and that scheme must be one of `http` or `https`.
+
+### request_uris
+
+{{< confkey type="list(string)" required="no" >}}
+
+A list of URIs which can be used for the OpenID Connect 1.0 Request Object to pass Authorize Request parameters via a
+JSON Web Token remote URI using the `request_uri` parameter.
+
+These URIs must have the `https` scheme.
 
 ### audience
 

--- a/docs/static/schemas/latest/json-schema/configuration.json
+++ b/docs/static/schemas/latest/json-schema/configuration.json
@@ -1205,9 +1205,14 @@
           "default": false
         },
         "redirect_uris": {
-          "$ref": "#/$defs/IdentityProvidersOpenIDConnectClientRedirectURIs",
+          "$ref": "#/$defs/IdentityProvidersOpenIDConnectClientURIs",
           "title": "Redirect URIs",
-          "description": "List of authorized redirect URIs."
+          "description": "List of whitelisted redirect URIs."
+        },
+        "request_uris": {
+          "$ref": "#/$defs/IdentityProvidersOpenIDConnectClientURIs",
+          "title": "Request URIs",
+          "description": "List of whitelisted request URIs."
         },
         "audience": {
           "items": {
@@ -1540,7 +1545,7 @@
       ],
       "description": "IdentityProvidersOpenIDConnectClient represents a configuration for an OpenID Connect 1.0 client."
     },
-    "IdentityProvidersOpenIDConnectClientRedirectURIs": {
+    "IdentityProvidersOpenIDConnectClientURIs": {
       "oneOf": [
         {
           "type": "string",

--- a/docs/static/schemas/v4.38/json-schema/configuration.json
+++ b/docs/static/schemas/v4.38/json-schema/configuration.json
@@ -1205,9 +1205,14 @@
           "default": false
         },
         "redirect_uris": {
-          "$ref": "#/$defs/IdentityProvidersOpenIDConnectClientRedirectURIs",
+          "$ref": "#/$defs/IdentityProvidersOpenIDConnectClientURIs",
           "title": "Redirect URIs",
-          "description": "List of authorized redirect URIs."
+          "description": "List of whitelisted redirect URIs."
+        },
+        "request_uris": {
+          "$ref": "#/$defs/IdentityProvidersOpenIDConnectClientURIs",
+          "title": "Request URIs",
+          "description": "List of whitelisted request URIs."
         },
         "audience": {
           "items": {
@@ -1540,7 +1545,7 @@
       ],
       "description": "IdentityProvidersOpenIDConnectClient represents a configuration for an OpenID Connect 1.0 client."
     },
-    "IdentityProvidersOpenIDConnectClientRedirectURIs": {
+    "IdentityProvidersOpenIDConnectClientURIs": {
       "oneOf": [
         {
           "type": "string",

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -1380,6 +1380,11 @@ notifier:
         # redirect_uris:
           # - 'https://oidc.example.com:8080/oauth2/callback'
 
+        ## Request URI's specifies a list of valid case-sensitive TLS-secured URIs for this client for use as
+        ## URIs to fetch Request Objects.
+        # request_uris:
+          # - 'https://oidc.example.com:8080/oidc/request-object.jwk'
+
         ## Audience this client is allowed to request.
         # audience: []
 

--- a/internal/configuration/schema/identity_providers.go
+++ b/internal/configuration/schema/identity_providers.go
@@ -115,7 +115,8 @@ type IdentityProvidersOpenIDConnectClient struct {
 	SectorIdentifierURI *url.URL        `koanf:"sector_identifier_uri" json:"sector_identifier_uri" jsonschema:"title=Sector Identifier URI" jsonschema_description:"The Client Sector Identifier URI for Privacy Isolation via Pairwise subject types."`
 	Public              bool            `koanf:"public" json:"public" jsonschema:"default=false,title=Public" jsonschema_description:"Enables the Public Client Type."`
 
-	RedirectURIs IdentityProvidersOpenIDConnectClientRedirectURIs `koanf:"redirect_uris" json:"redirect_uris" jsonschema:"title=Redirect URIs" jsonschema_description:"List of authorized redirect URIs."`
+	RedirectURIs IdentityProvidersOpenIDConnectClientURIs `koanf:"redirect_uris" json:"redirect_uris" jsonschema:"title=Redirect URIs" jsonschema_description:"List of whitelisted redirect URIs."`
+	RequestURIs  IdentityProvidersOpenIDConnectClientURIs `koanf:"request_uris" json:"request_uris" jsonschema:"title=Request URIs" jsonschema_description:"List of whitelisted request URIs."`
 
 	Audience      []string `koanf:"audience" json:"audience" jsonschema:"uniqueItems,title=Audience" jsonschema_description:"List of authorized audiences."`
 	Scopes        []string `koanf:"scopes" json:"scopes" jsonschema:"required,enum=openid,enum=offline_access,enum=groups,enum=email,enum=profile,enum=authelia.bearer.authz,uniqueItems,title=Scopes" jsonschema_description:"The Scopes this client is allowed request and be granted."`

--- a/internal/configuration/schema/keys.go
+++ b/internal/configuration/schema/keys.go
@@ -40,6 +40,7 @@ var Keys = []string{
 	"identity_providers.oidc.clients[].sector_identifier_uri",
 	"identity_providers.oidc.clients[].public",
 	"identity_providers.oidc.clients[].redirect_uris",
+	"identity_providers.oidc.clients[].request_uris",
 	"identity_providers.oidc.clients[].audience",
 	"identity_providers.oidc.clients[].scopes",
 	"identity_providers.oidc.clients[].grant_types",

--- a/internal/configuration/schema/types.go
+++ b/internal/configuration/schema/types.go
@@ -494,9 +494,9 @@ func (AccessControlRuleNetworks) JSONSchema() *jsonschema.Schema {
 	return &jsonschemaWeakStringUniqueSlice
 }
 
-type IdentityProvidersOpenIDConnectClientRedirectURIs []string
+type IdentityProvidersOpenIDConnectClientURIs []string
 
-func (IdentityProvidersOpenIDConnectClientRedirectURIs) JSONSchema() *jsonschema.Schema {
+func (IdentityProvidersOpenIDConnectClientURIs) JSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
 		OneOf: []*jsonschema.Schema{
 			&jsonschemaURI,

--- a/internal/configuration/schema/types_test.go
+++ b/internal/configuration/schema/types_test.go
@@ -365,7 +365,7 @@ func TestJSONSchema(t *testing.T) {
 		&AccessControlRuleMethods{},
 		&AccessControlRuleRegex{},
 		&AccessControlRuleSubjects{},
-		&IdentityProvidersOpenIDConnectClientRedirectURIs{},
+		&IdentityProvidersOpenIDConnectClientURIs{},
 	}
 
 	for _, tc := range testCases {

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -226,6 +226,15 @@ const (
 		"for the openid connect confidential client type"
 	errFmtOIDCClientRedirectURIAbsolute = errFmtOIDCClientRedirectURIHas +
 		"an invalid value: redirect uri '%s' must have a scheme but it's absent"
+
+	errFmtOIDCClientRequestURIHas          = errFmtOIDCClientOption + "'request_uris' has "
+	errFmtOIDCClientRequestURICantBeParsed = errFmtOIDCClientRequestURIHas +
+		"an invalid value: request uri '%s' could not be parsed: %v"
+	errFmtOIDCClientRequestURINotAbsolute = errFmtOIDCClientRequestURIHas +
+		"an invalid value: request uri '%s' must have a scheme but it's absent"
+	errFmtOIDCClientRequestURIInvalidScheme = errFmtOIDCClientRequestURIHas +
+		"an invalid scheme: scheme must be 'https' but request uri '%s' has a '%s' scheme"
+
 	errFmtOIDCClientInvalidConsentMode = "identity_providers: oidc: clients: client '%s': consent: option 'mode' must be one of " +
 		"%s but it's configured as '%s'"
 	errFmtOIDCClientInvalidEntries = errFmtOIDCClientOption + errFmtMustOnlyHaveValues +
@@ -512,6 +521,7 @@ const (
 	attrOIDCResponseModes         = "response_modes"
 	attrOIDCGrantTypes            = "grant_types"
 	attrOIDCRedirectURIs          = "redirect_uris"
+	attrOIDCRequestURIs           = "request_uris"
 	attrOIDCTokenAuthMethod       = "token_endpoint_auth_method"
 	attrOIDCDiscoSigAlg           = "discovery_signed_response_alg"
 	attrOIDCDiscoSigKID           = "discovery_signed_response_key_id"

--- a/internal/configuration/validator/identity_providers_test.go
+++ b/internal/configuration/validator/identity_providers_test.go
@@ -323,6 +323,54 @@ func TestShouldRaiseErrorWhenOIDCServerClientBadValues(t *testing.T) {
 			},
 		},
 		{
+			name: "RequestURINotValidURI",
+			clients: []schema.IdentityProvidersOpenIDConnectClient{
+				{
+					ID:                  "client-check-uri-parse",
+					Secret:              tOpenIDConnectPlainTextClientSecret,
+					AuthorizationPolicy: policyTwoFactor,
+					RequestURIs: []string{
+						"http://abc@%two",
+					},
+				},
+			},
+			errors: []string{
+				"identity_providers: oidc: clients: client 'client-check-uri-parse': option 'request_uris' has an invalid value: request uri 'http://abc@%two' could not be parsed: parse \"http://abc@%two\": invalid URL escape \"%tw\"",
+			},
+		},
+		{
+			name: "RequestURINotAbsolute",
+			clients: []schema.IdentityProvidersOpenIDConnectClient{
+				{
+					ID:                  "client-check-uri-parse",
+					Secret:              tOpenIDConnectPlainTextClientSecret,
+					AuthorizationPolicy: policyTwoFactor,
+					RequestURIs: []string{
+						exampleDotCom,
+					},
+				},
+			},
+			errors: []string{
+				"identity_providers: oidc: clients: client 'client-check-uri-parse': option 'request_uris' has an invalid value: request uri 'example.com' must have a scheme but it's absent",
+			},
+		},
+		{
+			name: "RequestURINotSecure",
+			clients: []schema.IdentityProvidersOpenIDConnectClient{
+				{
+					ID:                  "client-check-uri-parse",
+					Secret:              tOpenIDConnectPlainTextClientSecret,
+					AuthorizationPolicy: policyTwoFactor,
+					RequestURIs: []string{
+						"http://" + exampleDotCom,
+					},
+				},
+			},
+			errors: []string{
+				"identity_providers: oidc: clients: client 'client-check-uri-parse': option 'request_uris' has an invalid scheme: scheme must be 'https' but request uri 'http://example.com' has a 'http' scheme",
+			},
+		},
+		{
 			name: "ValidSectorIdentifier",
 			clients: []schema.IdentityProvidersOpenIDConnectClient{
 				{
@@ -1405,7 +1453,7 @@ func TestValidateOIDCClients(t *testing.T) {
 				}
 			},
 			func(t *testing.T, have *schema.IdentityProvidersOpenIDConnect) {
-				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientRedirectURIs([]string{"https://google.com"}), have.Clients[0].RedirectURIs)
+				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientURIs([]string{"https://google.com"}), have.Clients[0].RedirectURIs)
 			},
 			tcv{
 				nil,
@@ -1432,7 +1480,7 @@ func TestValidateOIDCClients(t *testing.T) {
 				}
 			},
 			func(t *testing.T, have *schema.IdentityProvidersOpenIDConnect) {
-				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientRedirectURIs([]string{oauth2InstalledApp}), have.Clients[0].RedirectURIs)
+				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientURIs([]string{oauth2InstalledApp}), have.Clients[0].RedirectURIs)
 			},
 			tcv{
 				nil,
@@ -1457,7 +1505,7 @@ func TestValidateOIDCClients(t *testing.T) {
 				}
 			},
 			func(t *testing.T, have *schema.IdentityProvidersOpenIDConnect) {
-				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientRedirectURIs([]string{oauth2InstalledApp}), have.Clients[0].RedirectURIs)
+				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientURIs([]string{oauth2InstalledApp}), have.Clients[0].RedirectURIs)
 			},
 			tcv{
 				nil,
@@ -1484,7 +1532,7 @@ func TestValidateOIDCClients(t *testing.T) {
 				}
 			},
 			func(t *testing.T, have *schema.IdentityProvidersOpenIDConnect) {
-				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientRedirectURIs([]string{"http://abc@%two"}), have.Clients[0].RedirectURIs)
+				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientURIs([]string{"http://abc@%two"}), have.Clients[0].RedirectURIs)
 			},
 			tcv{
 				nil,
@@ -1511,7 +1559,7 @@ func TestValidateOIDCClients(t *testing.T) {
 				}
 			},
 			func(t *testing.T, have *schema.IdentityProvidersOpenIDConnect) {
-				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientRedirectURIs([]string{"google.com"}), have.Clients[0].RedirectURIs)
+				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientURIs([]string{"google.com"}), have.Clients[0].RedirectURIs)
 			},
 			tcv{
 				nil,
@@ -1539,7 +1587,7 @@ func TestValidateOIDCClients(t *testing.T) {
 				}
 			},
 			func(t *testing.T, have *schema.IdentityProvidersOpenIDConnect) {
-				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientRedirectURIs([]string{"https://google.com", "https://google.com"}), have.Clients[0].RedirectURIs)
+				assert.Equal(t, schema.IdentityProvidersOpenIDConnectClientURIs([]string{"https://google.com", "https://google.com"}), have.Clients[0].RedirectURIs)
 			},
 			tcv{
 				nil,

--- a/internal/oidc/client.go
+++ b/internal/oidc/client.go
@@ -25,6 +25,7 @@ func NewClient(config schema.IdentityProvidersOpenIDConnectClient, c *schema.Ide
 		Audience:      config.Audience,
 		Scopes:        config.Scopes,
 		RedirectURIs:  config.RedirectURIs,
+		RequestURIs:   config.RequestURIs,
 		GrantTypes:    config.GrantTypes,
 		ResponseTypes: config.ResponseTypes,
 		ResponseModes: []oauthelia2.ResponseModeType{},


### PR DESCRIPTION
This fixes a missing option for OpenID Connect 1.0 clients 'request_uris'. This feature was effectively implemented but no way to configure it existed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration field `request_uris` for OpenID Connect clients, enabling the use of URIs for passing Authorize Request parameters.
- **Enhancements**
	- Updated Swagger UI version to "5.12.3" for improved user interface and stability.
- **Documentation**
	- Documented the addition of `request_uris` under the OpenID Connect client configuration section.
- **Bug Fixes**
	- Enhanced validation for OpenID Connect client request URIs to prevent configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->