### PR TITLE
Update smtp.md

### DIFF
--- a/docs/content/configuration/notifications/smtp.md
+++ b/docs/content/configuration/notifications/smtp.md
@@ -115,8 +115,8 @@ characters and the user password is changed to this value.
 The sender is used to construct both the SMTP command `MAIL FROM` and to add the `FROM` header. This address must be
 in [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4) format. This means it must one of two formats:
 
-* jsmith@domain.com
-* John Smith <jsmith@domain.com>
+* `jsmith@domain.com`
+* `John Smith <jsmith@domain.com>`
 
 The `MAIL FROM` command sent to SMTP servers will not include the name portion, this is only set in the `FROM` as per
 specifications.


### PR DESCRIPTION
Unquoted <> (&lt; &gt;) disappeared in documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the formatting of email addresses in the SMTP configuration section for enhanced clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->