### PR TITLE
fix(oidc): include missing amr with value pop

### DIFF
--- a/docs/content/integration/openid-connect/introduction.md
+++ b/docs/content/integration/openid-connect/introduction.md
@@ -304,16 +304,18 @@ it then you're encouraged to create a [feature request](https://www.authelia.com
 
 Below is a list of the potential values we place in the [Claim] and their meaning:
 
-| Value |                           Description                            | Factor | Channel  |
-|:-----:|:----------------------------------------------------------------:|:------:|:--------:|
-|  mfa  |     User used multiple factors to login (see factor column)      |  N/A   |   N/A    |
-|  mca  |    User used multiple channels to login (see channel column)     |  N/A   |   N/A    |
-| user  |  User confirmed they were present when using their hardware key  |  N/A   |   N/A    |
-|  pin  | User confirmed they are the owner of the hardware key with a pin |  N/A   |   N/A    |
-|  pwd  |            User used a username and password to login            |  Know  | Browser  |
-|  otp  |                     User used TOTP to login                      |  Have  | Browser  |
-|  hwk  |                User used a hardware key to login                 |  Have  | Browser  |
-|  sms  |                      User used Duo to login                      |  Have  | External |
+| Value |                            Description                            | Factor | Channel  |
+|:-----:|:-----------------------------------------------------------------:|:------:|:--------:|
+|  mfa  |      User used multiple factors to login (see factor column)      |  N/A   |   N/A    |
+|  mca  |     User used multiple channels to login (see channel column)     |  N/A   |   N/A    |
+| user  |  User confirmed they were present when using their hardware key   |  N/A   |   N/A    |
+|  pin  | User confirmed they are the owner of the hardware key with a pin  |  N/A   |   N/A    |
+|  pwd  |            User used a username and password to login             |  Know  | Browser  |
+|  otp  |                      User used TOTP to login                      |  Have  | Browser  |
+|  pop  | User used a software or hardware proof-of-possession key to login |  Have  | Browser  |
+|  hwk  |       User used a hardware proof-of-possession key to login       |  Have  | Browser  |
+|  swk  |       User used a software proof-of-possession key to login       |  Have  | Browser  |
+|  sms  |                      User used Duo to login                       |  Have  | External |
 
 ## Introspection Signing Algorithm
 

--- a/internal/handlers/handler_sign_webauthn.go
+++ b/internal/handlers/handler_sign_webauthn.go
@@ -262,6 +262,7 @@ func WebAuthnAssertionPOST(ctx *middlewares.AutheliaCtx) {
 	}
 
 	userSession.SetTwoFactorWebAuthn(ctx.Clock.Now(),
+		assertionResponse.ParsedPublicKeyCredential.AuthenticatorAttachment == protocol.CrossPlatform,
 		assertionResponse.Response.AuthenticatorData.Flags.HasUserPresent(),
 		assertionResponse.Response.AuthenticatorData.Flags.HasUserVerified())
 

--- a/internal/oidc/amr.go
+++ b/internal/oidc/amr.go
@@ -9,8 +9,14 @@ func NewAuthenticationMethodsReferencesFromClaim(claim []string) (amr Authentica
 			amr.TOTP = true
 		case AMRShortMessageService:
 			amr.Duo = true
+		case AMRProofOfPossession:
+			amr.WebAuthn = true
 		case AMRHardwareSecuredKey:
 			amr.WebAuthn = true
+			amr.WebAuthnHardware = true
+		case AMRSoftwareSecuredKey:
+			amr.WebAuthn = true
+			amr.WebAuthnSoftware = true
 		case AMRUserPresence:
 			amr.WebAuthnUserVerified = true
 		}
@@ -25,6 +31,8 @@ type AuthenticationMethodsReferences struct {
 	TOTP                 bool
 	Duo                  bool
 	WebAuthn             bool
+	WebAuthnHardware     bool
+	WebAuthnSoftware     bool
 	WebAuthnUserPresence bool
 	WebAuthnUserVerified bool
 }
@@ -36,7 +44,7 @@ func (r AuthenticationMethodsReferences) FactorKnowledge() bool {
 
 // FactorPossession returns true if a "something you have" factor of authentication was used.
 func (r AuthenticationMethodsReferences) FactorPossession() bool {
-	return r.TOTP || r.WebAuthn || r.Duo
+	return r.TOTP || r.Duo || r.WebAuthn || r.WebAuthnHardware || r.WebAuthnSoftware
 }
 
 // MultiFactorAuthentication returns true if multiple factors were used.
@@ -46,7 +54,7 @@ func (r AuthenticationMethodsReferences) MultiFactorAuthentication() bool {
 
 // ChannelBrowser returns true if a browser was used to authenticate.
 func (r AuthenticationMethodsReferences) ChannelBrowser() bool {
-	return r.UsernameAndPassword || r.TOTP || r.WebAuthn
+	return r.UsernameAndPassword || r.TOTP || r.WebAuthn || r.WebAuthnHardware || r.WebAuthnSoftware
 }
 
 // ChannelService returns true if a non-browser service was used to authenticate.
@@ -76,8 +84,16 @@ func (r AuthenticationMethodsReferences) MarshalRFC8176() []string {
 		amr = append(amr, AMRShortMessageService)
 	}
 
-	if r.WebAuthn {
+	if r.WebAuthn || r.WebAuthnHardware || r.WebAuthnSoftware {
+		amr = append(amr, AMRProofOfPossession)
+	}
+
+	if r.WebAuthnHardware {
 		amr = append(amr, AMRHardwareSecuredKey)
+	}
+
+	if r.WebAuthnSoftware {
+		amr = append(amr, AMRSoftwareSecuredKey)
 	}
 
 	if r.WebAuthnUserPresence {

--- a/internal/oidc/const.go
+++ b/internal/oidc/const.go
@@ -306,6 +306,11 @@ const (
 	// RFC6238: https://datatracker.ietf.org/doc/html/rfc6238
 	AMROneTimePassword = "otp"
 
+	// AMRProofOfPossession is an Authentication Method Reference Value that
+	// represents authentication via a proof-of-Possession (PoP) of a software-secured (swk) or hardware-secured (hwk)
+	// key.
+	AMRProofOfPossession = "pop"
+
 	// AMRHardwareSecuredKey is an RFC8176 Authentication Method Reference Value that
 	// represents authentication via a proof-of-Possession (PoP) of a hardware-secured key.
 	//
@@ -313,6 +318,14 @@ const (
 	//
 	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
 	AMRHardwareSecuredKey = "hwk"
+
+	// AMRSoftwareSecuredKey is an RFC8176 Authentication Method Reference Value that
+	// represents authentication via a proof-of-Possession (PoP) of a software-secured key.
+	//
+	// Authelia utilizes this when a user has used WebAuthn to authenticate. Factor: Have, Channel: Browser.
+	//
+	// RFC8176: https://datatracker.ietf.org/doc/html/rfc8176
+	AMRSoftwareSecuredKey = "swk"
 
 	// AMRShortMessageService is an RFC8176 Authentication Method Reference Value that
 	// represents authentication via confirmation using SMS text message to the user at a registered number.

--- a/internal/session/provider_test.go
+++ b/internal/session/provider_test.go
@@ -179,7 +179,7 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 		AuthenticationMethodRefs:  oidc.AuthenticationMethodsReferences{UsernameAndPassword: true},
 	}, session)
 
-	session.SetTwoFactorWebAuthn(timeTwoFactor, false, false)
+	session.SetTwoFactorWebAuthn(timeTwoFactor, true, false, false)
 
 	err = provider.SaveSession(ctx, session)
 	assert.NoError(t, err)
@@ -187,7 +187,7 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 	session, err = provider.GetSession(ctx)
 	assert.NoError(t, err)
 
-	assert.Equal(t, oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true}, session.AuthenticationMethodRefs)
+	assert.Equal(t, oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnHardware: true}, session.AuthenticationMethodRefs)
 	assert.True(t, session.AuthenticationMethodRefs.MultiFactorAuthentication())
 
 	authAt, err = session.AuthenticatedTime(authorization.OneFactor)
@@ -202,7 +202,7 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 	assert.EqualError(t, err, "invalid authorization level")
 	assert.Equal(t, timeZeroFactor, authAt)
 
-	session.SetTwoFactorWebAuthn(timeTwoFactor, false, false)
+	session.SetTwoFactorWebAuthn(timeTwoFactor, true, false, false)
 
 	err = provider.SaveSession(ctx, session)
 	assert.NoError(t, err)
@@ -211,10 +211,10 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true},
+		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnHardware: true},
 		session.AuthenticationMethodRefs)
 
-	session.SetTwoFactorWebAuthn(timeTwoFactor, false, false)
+	session.SetTwoFactorWebAuthn(timeTwoFactor, true, false, false)
 
 	err = provider.SaveSession(ctx, session)
 	assert.NoError(t, err)
@@ -223,10 +223,10 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true},
+		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnHardware: true},
 		session.AuthenticationMethodRefs)
 
-	session.SetTwoFactorWebAuthn(timeTwoFactor, true, false)
+	session.SetTwoFactorWebAuthn(timeTwoFactor, true, true, false)
 
 	err = provider.SaveSession(ctx, session)
 	assert.NoError(t, err)
@@ -235,10 +235,10 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnUserPresence: true},
+		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnUserPresence: true, WebAuthnHardware: true},
 		session.AuthenticationMethodRefs)
 
-	session.SetTwoFactorWebAuthn(timeTwoFactor, true, false)
+	session.SetTwoFactorWebAuthn(timeTwoFactor, true, true, false)
 
 	err = provider.SaveSession(ctx, session)
 	assert.NoError(t, err)
@@ -247,10 +247,10 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnUserPresence: true},
+		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnUserPresence: true, WebAuthnHardware: true},
 		session.AuthenticationMethodRefs)
 
-	session.SetTwoFactorWebAuthn(timeTwoFactor, false, true)
+	session.SetTwoFactorWebAuthn(timeTwoFactor, true, false, true)
 
 	err = provider.SaveSession(ctx, session)
 	assert.NoError(t, err)
@@ -259,10 +259,10 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnUserVerified: true},
+		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnUserVerified: true, WebAuthnHardware: true},
 		session.AuthenticationMethodRefs)
 
-	session.SetTwoFactorWebAuthn(timeTwoFactor, false, true)
+	session.SetTwoFactorWebAuthn(timeTwoFactor, true, false, true)
 
 	err = provider.SaveSession(ctx, session)
 	assert.NoError(t, err)
@@ -271,19 +271,7 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnUserVerified: true},
-		session.AuthenticationMethodRefs)
-
-	session.SetTwoFactorTOTP(timeTwoFactor)
-
-	err = provider.SaveSession(ctx, session)
-	assert.NoError(t, err)
-
-	session, err = provider.GetSession(ctx)
-	assert.NoError(t, err)
-
-	assert.Equal(t,
-		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, TOTP: true, WebAuthn: true, WebAuthnUserVerified: true},
+		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, WebAuthn: true, WebAuthnUserVerified: true, WebAuthnHardware: true},
 		session.AuthenticationMethodRefs)
 
 	session.SetTwoFactorTOTP(timeTwoFactor)
@@ -295,7 +283,19 @@ func TestShouldSetSessionAuthenticationLevelsAMR(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t,
-		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, TOTP: true, WebAuthn: true, WebAuthnUserVerified: true},
+		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, TOTP: true, WebAuthn: true, WebAuthnUserVerified: true, WebAuthnHardware: true},
+		session.AuthenticationMethodRefs)
+
+	session.SetTwoFactorTOTP(timeTwoFactor)
+
+	err = provider.SaveSession(ctx, session)
+	assert.NoError(t, err)
+
+	session, err = provider.GetSession(ctx)
+	assert.NoError(t, err)
+
+	assert.Equal(t,
+		oidc.AuthenticationMethodsReferences{UsernameAndPassword: true, TOTP: true, WebAuthn: true, WebAuthnUserVerified: true, WebAuthnHardware: true},
 		session.AuthenticationMethodRefs)
 }
 

--- a/internal/session/user_session.go
+++ b/internal/session/user_session.go
@@ -57,10 +57,17 @@ func (s *UserSession) SetTwoFactorDuo(now time.Time) {
 }
 
 // SetTwoFactorWebAuthn sets the relevant WebAuthn AMR's and sets the factor to 2FA.
-func (s *UserSession) SetTwoFactorWebAuthn(now time.Time, userPresence, userVerified bool) {
+func (s *UserSession) SetTwoFactorWebAuthn(now time.Time, hardware, userPresence, userVerified bool) {
 	s.setTwoFactor(now)
+
 	s.AuthenticationMethodRefs.WebAuthn = true
 	s.AuthenticationMethodRefs.WebAuthnUserPresence, s.AuthenticationMethodRefs.WebAuthnUserVerified = userPresence, userVerified
+
+	if hardware {
+		s.AuthenticationMethodRefs.WebAuthnHardware = true
+	} else {
+		s.AuthenticationMethodRefs.WebAuthnSoftware = true
+	}
 
 	s.WebAuthn = nil
 }

--- a/internal/session/user_session_test.go
+++ b/internal/session/user_session_test.go
@@ -1,0 +1,91 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/authelia/authelia/v4/internal/oidc"
+)
+
+func TestUserSession_SetTwoFactorWebAuthn(t *testing.T) {
+	testCases := []struct {
+		name                         string
+		at                           time.Time
+		hardware, presence, verified bool
+		expected                     oidc.AuthenticationMethodsReferences
+	}{
+		{
+			"ShouldHandleHardware",
+			time.Unix(1000, 0),
+			true,
+			true,
+			true,
+			oidc.AuthenticationMethodsReferences{
+				WebAuthn:             true,
+				WebAuthnHardware:     true,
+				WebAuthnUserPresence: true,
+				WebAuthnUserVerified: true,
+			},
+		},
+		{
+			"ShouldHandleSoftware",
+			time.Unix(1000, 0),
+			false,
+			true,
+			true,
+			oidc.AuthenticationMethodsReferences{
+				WebAuthn:             true,
+				WebAuthnSoftware:     true,
+				WebAuthnUserPresence: true,
+				WebAuthnUserVerified: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := &UserSession{}
+
+			actual.SetTwoFactorWebAuthn(tc.at, tc.hardware, tc.presence, tc.verified)
+
+			assert.Equal(t, tc.expected, actual.AuthenticationMethodRefs)
+		})
+	}
+}
+
+func TestUserSession_Misc(t *testing.T) {
+	session := &UserSession{}
+
+	assert.Equal(t, Identity{}, session.Identity())
+	assert.Equal(t, "", session.GetUsername())
+	assert.Equal(t, "", session.GetDisplayName())
+	assert.Nil(t, session.GetGroups())
+	assert.Nil(t, session.GetEmails())
+	assert.True(t, session.IsAnonymous())
+
+	session.Username = "abc"
+
+	assert.Equal(t, Identity{Username: "abc"}, session.Identity())
+	assert.Equal(t, "abc", session.GetUsername())
+
+	session.DisplayName = "A B C"
+
+	assert.Equal(t, Identity{Username: "abc", DisplayName: "A B C"}, session.Identity())
+	assert.Equal(t, "abc", session.GetUsername())
+	assert.Equal(t, "A B C", session.GetDisplayName())
+
+	session.Emails = []string{"abc@example.com", "xyz@example.com"}
+
+	assert.Equal(t, Identity{Username: "abc", DisplayName: "A B C", Email: "abc@example.com"}, session.Identity())
+	assert.Equal(t, "abc", session.GetUsername())
+	assert.Equal(t, "A B C", session.GetDisplayName())
+	assert.Equal(t, []string{"abc@example.com", "xyz@example.com"}, session.GetEmails())
+
+	session.Groups = []string{"agroup", "bgroup"}
+	assert.Equal(t, "abc", session.GetUsername())
+	assert.Equal(t, "A B C", session.GetDisplayName())
+	assert.Equal(t, []string{"abc@example.com", "xyz@example.com"}, session.GetEmails())
+	assert.Equal(t, []string{"agroup", "bgroup"}, session.GetGroups())
+}


### PR DESCRIPTION
This includes the missing Authentication Method Reference named 'pop' or proof-of-possession, as well as properly distinguishing between the 'hwk' and 'swk' variants of WebAuthn.