### PR TITLE
docs(oidc): fix misc express js example values

### DIFF
--- a/docs/content/integration/openid-connect/expressjs/index.md
+++ b/docs/content/integration/openid-connect/expressjs/index.md
@@ -78,7 +78,9 @@ mkdir authelia-example && cd authelia-example && npm init -y && npm install expr
 This application example assumes you're proxying the Node service with a proxy handling TLS termination for
 `https://express.example.com`.
 
-```js
+```js {title="server.js"}
+"use strict";
+
 const express = require('express');
 const { auth, requiresAuth } = require('express-openid-connect');
 const { randomBytes } = require('crypto');
@@ -117,12 +119,17 @@ app.get('/', requiresAuth(), (req, res) => {
     res.send(`<html lang='en'><body><pre><code>${data}</code></pre></body></html>`);
   });
 });
+
+app.listen(3000, function () {
+  console.log("Listening on port 3000")
+});
 ```
 
 Environment Example:
 
 ```env
 APP_BASE_URL=https://express.example.com
+SESSION_ENCRYPTION_SECRET=
 OIDC_ISSUER=https://auth.example.com
 OIDC_CLIENT_ID=Express.js
 OIDC_CLIENT_SECRET=insecure_secret

--- a/docs/content/integration/openid-connect/synapse/index.md
+++ b/docs/content/integration/openid-connect/synapse/index.md
@@ -66,7 +66,7 @@ To configure [Synapse] to utilize Authelia as an [OpenID Connect 1.0] Provider:
 
 1. Edit your [Synapse] `homeserver.yaml` configuration file and add configure the following:
 
-```yaml {title="configuration.yml"}
+```yaml {title="homeserver.yaml"}
 oidc_providers:
   - idp_id: authelia
     idp_name: "Authelia"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the Express.js integration guide to include server initialization steps in the application code snippet.
	- Updated the configuration file name from `configuration.yml` to `homeserver.yaml` for configuring Synapse with Authelia as an OpenID Connect 1.0 Provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->