### PR TITLE
docs: add helpful info to tmpl ref

### DIFF
--- a/docs/content/configuration/prologue/migration.md
+++ b/docs/content/configuration/prologue/migration.md
@@ -37,6 +37,11 @@ server:
 
 ## Migrations
 
+### 4.38.0
+
+No information currently exists for this version at this time with the exclusion of the
+[blog article](../../blog/release-notes-4.38/index.md). We would welcome the contribution.
+
 ### 4.36.0
 
 Automatic mapping was introduced in this version.

--- a/docs/content/configuration/prologue/security-sensitive-values.md
+++ b/docs/content/configuration/prologue/security-sensitive-values.md
@@ -15,7 +15,7 @@ seo:
 ---
 
 Authelia contains several security sensitive values which are documented as such and are also generally are named
-`secret`, `key`, `password`, `token`, or `certificate_chain`; alternatively they may be suffixed with a `_` followed one
+`secret`, `key`, `password`, `token`, or `certificate_chain`; alternatively they may be suffixed with a `_` followed by one
 of the previous values.
 
 We generally recommend not leaving these values directly in the configuration itself as this often leads to accidentally

--- a/docs/content/configuration/prologue/security-sensitive-values.md
+++ b/docs/content/configuration/prologue/security-sensitive-values.md
@@ -26,7 +26,7 @@ There are three special ways to achieve this goal:
 1. Using the native [Secrets](../methods/secrets.md) system which:
    - Loads the value from a file provided an environment variable with the file's location.
    - Generally easy to set up.
-   - Can't be used keys located within lists.
+   - Can't be used for keys located within lists.
    - Does not include the value in the environment which is slightly more secure.
 2. Using the `template` [file filter](../methods/files.md#file-filters) system which:
    - Loads the value from a file provided a template within the configuration itself making it easy to share.

--- a/docs/content/configuration/prologue/security-sensitive-values.md
+++ b/docs/content/configuration/prologue/security-sensitive-values.md
@@ -1,0 +1,89 @@
+---
+title: "Security Sensitive Values"
+description: "An introduction into configuring Authelia's security sensitive values."
+summary: "An introduction into configuring Authelia's security sensitive values."
+date: 2022-06-15T17:51:47+10:00
+draft: false
+images: []
+weight: 100150
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+Authelia contains several security sensitive values which are documented as such and are also generally are named
+`secret`, `key`, `password`, `token`, or `certificate_chain`; alternatively they may be suffixed with a `_` followed one
+of the previous values.
+
+We generally recommend not leaving these values directly in the configuration itself as this often leads to accidentally
+leaking the values when getting support and is generally slightly less secure.
+
+There are three special ways to achieve this goal:
+
+1. Using the native [Secrets](../methods/secrets.md) system which:
+   - Loads the value from a file provided an environment variable with the files location.
+   - Generally very easy to setup.
+   - Can't be used keys located within lists.
+   - Does not include the value in the environment which is slightly more secure.
+2. Using the `template` [file filter](../methods/files.md#file-filters) system which:
+   - Loads the value from a file provided a template within the configuration itself making it easy to share.
+   - Generally easy to setup but has a small learning curve.
+   - Can be used anywhere in the configuration generally for any purpose.
+   - Does not include the value in the environment which is slightly more secure.
+3. Using the native [Environment](../methods/environment.md) system which:
+  - Loads the value from the environment variable itself
+  - Generally very easy to setup.
+  - Can't be used keys located within lists.
+  - Does include the value in the environment which is slightly less secure.
+
+
+## Template Example
+
+This explains option 2 in the context of using it specifically for secret values. For more information on templating
+see the [Reference Guide](../../reference/guides/templating.md).
+
+### Single-Line Value
+
+This example shows how to do a single-line value. The single quotes are only relevant if the value is a string and can
+be excluded for other value types.
+
+```yaml
+identity_providers:
+  oidc:
+    hmac_secret: '{{ secret "/config/secrets/absolute/path/to/hmac_secret" }}'
+```
+
+Alternatively you can use the special `m` variants of the `indent` and `squote` functions to automatically adjust the
+layout depending on if the file has multiple lines, [msquote] will automatically single quote the value if it's not
+multiple lines, see [Multi-Line Value](#multi-line-value) for more information on [mindent].
+
+```yaml
+identity_providers:
+  oidc:
+    hmac_secret: {{ secret "/config/secrets/absolute/path/to/hmac_secret" | mindent 10 "|" | msquote }}
+```
+
+### Multi-Line Value
+
+This example shows how to do a multi-line value. QuotiThng is not possible in this scenario as such it's excluded.
+
+It's important to note the use of [mindent]:
+
+1. The value of `10` indicates the value should be indented with 10 spaces:
+   - You will need to adjust the indent depending on the context. The indent should be an additional indentation level
+     (in this case 2 spaces) than the start of the key name. In this case the `jwks` key name `key` is indented exactly
+     8 characters, so the value `10` is correct.
+2. The value of `|` indicates what multiline prefix to use.
+
+```yaml
+identity_providers:
+  oidc:
+    jwks:
+      - key: {{ secret "/config/secrets/absolute/path/to/jwks/rsa.2048.pem" | mindent 10 "|" | msquote }}
+```
+
+[mindent]: ../../reference/guides/templating.md#mindent
+[msquote]: ../../reference/guides/templating.md#msquote

--- a/docs/content/configuration/prologue/security-sensitive-values.md
+++ b/docs/content/configuration/prologue/security-sensitive-values.md
@@ -35,7 +35,7 @@ There are three special ways to achieve this goal:
    - Does not include the value in the environment which is slightly more secure.
 3. Using the native [Environment](../methods/environment.md) system which:
   - Loads the value from the environment variable itself
-  - Generally very easy to setup.
+  - Generally easy to set up.
   - Can't be used keys located within lists.
   - Does include the value in the environment which is slightly less secure.
 

--- a/docs/content/configuration/prologue/security-sensitive-values.md
+++ b/docs/content/configuration/prologue/security-sensitive-values.md
@@ -24,7 +24,7 @@ leaking the values when getting support and is generally slightly less secure.
 There are three special ways to achieve this goal:
 
 1. Using the native [Secrets](../methods/secrets.md) system which:
-   - Loads the value from a file provided an environment variable with the files location.
+   - Loads the value from a file provided an environment variable with the file's location.
    - Generally very easy to setup.
    - Can't be used keys located within lists.
    - Does not include the value in the environment which is slightly more secure.

--- a/docs/content/configuration/prologue/security-sensitive-values.md
+++ b/docs/content/configuration/prologue/security-sensitive-values.md
@@ -25,7 +25,7 @@ There are three special ways to achieve this goal:
 
 1. Using the native [Secrets](../methods/secrets.md) system which:
    - Loads the value from a file provided an environment variable with the file's location.
-   - Generally very easy to setup.
+   - Generally easy to set up.
    - Can't be used keys located within lists.
    - Does not include the value in the environment which is slightly more secure.
 2. Using the `template` [file filter](../methods/files.md#file-filters) system which:

--- a/docs/content/configuration/prologue/security-sensitive-values.md
+++ b/docs/content/configuration/prologue/security-sensitive-values.md
@@ -30,7 +30,7 @@ There are three special ways to achieve this goal:
    - Does not include the value in the environment which is slightly more secure.
 2. Using the `template` [file filter](../methods/files.md#file-filters) system which:
    - Loads the value from a file provided a template within the configuration itself making it easy to share.
-   - Generally easy to setup but has a small learning curve.
+   - Generally easy to set up but has a small learning curve.
    - Can be used anywhere in the configuration generally for any purpose.
    - Does not include the value in the environment which is slightly more secure.
 3. Using the native [Environment](../methods/environment.md) system which:

--- a/docs/content/configuration/prologue/security-sensitive-values.md
+++ b/docs/content/configuration/prologue/security-sensitive-values.md
@@ -18,7 +18,7 @@ Authelia contains several security sensitive values which are documented as such
 `secret`, `key`, `password`, `token`, or `certificate_chain`; alternatively they may be suffixed with a `_` followed by one
 of the previous values.
 
-We generally recommend not leaving these values directly in the configuration itself as this often leads to accidentally
+We generally recommend not leaving these values directly in the configuration itself, as this often leads to accidentally
 leaking the values when getting support and is generally slightly less secure.
 
 There are three special ways to achieve this goal:

--- a/docs/content/reference/guides/templating.md
+++ b/docs/content/reference/guides/templating.md
@@ -16,6 +16,27 @@ seo:
 
 Authelia has several methods where users can interact with templates.
 
+## Enable Templating
+
+By default the [Notification Templates](./notification-templates.md) have templating enabled. To enable templating in
+the configuration set the environment variable `X_AUTHELIA_CONFIG_FILTERS` to `template`. For more information see
+[Configuration > Methods > Files: File Filters](../../configuration/methods/files.md#file-filters).
+
+## Validation / Debugging
+
+### Notifications
+
+No specific method exists at this time to validate these templates, however a bad template may cause an error before
+startup.
+
+### Configuration
+
+Two methods exist to validate the config template output:
+
+1. The [authelia config template](../cli/authelia/authelia_config_template.md) command.
+2. The [log level](../../configuration/miscellaneous/logging.md#level) value of `trace` will output the fully rendered
+   configuration as a base64 string.
+
 ## Functions
 
 Functions can be used to perform specific actions when executing templates. The following is a simple guide on which

--- a/docs/content/reference/guides/templating.md
+++ b/docs/content/reference/guides/templating.md
@@ -18,8 +18,7 @@ Authelia has several methods where users can interact with templates.
 
 ## Enable Templating
 
-By default the [Notification Templates](./notification-templates.md) have templating enabled. To enable templating in
-the configuration set the environment variable `X_AUTHELIA_CONFIG_FILTERS` to `template`. For more information see
+By default the [Notification Templates](./notification-templates.md) have templating enabled. To enable templating in configuration files, set the environment variable `X_AUTHELIA_CONFIG_FILTERS` to `template`. For more information see
 [Configuration > Methods > Files: File Filters](../../configuration/methods/files.md#file-filters).
 
 ## Validation / Debugging


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the templating guide in Authelia documentation to include:
		- Instructions on enabling templating.
		- Methods for validating and debugging notifications and configuration templates.
		- Information on functions available for template execution.
	- Added a new section for version 4.38.0 with placeholder text and a reference to a blog article.
	- Included information on managing security sensitive values in Authelia configurations.
	- Provided guidance on secure methods for handling sensitive data in configuration files.
	- Emphasized security best practices for sensitive data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->