### PR TITLE
Update const.go

### DIFF
--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -416,8 +416,8 @@ This subcommand allows debugging the filtered YAML files with any of the availab
 command needs to be executed with the same environment variables and working path as when normally running Authelia to
 be useful.`
 
-	cmdAutheliaConfigTemplateExample = `authelia config template --fitlers.experimental.template
-authelia config template --fitlers.experimental.expand-env --config config.yml`
+	cmdAutheliaConfigTemplateExample = `authelia config template --filters.experimental.template
+authelia config template --filters.experimental.expand-env --config config.yml`
 
 	cmdAutheliaConfigValidateShort = "Check a configuration against the internal configuration validation mechanisms"
 


### PR DESCRIPTION
`fitlers` should be `filters`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the command examples for Authelia configuration templates to improve clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->