### PR TITLE
fix(web): adjust router basename behaviour

### DIFF
--- a/internal/logging/const.go
+++ b/internal/logging/const.go
@@ -46,6 +46,7 @@ const (
 	FieldRemoteIP   = "remote_ip"
 	FieldMethod     = "method"
 	FieldPath       = "path"
+	FieldPathRaw    = "path_raw"
 	FieldStatusCode = "status_code"
 )
 

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -23,12 +23,18 @@ import (
 )
 
 // NewRequestLogger create a new request logger for the given request.
-func NewRequestLogger(ctx *fasthttp.RequestCtx) *logrus.Entry {
-	return logging.Logger().WithFields(logrus.Fields{
+func NewRequestLogger(ctx *fasthttp.RequestCtx) (entry *logrus.Entry) {
+	fields := logrus.Fields{
 		logging.FieldMethod:   string(ctx.Method()),
-		logging.FieldPath:     string(ctx.Path()),
 		logging.FieldRemoteIP: RequestCtxRemoteIP(ctx).String(),
-	})
+		logging.FieldPath:     string(ctx.Path()),
+	}
+
+	if uri, ok := ctx.UserValue(UserValueKeyRawURI).(string); ok {
+		fields[logging.FieldPathRaw] = uri
+	}
+
+	return logging.Logger().WithFields(fields)
 }
 
 // NewAutheliaCtx instantiate an AutheliaCtx out of a RequestCtx.

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -87,6 +87,7 @@ const (
 const (
 	UserValueKeyBaseURL int8 = iota
 	UserValueKeyOpenIDConnectResponseModeFormPost
+	UserValueKeyRawURI
 )
 
 const (

--- a/internal/middlewares/strip_path.go
+++ b/internal/middlewares/strip_path.go
@@ -10,12 +10,13 @@ import (
 func StripPath(path string) (middleware Middleware) {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
-			uri := ctx.RequestURI()
+			uri := string(ctx.RequestURI())
 
-			if strings.HasPrefix(string(uri), path) {
+			if strings.HasPrefix(uri, path) {
 				ctx.SetUserValue(UserValueKeyBaseURL, path)
+				ctx.SetUserValue(UserValueKeyRawURI, uri)
 
-				newURI := strings.TrimPrefix(string(uri), path)
+				newURI := strings.TrimPrefix(uri, path)
 				ctx.Request.SetRequestURI(newURI)
 			}
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -433,6 +433,7 @@ func handleRouter(config *schema.Configuration, providers middlewares.Providers)
 		r.POST("/api/oidc/revoke", middlewares.Wrap(middlewares.NewMetricsRequestOpenIDConnect(providers.Metrics, oidc.EndpointRevocation), policyCORSRevocation.Middleware(bridgeOIDC(middlewares.NewHTTPToAutheliaHandlerAdaptor(handlers.OAuthRevocationPOST)))))
 	}
 
+	r.RedirectFixedPath = false
 	r.HandleMethodNotAllowed = true
 	r.MethodNotAllowed = handleMethodNotAllowed
 	r.NotFound = handleNotFound(bridge(serveIndexHandler))

--- a/internal/suites/example/compose/authelia/docker-compose.backend.dev.yml
+++ b/internal/suites/example/compose/authelia/docker-compose.backend.dev.yml
@@ -15,7 +15,7 @@ services:
     cap_add:
       - SYS_PTRACE
     volumes:
-      - './example/compose/authelia/resources/:/resources'
+      - './example/compose/authelia/resources:/resources'
       - '../..:/app'
       - '${GOPATH}:/go'
     labels:

--- a/internal/suites/example/compose/authelia/resources/entrypoint-backend.sh
+++ b/internal/suites/example/compose/authelia/resources/entrypoint-backend.sh
@@ -11,8 +11,4 @@ go install github.com/go-delve/delve/cmd/dlv@latest
 
 cd /app
 
-# Sleep 10 seconds to wait the end of npm install updating web directory
-# and making reflex reload multiple times.
-sleep 10
-
 reflex -c /resources/reflex.conf

--- a/internal/suites/example/compose/authelia/resources/reflex.conf
+++ b/internal/suites/example/compose/authelia/resources/reflex.conf
@@ -1,1 +1,1 @@
--R '^web/' -R 'users.yml' -r '(\.go$|go\.mod|\.sh|\.yml)' -s /resources/run-backend-dev.sh
+-R '(^web/|users\.yml$)' -r '(\.go$|go\.mod|\.sh|\.yml)' -s '/resources/run-backend-dev.sh'

--- a/internal/suites/example/compose/authelia/resources/run-backend-dev.sh
+++ b/internal/suites/example/compose/authelia/resources/run-backend-dev.sh
@@ -5,5 +5,5 @@ set -e
 while true;
 do
     AUTHELIA_SERVER_DISABLE_HEALTHCHECK=true CGO_ENABLED=1 dlv --listen 0.0.0.0:2345 --headless=true --output=./authelia --continue --accept-multiclient debug cmd/authelia/*.go
-    sleep 10
+    sleep 3
 done

--- a/internal/suites/scenario_reset_password_test.go
+++ b/internal/suites/scenario_reset_password_test.go
@@ -51,7 +51,7 @@ func (s *ResetPasswordScenario) TestShouldResetPassword() {
 		s.collectScreenshot(ctx.Err(), s.Page)
 	}()
 
-	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURLWithFallbackPrefix(BaseDomain, "/"))
+	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
 	// Reset the password to abc.
@@ -78,7 +78,7 @@ func (s *ResetPasswordScenario) TestShouldMakeAttackerThinkPasswordResetIsInitia
 		s.collectScreenshot(ctx.Err(), s.Page)
 	}()
 
-	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURLWithFallbackPrefix(BaseDomain, "/"))
+	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
 	// Try to initiate a password reset of an nonexistent user.
@@ -95,7 +95,7 @@ func (s *ResetPasswordScenario) TestShouldLetUserNoticeThereIsAPasswordMismatch(
 		s.collectScreenshot(ctx.Err(), s.Page)
 	}()
 
-	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURLWithFallbackPrefix(BaseDomain, "/"))
+	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
 	s.doInitiatePasswordReset(s.T(), s.Context(ctx), "john")

--- a/internal/suites/suite_pathprefix_test.go
+++ b/internal/suites/suite_pathprefix_test.go
@@ -1,7 +1,9 @@
 package suites
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -34,6 +36,50 @@ func (s *PathPrefixSuite) TestCustomHeaders() {
 
 func (s *PathPrefixSuite) TestResetPasswordScenario() {
 	suite.Run(s.T(), NewResetPasswordScenario())
+}
+
+func (s *PathPrefixSuite) TestShouldRenderFrontendWithTrailingSlash() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer func() {
+		cancel()
+		s.collectCoverage(s.Page)
+		s.collectScreenshot(ctx.Err(), s.Page)
+		s.MustClose()
+		err := s.RodSession.Stop()
+		s.Require().NoError(err)
+	}()
+
+	browser, err := NewRodSession(RodSessionWithCredentials(s))
+	s.Require().NoError(err)
+	s.RodSession = browser
+
+	s.Page = s.doCreateTab(s.T(), HomeBaseURL)
+	s.verifyIsHome(s.T(), s.Page)
+
+	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain)+"/")
+	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
+}
+
+func (s *PathPrefixSuite) TestShouldRenderFrontendWithoutTrailingSlash() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer func() {
+		cancel()
+		s.collectCoverage(s.Page)
+		s.collectScreenshot(ctx.Err(), s.Page)
+		s.MustClose()
+		err := s.RodSession.Stop()
+		s.Require().NoError(err)
+	}()
+
+	browser, err := NewRodSession(RodSessionWithCredentials(s))
+	s.Require().NoError(err)
+	s.RodSession = browser
+
+	s.Page = s.doCreateTab(s.T(), HomeBaseURL)
+	s.verifyIsHome(s.T(), s.Page)
+
+	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
+	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 }
 
 func (s *PathPrefixSuite) SetupSuite() {

--- a/internal/suites/suite_pathprefix_test.go
+++ b/internal/suites/suite_pathprefix_test.go
@@ -39,7 +39,7 @@ func (s *PathPrefixSuite) TestResetPasswordScenario() {
 }
 
 func (s *PathPrefixSuite) TestShouldRenderFrontendWithTrailingSlash() {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer func() {
 		cancel()
 		s.collectCoverage(s.Page)
@@ -61,7 +61,7 @@ func (s *PathPrefixSuite) TestShouldRenderFrontendWithTrailingSlash() {
 }
 
 func (s *PathPrefixSuite) TestShouldRenderFrontendWithoutTrailingSlash() {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer func() {
 		cancel()
 		s.collectCoverage(s.Page)

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -76,8 +76,6 @@ func GetLoginBaseURLWithFallbackPrefix(baseDomain, fallback string) string {
 
 	if prefix == "" {
 		prefix = fallback
-	} else {
-		prefix += "/"
 	}
 
 	return LoginBaseURLFmt(baseDomain) + prefix

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -58,7 +58,7 @@ const App: React.FC<Props> = (props: Props) => {
                     <CssBaseline />
                     <NotificationsContext.Provider value={{ notification, setNotification }}>
                         <LocalStorageMethodContextProvider>
-                            <Router basename={getBasePath() + "/"}>
+                            <Router basename={getBasePath()}>
                                 <NotificationBar onClose={() => setNotification(null)} />
                                 <Routes>
                                     <Route path={ResetPasswordStep1Route} element={<ResetPasswordStep1 />} />


### PR DESCRIPTION
This change adjusts the behaviour if Authelia is run with a sub-path and is visited without a trailing slash on the specified sub-path.
In 4.37.5 the base path would get normalized without a trailing slash, however, would cause issues when a refresh was completed while carrying a redirection query string.
In 4.38.x this was changed so the sub-path would not be normalized without the trailing slash and that it was therefore necessary. This change in behaviour would be observed as a regression by users with learned behaviours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced URL handling in the application to improve user navigation and system logging.
  - Improved the Docker Compose setup for backend development, including refined volume mapping and reduced script sleep times.

- **Bug Fixes**
  - Corrected method handling for requests that are not allowed, ensuring proper redirection and error handling.

- **Refactor**
  - Optimized the authentication middleware and URL processing logic to streamline user interactions and system performance.

- **Chores**
  - Removed unnecessary delays in development scripts to speed up the backend development process.

- **Tests**
  - Added new tests to verify correct rendering of the frontend with and without trailing slashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->