### PR TITLE
fix(authorization): mfa not detected in custom policies

### DIFF
--- a/internal/authorization/authorizer.go
+++ b/internal/authorization/authorizer.go
@@ -12,7 +12,6 @@ type Authorizer struct {
 	defaultPolicy Level
 	rules         []*AccessControlRule
 	mfa           bool
-	config        *schema.Configuration
 	log           *logrus.Logger
 }
 
@@ -21,7 +20,6 @@ func NewAuthorizer(config *schema.Configuration) (authorizer *Authorizer) {
 	authorizer = &Authorizer{
 		defaultPolicy: NewLevel(config.AccessControl.DefaultPolicy),
 		rules:         NewAccessControlRules(config.AccessControl),
-		config:        config,
 		log:           logging.Logger(),
 	}
 
@@ -39,15 +37,7 @@ func NewAuthorizer(config *schema.Configuration) (authorizer *Authorizer) {
 		}
 	}
 
-	if authorizer.config.IdentityProviders.OIDC != nil {
-		for _, client := range authorizer.config.IdentityProviders.OIDC.Clients {
-			if client.AuthorizationPolicy == twoFactor {
-				authorizer.mfa = true
-
-				return authorizer
-			}
-		}
-	}
+	authorizer.mfa = isOpenIDConnectMFA(config)
 
 	return authorizer
 }

--- a/internal/authorization/authorizer_test.go
+++ b/internal/authorization/authorizer_test.go
@@ -416,8 +416,6 @@ func (s *AuthorizerSuite) TestShouldCheckDomainMatching() {
 
 	s.Require().Len(tester.rules[0].Domains, 1)
 
-	s.Assert().Equal("public.example.com", tester.config.AccessControl.Rules[0].Domains[0])
-
 	ruleMatcher0, ok := tester.rules[0].Domains[0].Matcher.(*AccessControlDomainMatcher)
 	s.Require().True(ok)
 	s.Assert().Equal("public.example.com", ruleMatcher0.Name)
@@ -426,8 +424,6 @@ func (s *AuthorizerSuite) TestShouldCheckDomainMatching() {
 	s.Assert().False(ruleMatcher0.GroupWildcard)
 
 	s.Require().Len(tester.rules[1].Domains, 1)
-
-	s.Assert().Equal("one-factor.example.com", tester.config.AccessControl.Rules[1].Domains[0])
 
 	ruleMatcher1, ok := tester.rules[1].Domains[0].Matcher.(*AccessControlDomainMatcher)
 	s.Require().True(ok)
@@ -438,8 +434,6 @@ func (s *AuthorizerSuite) TestShouldCheckDomainMatching() {
 
 	s.Require().Len(tester.rules[2].Domains, 1)
 
-	s.Assert().Equal("two-factor.example.com", tester.config.AccessControl.Rules[2].Domains[0])
-
 	ruleMatcher2, ok := tester.rules[2].Domains[0].Matcher.(*AccessControlDomainMatcher)
 	s.Require().True(ok)
 	s.Assert().Equal("two-factor.example.com", ruleMatcher2.Name)
@@ -449,8 +443,6 @@ func (s *AuthorizerSuite) TestShouldCheckDomainMatching() {
 
 	s.Require().Len(tester.rules[3].Domains, 1)
 
-	s.Assert().Equal("*.example.com", tester.config.AccessControl.Rules[3].Domains[0])
-
 	ruleMatcher3, ok := tester.rules[3].Domains[0].Matcher.(*AccessControlDomainMatcher)
 	s.Require().True(ok)
 	s.Assert().Equal(".example.com", ruleMatcher3.Name)
@@ -459,8 +451,6 @@ func (s *AuthorizerSuite) TestShouldCheckDomainMatching() {
 	s.Assert().False(ruleMatcher3.GroupWildcard)
 
 	s.Require().Len(tester.rules[4].Domains, 1)
-
-	s.Assert().Equal("*.example.com", tester.config.AccessControl.Rules[4].Domains[0])
 
 	ruleMatcher4, ok := tester.rules[4].Domains[0].Matcher.(*AccessControlDomainMatcher)
 	s.Require().True(ok)
@@ -513,15 +503,11 @@ func (s *AuthorizerSuite) TestShouldCheckDomainRegexMatching() {
 
 	s.Require().Len(tester.rules[0].Domains, 1)
 
-	s.Assert().Equal("^.*\\.example.com$", tester.config.AccessControl.Rules[0].DomainsRegex[0].String())
-
 	ruleMatcher0, ok := tester.rules[0].Domains[0].Matcher.(RegexpStringSubjectMatcher)
 	s.Require().True(ok)
 	s.Assert().Equal("^.*\\.example.com$", ruleMatcher0.String())
 
 	s.Require().Len(tester.rules[1].Domains, 1)
-
-	s.Assert().Equal("^.*\\.example2.com$", tester.config.AccessControl.Rules[1].DomainsRegex[0].String())
 
 	ruleMatcher1, ok := tester.rules[1].Domains[0].Matcher.(RegexpStringSubjectMatcher)
 	s.Require().True(ok)
@@ -529,23 +515,17 @@ func (s *AuthorizerSuite) TestShouldCheckDomainRegexMatching() {
 
 	s.Require().Len(tester.rules[2].Domains, 1)
 
-	s.Assert().Equal("^(?P<User>[a-zA-Z0-9]+)\\.regex.com$", tester.config.AccessControl.Rules[2].DomainsRegex[0].String())
-
 	ruleMatcher2, ok := tester.rules[2].Domains[0].Matcher.(RegexpGroupStringSubjectMatcher)
 	s.Require().True(ok)
 	s.Assert().Equal("^(?P<User>[a-zA-Z0-9]+)\\.regex.com$", ruleMatcher2.String())
 
 	s.Require().Len(tester.rules[3].Domains, 1)
 
-	s.Assert().Equal("^group-(?P<Group>[a-zA-Z0-9]+)\\.regex.com$", tester.config.AccessControl.Rules[3].DomainsRegex[0].String())
-
 	ruleMatcher3, ok := tester.rules[3].Domains[0].Matcher.(RegexpGroupStringSubjectMatcher)
 	s.Require().True(ok)
 	s.Assert().Equal("^group-(?P<Group>[a-zA-Z0-9]+)\\.regex.com$", ruleMatcher3.String())
 
 	s.Require().Len(tester.rules[4].Domains, 1)
-
-	s.Assert().Equal("^.*\\.(one|two).com$", tester.config.AccessControl.Rules[4].DomainsRegex[0].String())
 
 	ruleMatcher4, ok := tester.rules[4].Domains[0].Matcher.(RegexpStringSubjectMatcher)
 	s.Require().True(ok)


### PR DESCRIPTION
This fixes an issue where the MFA enabled state is not correctly detected if the only 'two_factor' policy configured was a custom OpenID Connect 1.0 policy. This ends up being a bad UX as admins have to configure a dummy 'two_factor' policy instead of it being automatically detected.

Fixes #7103.