### PR TITLE
fix(session): revert usage to standard sentinel discovery

### DIFF
--- a/internal/session/provider_config.go
+++ b/internal/session/provider_config.go
@@ -121,7 +121,7 @@ func NewSessionProvider(config schema.Session, certPool *x509.CertPool) (name st
 
 			name = "redis-sentinel"
 
-			provider, err = redis.NewFailoverCluster(redis.FailoverConfig{
+			provider, err = redis.NewFailover(redis.FailoverConfig{
 				Logger:           logging.LoggerCtxPrintf(logrus.TraceLevel),
 				MasterName:       config.Redis.HighAvailability.SentinelName,
 				SentinelAddrs:    addrs,


### PR DESCRIPTION
This reverts the usage of redis sentinel auto discovery and instead just initializes with the values provided by the user.