### PR TITLE
docs: add env tabs

### DIFF
--- a/docs/assets/js/custom.js
+++ b/docs/assets/js/custom.js
@@ -1,1 +1,45 @@
-// Put your custom JS code here
+// Based on: https://github.com/gohugoio/hugoDocs/blob/master/_vendor/github.com/gohugoio/gohugoioTheme/assets/js/tabs.js
+
+/**
+ * Scripts which manages Code Toggle tabs.
+ */
+var i;
+// store tabs variable
+var allEnvTabs = document.querySelectorAll('[data-toggle-env-tab]');
+var allEnvPanes = document.querySelectorAll('[data-env-pane]');
+
+function toggleEnvTabs(event) {
+
+  if(event.target){
+    event.preventDefault();
+    var clickedTab = event.currentTarget;
+    var targetKey = clickedTab.getAttribute('data-toggle-env-tab')
+  } else {
+    var targetKey = event
+  }
+  // We store the config language selected in users' localStorage
+  if(window.localStorage){
+    window.localStorage.setItem('envPref', targetKey)
+  }
+  var selectedTabs = document.querySelectorAll('[data-toggle-env-tab=' + targetKey + ']');
+  var selectedPanes = document.querySelectorAll('[data-env-pane=' + targetKey + ']');
+
+  for (var i = 0; i < allEnvTabs.length; i++) {
+    allEnvTabs[i].classList.remove('active');
+    allEnvPanes[i].classList.remove('active');
+  }
+
+  for (var i = 0; i < selectedTabs.length; i++) {
+    selectedTabs[i].classList.add('active');
+    selectedPanes[i].classList.add('show', 'active');
+  }
+
+}
+
+for (i = 0; i < allEnvTabs.length; i++) {
+  allEnvTabs[i].addEventListener('click', toggleEnvTabs)
+}
+// Upon page load, if user has a preferred language in its localStorage, tabs are set to it.
+if(window.localStorage.getItem('envPref')) {
+  toggleEnvTabs(window.localStorage.getItem('envPref'))
+}

--- a/docs/content/blog/release-notes-4.38/index.md
+++ b/docs/content/blog/release-notes-4.38/index.md
@@ -514,8 +514,10 @@ second will use the go template engine in a very similar way to how Helm operate
 As these features are experimental they may break, be removed, or otherwise not operate as expected. However most of our
 testing indicates they're incredibly solid.
 
-More information about this can be read in the [File Configuration](../../configuration/methods/files.md#file-filters)
-guide and the [Templating Reference Guide](../../reference/guides/templating.md).
+See Also:
+- [Configuration > Prologue > Security Sensitive Values](../../configuration/prologue/security-sensitive-values.md)
+- [Configuration > Methods > Files: File Filters](../../configuration/methods/files.md#file-filters)
+- [Reference > Guides > Templating](../../reference/guides/templating.md)
 
 ## Miscellaneous
 

--- a/docs/content/configuration/methods/files.md
+++ b/docs/content/configuration/methods/files.md
@@ -43,9 +43,18 @@ misconfiguration scenarios it's not perfect. Each file type has recommended meth
 *Authelia* loads `configuration.yml` as the configuration if you just run it. You can override this behavior with the
 following syntax:
 
+{{< envTabs "Validate Configuration" >}}
+{{< envTab "Docker" >}}
 ```bash
-authelia --config config.custom.yml
+$ docker run authelia/authelia:latest authelia --config config.custom.yml
 ```
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
+```bash
+$ authelia --config config.custom.yml
+```
+{{< /envTab >}}
+{{< /envTabs >}}
 
 #### YAML Validation
 
@@ -62,10 +71,26 @@ on how to utilize the schemas.
 You can have multiple configuration files which will be merged in the order specified. If duplicate keys are specified
 the last one to be specified is the one that takes precedence. Example:
 
+{{< envTabs "Run With Multiple Configurations" >}}
+{{< envTab "Docker" >}}
 ```bash
-authelia --config configuration.yml --config config-acl.yml --config config-other.yml
-authelia --config configuration.yml,config-acl.yml,config-other.yml
+$ docker run -d authelia/authelia:latest authelia --config configuration.yml --config config-acl.yml --config config-other.yml
 ```
+
+```bash
+$ docker run -d authelia/authelia:latest authelia --config configuration.yml,config-acl.yml,config-other.yml
+```
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
+```bash
+$ authelia --config configuration.yml --config config-acl.yml --config config-other.yml
+```
+
+```bash
+$ authelia --config configuration.yml,config-acl.yml,config-other.yml
+```
+{{< /envTab >}}
+{{< /envTabs >}}
 
 Authelia's configuration files use the YAML format. A template with all possible options can be found at the root of the
 repository {{< github-link name="here" path="config.template.yml" >}}.
@@ -176,13 +201,31 @@ filter and if it isn't that it's last._
 
 Examples:
 
+{{< envTabs "Filters By Argument" >}}
+{{< envTab "Docker" >}}
 ```bash
-authelia --config config.yml --config.experimental.filters expand-env,template
+$ docker run -d authelia/authelia:latest authelia --config /config/configuration.yml --config.experimental.filters expand-env,template
 ```
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
+```bash
+$ authelia --config /config/configuration.yml --config.experimental.filters expand-env,template
+```
+{{< /envTab >}}
+{{< /envTabs >}}
 
-```text
-X_AUTHELIA_CONFIG_FILTERS=expand-env,template
+{{< envTabs "Filters By Environment" >}}
+{{< envTab "Docker" >}}
+```bash
+$ docker run -d -e X_AUTHELIA_CONFIG_FILTERS=expand-env,template -e X_AUTHELIA_CONFIG=/config/configuration.yml authelia/authelia:latest authelia
 ```
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
+```bash
+$ X_AUTHELIA_CONFIG_FILTERS=expand-env,template X_AUTHELIA_CONFIG=/config/configuration.yml authelia
+```
+{{< /envTab >}}
+{{< /envTabs >}}
 
 ### Expand Environment Variable Filter
 

--- a/docs/content/configuration/prologue/introduction.md
+++ b/docs/content/configuration/prologue/introduction.md
@@ -38,12 +38,21 @@ that don't exist, configuration keys that have changed, the values of the keys a
 key isn't supplied at the same time as a secret for the same configuration option.
 
 You may also optionally validate your configuration against this validation process manually by using the
-`authelia validate-config` command. This command is useful prior to upgrading to prevent configuration changes from
+`authelia config validate` command. This command is useful prior to upgrading to prevent configuration changes from
 impacting downtime in an upgrade. This process does not validate integrations, it only checks that your configuration
 syntax is valid.
 
+{{< envTabs "Validate Configuration" >}}
+{{< envTab "Docker" >}}
 ```bash
-authelia validate-config --config configuration.yml
+$ docker run authelia/authelia:latest authelia config validate --config /config/configuration.yml
 ```
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
+```bash
+$ authelia config validate --config configuration.yml
+```
+{{< /envTab >}}
+{{< /envTabs >}}
 
 [YAML]: https://yaml.org/

--- a/docs/content/integration/openid-connect/frequently-asked-questions.md
+++ b/docs/content/integration/openid-connect/frequently-asked-questions.md
@@ -41,27 +41,51 @@ Authelia provides an easy way to perform such actions.
 #### Client ID / Identifier
 
 Users can easily generate a client id / identifier by following the [Generating a Random Alphanumeric String] guide. For
-example users can perform the
-`authelia crypto rand --length 72 --charset rfc3986` command to generate a client id / identifier with 72 characters
+example users can perform the below command to generate a client id / identifier with 72 characters
 which is printed. This random command also avoids issues with
 a relying party / client application encoding the characters correctly as it uses the [RFC3986 Unreserved Characters].
 
 If a different charset is used if the value would be different when URL encoded then it will also print this value
 separately.
 
+{{< envTabs "Generate a Random Client ID" >}}
+{{< envTab "Docker" >}}
+```bash
+$ docker run authelia/authelia:latest authelia crypto rand --length 72 --charset rfc3986
+```
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
+```bash
+$ authelia crypto rand --length 72 --charset rfc3986
+```
+{{< /envTab >}}
+{{< /envTabs >}}
+
 [Generating a Random Alphanumeric String]: ../../reference/guides/generating-secure-values.md#generating-a-random-alphanumeric-string
 
 #### Client Secret
 
 Users can easily generate a client secret by following the [Generating a Random Password Hash] guide. For example users
-can perform the
-`authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72 --random.charset rfc3986` command to
-both generate a client secret with 72 characters which is printed and is to be used with the relying party
-and hash it using PBKDF2 which can be stored in the Authelia configuration. This random command also avoids issues with
-a relying party / client application encoding the characters correctly as it uses the [RFC3986 Unreserved Characters].
+can perform the below command to both generate a client secret with 72 characters which is printed and is to be used
+with the relying party and hash it using PBKDF2 which can be stored in the Authelia configuration. This random command
+also avoids issues with a relying party / client application encoding the characters correctly as it uses the
+[RFC3986 Unreserved Characters].
 
 If a different charset is used if the value would be different when URL encoded then it will also print this value
 separately.
+
+{{< envTabs "Generate a Random Client Secret" >}}
+{{< envTab "Docker" >}}
+```bash
+$ docker run authelia/authelia:latest authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72 --random.charset rfc3986
+```
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
+```bash
+$ authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72 --random.charset rfc3986
+```
+{{< /envTab >}}
+{{< /envTabs >}}
 
 [Generating a Random Password Hash]: ../../reference/guides/generating-secure-values.md#generating-a-random-password-hash
 

--- a/docs/content/reference/guides/generating-secure-values.md
+++ b/docs/content/reference/guides/generating-secure-values.md
@@ -27,17 +27,18 @@ string and the hash at the same time.
 Use the `authelia crypto hash generate --help` command or see the [authelia crypto hash generate] reference guide for
 more information on all available options and algorithms.
 
-##### Using Docker
-
+{{< envTabs "Generate Random Password" >}}
+{{< envTab "Docker" >}}
 ```bash
-docker run authelia/authelia:latest authelia crypto hash generate argon2 --random --random.length 64 --random.charset alphanumeric
+$ docker run authelia/authelia:latest authelia crypto hash generate argon2 --random --random.length 64 --random.charset alphanumeric
 ```
-
-##### Using the Binary
-
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
 ```bash
-authelia crypto hash generate argon2 --random --random.length 64 --random.charset alphanumeric
+$ authelia crypto hash generate argon2 --random --random.length 64 --random.charset alphanumeric
 ```
+{{< /envTab >}}
+{{< /envTabs >}}
 
 ## Generating a Random Alphanumeric String
 
@@ -51,17 +52,18 @@ The __Authelia__ docker container or CLI binary can be used to generate a random
 Use the `authelia crypto rand --help` command or see the [authelia crypto rand] reference guide for more information on
 all available options.
 
-##### Using Docker
-
+{{< envTabs "Generate Random String" >}}
+{{< envTab "Docker" >}}
 ```bash
-docker run authelia/authelia:latest authelia crypto rand --length 64 --charset alphanumeric
+$ docker run authelia/authelia:latest authelia crypto rand --length 64 --charset alphanumeric
 ```
-
-##### Using the Binary
-
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
 ```bash
-authelia crypto rand --length 64 --charset alphanumeric
+$ authelia crypto rand --length 64 --charset alphanumeric
 ```
+{{< /envTab >}}
+{{< /envTabs >}}
 
 ### openssl
 
@@ -92,17 +94,18 @@ The __Authelia__ docker container or CLI binary can be used to generate a RSA 40
 Use the `authelia crypto pair --help` command or see the [authelia crypto pair] reference guide for more
 information on all available options.
 
-##### Using Docker
-
+{{< envTabs "Generate RSA Key Pair" >}}
+{{< envTab "Docker" >}}
 ```bash
-docker run -u "$(id -u):$(id -g)" -v "$(pwd)":/keys authelia/authelia:latest authelia crypto pair rsa generate --bits 4096 --directory /keys
+$ docker run -u "$(id -u):$(id -g)" -v "$(pwd)":/keys authelia/authelia:latest authelia crypto pair rsa generate --bits 4096 --directory /keys
 ```
-
-##### Using the Binary
-
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
 ```bash
-authelia crypto pair rsa generate --directory /path/to/keys
+$ authelia crypto pair rsa generate --directory /path/to/keys
 ```
+{{< /envTab >}}
+{{< /envTabs >}}
 
 ### openssl
 
@@ -126,17 +129,18 @@ domain `example.com`.
 Use the `authelia crypto certificate --help` command or see the [authelia crypto certificate] reference guide for more
 information on all available options.
 
-##### Using Docker
-
+{{< envTabs "Generate RSA Key Pair" >}}
+{{< envTab "Docker" >}}
 ```bash
-docker run -u "$(id -u):$(id -g)" -v "$(pwd)":/keys authelia/authelia authelia crypto certificate rsa generate --common-name example.com --directory /keys
+$ docker run -u "$(id -u):$(id -g)" -v "$(pwd)":/keys authelia/authelia:latest authelia crypto certificate rsa generate --common-name example.com --directory /keys
 ```
-
-##### Using the Binary
-
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
 ```bash
-authelia crypto certificate rsa generate --common-name example.com --directory /path/to/keys
+$ authelia crypto certificate rsa generate --common-name example.com --directory /path/to/keys
 ```
+{{< /envTab >}}
+{{< /envTabs >}}
 
 ### openssl
 

--- a/docs/content/reference/guides/passwords.md
+++ b/docs/content/reference/guides/passwords.md
@@ -68,8 +68,21 @@ Passwords passed to [crypt hash generate] should be single quoted if using the `
 console prompt, especially if it has  special characters to prevent parameter substitution. For instance to generate an
 [Argon2] hash with the docker image just run:
 
+{{< envTabs "Generate Password" >}}
+{{< envTab "Docker" >}}
 ```bash
 $ docker run authelia/authelia:latest authelia crypto hash generate argon2 --password 'password'
+```
+{{< /envTab >}}
+{{< envTab "Bare-Metal" >}}
+```bash
+$ authelia crypto hash generate argon2 --password 'password'
+```
+{{< /envTab >}}
+{{< /envTabs >}}
+
+Output Example:
+```bash
 Digest: $argon2id$v=19$m=65536,t=3,p=4$Hjc8e7WYcBFcJmEDUOsS9A$ozM7RyZR1EyDR8cuyVpDDfmLrGPGFgo5E2NNqRumui4
 ```
 
@@ -77,8 +90,22 @@ You may also use the `--config` flag to point to your existing configuration. Wh
 config will be used instead. For example to generate the password with a configuration file named `configuration.yml`
 in the current directory:
 
+{{< envTabs "Generate Password (Interactive)" >}}
+{{< envTab "Docker" >}}
 ```bash
 $ docker run -v ./configuration.yml:/configuration.yml -it authelia/authelia:latest authelia crypto hash generate --config /configuration.yml
+```
+{{< /envTab >}}
+{{< envTab "Bare Metal" >}}
+```bash
+$ authelia crypto hash generate --config /configuration.yml
+```
+{{< /envTab >}}
+{{< /envTabs >}}
+
+Output Example:
+
+```bash
 Enter Password:
 Confirm Password:
 

--- a/docs/layouts/shortcodes/envTab.html
+++ b/docs/layouts/shortcodes/envTab.html
@@ -1,0 +1,16 @@
+<!--
+  Source: https://github.com/alex-shpak/hugo-book/blob/master/layouts/shortcodes/tab.html
+-->
+
+{{ if .Parent -}}
+{{ $name := .Get 0 }}
+{{ $group := printf "env-tabs-%s" (.Parent.Get 0) }}
+
+{{ if not (.Parent.Scratch.Get $group) }}
+{{ .Parent.Scratch.Set $group slice }}
+{{ end }}
+
+{{ .Parent.Scratch.Add $group (dict "Name" $name "Content" .Inner) }}
+{{ else -}}
+{{ errorf "%q: 'envTab' shortcode must be inside 'envTabs' shortcode" .Page.Path }}
+{{ end -}}

--- a/docs/layouts/shortcodes/envTabs.html
+++ b/docs/layouts/shortcodes/envTabs.html
@@ -1,0 +1,25 @@
+<!--
+  Based on: https://github.com/alex-shpak/hugo-book/blob/master/layouts/shortcodes/tabs.html
+-->
+
+{{ if .Inner }}{{ end }}
+{{ $id := .Get 0 }}
+{{ $group := printf "env-tabs-%s" $id }}
+
+<nav>
+  <div class="nav nav-tabs" id="nav-tab" role="tablist">
+    {{ range $index, $tab := .Scratch.Get $group -}}
+    <button data-toggle-env-tab="{{ replace ($tab.Name | lower) " " "-" }}" class="nav-link{{ if not $index }} active{{ end }}" id="{{ printf "%s-%d" $group $index }}-tab" data-bs-toggle="tab" data-bs-target="#{{ printf "%s-%d" $group $index }}" type="button" role="tab" aria-controls="{{ printf "%s-%d" $group $index }}" aria-selected="true">
+    {{ $tab.Name -}}
+    </button>
+    {{ end -}}
+  </div>
+</nav>
+
+<div class="tab-content" id="nav-tabContent">
+  {{ range $index, $tab := .Scratch.Get $group -}}
+  <div data-env-pane="{{ replace ($tab.Name | lower) " " "-" }}" class="tab-pane fade{{ if not $index }} show active{{ end }}" id="{{ printf "%s-%d" $group $index }}" role="tabpanel" aria-labelledby="{{ printf "%s-%d" $group $index }}-tab" tabindex="0">
+  {{ .Content | $.Page.RenderString -}}
+</div>
+{{ end -}}
+</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Revised `custom.js` to manage Code Toggle tabs with functions for toggling tabs and saving user preferences.
    - Simplified instructions for generating client ID and client secret in Authelia.
    - Introduced environment tabs for generating secure values in Authelia setups.
    - Added examples for generating passwords interactively in Docker and Bare Metal environments.
- **Documentation**
    - Enhanced documentation references by linking to different sections for Configuration and Reference guides.
- **Refactor**
    - Introduced shortcodes `envTab` and `envTabs` for creating tabbed content in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->