### PR TITLE
refactor: use explicit uuid comparison

### DIFF
--- a/internal/handlers/handler_oidc_authorization_consent.go
+++ b/internal/handlers/handler_oidc_authorization_consent.go
@@ -229,24 +229,20 @@ func handleOpenIDConnectNewConsentSession(subject uuid.UUID, requester oauthelia
 }
 
 func verifyOIDCUserAuthorizedForConsent(ctx *middlewares.AutheliaCtx, client oidc.Client, userSession session.UserSession, consent *model.OAuth2ConsentSession, subject uuid.UUID) (err error) {
-	var sid uint32
-
 	if client == nil {
 		if client, err = ctx.Providers.OpenIDConnect.GetRegisteredClient(ctx, consent.ClientID); err != nil {
 			return fmt.Errorf("failed to retrieve client: %w", err)
 		}
 	}
 
-	if sid = subject.ID(); sid == 0 {
+	if subject == uuid.Nil {
 		if subject, err = ctx.Providers.OpenIDConnect.GetSubject(ctx, client.GetSectorIdentifierURI(), userSession.Username); err != nil {
 			return fmt.Errorf("failed to lookup subject: %w", err)
 		}
-
-		sid = subject.ID()
 	}
 
 	if !consent.Subject.Valid {
-		if sid == 0 {
+		if subject == uuid.Nil {
 			return fmt.Errorf("the consent subject is null for consent session with id '%d' for anonymous user", consent.ID)
 		}
 
@@ -257,7 +253,7 @@ func verifyOIDCUserAuthorizedForConsent(ctx *middlewares.AutheliaCtx, client oid
 		}
 	}
 
-	if consent.Subject.UUID.ID() != sid {
+	if consent.Subject.UUID != subject {
 		return fmt.Errorf("the consent subject identifier '%s' isn't owned by user '%s' who has a subject identifier of '%s' with sector identifier '%s'", consent.Subject.UUID, userSession.Username, subject, client.GetSectorIdentifierURI())
 	}
 

--- a/internal/handlers/handler_oidc_authorization_consent_explicit.go
+++ b/internal/handlers/handler_oidc_authorization_consent_explicit.go
@@ -46,7 +46,7 @@ func handleOIDCAuthorizationConsentModeExplicitWithID(ctx *middlewares.AutheliaC
 		err error
 	)
 
-	if consentID.ID() == 0 {
+	if consentID == uuid.Nil {
 		ctx.Logger.Errorf(logFmtErrConsentZeroID, requester.GetID(), client.GetID(), client.GetConsentPolicy())
 
 		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrConsentCouldNotLookup)
@@ -62,7 +62,7 @@ func handleOIDCAuthorizationConsentModeExplicitWithID(ctx *middlewares.AutheliaC
 		return nil, true
 	}
 
-	if subject.ID() != consent.Subject.UUID.ID() {
+	if subject != consent.Subject.UUID {
 		ctx.Logger.Errorf(logFmtErrConsentSessionSubjectNotAuthorized, requester.GetID(), client.GetID(), client.GetConsentPolicy(), consent.ChallengeID, userSession.Username, subject, consent.Subject.UUID)
 
 		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrConsentCouldNotLookup)

--- a/internal/handlers/handler_oidc_authorization_consent_implicit.go
+++ b/internal/handlers/handler_oidc_authorization_consent_implicit.go
@@ -44,7 +44,7 @@ func handleOIDCAuthorizationConsentModeImplicitWithID(ctx *middlewares.AutheliaC
 		err error
 	)
 
-	if consentID.ID() == 0 {
+	if consentID == uuid.Nil {
 		ctx.Logger.Errorf(logFmtErrConsentZeroID, requester.GetID(), client.GetID(), client.GetConsentPolicy())
 
 		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrConsentCouldNotLookup)
@@ -60,7 +60,7 @@ func handleOIDCAuthorizationConsentModeImplicitWithID(ctx *middlewares.AutheliaC
 		return nil, true
 	}
 
-	if subject.ID() != consent.Subject.UUID.ID() {
+	if subject != consent.Subject.UUID {
 		ctx.Logger.Errorf(logFmtErrConsentSessionSubjectNotAuthorized, requester.GetID(), client.GetID(), client.GetConsentPolicy(), consent.ChallengeID, userSession.Username, subject, consent.Subject.UUID)
 
 		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrConsentCouldNotLookup)

--- a/internal/handlers/handler_oidc_authorization_consent_pre_configured.go
+++ b/internal/handlers/handler_oidc_authorization_consent_pre_configured.go
@@ -51,7 +51,7 @@ func handleOIDCAuthorizationConsentModePreConfiguredWithID(ctx *middlewares.Auth
 		err    error
 	)
 
-	if consentID.ID() == 0 {
+	if consentID == uuid.Nil {
 		ctx.Logger.Errorf(logFmtErrConsentZeroID, requester.GetID(), client.GetID(), client.GetConsentPolicy())
 
 		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrConsentCouldNotLookup)
@@ -67,7 +67,7 @@ func handleOIDCAuthorizationConsentModePreConfiguredWithID(ctx *middlewares.Auth
 		return nil, true
 	}
 
-	if subject.ID() != consent.Subject.UUID.ID() {
+	if subject != consent.Subject.UUID {
 		ctx.Logger.Errorf(logFmtErrConsentSessionSubjectNotAuthorized, requester.GetID(), client.GetID(), client.GetConsentPolicy(), consent.ChallengeID, userSession.Username, subject, consent.Subject.UUID)
 
 		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrConsentCouldNotLookup)

--- a/internal/model/uuid.go
+++ b/internal/model/uuid.go
@@ -14,7 +14,7 @@ func NewRandomNullUUID() (uuid.NullUUID, error) {
 
 // NullUUID converts a uuid.UUID to a uuid.NullUUID.
 func NullUUID(in uuid.UUID) uuid.NullUUID {
-	return uuid.NullUUID{UUID: in, Valid: in.ID() != 0}
+	return uuid.NullUUID{UUID: in, Valid: in != uuid.Nil}
 }
 
 // MustNullUUID is a uuid.Must variant for the uuid.NullUUID methods.

--- a/internal/oidc/store_test.go
+++ b/internal/oidc/store_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	oauthelia2 "authelia.com/provider/oauth2"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -184,7 +185,7 @@ func (s *StoreSuite) TestGetSubject() {
 		opaqueID, err := s.store.GetSubject(s.ctx, "", "john")
 
 		assert.EqualError(t, err, "failed to load")
-		assert.Equal(t, uint32(0), opaqueID.ID())
+		assert.Equal(t, uuid.Nil, opaqueID)
 	})
 
 	s.T().Run("ReturnDatabaseErrorOnSave", func(t *testing.T) {
@@ -201,7 +202,7 @@ func (s *StoreSuite) TestGetSubject() {
 		opaqueID, err := s.store.GetSubject(s.ctx, "", "john")
 
 		assert.EqualError(t, err, "failed to save")
-		assert.Equal(t, uint32(0), opaqueID.ID())
+		assert.Equal(t, uuid.Nil, opaqueID)
 	})
 }
 


### PR DESCRIPTION
Instead of utilizing the ID of the UUID this compares it directly which was intentionally intended by the authors.