### PR TITLE
docs: require pkce for supported clients

### DIFF
--- a/docs/content/integration/openid-connect/jellyfin/index.md
+++ b/docs/content/integration/openid-connect/jellyfin/index.md
@@ -53,6 +53,8 @@ identity_providers:
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://jellyfin.example.com/sso/OID/redirect/authelia'
         scopes:

--- a/docs/content/integration/openid-connect/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/nextcloud/index.md
@@ -149,6 +149,8 @@ identity_providers:
         client_secret: 'insecure_secret'
         public: false
         authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://nextcloud.example.com/apps/user_oidc/code'
         scopes:
@@ -172,6 +174,13 @@ To configure [Nextcloud] to utilize Authelia as an [OpenID Connect 1.0] Provider
 * Client secret : insecure_secret
 * Discovery endpoint : https://auth.example.com/.well-known/openid-configuration
 * Scope : openid email profile
+
+3. Add the following to the [Nextcloud] `config.php` configuration:
+``` php
+'user_oidc' => [
+    'use_pkce' => true,
+],
+```
 
 ## See Also
 

--- a/docs/content/integration/openid-connect/paperless/index.md
+++ b/docs/content/integration/openid-connect/paperless/index.md
@@ -53,6 +53,8 @@ identity_providers:
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://paperless.example.com/accounts/authelia/login/callback'
         scopes:
@@ -72,7 +74,7 @@ To configure [Paperless] to utilize Authelia as an [OpenID Connect 1.0] Provider
 
 ```env
 PAPERLESS_APPS=allauth.socialaccount.providers.openid_connect
-PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect":{"SCOPE":["openid","profile","email"],"APPS":[{"provider_id":"authelia","name":"Authelia","client_id":"paperless","secret":"insecure_secret","settings":{"server_url":"https://auth.example.com","token_auth_method":"client_secret_basic"}}]}}
+PAPERLESS_SOCIALACCOUNT_PROVIDERS={"openid_connect":{"SCOPE":["openid","profile","email"],"OAUTH_PKCE_ENABLED":true,"APPS":[{"provider_id":"authelia","name":"Authelia","client_id":"paperless","secret":"insecure_secret","settings":{"server_url":"https://auth.example.com","token_auth_method":"client_secret_basic"}}]}}
 ```
 
 The `PAPERLESS_SOCIALACCOUNT_PROVIDERS` environment variable is the minified version of the following:
@@ -81,6 +83,7 @@ The `PAPERLESS_SOCIALACCOUNT_PROVIDERS` environment variable is the minified ver
 {
   "openid_connect": {
     "SCOPE": ["openid", "profile", "email"],
+    "OAUTH_PKCE_ENABLED": true,
     "APPS": [
       {
         "provider_id": "authelia",

--- a/docs/content/integration/openid-connect/proxmox/index.md
+++ b/docs/content/integration/openid-connect/proxmox/index.md
@@ -61,6 +61,8 @@ identity_providers:
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://proxmox.example.com'
         scopes:

--- a/docs/content/integration/trusted-header-sso/paperless/index.md
+++ b/docs/content/integration/trusted-header-sso/paperless/index.md
@@ -38,7 +38,7 @@ This example makes the following assumptions:
 
 ## Configuration
 
-To configure [Organizr] to trust the `Remote-User` header do the following:
+To configure [Paperless] to trust the `Remote-User` header do the following:
 
 1. Configure the environment variables:
 
@@ -50,6 +50,6 @@ PAPERLESS_LOGOUT_REDIRECT_URL=https://auth.example.com/logout
 
 ## See Also
 
-[Organizr] does not appear to have documentation around their `Auth Proxy` configuration.
+- [Paperless Advanced Usage Remote User Authentication Documentation](https://docs.paperless-ngx.com/advanced_usage/#remote-user-authentication)
 
-[Organizr]: https://organizr.app/
+[Paperless]: https://docs.paperless-ngx.com/


### PR DESCRIPTION
This adds the PKCE requirement for paperless, proxmox, jellyfin and the nextcloud user_oidc plugin in the example configurations.
I use all of these apps personally and verified them to be working with PKCE required.
This also fixes a small copy and paste error in the paperless trusted header sso example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced security documentation for multiple integrations (Jellyfin, Nextcloud, Paperless, Proxmox) by adding support for Proof Key for Code Exchange (PKCE). This improvement ensures a more secure authorization flow.
	- Updated Single Sign-On (SSO) documentation for Paperless, refining header trust configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->