### PR TITLE
ci(buildkite): adjust integration tests pre-command hook

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -33,8 +33,9 @@ if [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
   mkdir coverage
 
   if [[ "${BUILDKITE_AGENT_NAME}" =~ ^(atlas|vega)[0-9]+$ ]]; then
-    BUILDKITE_S3_ENDPOINT="${S3_ENDPOINT}" BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="${S3_BUCKET}" BUILDKITE_S3_ACCESS_URL="${S3_ACCESS_URL}" BUILDKITE_S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" BUILDKITE_S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" buildkite-agent artifact download "authelia-image-coverage-cygnus*" .
-    mv authelia-image-coverage-cygnus.tar.zst authelia-image-coverage.tar.zst
+    BUILDKITE_S3_ENDPOINT="${S3_ENDPOINT}" BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="${S3_BUCKET}" BUILDKITE_S3_ACCESS_URL="${S3_ACCESS_URL}" BUILDKITE_S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID}" BUILDKITE_S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY}" buildkite-agent artifact download "authelia-image-coverage-cygnus*" . && \
+    mv authelia-image-coverage-cygnus.tar.zst authelia-image-coverage.tar.zst || \
+    buildkite-agent artifact download "authelia-image-coverage.*" .
   else
     buildkite-agent artifact download "authelia-image-coverage.*" .
   fi


### PR DESCRIPTION
This change ensures that if nodes that share artifacts through MinIO happen to error and are brought back up, they can finish builds that had the coverage step run by nodes that upload to Buildkites S3 instance.