### PR TITLE
docs(oidc): update integration documentation for Paperless

### DIFF
--- a/docs/content/integration/openid-connect/paperless/index.md
+++ b/docs/content/integration/openid-connect/paperless/index.md
@@ -21,9 +21,9 @@ seo:
 ## Tested Versions
 
 * [Authelia]
-  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+  * [v4.38.10](https://github.com/authelia/authelia/releases/tag/v4.38.10)
 * [Paperless]
-  * [v2.7.2](https://github.com/paperless-ngx/paperless-ngx/releases/tag/v2.7.2)
+  * [v2.11.6](https://github.com/paperless-ngx/paperless-ngx/releases/tag/v2.11.6)
 
 {{% oidc-common %}}
 
@@ -61,7 +61,7 @@ identity_providers:
         require_pkce: true
         pkce_challenge_method: 'S256'
         redirect_uris:
-          - 'https://paperless.{{< sitevar name="domain" nojs="example.com" >}}/accounts/authelia/login/callback/'
+          - 'https://paperless.{{< sitevar name="domain" nojs="example.com" >}}/accounts/oidc/authelia/login/callback/'
         scopes:
           - 'openid'
           - 'profile'


### PR DESCRIPTION
Due to changes in the `django-allauth` dependency in Paperless, the current integration instructions did not work with the latest version of Paperless.

This PR updates the `redirect_uris` parameter in the documentation to fix this.