### PR TITLE
refactor web: change 2fa method created_at last_used time to time-since-date from formatted date

### DIFF
--- a/web/src/hooks/RelativeTimeString.ts
+++ b/web/src/hooks/RelativeTimeString.ts
@@ -6,8 +6,8 @@ function getRelativeTimeString(date: Date): string {
     const ONEMINUTE = 60;
     const ONEHOUR = 3600;
     const ONEDAY = 86400;
-    const ONEMONTH = 82592000;
-    const ONEYEAR = 3153600;
+    const ONEMONTH = 2592000;
+    const ONEYEAR = 31536000;
 
     if (secondsSinceUse < ONEMINUTE) {
         return "just now";

--- a/web/src/hooks/RelativeTimeString.ts
+++ b/web/src/hooks/RelativeTimeString.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+function getRelativeTimeString(date: Date): string {
+    const now = new Date();
+    const secondsSinceUse = (now.getTime() - date.getTime()) / 1000;
+    const ONEMINUTE = 60;
+    const ONEHOUR = 3600;
+    const ONEDAY = 86400;
+    const ONEMONTH = 82592000;
+    const ONEYEAR = 3153600;
+
+    if (secondsSinceUse < ONEMINUTE) {
+        return "just now";
+    } else if (secondsSinceUse < ONEHOUR) {
+        const minutes = Math.floor(secondsSinceUse / ONEMINUTE);
+        return `${minutes} minute${minutes > 1 ? "s" : ""} ago`;
+    } else if (secondsSinceUse < ONEDAY) {
+        const hours = Math.floor(secondsSinceUse / ONEHOUR);
+        return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+    } else if (secondsSinceUse < ONEMONTH) {
+        const days = Math.floor(secondsSinceUse / ONEDAY);
+        return `${days} day${days > 1 ? "s" : ""} ago`;
+    } else if (secondsSinceUse < ONEYEAR) {
+        const months = Math.floor(secondsSinceUse / ONEMONTH);
+        return `${months} month${months > 1 ? "s" : ""} ago`;
+    } else if (secondsSinceUse > ONEYEAR) {
+        const years = Math.floor(secondsSinceUse / ONEYEAR);
+        return years === 1 ? "Over a year ago" : `${years} years ago`;
+    } else {
+        return "never";
+    }
+}
+
+function useRelativeTime(date: Date): string {
+    const [relativeTime, setRelativeTime] = useState<string>(getRelativeTimeString(date));
+
+    useEffect(() => {
+        const intervalId = setInterval(() => {
+            setRelativeTime(getRelativeTimeString(date));
+        }, 60000); //Every minute
+        return () => clearInterval(intervalId);
+    }, [date]);
+    return relativeTime;
+}
+
+export { useRelativeTime, getRelativeTimeString };

--- a/web/src/hooks/RelativeTimeString.ts
+++ b/web/src/hooks/RelativeTimeString.ts
@@ -1,37 +1,84 @@
+/**
+ * @module RelativeTimeString
+ * @description This module provides utilities for generating and updating relative time strings.
+ */
+
 import { useEffect, useState } from "react";
 
-function getRelativeTimeString(date: Date): string {
+import i18next from "i18next";
+
+/**
+ * Time constants in seconds
+ * @constant
+ */
+const ONEMINUTE = 60;
+const ONEHOUR = 3600;
+const ONEDAY = 86400;
+const ONEMONTH = 2592000;
+const ONEYEAR = 31536000;
+
+/**
+ *
+ * @function
+ * @param {Date} date - The date used to compare against the current time.
+ * @returns {string} A human-readable string representing the time since the date specified. Returned in the current browser locale.
+ *
+ * @example
+ * // Returns "2 hours ago" if the date was 2 hours before the current time
+ * const relativeTime = getRelativeTimeString(new Date(Date.now() - 2 * 60 * 60 * 1000));
+ */
+export function getRelativeTimeString(date: Date): string {
     const now = new Date();
     const secondsSinceUse = (now.getTime() - date.getTime()) / 1000;
-    const ONEMINUTE = 60;
-    const ONEHOUR = 3600;
-    const ONEDAY = 86400;
-    const ONEMONTH = 2592000;
-    const ONEYEAR = 31536000;
 
     if (secondsSinceUse < ONEMINUTE) {
-        return "just now";
+        return new Intl.RelativeTimeFormat(i18next.languages, { numeric: "auto" }).format(
+            0 - Math.floor(secondsSinceUse / ONEMINUTE),
+            "seconds",
+        );
     } else if (secondsSinceUse < ONEHOUR) {
-        const minutes = Math.floor(secondsSinceUse / ONEMINUTE);
-        return `${minutes} minute${minutes > 1 ? "s" : ""} ago`;
+        return new Intl.RelativeTimeFormat(i18next.languages, { numeric: "auto" }).format(
+            0 - Math.floor(secondsSinceUse / ONEMINUTE),
+            "minutes",
+        );
     } else if (secondsSinceUse < ONEDAY) {
-        const hours = Math.floor(secondsSinceUse / ONEHOUR);
-        return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+        return new Intl.RelativeTimeFormat(i18next.languages, { numeric: "auto" }).format(
+            0 - Math.floor(secondsSinceUse / ONEHOUR),
+            "hours",
+        );
     } else if (secondsSinceUse < ONEMONTH) {
-        const days = Math.floor(secondsSinceUse / ONEDAY);
-        return `${days} day${days > 1 ? "s" : ""} ago`;
+        return new Intl.RelativeTimeFormat(i18next.languages, { numeric: "auto" }).format(
+            0 - Math.floor(secondsSinceUse / ONEDAY),
+            "days",
+        );
     } else if (secondsSinceUse < ONEYEAR) {
-        const months = Math.floor(secondsSinceUse / ONEMONTH);
-        return `${months} month${months > 1 ? "s" : ""} ago`;
+        return new Intl.RelativeTimeFormat(i18next.languages, { numeric: "auto" }).format(
+            0 - Math.floor(secondsSinceUse / ONEMONTH),
+            "months",
+        );
     } else if (secondsSinceUse > ONEYEAR) {
-        const years = Math.floor(secondsSinceUse / ONEYEAR);
-        return years === 1 ? "Over a year ago" : `${years} years ago`;
+        return new Intl.RelativeTimeFormat(i18next.languages, { numeric: "auto" }).format(
+            0 - Math.floor(secondsSinceUse / ONEYEAR),
+            "years",
+        );
     } else {
         return "never";
     }
 }
 
-function useRelativeTime(date: Date): string {
+/**
+ *
+ * @function
+ * @param {Date} date - The date to compare against the current time
+ * @returns {string} A human readable string representing the time since the date specified, updated every minute. Returned in the current browser locale.
+ *
+ * @example
+ * function LastLoginTime({ loginDate }){
+ *  const relativeTime = useRelativeTime(loginDate);
+ *  return <span>Last Login: {relativeTime}</span>;
+ * }
+ */
+export function useRelativeTime(date: Date): string {
     const [relativeTime, setRelativeTime] = useState<string>(getRelativeTimeString(date));
 
     useEffect(() => {
@@ -42,5 +89,3 @@ function useRelativeTime(date: Date): string {
     }, [date]);
     return relativeTime;
 }
-
-export { useRelativeTime, getRelativeTimeString };

--- a/web/src/views/Settings/TwoFactorAuthentication/CredentialItem.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/CredentialItem.tsx
@@ -7,7 +7,6 @@ import Grid from "@mui/material/Unstable_Grid2/Grid2";
 import { useTranslation } from "react-i18next";
 
 import { useRelativeTime } from "@hooks/RelativeTimeString";
-// import { FormatDateHumanReadable } from "@i18n/formats";
 
 interface Props {
     id: string;
@@ -53,16 +52,12 @@ const CredentialItem = function (props: Props) {
                                 </Typography>
                             </Stack>
                             <Typography variant={"caption"} display={{ xs: "none", sm: "block" }}>
-                                {translate("Added when", {
-                                    when: timeSinceAdded,
-                                })}
+                                {`${translate("Added")} ${timeSinceAdded}`}
                             </Typography>
                             <Typography variant={"caption"} display={{ xs: "none", sm: "block" }}>
                                 {props.last_used_at === undefined
-                                    ? translate("Never used")
-                                    : translate("Last used {{when}}", {
-                                          when: timeSinceLastUsed,
-                                      })}
+                                    ? translate("Never Used")
+                                    : `${translate("Last Used")} ${timeSinceLastUsed}`}
                             </Typography>
                         </Stack>
                     </Grid>

--- a/web/src/views/Settings/TwoFactorAuthentication/CredentialItem.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/CredentialItem.tsx
@@ -6,7 +6,8 @@ import IconButton from "@mui/material/IconButton";
 import Grid from "@mui/material/Unstable_Grid2/Grid2";
 import { useTranslation } from "react-i18next";
 
-import { FormatDateHumanReadable } from "@i18n/formats";
+import { useRelativeTime } from "@hooks/RelativeTimeString";
+// import { FormatDateHumanReadable } from "@i18n/formats";
 
 interface Props {
     id: string;
@@ -27,6 +28,8 @@ interface Props {
 
 const CredentialItem = function (props: Props) {
     const { t: translate } = useTranslation("settings");
+    const timeSinceAdded = useRelativeTime(props.created_at);
+    const timeSinceLastUsed = useRelativeTime(props.last_used_at || new Date(0));
 
     return (
         <Paper variant="outlined" id={props.id}>
@@ -51,16 +54,14 @@ const CredentialItem = function (props: Props) {
                             </Stack>
                             <Typography variant={"caption"} display={{ xs: "none", sm: "block" }}>
                                 {translate("Added when", {
-                                    when: props.created_at,
-                                    formatParams: { when: FormatDateHumanReadable },
+                                    when: timeSinceAdded,
                                 })}
                             </Typography>
                             <Typography variant={"caption"} display={{ xs: "none", sm: "block" }}>
                                 {props.last_used_at === undefined
                                     ? translate("Never used")
-                                    : translate("Last Used when", {
-                                          when: props.last_used_at,
-                                          formatParams: { when: FormatDateHumanReadable },
+                                    : translate("Last used {{when}}", {
+                                          when: timeSinceLastUsed,
                                       })}
                             </Typography>
                         </Stack>


### PR DESCRIPTION
The existing date format for creation time/last used time for 2fa methods in the user settings menu is a bit lengthy and doesn't render too well even on desktop devices. This changes it to a delta-time format. Instead of showing the date, it shows the time since the last event e.g. just now, one day ago, 2 years ago etc.

Creation time/last used time doesn't need to be very specific, having the exact date and time when a credential was created/used isn't a super big issue.
For webauthn credentials, users still have the ability to see the exact date and time by inspecting the credential.

I think this should increase the readability of the settings page while also cutting down on the clutter, while maintaining clarity on when credentials were created/used.