### PR TITLE
chore: fix function names in comment

### DIFF
--- a/internal/commands/storage.go
+++ b/internal/commands/storage.go
@@ -470,7 +470,7 @@ func newStorageSchemaInfoCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 	return cmd
 }
 
-// NewMigrationCmd returns a new Migration Cmd.
+// newStorageMigrateCmd returns a new Migration Cmd.
 func newStorageMigrateCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 	cmd = &cobra.Command{
 		Use:     "migrate",

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -253,7 +253,7 @@ func fixCoveragePath(path string, file os.FileInfo, err error) error {
 	return nil
 }
 
-// getEnvInfoFromURL gets environments variables for specified cookie domain
+// getDomainEnvInfo gets environments variables for specified cookie domain
 // this func makes a http call to https://login.<domain>/devworkflow and is only useful for suite tests.
 func getDomainEnvInfo(domain string) (info map[string]string, err error) {
 	info = make(map[string]string)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `NewMigrationCmd` to `newStorageMigrateCmd` for better clarity.
	- Updated the function name from `getEnvInfoFromURL` to `getDomainEnvInfo` to enhance understandability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->