### PR TITLE
docs: improve clarity - oidc client field is required

### DIFF
--- a/docs/content/configuration/identity-providers/openid-connect/provider.md
+++ b/docs/content/configuration/identity-providers/openid-connect/provider.md
@@ -554,6 +554,8 @@ localhost.
 
 ### clients
 
+{{< confkey type="list(object)" required="yes" >}}
+
 See the [OpenID Connect 1.0 Registered Clients](clients.md) documentation for configuring clients.
 
 ## Integration


### PR DESCRIPTION
Improve documentation clarity by adding "required" tag to OIDC provider field: clients.

It is intended behavior that there be at least one configured open id connect client in order for OIDC config to be valid.