### PR TITLE
docs: make nginx location exact

### DIFF
--- a/docs/content/integration/proxies/nginx.md
+++ b/docs/content/integration/proxies/nginx.md
@@ -232,7 +232,7 @@ server {
         proxy_pass $upstream;
     }
 
-    location /api/verify {
+    location = /api/verify {
         proxy_pass $upstream;
     }
 


### PR DESCRIPTION
This makes the location /api/verify an exact location. This has no major effects but is a best practice.