### PR TITLE
docs(oidc): add several integrations

### DIFF
--- a/docs/content/integration/openid-connect/grafana/index.md
+++ b/docs/content/integration/openid-connect/grafana/index.md
@@ -53,6 +53,8 @@ identity_providers:
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://grafana.example.com/login/generic_oauth'
         scopes:
@@ -61,6 +63,7 @@ identity_providers:
           - 'groups'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/hedge-doc/index.md
+++ b/docs/content/integration/openid-connect/hedge-doc/index.md
@@ -1,0 +1,102 @@
+---
+title: "HedgeDoc"
+description: "Integrating HedgeDoc with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2023-03-21T11:21:23+11:00
+draft: false
+images: []
+weight: 620
+toc: true
+community: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+* [Authelia]
+  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+* [HedgeDoc]
+  * [v1.9.9](https://github.com/hedgedoc/hedgedoc/releases/tag/1.9.9)
+
+## Before You Begin
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://hedgedoc.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+* __Client ID:__ `hedgedoc`
+* __Client Secret:__ `insecure_secret`
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [HedgeDoc] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'hedgedoc'
+        client_name: 'HedgeDoc'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        redirect_uris:
+          - 'https://hedgedoc.example.com/auth/oauth2/callback'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+          - 'groups'
+        userinfo_signed_response_alg: 'none'
+```
+
+### Application
+
+_**Important Note:** This configuration assumes [HedgeDoc] users are part of the `hedgedoc-users` group. Depending on
+your specific group configuration, you will have to adapt the `CMD_OAUTH2_ACCESS_ROLE` variable. Alternatively you may
+elect to create a new authorization policy in [provider authorization policies] then utilize that policy as the
+[client authorization policy]._
+
+[client authorization policy]: ../../../configuration/identity-providers/openid-connect/clients.md#authorization_policy
+[provider authorization policies]: ../../../configuration/identity-providers/openid-connect/provider.md#authorization_policies
+
+To configure [HedgeDoc] to utilize Authelia as an [OpenID Connect 1.0] Provider:
+
+1. Add the following configuration variables:
+
+```env
+CMD_OAUTH2_PROVIDERNAME=Authelia
+CMD_OAUTH2_AUTHORIZATION_URL=https://auth.example.com/api/oidc/authorization
+CMD_OAUTH2_TOKEN_URL=https://auth.example.com/api/oidc/token
+CMD_OAUTH2_USER_PROFILE_URL=https://auth.example.com/api/oidc/userinfo
+CMD_OAUTH2_CLIENT_ID=hedgedoc
+CMD_OAUTH2_CLIENT_SECRET=insecure_secret
+CMD_OAUTH2_SCOPE=openid email profile groups
+CMD_OAUTH2_USER_PROFILE_USERNAME_ATTR=preferred_username
+CMD_OAUTH2_USER_PROFILE_DISPLAY_NAME_ATTR=name
+CMD_OAUTH2_USER_PROFILE_EMAIL_ATTR=email
+CMD_OAUTH2_ROLES_CLAIM=groups
+CMD_OAUTH2_ACCESS_ROLE=hedgedoc
+```
+
+## See Also
+
+- [HedgeDoc OAuth2 Login Documentation](https://docs.hedgedoc.org/configuration/#oauth2-login)
+
+[HedgeDoc]: https://hedgedoc.org/
+[Authelia]: https://www.authelia.com
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/jellyfin/index.md
+++ b/docs/content/integration/openid-connect/jellyfin/index.md
@@ -67,7 +67,11 @@ identity_providers:
 
 _**Important Note:** This configuration assumes [Jellyfin] administrators are part of the `admins` group, and [Jellyfin]
 users are part of the `users` group. Depending on your specific group configuration, you will have to adapt the
-`AdminRoles` and `Roles` nodes respectively._
+`AdminRoles` and `Roles` nodes respectively. Alternatively you may elect to create a new authorization policy in
+[provider authorization policies] then utilize that policy as the [client authorization policy]._
+
+[client authorization policy]: ../../../configuration/identity-providers/openid-connect/clients.md#authorization_policy
+[provider authorization policies]: ../../../configuration/identity-providers/openid-connect/provider.md#authorization_policies
 
 To configure [Jellyfin] to utilize Authelia as an [OpenID Connect 1.0] Provider:
 

--- a/docs/content/integration/openid-connect/jenkins/index.md
+++ b/docs/content/integration/openid-connect/jenkins/index.md
@@ -1,0 +1,155 @@
+---
+title: "Jenkins"
+description: "Integrating Jenkins with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2023-03-21T11:21:23+11:00
+draft: false
+images: []
+weight: 620
+toc: true
+community: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+* [Authelia]
+  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+* [Jenkins]
+  * [v2.453](https://www.jenkins.io/changelog/2.453/)
+
+## Before You Begin
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://jenkins.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+* __Client ID:__ `jenkins`
+* __Client Secret:__ `insecure_secret`
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Jenkins] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'jenkins'
+        client_name: 'Jenkins'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
+        redirect_uris:
+          - 'https://jenkins.example.com/accounts/authelia/login/callback'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+          - 'groups'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+#### Installation
+
+The plugin required to use [OpenID Connect 1.0] can either be installed and configured via the GUI or via [Jenkins]
+Configuration as Code.
+
+##### Via the UI
+
+To install the [Jenkins] plugin for [OpenID Connect 1.0] via the UI:
+
+1. Visit `Manage Jenkins`.
+
+2. Visit `Plugins`.
+
+3. Visit `Available Plugins`.
+
+4. Search for `oic-auth`.
+
+5. Install.
+
+6. Restart [Jenkins].
+
+7. Proceed to the [Configuration](#configuration-1) step.
+
+##### Via Jenkins Configuration as Code
+
+Ensure the plugin is installed before running the Jenkins Configuration as Code:
+
+```bash
+jenkins-plugin-cli --plugins oic-auth
+```
+
+Add this to your Jenkins Configuration as Code:
+
+```yaml
+jenkins:
+  systemMessage: "This Jenkins instance was configured using the Authelia example Configuration as Code, thanks Authelia!"
+  securityRealm:
+    oic:
+      automanualconfigure: auto
+      wellKnownOpenIDConfigurationUrl: https://auth.example.com/.well-known/openid-configuration
+      clientId: jenkins
+      clientSecret: insecure_secret
+      tokenAuthMethod: client_secret_basic
+      scopes: openid profile email groups
+      userNameField: preferred_username
+      groupsFieldName: groups
+      fullNameFieldName: name
+      emailFieldName: email
+      pkceEnabled: true
+      # escapeHatchEnabled: <boolean>
+      # escapeHatchUsername: escapeHatchUsername
+      # escapeHatchSecret: <string:secret>
+      # escapeHatchGroup: <string>
+```
+
+#### Configuration
+
+To configure [Jenkins] to utilize Authelia as an [OpenID Connect 1.0] Provider:
+
+1. Visit `Manage Jenkins`.
+2. Visit `Security`.
+3. Select `Login with Openid Connect` in the Security Realm.
+4. Enter `jenkins` in the `Client id` field.
+5. Enter `insecure_secret` in the `Client secret` field.
+6. Select `Automatic configuration` from the configuration mode.
+7. Enter `https://auth.example.com/.well-known/openid-configuration` in the `Well-known configuration endpoint` field.
+8. Select `Override scopes`.
+9. Enter `openid profile email groups` in the `Scopes` field.
+10. Expand `Advanced`.
+11. Enter `preferred_username` into the `User name field name` field.
+12. Enter `name` into the `Full name field name` field.
+13. Enter `email` into the `Email field name` field.
+14. Enter `groups` into the `Groups field name` field.
+15. Select `Enable Proof Key for Code Exchange`.
+16. Consider using the `Configure 'escape hatch' for when the OpenID Provider is unavailable` to prevent login issues.
+
+## See Also
+
+- [Jenkins OpenID Connect Documentation](https://plugins.jenkins.io/oic-auth/)
+- [Jenkins OpenID JCasC Documentation](https://github.com/jenkinsci/oic-auth-plugin/blob/master/docs/configuration/README.md)
+
+[Jenkins]: https://www.jenkins.io/
+[Authelia]: https://www.authelia.com
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/mastodon/index.md
+++ b/docs/content/integration/openid-connect/mastodon/index.md
@@ -1,0 +1,91 @@
+---
+title: "Mastodon"
+description: "Integrating Mastodon with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2023-03-21T11:21:23+11:00
+draft: false
+images: []
+weight: 620
+toc: true
+community: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+* [Authelia]
+  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+* [Mastodon]
+  * [v4.2.8](https://github.com/mastodon/mastodon/releases/tag/v4.2.8)
+
+## Before You Begin
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://mastodon.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+* __Client ID:__ `mastodon`
+* __Client Secret:__ `insecure_secret`
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Mastodon] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'mastodon'
+        client_name: 'Mastodon'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        redirect_uris:
+          - 'https://mastodon.example.com/auth/auth/openid_connect/callback'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+        userinfo_signed_response_alg: 'none'
+```
+
+### Application
+
+To configure [Mastodon] to utilize Authelia as an [OpenID Connect 1.0] Provider:
+
+1. Add the following configuration variables:
+
+```env
+OIDC_ENABLED=true
+OIDC_DISPLAY_NAME=Authelia
+OIDC_DISCOVERY=true
+OIDC_ISSUER=https://auth.example.com
+OIDC_SCOPE=openid,profile,email
+OIDC_UID_FIELD=preferred_username
+OIDC_CLIENT_ID=mastodon
+OIDC_CLIENT_SECRET=insecure_secret
+OIDC_REDIRECT_URI=https://mastodon.example.com/auth/auth/openid_connect/callback
+OIDC_SECURITY_ASSUME_EMAIL_IS_VERIFIED=true
+```
+
+## See Also
+
+- [OmniAuth OpenID Connect 1.0 Docs](https://github.com/omniauth/omniauth_openid_connect)
+
+[Mastodon]: https://joinmastodon.org/
+[Authelia]: https://www.authelia.com
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/nextcloud/index.md
@@ -71,6 +71,8 @@ identity_providers:
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://nextcloud.example.com/apps/oidc_login/oidc'
         scopes:
@@ -80,8 +82,6 @@ identity_providers:
           - 'groups'
         userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'client_secret_basic'
-        require_pkce: true
-        pkce_challenge_method: 'S256'
 ```
 
 #### Application

--- a/docs/content/integration/openid-connect/oauth-2.0-bearer-token-usage.md
+++ b/docs/content/integration/openid-connect/oauth-2.0-bearer-token-usage.md
@@ -202,6 +202,8 @@ identity_providers:
     clients:
       - client_id: 'example-one'
         public: true
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'http://localhost/callback'
         scopes:
@@ -219,8 +221,6 @@ identity_providers:
           - 'form_post'
         consent_mode: 'explicit'
         require_pushed_authorization_requests: true
-        require_pkce: true
-        pkce_challenge_method: 'S256'
         token_endpoint_auth_method: 'none'
 ```
 
@@ -235,6 +235,8 @@ identity_providers:
       - client_id: 'example-two'
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'http://localhost/callback'
         scopes:
@@ -252,8 +254,6 @@ identity_providers:
           - 'form_post'
         consent_mode: 'explicit'
         require_pushed_authorization_requests: true
-        require_pkce: true
-        pkce_challenge_method: 'S256'
         token_endpoint_auth_method: 'client_secret_basic'
 ```
 

--- a/docs/content/integration/openid-connect/paperless/index.md
+++ b/docs/content/integration/openid-connect/paperless/index.md
@@ -1,0 +1,107 @@
+---
+title: "Paperless"
+description: "Integrating Paperless with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2023-03-21T11:21:23+11:00
+draft: false
+images: []
+weight: 620
+toc: true
+community: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+* [Authelia]
+  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+* [Paperless]
+  * [v2.7.2](https://github.com/paperless-ngx/paperless-ngx/releases/tag/v2.7.2)
+
+## Before You Begin
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://paperless.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+* __Client ID:__ `paperless`
+* __Client Secret:__ `insecure_secret`
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Paperless] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'paperless'
+        client_name: 'Paperless'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        redirect_uris:
+          - 'https://paperless.example.com/accounts/authelia/login/callback'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+          - 'groups'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+To configure [Paperless] to utilize Authelia as an [OpenID Connect 1.0] Provider:
+
+1. Set the following environment variables:
+
+```env
+PAPERLESS_APPS=allauth.socialaccount.providers.openid_connect
+PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect":{"SCOPE":["openid","profile","email"],"APPS":[{"provider_id":"authelia","name":"Authelia","client_id":"paperless","secret":"insecure_secret","settings":{"server_url":"https://auth.example.com","token_auth_method":"client_secret_basic"}}]}}
+```
+
+The `PAPERLESS_SOCIALACCOUNT_PROVIDERS` environment variable is the minified version of the following:
+
+```json
+{
+  "openid_connect": {
+    "SCOPE": ["openid", "profile", "email"],
+    "APPS": [
+      {
+        "provider_id": "authelia",
+        "name": "Authelia",
+        "client_id": "paperless",
+        "secret": "insecure_secret",
+        "settings": {
+          "server_url": "https://auth.example.com",
+          "token_auth_method": "client_secret_basic"
+        }
+      }
+    ]
+  }
+}
+```
+
+## See Also
+
+- [Paperless Advanced Usage OpenID Connect Documentation](https://docs.paperless-ngx.com/advanced_usage/#openid-connect-and-social-authentication)
+
+[Paperless]: https://docs.paperless-ngx.com/
+[Authelia]: https://www.authelia.com
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/pgadmin/index.md
+++ b/docs/content/integration/openid-connect/pgadmin/index.md
@@ -1,0 +1,99 @@
+---
+title: "pgAdmin"
+description: "Integrating pgAdmin with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2023-03-21T11:21:23+11:00
+draft: false
+images: []
+weight: 620
+toc: true
+community: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+* [Authelia]
+  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+* [pgAdmin]
+  * [v8.5](https://www.pgadmin.org/docs/pgadmin4/8.5/index.html)
+
+## Before You Begin
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://pgadmin.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+* __Client ID:__ `pgadmin`
+* __Client Secret:__ `insecure_secret`
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [pgAdmin] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'pgadmin'
+        client_name: 'pgAdmin'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        redirect_uris:
+          - 'https://pgadmin.example.com/oauth2/authorize'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+To configure [pgAdmin] to utilize Authelia as an [OpenID Connect 1.0] Provider:
+
+1. Add the following YAML to your configuration:
+
+```python {title="config_local.py"}
+AUTHENTICATION_SOURCES = ['oauth2', 'internal']
+OAUTH2_AUTO_CREATE_USER = True
+OAUTH2_CONFIG = [{
+	'OAUTH2_NAME': 'Authelia',
+	'OAUTH2_DISPLAY_NAME': 'Authelia',
+	'OAUTH2_CLIENT_ID': 'pgadmin',
+	'OAUTH2_CLIENT_SECRET': 'insecure_secret',
+	'OAUTH2_API_BASE_URL': 'https://auth.example.com',
+	'OAUTH2_AUTHORIZATION_URL': 'https://auth.example.com/api/oidc/authorization',
+	'OAUTH2_TOKEN_URL': 'https://auth.example.com/api/oidc/token',
+	'OAUTH2_USERINFO_ENDPOINT': 'https://auth.example.com/api/oidc/userinfo',
+	'OAUTH2_SERVER_METADATA_URL': 'https://auth.example.com/.well-known/openid-configuration',
+	'OAUTH2_SCOPE': 'openid email profile',
+	'OAUTH2_USERNAME_CLAIM': 'email',
+	'OAUTH2_ICON': 'fa-key',
+	'OAUTH2_BUTTON_COLOR': '<button-color>'
+}]
+```
+
+## See Also
+
+- [pgAdmin OAuth2 Documentation](https://www.pgadmin.org/docs/pgadmin4/8.4/oauth2.html)
+
+[pgAdmin]: https://www.pgadmin.org/
+[Authelia]: https://www.authelia.com
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/vikunja/index.md
+++ b/docs/content/integration/openid-connect/vikunja/index.md
@@ -1,0 +1,92 @@
+---
+title: "Vikunja"
+description: "Integrating Vikunja with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2023-03-21T11:21:23+11:00
+draft: false
+images: []
+weight: 620
+toc: true
+community: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+* [Authelia]
+  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+* [Vikunja]
+  * [v0.23.0](https://kolaente.dev/vikunja/vikunja/releases/tag/v0.23.0)
+
+## Before You Begin
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://vikunja.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+* __Client ID:__ `vikunja`
+* __Client Secret:__ `insecure_secret`
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Vikunja] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'vikunja'
+        client_name: 'Vikunja'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        redirect_uris:
+          - 'https://vikunja.example.com/auth/openid/authelia'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+To configure [Vikunja] to utilize Authelia as an [OpenID Connect 1.0] Provider:
+
+1. Add the following YAML to your configuration:
+
+```yaml {title="config.yml"}
+auth:
+  openid:
+    enabled: true
+    redirecturl: https://vikunja.example.com/auth/openid/
+    providers:
+      - name: Authelia
+        authurl: https://auth.example.com
+        clientid: vikunja
+        clientsecret: insecure_secret
+        scope: openid profile email
+```
+
+## See Also
+
+- [Vikunja OpenID Documentation](https://vikunja.io/docs/openid/)
+
+[Vikunja]: https://vikunja.io/
+[Authelia]: https://www.authelia.com
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/wekan/index.md
+++ b/docs/content/integration/openid-connect/wekan/index.md
@@ -1,0 +1,94 @@
+---
+title: "WeKan"
+description: "Integrating WeKan with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2023-03-21T11:21:23+11:00
+draft: false
+images: []
+weight: 620
+toc: true
+community: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+* [Authelia]
+  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+* [WeKan]
+  * [v7.42](https://github.com/wekan/wekan/releases/tag/v7.42)
+
+## Before You Begin
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://wekan.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+* __Client ID:__ `wekan`
+* __Client Secret:__ `insecure_secret`
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [WeKan] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'wekan'
+        client_name: 'WeKan'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        redirect_uris:
+          - 'https://wekan.example.com/_oauth/oidc'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+To configure [WeKan] to utilize Authelia as an [OpenID Connect 1.0] Provider:
+
+1. Add the following YAML to your configuration:
+
+```env
+OAUTH2_ENABLED=true
+OAUTH2_LOGIN_STYLE=redirect
+OAUTH2_CLIENT_ID=wekan
+OAUTH2_SECRET=insecure_secret
+OAUTH2_SERVER_URL=https://auth.example.com
+OAUTH2_AUTH_ENDPOINT=/api/oidc/authorization
+OAUTH2_TOKEN_ENDPOINT=/api/oidc/token
+OAUTH2_USERINFO_ENDPOINT=/api/oidc/userinfo
+OAUTH2_ID_MAP=sub
+OAUTH2_USERNAME_MAP=email
+OAUTH2_FULLNAME_MAP=name
+OAUTH2_EMAIL_MAP=email
+```
+
+## See Also
+
+- [WeKan OAuth2 Documentation](https://github.com/wekan/wekan/wiki/OAuth2)
+
+[WeKan]: https://github.com/wekan/wekan
+[Authelia]: https://www.authelia.com
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/wordpress/index.md
+++ b/docs/content/integration/openid-connect/wordpress/index.md
@@ -1,0 +1,93 @@
+---
+title: "WordPress"
+description: "Integrating WordPress with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2023-03-21T11:21:23+11:00
+draft: false
+images: []
+weight: 620
+toc: true
+community: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+* [Authelia]
+  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+* [Wordpress]
+  * [v6.5.2](https://core.svn.wordpress.org/tags/6.5.2/)
+
+## Before You Begin
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://wordpress.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+* __Client ID:__ `wordpress`
+* __Client Secret:__ `insecure_secret`
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [WordPress] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'wordpress'
+        client_name: 'WordPress'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
+        redirect_uris:
+          - 'https://wordpress.example.com/wp-admin/admin-ajax.php?action=openid-connect-authorize'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+          - 'groups'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+1. Install the Plugin:
+   1. Visit `Plugins`.
+   2. Visit `Add New`.
+   3. Install `OpenID Connect Generic Client` by `daggerhart`.
+2. Configure the Plugin:
+   1. Visit `Settings`.
+   2. Visit `OpenID Connect Client`.
+   3. Select the `OpenID Connect button on login form` option from `Login Type`.
+   4. Enter `wordpress` in the `Client ID` field.
+   5. Enter `insecure_secret` in the `Client Secret` field.
+   6. Enter `openid profile email` in the `OpenID Scope` field.
+   7. Enter `https://auth.example.com/api/oidc/authorization` in the `Login Endpoint URL` field.
+   8. Enter `https://auth.example.com/api/oidc/token` in the `Token Validation Endpoint URL` field.
+   9. Enter `https://auth.example.com/api/oidc/userinfo` in the `Userinfo Endpoint URL` field.
+
+## See Also
+
+- [WordPress OpenID Connect Generic Client Documentation](https://wordpress.org/plugins/daggerhart-openid-connect-generic/)
+
+[WordPress]: https://en-au.wordpress.org/
+[Authelia]: https://www.authelia.com
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/trusted-header-sso/paperless/index.md
+++ b/docs/content/integration/trusted-header-sso/paperless/index.md
@@ -1,0 +1,55 @@
+---
+title: "Paperless"
+description: "Trusted Header SSO Integration for Paperless"
+summary: ""
+date: 2022-06-15T17:51:47+10:00
+draft: false
+images: []
+weight: 420
+toc: true
+community: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Introduction
+
+This is a guide on integration of __Authelia__ and [Paperless] (specifically Paperless-ngx) via the trusted header SSO
+authentication.
+
+As with all guides in this section it's important you read the [introduction](../introduction.md) first.
+
+## Tested Versions
+
+* Authelia:
+  * v4.38.7
+* Paperless:
+  * v2.7.2
+
+## Before You Begin
+
+This example makes the following assumptions:
+
+* __Application Root URL:__ `https://paperless.example.com/`
+* __Authelia Root URL:__ `https://auth.example.com/`
+
+## Configuration
+
+To configure [Organizr] to trust the `Remote-User` header do the following:
+
+1. Configure the environment variables:
+
+```env
+PAPERLESS_ENABLE_HTTP_REMOTE_USER=true
+PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME=HTTP_REMOTE_USER
+PAPERLESS_LOGOUT_REDIRECT_URL=https://auth.example.com/logout
+```
+
+## See Also
+
+[Organizr] does not appear to have documentation around their `Auth Proxy` configuration.
+
+[Organizr]: https://organizr.app/


### PR DESCRIPTION
This adds several integrations for popular projects and products. All of these are based on examples from the project authors or miscellaneous users around the web.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced OpenID Connect integration instructions for Grafana, including new security parameters.
	- Added comprehensive integration guides for multiple platforms (HedgeDoc, Jellyfin, Jenkins, Mastodon, Nextcloud, Paperless, pgAdmin, Vikunja, Wekan) with Authelia OpenID Connect 1.0 Provider.
	- Updated OAuth 2.0 documentation to refine PKCE settings across different clients.
	- Introduced a guide for Trusted Header SSO authentication with Paperless.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->