### PR TITLE
fix(oidc): delayed user details refresh

### DIFF
--- a/docs/content/configuration/security/access-control.md
+++ b/docs/content/configuration/security/access-control.md
@@ -420,10 +420,6 @@ option).
 
 In addition to standard regex patterns this criteria can match some [Named Regex Groups](#named-regex-groups).
 
-*__Note:__ Prior to 4.27.0 the regular expressions only matched the path excluding the query parameters. After 4.27.0
-they match the entire path including the query parameters. When upgrading you may be required to alter some of your
-resource rules to get them to operate as they previously did.*
-
 It's important when configuring resource rules that you enclose them in quotes otherwise you may run into some issues
 with escaping the expressions. Failure to do so may prevent Authelia from starting. It's technically optional but will
 likely save you a lot of time if you do it for all resource rules.

--- a/internal/authentication/types.go
+++ b/internal/authentication/types.go
@@ -77,6 +77,22 @@ func (d UserDetails) Addresses() (addresses []mail.Address) {
 	return addresses
 }
 
+func (d UserDetails) GetUsername() (username string) {
+	return d.Username
+}
+
+func (d UserDetails) GetGroups() (groups []string) {
+	return d.Groups
+}
+
+func (d UserDetails) GetDisplayName() (name string) {
+	return d.DisplayName
+}
+
+func (d UserDetails) GetEmails() (emails []string) {
+	return d.Emails
+}
+
 type ldapUserProfile struct {
 	DN          string
 	Emails      []string

--- a/internal/handlers/handler_oidc_authorization.go
+++ b/internal/handlers/handler_oidc_authorization.go
@@ -112,6 +112,8 @@ func OpenIDConnectAuthorization(ctx *middlewares.AutheliaCtx, rw http.ResponseWr
 		return
 	}
 
+	_ = handleSessionValidateRefresh(ctx, &userSession, ctx.Configuration.AuthenticationBackend.RefreshInterval)
+
 	extraClaims := oidcGrantRequests(requester, consent, &userSession)
 
 	if authTime, err = userSession.AuthenticatedTime(client.GetAuthorizationPolicyRequiredLevel(authorization.Subject{Username: userSession.Username, Groups: userSession.Groups, IP: ctx.RemoteIP()})); err != nil {

--- a/internal/handlers/handler_oidc_authorization.go
+++ b/internal/handlers/handler_oidc_authorization.go
@@ -8,6 +8,7 @@ import (
 
 	oauthelia2 "authelia.com/provider/oauth2"
 
+	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/model"
@@ -75,6 +76,7 @@ func OpenIDConnectAuthorization(ctx *middlewares.AutheliaCtx, rw http.ResponseWr
 	}
 
 	var (
+		details     *authentication.UserDetails
 		userSession session.UserSession
 		consent     *model.OAuth2ConsentSession
 		handled     bool
@@ -112,11 +114,17 @@ func OpenIDConnectAuthorization(ctx *middlewares.AutheliaCtx, rw http.ResponseWr
 		return
 	}
 
-	_ = handleSessionValidateRefresh(ctx, &userSession, ctx.Configuration.AuthenticationBackend.RefreshInterval)
+	if details, err = ctx.Providers.UserProvider.GetDetails(userSession.Username); err != nil {
+		ctx.Logger.WithError(err).Errorf("Authorization Request with id '%s' on client with id '%s' could not be processed: error occurred retrieving user details for '%s' from the backend", requester.GetID(), client.GetID(), userSession.Username)
 
-	extraClaims := oidcGrantRequests(requester, consent, &userSession)
+		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oauthelia2.ErrServerError.WithHint("Could not obtain the users details."))
 
-	if authTime, err = userSession.AuthenticatedTime(client.GetAuthorizationPolicyRequiredLevel(authorization.Subject{Username: userSession.Username, Groups: userSession.Groups, IP: ctx.RemoteIP()})); err != nil {
+		return
+	}
+
+	extraClaims := oidcGrantRequests(requester, consent, details)
+
+	if authTime, err = userSession.AuthenticatedTime(client.GetAuthorizationPolicyRequiredLevel(authorization.Subject{Username: details.Username, Groups: details.Groups, IP: ctx.RemoteIP()})); err != nil {
 		ctx.Logger.Errorf("Authorization Request with id '%s' on client with id '%s' could not be processed: error occurred checking authentication time: %+v", requester.GetID(), client.GetID(), err)
 
 		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oauthelia2.ErrServerError.WithHint("Could not obtain the authentication time."))
@@ -126,7 +134,7 @@ func OpenIDConnectAuthorization(ctx *middlewares.AutheliaCtx, rw http.ResponseWr
 
 	ctx.Logger.Debugf("Authorization Request with id '%s' on client with id '%s' was successfully processed, proceeding to build Authorization Response", requester.GetID(), clientID)
 
-	session := oidc.NewSessionWithAuthorizeRequest(ctx, issuer, ctx.Providers.OpenIDConnect.KeyManager.GetKeyID(ctx, client.GetIDTokenSignedResponseKeyID(), client.GetIDTokenSignedResponseAlg()), userSession.Username, userSession.AuthenticationMethodRefs.MarshalRFC8176(), extraClaims, authTime, consent, requester)
+	session := oidc.NewSessionWithAuthorizeRequest(ctx, issuer, ctx.Providers.OpenIDConnect.KeyManager.GetKeyID(ctx, client.GetIDTokenSignedResponseKeyID(), client.GetIDTokenSignedResponseAlg()), details.Username, userSession.AuthenticationMethodRefs.MarshalRFC8176(), extraClaims, authTime, consent, requester)
 
 	ctx.Logger.Tracef("Authorization Request with id '%s' on client with id '%s' creating session for Authorization Response for subject '%s' with username '%s' with claims: %+v",
 		requester.GetID(), session.ClientID, session.Subject, session.Username, session.Claims)

--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -8,14 +8,13 @@ import (
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/oidc"
-	"github.com/authelia/authelia/v4/internal/session"
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
-func oidcGrantRequests(ar oauthelia2.AuthorizeRequester, consent *model.OAuth2ConsentSession, userSession *session.UserSession) (extraClaims map[string]any) {
+func oidcGrantRequests(ar oauthelia2.AuthorizeRequester, consent *model.OAuth2ConsentSession, details oidc.UserDetailer) (extraClaims map[string]any) {
 	extraClaims = map[string]any{}
 
-	oidcApplyScopeClaims(extraClaims, consent.GrantedScopes, userSession)
+	oidcApplyScopeClaims(extraClaims, consent.GrantedScopes, details)
 
 	if ar != nil {
 		for _, scope := range consent.GrantedScopes {

--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -2,40 +2,26 @@ package handlers
 
 import (
 	oauthelia2 "authelia.com/provider/oauth2"
+	"github.com/google/uuid"
 
+	"github.com/authelia/authelia/v4/internal/authentication"
+	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/oidc"
 	"github.com/authelia/authelia/v4/internal/session"
+	"github.com/authelia/authelia/v4/internal/utils"
 )
 
 func oidcGrantRequests(ar oauthelia2.AuthorizeRequester, consent *model.OAuth2ConsentSession, userSession *session.UserSession) (extraClaims map[string]any) {
 	extraClaims = map[string]any{}
 
-	for _, scope := range consent.GrantedScopes {
-		if ar != nil {
+	oidcApplyScopeClaims(extraClaims, consent.GrantedScopes, userSession)
+
+	if ar != nil {
+		for _, scope := range consent.GrantedScopes {
 			ar.GrantScope(scope)
 		}
 
-		switch scope {
-		case oidc.ScopeGroups:
-			extraClaims[oidc.ClaimGroups] = userSession.Groups
-		case oidc.ScopeProfile:
-			extraClaims[oidc.ClaimPreferredUsername] = userSession.Username
-			extraClaims[oidc.ClaimFullName] = userSession.DisplayName
-		case oidc.ScopeEmail:
-			if len(userSession.Emails) != 0 {
-				extraClaims[oidc.ClaimPreferredEmail] = userSession.Emails[0]
-				if len(userSession.Emails) > 1 {
-					extraClaims[oidc.ClaimEmailAlts] = userSession.Emails[1:]
-				}
-
-				// TODO (james-d-elliott): actually verify emails and record that information.
-				extraClaims[oidc.ClaimEmailVerified] = true
-			}
-		}
-	}
-
-	if ar != nil {
 		for _, audience := range consent.GrantedAudience {
 			ar.GrantAudience(audience)
 		}
@@ -43,3 +29,148 @@ func oidcGrantRequests(ar oauthelia2.AuthorizeRequester, consent *model.OAuth2Co
 
 	return extraClaims
 }
+
+func oidcApplyScopeClaims(claims map[string]any, scopes []string, detailer oidc.UserDetailer) {
+	for _, scope := range scopes {
+		switch scope {
+		case oidc.ScopeGroups:
+			claims[oidc.ClaimGroups] = detailer.GetGroups()
+		case oidc.ScopeProfile:
+			claims[oidc.ClaimPreferredUsername] = detailer.GetUsername()
+			claims[oidc.ClaimFullName] = detailer.GetDisplayName()
+		case oidc.ScopeEmail:
+			if emails := detailer.GetEmails(); len(emails) != 0 {
+				claims[oidc.ClaimPreferredEmail] = emails[0]
+				if len(emails) > 1 {
+					claims[oidc.ClaimEmailAlts] = emails[1:]
+				}
+
+				// TODO (james-d-elliott): actually verify emails and record that information.
+				claims[oidc.ClaimEmailVerified] = true
+			}
+		}
+	}
+}
+
+func oidcGetAudience(claims map[string]any) (audience []string, ok bool) {
+	var aud any
+
+	if aud, ok = claims[oidc.ClaimAudience]; ok {
+		switch v := aud.(type) {
+		case string:
+			ok = true
+
+			audience = []string{v}
+		case []any:
+			var value string
+
+			for _, a := range v {
+				if value, ok = a.(string); !ok {
+					return nil, false
+				}
+
+				audience = append(audience, value)
+			}
+
+			ok = true
+		case []string:
+			ok = true
+
+			audience = v
+		}
+	}
+
+	return audience, ok
+}
+
+func oidcApplyUserInfoClaims(clientID string, scopes oauthelia2.Arguments, originalClaims, claims map[string]any, resolver oidcDetailResolver) {
+	for claim, value := range originalClaims {
+		switch claim {
+		case oidc.ClaimJWTID, oidc.ClaimSessionID, oidc.ClaimAccessTokenHash, oidc.ClaimCodeHash, oidc.ClaimExpirationTime, oidc.ClaimNonce, oidc.ClaimStateHash:
+			// Skip special OpenID Connect 1.0 Claims.
+			continue
+		case oidc.ClaimPreferredUsername, oidc.ClaimPreferredEmail, oidc.ClaimEmailVerified, oidc.ClaimEmailAlts, oidc.ClaimGroups, oidc.ClaimFullName:
+			continue
+		default:
+			claims[claim] = value
+		}
+	}
+
+	audience, ok := oidcGetAudience(originalClaims)
+
+	if !ok || len(audience) == 0 {
+		audience = []string{clientID}
+	} else if !utils.IsStringInSlice(clientID, audience) {
+		audience = append(audience, clientID)
+	}
+
+	claims[oidc.ClaimAudience] = audience
+
+	oidcApplyUserInfoDetailsClaims(scopes, claims, resolver)
+}
+
+func oidcApplyUserInfoDetailsClaims(scopes oauthelia2.Arguments, claims map[string]any, resolver oidcDetailResolver) {
+	var (
+		detailer oidc.UserDetailer
+		subject  uuid.UUID
+		ok       bool
+		err      error
+	)
+
+	if subject, ok = oidcApplyUserInfoDetailsClaimsGetSubject(scopes, claims); !ok {
+		return
+	}
+
+	if detailer, err = resolver(subject); err != nil {
+		return
+	}
+
+	oidcApplyScopeClaims(claims, scopes, detailer)
+}
+
+func oidcApplyUserInfoDetailsClaimsGetSubject(scopes oauthelia2.Arguments, claims map[string]any) (subject uuid.UUID, ok bool) {
+	if !scopes.HasOneOf(oidc.ScopeProfile, oidc.ScopeEmail, oidc.ScopeGroups) {
+		return uuid.UUID{}, false
+	}
+
+	var (
+		raw   any
+		claim string
+		err   error
+	)
+
+	if raw, ok = claims[oidc.ClaimSubject]; !ok {
+		return uuid.UUID{}, false
+	}
+
+	if claim, ok = raw.(string); !ok {
+		return uuid.UUID{}, false
+	}
+
+	if subject, err = uuid.Parse(claim); err != nil {
+		return uuid.UUID{}, false
+	}
+
+	return subject, true
+}
+
+func oidcCtxDetailResolver(ctx *middlewares.AutheliaCtx) oidcDetailResolver {
+	return func(subject uuid.UUID) (detailer oidc.UserDetailer, err error) {
+		var (
+			identifier *model.UserOpaqueIdentifier
+			details    *authentication.UserDetails
+		)
+
+		if identifier, err = ctx.Providers.StorageProvider.LoadUserOpaqueIdentifier(ctx, subject); err != nil {
+			return nil, err
+		}
+
+		if details, err = ctx.Providers.UserProvider.GetDetails(identifier.Username); err != nil {
+			return nil, err
+		}
+
+		return details, nil
+	}
+}
+
+type oidcDetailResolver func(subject uuid.UUID) (detailer oidc.UserDetailer, err error)

--- a/internal/handlers/oidc_test.go
+++ b/internal/handlers/oidc_test.go
@@ -1,11 +1,15 @@
 package handlers
 
 import (
+	"fmt"
 	"testing"
 
+	oauthelia2 "authelia.com/provider/oauth2"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/oidc"
 	"github.com/authelia/authelia/v4/internal/session"
@@ -104,6 +108,156 @@ func TestShouldGrantAppropriateClaimsForScopeOpenIDAndProfile(t *testing.T) {
 
 	require.Contains(t, extraClaims, oidc.ClaimFullName)
 	assert.Equal(t, extraClaims[oidc.ClaimFullName], "Fred Smith")
+}
+
+func TestOIDCApplyUserInfoClaims(t *testing.T) {
+	testCases := []struct {
+		name               string
+		clientID           string
+		scopes             oauthelia2.Arguments
+		resolver           oidcDetailResolver
+		details            *authentication.UserDetails
+		original, expected map[string]any
+	}{
+		{
+			name:     "ShouldNotMapClaimsWhenSubjectAbsent",
+			clientID: "test",
+			scopes:   []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeGroups, oidc.ScopeEmail},
+			details: &authentication.UserDetails{
+				Username:    "john",
+				DisplayName: "John Smith",
+				Groups:      []string{"abc", "123"},
+				Emails:      []string{"john@example.com", "john.smith@example.com"},
+			},
+			original: map[string]any{},
+			expected: map[string]any{oidc.ClaimAudience: []string{"test"}},
+		},
+		{
+			name:     "ShouldNotMapClaimsWhenSubjectNotUUID",
+			clientID: "test",
+			scopes:   []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeGroups, oidc.ScopeEmail},
+			details: &authentication.UserDetails{
+				Username:    "john",
+				DisplayName: "John Smith",
+				Groups:      []string{"abc", "123"},
+				Emails:      []string{"john@example.com", "john.smith@example.com"},
+			},
+			original: map[string]any{oidc.ClaimSubject: "abc"},
+			expected: map[string]any{oidc.ClaimAudience: []string{"test"}, oidc.ClaimSubject: "abc"},
+		},
+		{
+			name:     "ShouldNotMapClaimsWhenSubjectNotString",
+			clientID: "test",
+			scopes:   []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeGroups, oidc.ScopeEmail},
+			details: &authentication.UserDetails{
+				Username:    "john",
+				DisplayName: "John Smith",
+				Groups:      []string{"abc", "123"},
+				Emails:      []string{"john@example.com", "john.smith@example.com"},
+			},
+			original: map[string]any{oidc.ClaimSubject: 1},
+			expected: map[string]any{oidc.ClaimAudience: []string{"test"}, oidc.ClaimSubject: 1},
+		},
+		{
+			name:     "ShouldNotMapClaimsWhenScopesAbsent",
+			clientID: "test",
+			scopes:   []string{oidc.ScopeOpenID},
+			details: &authentication.UserDetails{
+				Username:    "john",
+				DisplayName: "John Smith",
+				Groups:      []string{"abc", "123"},
+				Emails:      []string{"john@example.com", "john.smith@example.com"},
+			},
+			original: map[string]any{oidc.ClaimSubject: "6f05a84f-de27-47e7-8b95-351966532c42"},
+			expected: map[string]any{oidc.ClaimAudience: []string{"test"}, oidc.ClaimSubject: "6f05a84f-de27-47e7-8b95-351966532c42"},
+		},
+		{
+			name:     "ShouldNotMapClaimsWhenResolverError",
+			clientID: "test",
+			scopes:   []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeGroups, oidc.ScopeEmail},
+			resolver: func(subject uuid.UUID) (detailer oidc.UserDetailer, err error) {
+				return nil, fmt.Errorf("an error")
+			},
+			original: map[string]any{oidc.ClaimSubject: "6f05a84f-de27-47e7-8b95-351966532c42"},
+			expected: map[string]any{oidc.ClaimAudience: []string{"test"}, oidc.ClaimSubject: "6f05a84f-de27-47e7-8b95-351966532c42"},
+		},
+		{
+			name:     "ShouldMapAllClaims",
+			clientID: "test",
+			scopes:   []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeGroups, oidc.ScopeEmail},
+			details: &authentication.UserDetails{
+				Username:    "john",
+				DisplayName: "John Smith",
+				Groups:      []string{"abc", "123"},
+				Emails:      []string{"john@example.com", "john.smith@example.com"},
+			},
+			original: map[string]any{oidc.ClaimSubject: "6f05a84f-de27-47e7-8b95-351966532c42"},
+			expected: map[string]any{
+				oidc.ClaimAudience:          []string{"test"},
+				oidc.ClaimSubject:           "6f05a84f-de27-47e7-8b95-351966532c42",
+				oidc.ClaimFullName:          "John Smith",
+				oidc.ClaimPreferredUsername: "john",
+				oidc.ClaimGroups:            []string{"abc", "123"},
+				oidc.ClaimPreferredEmail:    "john@example.com",
+				oidc.ClaimEmailVerified:     true,
+				oidc.ClaimEmailAlts:         []string{"john.smith@example.com"},
+			},
+		},
+		{
+			name:     "ShouldMapAllClaimsWithExtras",
+			clientID: "test",
+			scopes:   []string{oidc.ScopeOpenID, oidc.ScopeProfile, oidc.ScopeGroups, oidc.ScopeEmail},
+			details: &authentication.UserDetails{
+				Username:    "john",
+				DisplayName: "John Smith",
+				Groups:      []string{"abc", "123"},
+				Emails:      []string{"john@example.com", "john.smith@example.com"},
+			},
+			original: map[string]any{
+				oidc.ClaimSubject:           "6f05a84f-de27-47e7-8b95-351966532c42",
+				oidc.ClaimAudience:          []string{"example"},
+				oidc.ClaimAccessTokenHash:   "abc",
+				oidc.ClaimPreferredUsername: "not-john",
+				oidc.ClaimGroups:            []string{"old", "999"},
+				oidc.ClaimEmailVerified:     false,
+				oidc.ClaimPreferredEmail:    "not-john@example.com",
+				oidc.ClaimFullName:          "John Smithy",
+				oidc.ClaimEmailAlts:         []string{"john.smithy@example.com"},
+			},
+			expected: map[string]any{
+				oidc.ClaimAudience:          []string{"example", "test"},
+				oidc.ClaimSubject:           "6f05a84f-de27-47e7-8b95-351966532c42",
+				oidc.ClaimFullName:          "John Smith",
+				oidc.ClaimPreferredUsername: "john",
+				oidc.ClaimGroups:            []string{"abc", "123"},
+				oidc.ClaimPreferredEmail:    "john@example.com",
+				oidc.ClaimEmailVerified:     true,
+				oidc.ClaimEmailAlts:         []string{"john.smith@example.com"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			claims := map[string]any{}
+
+			resolver := tc.resolver
+
+			if resolver == nil {
+				resolver = oidcTestDetailerFromSubject(tc.details)
+			}
+
+			oidcApplyUserInfoClaims(tc.clientID, tc.scopes, tc.original, claims, resolver)
+
+			assert.Equal(t, tc.expected, claims)
+		})
+	}
+}
+
+func oidcTestDetailerFromSubject(details *authentication.UserDetails) oidcDetailResolver {
+	return func(subject uuid.UUID) (detailer oidc.UserDetailer, err error) {
+		return details, nil
+	}
 }
 
 var (

--- a/internal/oidc/const.go
+++ b/internal/oidc/const.go
@@ -22,6 +22,7 @@ const (
 	ClaimSessionID                           = "sid"
 	ClaimAccessTokenHash                     = "at_hash"
 	ClaimCodeHash                            = "c_hash"
+	ClaimStateHash                           = "s_hash"
 	ClaimIssuedAt                            = "iat"
 	ClaimNotBefore                           = "nbf"
 	ClaimRequestedAt                         = "rat"

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -199,6 +199,13 @@ type IDTokenSessionContainer interface {
 	IDTokenClaims() *fjwt.IDTokenClaims
 }
 
+type UserDetailer interface {
+	GetUsername() (username string)
+	GetGroups() (groups []string)
+	GetDisplayName() (name string)
+	GetEmails() (emails []string)
+}
+
 // NilErrorReporter is a true nil herodot.ErrorReporter.
 type NilErrorReporter struct{}
 

--- a/internal/session/user_session.go
+++ b/internal/session/user_session.go
@@ -90,3 +90,19 @@ func (s *UserSession) Identity() Identity {
 
 	return identity
 }
+
+func (s *UserSession) GetUsername() (username string) {
+	return s.Username
+}
+
+func (s *UserSession) GetGroups() (groups []string) {
+	return s.Groups
+}
+
+func (s *UserSession) GetDisplayName() (name string) {
+	return s.DisplayName
+}
+
+func (s *UserSession) GetEmails() (emails []string) {
+	return s.Emails
+}


### PR DESCRIPTION
The user details refresh does not naturally occur via OpenID Connect 1.0 flows and instead relies on alternative activity. This helps ensure the details are more frequently updated via normal OAuth 2.0 flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user details retrieval in authentication processes.
	- Improved OpenID Connect (OIDC) authorization flow with extended claims handling.
	- Updated session validation and refresh mechanisms.
	- Introduced new constants and interfaces for better OIDC support.
- **Refactor**
	- Simplified authentication handler names for clarity.
	- Refactored OIDC userinfo claims processing for efficiency.
- **Documentation**
	- Updated security access control documentation to reflect changes in regex pattern matching behavior for resource rules.
- **Bug Fixes**
	- Refined `sector_identifier_uri` validation in OIDC configuration, including error messaging and handling of various URI components.
- **Chores**
	- Removed unused string utility functions and associated tests to streamline the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->