### PR TITLE
fix(oidc): return correct extra claims

### DIFF
--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -167,10 +167,6 @@ func (s *Session) GetIDTokenClaims() *jwt.IDTokenClaims {
 
 // GetExtraClaims returns the Extra/Unregistered claims for this session.
 func (s *Session) GetExtraClaims() map[string]any {
-	if s.DefaultSession != nil && s.DefaultSession.Claims != nil {
-		return s.DefaultSession.Claims.Extra
-	}
-
 	return s.Extra
 }
 

--- a/internal/oidc/session_test.go
+++ b/internal/oidc/session_test.go
@@ -48,7 +48,7 @@ func TestOpenIDSession_GetExtraClaims(t *testing.T) {
 			},
 		},
 		{
-			"ShouldReturnIDTokenClaimsExtra",
+			"ShouldNotReturnIDTokenClaimsExtra",
 			&oidc.Session{
 				DefaultSession: &openid.DefaultSession{
 					Claims: &jwt.IDTokenClaims{
@@ -62,7 +62,7 @@ func TestOpenIDSession_GetExtraClaims(t *testing.T) {
 				},
 			},
 			map[string]any{
-				"b": 2,
+				"a": 1,
 			},
 		},
 	}


### PR DESCRIPTION
The GetExtraClaims function is called during introspection which doesn't need the extra claims from the ID Token Session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Simplified the logic for retrieving extra claims in OIDC sessions.

- **Tests**
	- Updated a test case to reflect the new logic for extra claims handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->