### PR TITLE
fix(middlewares): header allow set instead of acam

### DIFF
--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -24,7 +24,6 @@ var (
 	headerXForwardedMethod = []byte("X-Forwarded-Method")
 
 	headerVary   = []byte(fasthttp.HeaderVary)
-	headerAllow  = []byte(fasthttp.HeaderAllow)
 	headerOrigin = []byte(fasthttp.HeaderOrigin)
 
 	headerAccessControlAllowCredentials = []byte(fasthttp.HeaderAccessControlAllowCredentials)

--- a/internal/middlewares/cors.go
+++ b/internal/middlewares/cors.go
@@ -246,7 +246,7 @@ func (p *CORSPolicy) handleOPTIONS(ctx *fasthttp.RequestCtx) {
 	ctx.Response.Header.SetBytesKV(headerContentLength, headerValueZero)
 
 	if len(p.methods) != 0 {
-		ctx.Response.Header.SetBytesKV(headerAllow, p.methods)
+		ctx.Response.Header.SetBytesKV(headerAccessControlAllowMethods, p.methods)
 	}
 }
 
@@ -278,8 +278,12 @@ func (p *CORSPolicy) handleCORS(ctx *fasthttp.RequestCtx) {
 		for i := 0; i < len(p.origins); i++ {
 			if bytes.Equal(p.origins[i], headerValueOriginWildcard) {
 				allowedOrigin = headerValueOriginWildcard
+
+				break
 			} else if bytes.Equal(p.origins[i], origin) {
 				allowedOrigin = origin
+
+				break
 			}
 		}
 


### PR DESCRIPTION
The Allow header was set instead of the Cross-Origin Resource Sharing header Access-Control-Allow-Methods. This fixes that issue.