### PR TITLE
feat(web):  introduction of an access denied page

### DIFF
--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -45,6 +45,7 @@ const (
 	queryArgConsentID  = "consent_id"
 	queryArgWorkflow   = "workflow"
 	queryArgWorkflowID = "workflow_id"
+	queryArgEC         = "ec"
 )
 
 var (
@@ -52,6 +53,14 @@ var (
 	qryArgRD        = []byte(queryArgRD)
 	qryArgAuth      = []byte(queryArgAuth)
 	qryArgConsentID = []byte(queryArgConsentID)
+)
+
+var (
+	baseErrorPath = "error"
+)
+
+var (
+	errorForbidden = "forbidden"
 )
 
 var (
@@ -91,7 +100,7 @@ const (
 )
 
 const (
-	logFmtAuthzRedirect = "Access to %s (method %s) is not authorized to user %s, responding with status code %d with location redirect to %s"
+	logFmtAuthzRedirect = "Access to %s (method %s) is not granted to user %s, responding with status code %d with location redirect to %s"
 
 	logFmtAuthorizationPrefix = "Authorization Request with id '%s' on client with id '%s' "
 

--- a/internal/handlers/handler_authz_builder.go
+++ b/internal/handlers/handler_authz_builder.go
@@ -128,18 +128,22 @@ func (b *AuthzBuilder) Build() (authz *Authz) {
 		authz.config.StatusCodeBadRequest = fasthttp.StatusUnauthorized
 		authz.handleGetObject = handleAuthzGetObjectLegacy
 		authz.handleUnauthorized = handleAuthzUnauthorizedLegacy
+		authz.handleForbidden = handleAuthzForbiddenLegacy
 		authz.handleGetAutheliaURL = handleAuthzPortalURLLegacy
 	case AuthzImplForwardAuth:
 		authz.handleGetObject = handleAuthzGetObjectForwardAuth
 		authz.handleUnauthorized = handleAuthzUnauthorizedForwardAuth
+		authz.handleForbidden = handleAuthzForbiddenForwardAuth
 		authz.handleGetAutheliaURL = handleAuthzPortalURLFromQuery
 	case AuthzImplAuthRequest:
 		authz.handleGetObject = handleAuthzGetObjectAuthRequest
 		authz.handleUnauthorized = handleAuthzUnauthorizedAuthRequest
+		authz.handleForbidden = handleAuthzForbiddenAuthRequest
 		authz.handleGetAutheliaURL = handleAuthzPortalURLFromQuery
 	case AuthzImplExtAuthz:
 		authz.handleGetObject = handleAuthzGetObjectExtAuthz
 		authz.handleUnauthorized = handleAuthzUnauthorizedExtAuthz
+		authz.handleForbidden = handleAuthzForbiddenExtAuthz
 		authz.handleGetAutheliaURL = handleAuthzPortalURLFromHeader
 	}
 

--- a/internal/handlers/handler_authz_impl_authrequest.go
+++ b/internal/handlers/handler_authz_impl_authrequest.go
@@ -37,12 +37,9 @@ func handleAuthzGetObjectAuthRequest(ctx *middlewares.AutheliaCtx) (object autho
 }
 
 func handleAuthzUnauthorizedAuthRequest(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL) {
-	ctx.Logger.Infof(logFmtAuthzRedirect, authn.Object.URL.String(), authn.Method, authn.Username, fasthttp.StatusUnauthorized, redirectionURL)
+	handleAuthzSpecialRedirect(ctx, authn, redirectionURL, fasthttp.StatusUnauthorized)
+}
 
-	switch authn.Object.Method {
-	case fasthttp.MethodHead:
-		ctx.SpecialRedirectNoBody(redirectionURL.String(), fasthttp.StatusUnauthorized)
-	default:
-		ctx.SpecialRedirect(redirectionURL.String(), fasthttp.StatusUnauthorized)
-	}
+func handleAuthzForbiddenAuthRequest(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL) {
+	handleAuthzSpecialRedirect(ctx, authn, redirectionURL, fasthttp.StatusForbidden)
 }

--- a/internal/handlers/handler_authz_impl_extauthz.go
+++ b/internal/handlers/handler_authz_impl_extauthz.go
@@ -38,24 +38,25 @@ func handleAuthzUnauthorizedExtAuthz(ctx *middlewares.AutheliaCtx, authn *Authn,
 		statusCode int
 	)
 
-	switch {
-	case ctx.IsXHR() || !ctx.AcceptsMIME("text/html"):
+	if isNotRequestingWebpage(ctx) {
 		statusCode = fasthttp.StatusUnauthorized
-	default:
-		switch authn.Object.Method {
-		case fasthttp.MethodGet, fasthttp.MethodOptions, fasthttp.MethodHead:
-			statusCode = fasthttp.StatusFound
-		default:
-			statusCode = fasthttp.StatusSeeOther
-		}
+	} else {
+		statusCode = deriveStatusCodeFromAuthnMethod(authn)
 	}
 
-	ctx.Logger.Infof(logFmtAuthzRedirect, authn.Object.String(), authn.Method, authn.Username, statusCode, redirectionURL)
+	handleAuthzSpecialRedirect(ctx, authn, redirectionURL, statusCode)
+}
 
-	switch authn.Object.Method {
-	case fasthttp.MethodHead:
-		ctx.SpecialRedirectNoBody(redirectionURL.String(), statusCode)
-	default:
-		ctx.SpecialRedirect(redirectionURL.String(), statusCode)
+func handleAuthzForbiddenExtAuthz(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL) {
+	var (
+		statusCode int
+	)
+
+	if isNotRequestingWebpage(ctx) {
+		statusCode = fasthttp.StatusForbidden
+	} else {
+		statusCode = deriveStatusCodeFromAuthnMethod(authn)
 	}
+
+	handleAuthzSpecialRedirect(ctx, authn, redirectionURL, statusCode)
 }

--- a/internal/handlers/handler_authz_test.go
+++ b/internal/handlers/handler_authz_test.go
@@ -162,7 +162,29 @@ func (s *AuthzSuite) TestShouldApplyDefaultPolicy() {
 
 	authz.Handler(mock.Ctx)
 
-	s.Equal(fasthttp.StatusForbidden, mock.Ctx.Response.StatusCode())
+	switch s.implementation {
+	case AuthzImplAuthRequest, AuthzImplLegacy:
+		s.Equal(fasthttp.StatusForbidden, mock.Ctx.Response.StatusCode())
+	default:
+		s.Equal(fasthttp.StatusFound, mock.Ctx.Response.StatusCode())
+		location := s.RequireParseRequestURI(mock.Ctx.Configuration.Session.Cookies[0].AutheliaURL.String())
+
+		if location.Path == "" {
+			location.Path = "/"
+		}
+
+		location.Path += baseErrorPath
+
+		query := location.Query()
+		query.Set(queryArgRD, targetURI.String())
+		query.Set(queryArgRM, fasthttp.MethodGet)
+		query.Set(queryArgEC, errorForbidden)
+
+		location.RawQuery = query.Encode()
+
+		s.Equal(location.String(), string(mock.Ctx.Response.Header.Peek(fasthttp.HeaderLocation)))
+	}
+
 	s.Equal([]byte(nil), mock.Ctx.Response.Header.Peek(fasthttp.HeaderWWWAuthenticate))
 	s.Equal([]byte(nil), mock.Ctx.Response.Header.Peek(fasthttp.HeaderProxyAuthenticate))
 }
@@ -636,7 +658,29 @@ func (s *AuthzSuite) TestShouldApplyPolicyOfDenyDomain() {
 
 	authz.Handler(mock.Ctx)
 
-	s.Equal(fasthttp.StatusForbidden, mock.Ctx.Response.StatusCode())
+	switch s.implementation {
+	case AuthzImplAuthRequest, AuthzImplLegacy:
+		s.Equal(fasthttp.StatusForbidden, mock.Ctx.Response.StatusCode())
+	default:
+		s.Equal(fasthttp.StatusFound, mock.Ctx.Response.StatusCode())
+		location := s.RequireParseRequestURI(mock.Ctx.Configuration.Session.Cookies[0].AutheliaURL.String())
+
+		if location.Path == "" {
+			location.Path = "/"
+		}
+
+		location.Path += baseErrorPath
+
+		query := location.Query()
+		query.Set(queryArgRD, targetURI.String())
+		query.Set(queryArgRM, fasthttp.MethodGet)
+		query.Set(queryArgEC, errorForbidden)
+
+		location.RawQuery = query.Encode()
+
+		s.Equal(location.String(), string(mock.Ctx.Response.Header.Peek(fasthttp.HeaderLocation)))
+	}
+
 	s.Equal([]byte(nil), mock.Ctx.Response.Header.Peek(fasthttp.HeaderWWWAuthenticate))
 	s.Equal([]byte(nil), mock.Ctx.Response.Header.Peek(fasthttp.HeaderProxyAuthenticate))
 }
@@ -1286,7 +1330,28 @@ func (s *AuthzSuite) TestShouldUpdateRemovedUserGroupsFromBackendAndDeny() {
 
 	authz.Handler(mock.Ctx)
 
-	s.Equal(fasthttp.StatusForbidden, mock.Ctx.Response.StatusCode())
+	switch s.implementation {
+	case AuthzImplAuthRequest, AuthzImplLegacy:
+		s.Equal(fasthttp.StatusForbidden, mock.Ctx.Response.StatusCode())
+	default:
+		s.Equal(fasthttp.StatusFound, mock.Ctx.Response.StatusCode())
+		location := s.RequireParseRequestURI(mock.Ctx.Configuration.Session.Cookies[0].AutheliaURL.String())
+
+		if location.Path == "" {
+			location.Path = "/"
+		}
+
+		location.Path += baseErrorPath
+
+		query := location.Query()
+		query.Set(queryArgRD, targetURI.String())
+		query.Set(queryArgRM, fasthttp.MethodGet)
+		query.Set(queryArgEC, errorForbidden)
+
+		location.RawQuery = query.Encode()
+
+		s.Equal(location.String(), string(mock.Ctx.Response.Header.Peek(fasthttp.HeaderLocation)))
+	}
 
 	userSession, err = mock.Ctx.GetSession()
 	s.Require().NoError(err)
@@ -1355,7 +1420,28 @@ func (s *AuthzSuite) TestShouldUpdateAddedUserGroupsFromBackendAndDeny() {
 
 	authz.Handler(mock.Ctx)
 
-	s.Equal(fasthttp.StatusForbidden, mock.Ctx.Response.StatusCode())
+	switch s.implementation {
+	case AuthzImplAuthRequest, AuthzImplLegacy:
+		s.Equal(fasthttp.StatusForbidden, mock.Ctx.Response.StatusCode())
+	default:
+		s.Equal(fasthttp.StatusFound, mock.Ctx.Response.StatusCode())
+		location := s.RequireParseRequestURI(mock.Ctx.Configuration.Session.Cookies[0].AutheliaURL.String())
+
+		if location.Path == "" {
+			location.Path = "/"
+		}
+
+		location.Path += baseErrorPath
+
+		query := location.Query()
+		query.Set(queryArgRD, targetURI.String())
+		query.Set(queryArgRM, fasthttp.MethodGet)
+		query.Set(queryArgEC, errorForbidden)
+
+		location.RawQuery = query.Encode()
+
+		s.Equal(location.String(), string(mock.Ctx.Response.Header.Peek(fasthttp.HeaderLocation)))
+	}
 
 	userSession, err = mock.Ctx.GetSession()
 	s.Require().NoError(err)

--- a/internal/handlers/handler_authz_types.go
+++ b/internal/handlers/handler_authz_types.go
@@ -29,12 +29,16 @@ type Authz struct {
 
 	handleAuthorized   HandlerAuthzAuthorized
 	handleUnauthorized HandlerAuthzUnauthorized
+	handleForbidden    HandlerAuthzForbidden
 
 	implementation AuthzImplementation
 }
 
 // HandlerAuthzUnauthorized is a Authz handler func that handles unauthorized responses.
 type HandlerAuthzUnauthorized func(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL)
+
+// HandlerAuthzForbidden is a Authz handler func that handles forbidden responses.
+type HandlerAuthzForbidden func(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL)
 
 // HandlerAuthzAuthorized is a Authz handler func that handles authorized responses.
 type HandlerAuthzAuthorized func(ctx *middlewares.AutheliaCtx, authn *Authn)

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -615,7 +615,7 @@ func (ctx *AutheliaCtx) SpecialRedirectNoBody(uri string, statusCode int) {
 }
 
 func (ctx *AutheliaCtx) setSpecialRedirect(uri string, statusCode int) ([]byte, int) {
-	if statusCode < fasthttp.StatusMovedPermanently || (statusCode > fasthttp.StatusSeeOther && statusCode != fasthttp.StatusTemporaryRedirect && statusCode != fasthttp.StatusPermanentRedirect && statusCode != fasthttp.StatusUnauthorized) {
+	if statusCode < fasthttp.StatusMovedPermanently || (statusCode > fasthttp.StatusSeeOther && statusCode != fasthttp.StatusTemporaryRedirect && statusCode != fasthttp.StatusPermanentRedirect && statusCode != fasthttp.StatusUnauthorized && statusCode != fasthttp.StatusForbidden) {
 		statusCode = fasthttp.StatusFound
 	}
 

--- a/internal/suites/example/compose/nginx/portal/nginx.conf
+++ b/internal/suites/example/compose/nginx/portal/nginx.conf
@@ -212,7 +212,7 @@ http {
             auth_request_set $redirection_url $upstream_http_location;
 
             ## Modern Method: When there is a 401 response code from the Authz endpoint redirect to the $redirection_url.
-            error_page 401 =302 $redirection_url;
+            error_page 401 403 =302 $redirection_url;
 
             ## Legacy Method: Set $target_url to the original requested URL.
             ## This requires http_set_misc module, replace 'set_escape_uri' with 'set' if you don't have this module.
@@ -310,7 +310,7 @@ http {
             auth_request_set $redirection_url $upstream_http_location;
 
             ## Modern Method: When there is a 401 response code from the Authz endpoint redirect to the $redirection_url.
-            error_page 401 =302 $redirection_url;
+            error_page 401 403 =302 $redirection_url;
 
             ## Legacy Method: Set $target_url to the original requested URL.
             ## This requires http_set_misc module, replace 'set_escape_uri' with 'set' if you don't have this module.
@@ -386,7 +386,7 @@ http {
             auth_request_set $redirection_url $upstream_http_location;
 
             ## Modern Method: When there is a 401 response code from the Authz endpoint redirect to the $redirection_url.
-            error_page 401 =302 $redirection_url;
+            error_page 401 403 =302 $redirection_url;
 
             ## Legacy Method: Set $target_url to the original requested URL.
             ## This requires http_set_misc module, replace 'set_escape_uri' with 'set' if you don't have this module.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
 import NotificationBar from "@components/NotificationBar";
 import {
     ConsentRoute,
+    ErrorRoute,
     IndexRoute,
     LogoutRoute,
     ResetPasswordStep1Route,
@@ -23,6 +24,7 @@ import NotificationsContext from "@hooks/NotificationsContext";
 import { Notification } from "@models/Notifications";
 import { getBasePath } from "@utils/BasePath";
 import { getDuoSelfEnrollment, getRememberMe, getResetPassword, getResetPasswordCustomURL } from "@utils/Configuration";
+import BaseErrorView from "@views/Error/BaseErrorPage";
 import LoadingPage from "@views/LoadingPage/LoadingPage";
 import LoginPortal from "@views/LoginPortal/LoginPortal";
 
@@ -65,6 +67,7 @@ const App: React.FC<Props> = (props: Props) => {
                                     <Route path={ResetPasswordStep2Route} element={<ResetPasswordStep2 />} />
                                     <Route path={LogoutRoute} element={<SignOut />} />
                                     <Route path={ConsentRoute} element={<ConsentView />} />
+                                    <Route path={ErrorRoute} element={<BaseErrorView />} />
                                     <Route path={RevokeOneTimeCodeRoute} element={<RevokeOneTimeCodeView />} />
                                     <Route path={RevokeResetPasswordRoute} element={<RevokeResetPasswordTokenView />} />
                                     <Route path={`${SettingsRoute}/*`} element={<SettingsRouter />} />

--- a/web/src/constants/Routes.ts
+++ b/web/src/constants/Routes.ts
@@ -10,7 +10,7 @@ export const SecondFactorPushSubRoute: string = "/push-notification";
 export const ResetPasswordStep1Route: string = "/reset-password/step1";
 export const ResetPasswordStep2Route: string = "/reset-password/step2";
 export const LogoutRoute: string = "/logout";
-
+export const ErrorRoute: string = "/error";
 export const SettingsRoute: string = "/settings";
 export const SettingsTwoFactorAuthenticationSubRoute: string = "/two-factor-authentication";
 export const RevokeOneTimeCodeRoute: string = "/revoke/one-time-code";

--- a/web/src/constants/SearchParams.ts
+++ b/web/src/constants/SearchParams.ts
@@ -1,3 +1,5 @@
+export const ErrorCode: string = "ec";
+
 export const Identifier: string = "id";
 
 export const IdentityToken: string = "token";

--- a/web/src/hooks/QueryParam.ts
+++ b/web/src/hooks/QueryParam.ts
@@ -3,5 +3,5 @@ import { useSearchParams } from "react-router-dom";
 export function useQueryParam(queryParam: string) {
     const [searchParams] = useSearchParams();
     const value = searchParams.get(queryParam);
-    return value !== "" ? (value as string) : undefined;
+    return value !== "" && value !== null ? (value as string) : undefined;
 }

--- a/web/src/models/Errors.ts
+++ b/web/src/models/Errors.ts
@@ -1,0 +1,15 @@
+export enum Errors {
+    forbidden = "forbidden",
+}
+
+export interface ErrorInfo {
+    errorCode?: string;
+    redirectionUrl?: string;
+}
+
+export interface ErrorProps {
+    info: ErrorInfo;
+    children?: any;
+}
+
+export type ErrorComponent = (props: ErrorProps) => JSX.Element;

--- a/web/src/views/Error/BaseErrorPage.tsx
+++ b/web/src/views/Error/BaseErrorPage.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from "react";
+
+import { Button, Grid, Theme } from "@mui/material";
+import makeStyles from "@mui/styles/makeStyles";
+import { useTranslation } from "react-i18next";
+import { Path, useNavigate, useSearchParams } from "react-router-dom";
+
+import { IndexRoute, LogoutRoute } from "@constants/Routes";
+import { ErrorCode, RedirectionURL } from "@constants/SearchParams";
+import { useNotifications } from "@hooks/NotificationsContext";
+import { useAutheliaState } from "@hooks/State";
+import { useUserInfoPOST } from "@hooks/UserInfo";
+import LoginLayout from "@layouts/LoginLayout";
+import { Errors } from "@models/Errors";
+import { AuthenticationLevel } from "@services/State";
+import GenericError from "@views/Error/GenericError";
+import ForbiddenError from "@views/Error/NamedErrors/ForbiddenError";
+import { ComponentOrLoading } from "@views/Generic/ComponentOrLoading";
+
+const BaseErrorView = function () {
+    const styles = useStyles();
+    const navigate = useNavigate();
+    const { t: translate } = useTranslation();
+    const [navigationRoute] = useState({ pathname: LogoutRoute } as Partial<Path>);
+    const { createErrorNotification } = useNotifications();
+    const [state, fetchState, , fetchStateError] = useAutheliaState();
+    const [searchParams] = useSearchParams();
+    const [searchParamsOverride] = useState(new URLSearchParams());
+    const [userInfo, fetchUserInfo, , fetchUserInfoError] = useUserInfoPOST();
+
+    // Fetch the state when portal is mounted.
+    useEffect(() => {
+        fetchState();
+    }, [fetchState]);
+
+    // Fetch preferences and configuration when user is authenticated.
+    useEffect(() => {
+        if (state && state.authentication_level >= AuthenticationLevel.OneFactor) {
+            fetchUserInfo();
+        }
+    }, [state, fetchUserInfo]);
+
+    // Display an error when state fetching fails
+    useEffect(() => {
+        if (fetchStateError) {
+            createErrorNotification("There was an issue fetching the current user state");
+        }
+    }, [fetchStateError, createErrorNotification]);
+
+    useEffect(() => {
+        switch (searchParams.get(ErrorCode)) {
+            case Errors.forbidden: {
+                if (searchParams.has(RedirectionURL)) {
+                    searchParamsOverride.set(RedirectionURL, searchParams.get(RedirectionURL) as string);
+                    navigationRoute.search = searchParamsOverride.toString();
+                }
+                if (state?.authentication_level === AuthenticationLevel.Unauthenticated) {
+                    navigationRoute.pathname = IndexRoute;
+                    navigate(navigationRoute);
+                }
+                break;
+            }
+            default: {
+                break;
+            }
+        }
+    }, [state, searchParams, navigationRoute, navigate, searchParamsOverride]);
+
+    // Display an error when user information fetching fails
+    useEffect(() => {
+        if (fetchUserInfoError) {
+            createErrorNotification("There was an issue retrieving user information");
+        }
+    }, [fetchUserInfoError, createErrorNotification]);
+
+    const handleErrorCodeJSX = () => {
+        switch (searchParams.get(ErrorCode)) {
+            case Errors.forbidden: {
+                return <ForbiddenError />;
+            }
+            default: {
+                return <GenericError />;
+            }
+        }
+    };
+
+    const handleLogoutClick = () => {
+        navigate(navigationRoute);
+    };
+
+    const infoLoaded = userInfo !== undefined;
+
+    return (
+        <ComponentOrLoading ready={infoLoaded}>
+            <LoginLayout id="base-error-stage" title={`${translate("Hi")} ${userInfo?.display_name || ""}`}>
+                <Grid container>
+                    <Grid item xs={12}>
+                        <Button color="secondary" onClick={handleLogoutClick} id="logout-button">
+                            {translate("Logout")}
+                        </Button>
+                    </Grid>
+                    <Grid item xs={12} className={styles.mainContainer}>
+                        {handleErrorCodeJSX()}
+                    </Grid>
+                </Grid>
+            </LoginLayout>
+        </ComponentOrLoading>
+    );
+};
+
+export default BaseErrorView;
+
+const useStyles = makeStyles((theme: Theme) => ({
+    mainContainer: {
+        border: "1px solid #d6d6d6",
+        borderRadius: "10px",
+        padding: theme.spacing(4),
+        marginTop: theme.spacing(2),
+        marginBottom: theme.spacing(2),
+    },
+}));

--- a/web/src/views/Error/GenericError.tsx
+++ b/web/src/views/Error/GenericError.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { Theme, Typography } from "@mui/material";
+import makeStyles from "@mui/styles/makeStyles";
+import { useTranslation } from "react-i18next";
+
+import FailureIcon from "@components/FailureIcon";
+
+const GenericError = function () {
+    const styles = useStyles();
+    const { t: translate } = useTranslation();
+    return (
+        <div id="generic-error-stage">
+            <div className={styles.iconContainer}>
+                <FailureIcon />
+            </div>
+            <Typography>{translate("Error")}</Typography>
+        </div>
+    );
+};
+
+export default GenericError;
+
+const useStyles = makeStyles((theme: Theme) => ({
+    iconContainer: {
+        marginBottom: theme.spacing(2),
+        flex: "0 0 100%",
+    },
+}));

--- a/web/src/views/Error/NamedErrors/ForbiddenError.tsx
+++ b/web/src/views/Error/NamedErrors/ForbiddenError.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { Theme, Typography } from "@mui/material";
+import makeStyles from "@mui/styles/makeStyles";
+import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
+
+import FailureIcon from "@components/FailureIcon";
+import { RedirectionURL } from "@constants/SearchParams";
+
+const ForbiddenError = function () {
+    const styles = useStyles();
+    const { t: translate } = useTranslation();
+    const [searchParams] = useSearchParams();
+
+    const getMessage = () => {
+        if (!searchParams.has(RedirectionURL)) {
+            return "Access Denied";
+        } else {
+            return "Access Denied To:";
+        }
+    };
+
+    return (
+        <div id="access-denied-stage">
+            <div className={styles.iconContainer}>
+                <FailureIcon />
+            </div>
+            <Typography>{translate(getMessage())}</Typography>
+            <Typography className={styles.textEllipsis}>{searchParams.get(RedirectionURL) || ""}</Typography>
+        </div>
+    );
+};
+
+export default ForbiddenError;
+
+const useStyles = makeStyles((theme: Theme) => ({
+    iconContainer: {
+        marginBottom: theme.spacing(2),
+        flex: "0 0 100%",
+    },
+    textEllipsis: {
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+    },
+}));

--- a/web/src/views/Generic/ComponentOrLoading.tsx
+++ b/web/src/views/Generic/ComponentOrLoading.tsx
@@ -1,0 +1,20 @@
+import { Fragment, ReactNode } from "react";
+
+import LoadingPage from "@views/LoadingPage/LoadingPage";
+
+interface ComponentOrLoadingProps {
+    ready: boolean;
+
+    children: ReactNode;
+}
+
+export const ComponentOrLoading = (props: ComponentOrLoadingProps) => {
+    return (
+        <Fragment>
+            <div className={props.ready ? "hidden" : ""}>
+                <LoadingPage />
+            </div>
+            {props.ready ? props.children : null}
+        </Fragment>
+    );
+};

--- a/web/src/views/LoginPortal/ConsentView/ConsentView.tsx
+++ b/web/src/views/LoginPortal/ConsentView/ConsentView.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactNode, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { AccountBox, Autorenew, CheckBox, Contacts, Drafts, Group, LockOpen } from "@mui/icons-material";
 import {
@@ -25,7 +25,7 @@ import { useRedirector } from "@hooks/Redirector";
 import { useUserInfoGET } from "@hooks/UserInfo";
 import LoginLayout from "@layouts/LoginLayout";
 import { ConsentGetResponseBody, acceptConsent, getConsentResponse, rejectConsent } from "@services/Consent";
-import LoadingPage from "@views/LoadingPage/LoadingPage";
+import { ComponentOrLoading } from "@views/Generic/ComponentOrLoading";
 
 export interface Props {}
 
@@ -278,22 +278,5 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     preConfigure: {},
 }));
-
-interface ComponentOrLoadingProps {
-    ready: boolean;
-
-    children: ReactNode;
-}
-
-function ComponentOrLoading(props: ComponentOrLoadingProps) {
-    return (
-        <Fragment>
-            <div className={props.ready ? "hidden" : ""}>
-                <LoadingPage />
-            </div>
-            {props.ready ? props.children : null}
-        </Fragment>
-    );
-}
 
 export default ConsentView;

--- a/web/src/views/LoginPortal/LoginPortal.tsx
+++ b/web/src/views/LoginPortal/LoginPortal.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactNode, lazy, useEffect, useState } from "react";
+import React, { lazy, useEffect, useState } from "react";
 
 import { useTranslation } from "react-i18next";
 import { Route, Routes, useLocation } from "react-router-dom";
@@ -23,7 +23,7 @@ import { useUserInfoPOST } from "@hooks/UserInfo";
 import { SecondFactorMethod } from "@models/Methods";
 import { checkSafeRedirection } from "@services/SafeRedirection";
 import { AuthenticationLevel } from "@services/State";
-import LoadingPage from "@views/LoadingPage/LoadingPage";
+import { ComponentOrLoading } from "@views/Generic/ComponentOrLoading";
 
 const AuthenticatedView = lazy(() => import("@views/LoginPortal/AuthenticatedView/AuthenticatedView"));
 const FirstFactorForm = lazy(() => import("@views/LoginPortal/FirstFactor/FirstFactorForm"));
@@ -217,22 +217,5 @@ const LoginPortal = function (props: Props) {
         </Routes>
     );
 };
-
-interface ComponentOrLoadingProps {
-    ready: boolean;
-
-    children: ReactNode;
-}
-
-function ComponentOrLoading(props: ComponentOrLoadingProps) {
-    return (
-        <Fragment>
-            <div className={props.ready ? "hidden" : ""}>
-                <LoadingPage />
-            </div>
-            {props.ready ? props.children : null}
-        </Fragment>
-    );
-}
 
 export default LoginPortal;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,11 +1,11 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { PluginOption, UserConfig, defineConfig } from "vite";
 import checkerPlugin from "vite-plugin-checker";
 import istanbul from "vite-plugin-istanbul";
 import svgr from "vite-plugin-svgr";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
     const isCoverage = process.env.VITE_COVERAGE === "true";
     const sourcemap = isCoverage ? "inline" : undefined;
 
@@ -20,7 +20,7 @@ export default defineConfig(({ mode }) => {
           })
         : undefined;
 
-    return {
+    const config: UserConfig = {
         base: "./",
         build: {
             assetsDir: "static",
@@ -111,4 +111,27 @@ export default defineConfig(({ mode }) => {
             tsconfigPaths(),
         ],
     };
+
+    if (command === "serve") {
+        config.plugins?.push(injectDevHomeLinkToIndex());
+    }
+
+    return config;
 });
+
+const injectDevHomeLinkToIndex: () => PluginOption = () => {
+    return {
+        name: "html-transform",
+        transformIndexHtml(html: string) {
+            const injectedHomeLinkHtml: string = `
+            <a style="position:absolute; height: 30px; z-index: 99; top: 0px;
+                    left: 0px; background-color: white;" href="https://home.example.com:8080">
+                <b> &#127968; Demo Home</b>
+            </a>`;
+
+            const htmlArray = html.split("</body>");
+
+            return htmlArray[0] + injectedHomeLinkHtml + "</body>" + htmlArray[1];
+        },
+    };
+};


### PR DESCRIPTION
When a user does not have the required permissions, a redirection url to a new 'Access Denied' page is passed back to the reverse proxy along with the 403 error code. This follows the same sequence as an unauthenticated user getting redirected to the login. The Access Denied page presents the user with an option to logout, as well as the details of the page they were denied access to.

Work includes a slight refactor of authz handlers to allow for code reuse.

Also includes a simple 'demo home' button injected into the development login page to allow for easier navigation back to home.example.com for the Standalone suite.

Fixes #2319.