### PR TITLE
Update nextcloud integration docs

### DIFF
--- a/docs/content/integration/openid-connect/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/nextcloud/index.md
@@ -24,7 +24,7 @@ seo:
   * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
 * [Nextcloud]
   * 22.1.0 with the application oidc_login
-  * 28.0.4 with the application user_oidc
+  * 29.0.4 with the application user_oidc v6.0.1
 
 {{% oidc-common %}}
 
@@ -164,7 +164,7 @@ identity_providers:
           - 'email'
           - 'groups'
         userinfo_signed_response_alg: 'none'
-        token_endpoint_auth_method: 'client_secret_post'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 #### Application


### PR DESCRIPTION
PR https://github.com/nextcloud/user_oidc/pull/897 broke the integration by preferring `client_secret_basic` over `client_secret_post`. 

More here: https://github.com/nextcloud/user_oidc/issues/907

Tested on Authelia v4.38.9, Nextcloud v29.0.4, user_oidc v6.0.1