### PR TITLE
ci: update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,49 +5,4 @@ updates:
     directory: /
     schedule:
       interval: daily
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /docs
-    schedule:
-      interval: daily
-
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily
-
-  - package-ecosystem: docker
-    directory: /internal/suites/example/compose/caddy
-    schedule:
-      interval: daily
-
-  - package-ecosystem: docker
-    directory: /internal/suites/example/compose/duo-api
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /internal/suites/example/compose/duo-api
-    schedule:
-      interval: daily
-
-  - package-ecosystem: docker
-    directory: /internal/suites/example/compose/haproxy
-    schedule:
-      interval: daily
-
-  - package-ecosystem: docker
-    directory: /internal/suites/example/compose/samba
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /web
-    schedule:
-      interval: daily
 ...


### PR DESCRIPTION
As we use renovate for all other packages this creates quite the overlap from the recommended configuration. Instead we just need to ensure dependabot handles the github actions elements.