### PR TITLE
Update authelia_config_template.md

### DIFF
--- a/docs/content/reference/cli/authelia/authelia_config_template.md
+++ b/docs/content/reference/cli/authelia/authelia_config_template.md
@@ -33,8 +33,8 @@ authelia config template [flags]
 ### Examples
 
 ```
-authelia config template --fitlers.experimental.template
-authelia config template --fitlers.experimental.expand-env --config config.yml
+authelia config template --filters.experimental.template
+authelia config template --filters.experimental.expand-env --config config.yml
 ```
 
 ### Options


### PR DESCRIPTION
`fitlers` should be `filters`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typo in the command line options documentation for `authelia config template`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->