### PR TITLE
docs: use modern callout instead of alert

### DIFF
--- a/docs/layouts/shortcodes/config-alert-example.html
+++ b/docs/layouts/shortcodes/config-alert-example.html
@@ -1,7 +1,11 @@
-<div class="alert alert-warning d-flex" role="alert">
-  <div class="flex-shrink-1 alert-icon">⚠️</div>
-  <div class="w-100">
-    This section is intended as an example configuration to help users with a rough contextual layout of this configuration section, it is <b>not</b> intended to explain the <a class="alert-link" href="#options">options</a>.
-    The configuration shown may not be a valid configuration, and you should see the <a class="alert-link" href="#options">options section</a> below and the navigation links to properly understand each option individually.
+<div class="callout callout-caution d-flex flex-row mt-4 mb-4 pt-4 pe-4 pb-2 ps-3">
+  <svg class="outline/alert-triangle svg-inline callout-icon me-2 mb-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentcolor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M12 9v4"></path><path d="M10.363 3.591 2.257 17.125a1.914 1.914.0 001.636 2.871h16.214a1.914 1.914.0 001.636-2.87L13.637 3.59a1.914 1.914.0 00-3.274.0z"></path><path d="M12 16h.01"></path></svg>
+  <div class="callout-content">
+    <div class="callout-title">
+      <p>Example Configuration</p>
+    </div>
+    <div class="callout-body">
+      <p>This section is intended as an example configuration to help users with a rough contextual layout of this configuration section, it is <b>not</b> intended to explain the <a href="#options">options</a>. The configuration shown may not be a valid configuration, and you should see the <a href="#options">options section</a> below and the navigation links to properly understand each option individually.</p>
+    </div>
   </div>
 </div>

--- a/docs/layouts/shortcodes/confkey.html
+++ b/docs/layouts/shortcodes/confkey.html
@@ -65,7 +65,7 @@
       <p>Reference Note</p>
     </div>
     <div class="callout-body">
-      <p>{{ $text }}For more information please see both the <a href="#configuration" class="alert-link">configuration example</a> and the <a href="/configuration/prologue/common/#{{ $ref }}" class="alert-link">{{ $description }}</a> reference guide.</p>
+      <p>{{ $text }}For more information please see both the <a href="#configuration">configuration example</a> and the <a href="/configuration/prologue/common/#{{ $ref }}">{{ $description }}</a> reference guide.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This uses the modern callout design instead of alerts for in doc alerts.