### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters will much better

### DIFF
--- a/cmd/authelia-gen/cmd_docs_jsonschema.go
+++ b/cmd/authelia-gen/cmd_docs_jsonschema.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -256,7 +257,7 @@ func docsJSONSchemaGenerateRunE(cmd *cobra.Command, _ []string, version *model.S
 	next := utils.IsStringInSlice(metaVersionNext, versions)
 
 	if next && utils.IsStringInSlice(metaVersionCurrent, versions) {
-		return fmt.Errorf("failed to generate: meta version next and current are mutually exclusive")
+		return errors.New("failed to generate: meta version next and current are mutually exclusive")
 	}
 
 	schema := r.Reflect(v)

--- a/cmd/authelia-gen/helpers.go
+++ b/cmd/authelia-gen/helpers.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/mail"
 	"net/url"
@@ -24,7 +25,7 @@ import (
 
 func getPFlagPath(flags *pflag.FlagSet, flagNames ...string) (fullPath string, err error) {
 	if len(flagNames) == 0 {
-		return "", fmt.Errorf("no flag names")
+		return "", errors.New("no flag names")
 	}
 
 	var p string

--- a/internal/model/authorization.go
+++ b/internal/model/authorization.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -77,14 +78,14 @@ func (a *Authorization) BasicUsername() (username string) {
 
 func (a *Authorization) ParseBasic(username, password string) (err error) {
 	if a.parsed {
-		return fmt.Errorf("invalid state: this scheme has already performed a parse action")
+		return errors.New("invalid state: this scheme has already performed a parse action")
 	}
 
 	switch {
 	case len(username) == 0:
-		return fmt.Errorf("invalid value: username must not be empty")
+		return errors.New("invalid value: username must not be empty")
 	case strings.Contains(username, ":"):
-		return fmt.Errorf("invalid value: username must not contain the ':' character")
+		return errors.New("invalid value: username must not contain the ':' character")
 	case len(password) == 0:
 		return fmt.Errorf("invalid value: password must not be empty")
 	}

--- a/internal/model/oidc.go
+++ b/internal/model/oidc.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -52,7 +53,7 @@ func NewOAuth2BlacklistedJTI(jti string, exp time.Time) (jtiBlacklist OAuth2Blac
 // NewOAuth2SessionFromRequest creates a new OAuth2Session from a signature and oauthelia2.Requester.
 func NewOAuth2SessionFromRequest(signature string, r oauthelia2.Requester) (session *OAuth2Session, err error) {
 	if r == nil {
-		return nil, fmt.Errorf("failed to create new *model.OAuth2Session: the oauthelia2.Requester was nil")
+		return nil, errors.New("failed to create new *model.OAuth2Session: the oauthelia2.Requester was nil")
 	}
 
 	var (

--- a/internal/oidc/keys.go
+++ b/internal/oidc/keys.go
@@ -69,7 +69,7 @@ func (m *KeyManager) GetKeyIDFromAlgStrict(ctx context.Context, alg string) (kid
 		return jwks.kid, nil
 	}
 
-	return "", fmt.Errorf("alg not found")
+	return "", errors.New("alg not found")
 }
 
 // GetKeyIDFromAlg returns the key id given an alg or the default if it doesn't exist.
@@ -124,7 +124,7 @@ func (m *KeyManager) GetByHeader(ctx context.Context, header fjwt.Mapper) (jwk *
 	)
 
 	if header == nil {
-		return nil, fmt.Errorf("jwt header was nil")
+		return nil, errors.New("jwt header was nil")
 	}
 
 	kid, _ = header.Get(JWTHeaderKeyIdentifier).(string)
@@ -146,7 +146,7 @@ func (m *KeyManager) GetByHeader(ctx context.Context, header fjwt.Mapper) (jwk *
 		return nil, fmt.Errorf("jwt header '%s' with value '%s' does not match a managed jwk", JWTHeaderKeyAlgorithm, alg)
 	}
 
-	return nil, fmt.Errorf("jwt header did not match a known jwk")
+	return nil, errors.New("jwt header did not match a known jwk")
 }
 
 // GetByTokenString does an invalidated decode of a token to get the  header, then calls GetByHeader.

--- a/internal/oidc/util.go
+++ b/internal/oidc/util.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -348,7 +349,7 @@ func IsAccessToken(ctx Context, value string) (is bool, err error) {
 	}
 
 	if !IsJWTProfileAccessToken(token.Header) {
-		return false, fmt.Errorf("error occurred checking the token: the token is not a JWT profile access token")
+		return false, errors.New("error occurred checking the token: the token is not a JWT profile access token")
 	}
 
 	var iss string


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters will much better

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced error handling across various components to provide more specific error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->