### PR TITLE
test(suites): rename 2fa and totp scenario suites

### DIFF
--- a/internal/suites/scenario_two_factor_totp_test.go
+++ b/internal/suites/scenario_two_factor_totp_test.go
@@ -16,7 +16,7 @@ type TwoFactorTOTPSuite struct {
 	*RodSuite
 }
 
-func NewTwoFactorTOTPScenario() *TwoFactorTOTPSuite {
+func New2FATOTPScenario() *TwoFactorTOTPSuite {
 	return &TwoFactorTOTPSuite{
 		RodSuite: NewRodSuite(""),
 	}
@@ -137,5 +137,5 @@ func TestRunTwoFactorTOTP(t *testing.T) {
 		t.Skip("skipping suite test in short mode")
 	}
 
-	suite.Run(t, NewTwoFactorTOTPScenario())
+	suite.Run(t, New2FATOTPScenario())
 }

--- a/internal/suites/suite_activedirectory_test.go
+++ b/internal/suites/suite_activedirectory_test.go
@@ -20,8 +20,8 @@ func (s *ActiveDirectorySuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *ActiveDirectorySuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *ActiveDirectorySuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *ActiveDirectorySuite) TestResetPassword() {

--- a/internal/suites/suite_caddy_test.go
+++ b/internal/suites/suite_caddy_test.go
@@ -20,8 +20,8 @@ func (s *CaddySuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *CaddySuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *CaddySuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *CaddySuite) TestCustomHeaders() {

--- a/internal/suites/suite_docker_test.go
+++ b/internal/suites/suite_docker_test.go
@@ -20,8 +20,8 @@ func (s *DockerSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *DockerSuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *DockerSuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func TestDockerSuite(t *testing.T) {

--- a/internal/suites/suite_envoy_test.go
+++ b/internal/suites/suite_envoy_test.go
@@ -20,8 +20,8 @@ func (s *EnvoySuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *EnvoySuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *EnvoySuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *EnvoySuite) TestCustomHeaders() {

--- a/internal/suites/suite_haproxy_test.go
+++ b/internal/suites/suite_haproxy_test.go
@@ -20,8 +20,8 @@ func (s *HAProxySuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *HAProxySuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *HAProxySuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *HAProxySuite) TestCustomHeaders() {

--- a/internal/suites/suite_high_availability_test.go
+++ b/internal/suites/suite_high_availability_test.go
@@ -302,8 +302,8 @@ func (s *HighAvailabilitySuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *HighAvailabilitySuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *HighAvailabilitySuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *HighAvailabilitySuite) TestRegulationScenario() {

--- a/internal/suites/suite_kubernetes_test.go
+++ b/internal/suites/suite_kubernetes_test.go
@@ -20,8 +20,8 @@ func (s *KubernetesSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *KubernetesSuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *KubernetesSuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *KubernetesSuite) TestRedirectionURLScenario() {

--- a/internal/suites/suite_ldap_test.go
+++ b/internal/suites/suite_ldap_test.go
@@ -20,8 +20,8 @@ func (s *LDAPSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *LDAPSuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *LDAPSuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *LDAPSuite) TestResetPassword() {

--- a/internal/suites/suite_mariadb_test.go
+++ b/internal/suites/suite_mariadb_test.go
@@ -20,8 +20,8 @@ func (s *MariaDBSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *MariaDBSuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *MariaDBSuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func TestMariaDBSuite(t *testing.T) {

--- a/internal/suites/suite_mysql_test.go
+++ b/internal/suites/suite_mysql_test.go
@@ -20,8 +20,8 @@ func (s *MySQLSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *MySQLSuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *MySQLSuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func TestMySQLSuite(t *testing.T) {

--- a/internal/suites/suite_pathprefix_test.go
+++ b/internal/suites/suite_pathprefix_test.go
@@ -24,8 +24,8 @@ func (s *PathPrefixSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *PathPrefixSuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *PathPrefixSuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *PathPrefixSuite) TestCustomHeaders() {

--- a/internal/suites/suite_postgres_test.go
+++ b/internal/suites/suite_postgres_test.go
@@ -20,8 +20,8 @@ func (s *PostgresSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *PostgresSuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *PostgresSuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func TestPostgresSuite(t *testing.T) {

--- a/internal/suites/suite_standalone_test.go
+++ b/internal/suites/suite_standalone_test.go
@@ -330,12 +330,8 @@ func (s *StandaloneSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *StandaloneSuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
-}
-
-func (s *StandaloneSuite) TestTwoFactorWebAuthnScenario() {
-	suite.Run(s.T(), NewTwoFactorWebAuthnScenario())
+func (s *StandaloneSuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *StandaloneSuite) TestBypassPolicyScenario() {

--- a/internal/suites/suite_traefik2_test.go
+++ b/internal/suites/suite_traefik2_test.go
@@ -23,8 +23,8 @@ func (s *Traefik2Suite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *Traefik2Suite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *Traefik2Suite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *Traefik2Suite) TestCustomHeaders() {

--- a/internal/suites/suite_traefik_test.go
+++ b/internal/suites/suite_traefik_test.go
@@ -20,8 +20,8 @@ func (s *TraefikSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
 
-func (s *TraefikSuite) TestTwoFactorTOTPScenario() {
-	suite.Run(s.T(), NewTwoFactorTOTPScenario())
+func (s *TraefikSuite) Test2FATOTPScenario() {
+	suite.Run(s.T(), New2FATOTPScenario())
 }
 
 func (s *TraefikSuite) TestRedirectionURLScenario() {

--- a/internal/suites/suite_two_factor.go
+++ b/internal/suites/suite_two_factor.go
@@ -34,6 +34,10 @@ func init() {
 		return updateDevEnvFileForDomain(BaseDomain, true)
 	}
 
+	displayAutheliaLogs := func() error {
+		return dockerEnvironment.PrintLogs("authelia-backend", "authelia-frontend")
+	}
+
 	teardown := func(suitePath string) error {
 		err := dockerEnvironment.Down()
 		_ = os.Remove("/tmp/db.sqlite3")
@@ -44,10 +48,10 @@ func init() {
 	GlobalRegistry.Register(twoFactorSuiteName, Suite{
 		SetUp:           setup,
 		SetUpTimeout:    5 * time.Minute,
-		OnError:         nil,
-		OnSetupTimeout:  nil,
+		OnError:         displayAutheliaLogs,
+		OnSetupTimeout:  displayAutheliaLogs,
 		TearDown:        teardown,
-		TestTimeout:     6 * time.Minute,
+		TestTimeout:     4 * time.Minute,
 		TearDownTimeout: 2 * time.Minute,
 		Description: `This suite is used to test Authelia in a two factor
 configuration with in-memory sessions and a local sqlite db stored on disk`,

--- a/internal/suites/suite_two_factor_test.go
+++ b/internal/suites/suite_two_factor_test.go
@@ -18,11 +18,11 @@ func NewTwoFactorSuite() *TwoFactorSuite {
 	}
 }
 
-func (s *TwoFactorSuite) TestTwoFactorOneTimePasswordScenario() {
+func (s *TwoFactorSuite) TestTwoFactorOneTimePasswordRegistrationScenario() {
 	suite.Run(s.T(), NewTwoFactorOneTimePasswordScenario())
 }
 
-func (s *TwoFactorSuite) TestTwoFactorWebAuthnScenario() {
+func (s *TwoFactorSuite) TestTwoFactorWebAuthnRegistrationScenario() {
 	suite.Run(s.T(), NewTwoFactorWebAuthnScenario())
 }
 


### PR DESCRIPTION
Align test name for readability and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Standardized naming of test functions across various suites to improve consistency and clarity.
- **Tests**
	- Updated test suite configurations to enhance error handling and reduce setup timeouts, improving reliability and performance in testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->