### PR TITLE
Add support information for Okta Verify

### DIFF
--- a/docs/data/support.json
+++ b/docs/data/support.json
@@ -7,6 +7,7 @@
     {"name": "1Password", "clear": false, "algorithms": {"SHA1": true, "SHA256": true, "SHA512": false}, "digits": {"six": true, "eight": false}, "url": "https://1password.com/"},
     {"name": "Ravio", "clear": false, "algorithms": {"SHA1": true, "SHA256": true, "SHA512": false}, "digits": {"six": true, "eight": false}, "url": "https://raivo-otp.com/"},
     {"name": "Authy", "clear": false, "algorithms": {"SHA1": true, "SHA256": false, "SHA512": false}, "digits": {"six": false, "eight": true}, "url": "https://authy.com/"},
-    {"name": "Aegis", "clear": false, "algorithms": {"SHA1": true, "SHA256": false, "SHA512": true}, "digits": {"six": true, "eight": true}, "url": "https://getaegis.app/"}
+    {"name": "Aegis", "clear": false, "algorithms": {"SHA1": true, "SHA256": false, "SHA512": true}, "digits": {"six": true, "eight": true}, "url": "https://getaegis.app/"},
+    {"name": "Okta Verify", "clear": false, "algorithms": {"SHA1": true, "SHA256": false, "SHA512": false}, "digits": {"six": true, "eight": false}, "url": "https://help.okta.com/eu/en-us/content/topics/end-user/ov-overview.htm"}
   ]
 }


### PR DESCRIPTION
Tested Okta Verify for different TOTP options (since I was unable to get it to work when I first tried it).  Okta Verify only supports SHA1 with 6-digits.