### PR TITLE
Remove a curly brace that breaks a command in generating-secure-values.md

### DIFF
--- a/docs/content/reference/guides/generating-secure-values.md
+++ b/docs/content/reference/guides/generating-secure-values.md
@@ -102,7 +102,7 @@ information on all available options.
 {{< envTabs "Generate RSA Key Pair" >}}
 {{< envTab "Docker" >}}
 ```bash
-docker run -u "$(id -u):$(id -g)" -v "$(pwd)}":/keys authelia/authelia:latest authelia crypto pair rsa generate --directory /keys
+docker run -u "$(id -u):$(id -g)" -v "$(pwd)":/keys authelia/authelia:latest authelia crypto pair rsa generate --directory /keys
 ```
 {{< /envTab >}}
 {{< envTab "Bare-Metal" >}}


### PR DESCRIPTION
Was following the tutorial and noticed this small mistake