### PR TITLE
fix(oidc): jwt assertions aud overly strict

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.23.0
 
 require (
-	authelia.com/provider/oauth2 v0.1.16
+	authelia.com/provider/oauth2 v0.1.17
 	github.com/Gurpartap/logrus-stack v0.0.0-20170710170904-89c00d8a28f4
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/authelia/jsonschema v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-authelia.com/provider/oauth2 v0.1.16 h1:u+FIkbzH+AXU48mQYgWKMmatlXg4NbsnRS3F17LEfUE=
-authelia.com/provider/oauth2 v0.1.16/go.mod h1:iRv6hEajT+3OkS2I2NUCHRhwTQ86J4Gld+Nn3LSBnss=
+authelia.com/provider/oauth2 v0.1.17 h1:khSjp+5mrpnDUWdBqR9+P+Hh9FC/hd/FrEHcZKnW6gM=
+authelia.com/provider/oauth2 v0.1.17/go.mod h1:iRv6hEajT+3OkS2I2NUCHRhwTQ86J4Gld+Nn3LSBnss=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -663,3 +663,13 @@ func (ctx *AutheliaCtx) GetJWTWithTimeFuncOption() (option jwt.ParserOption) {
 func (ctx *AutheliaCtx) GetConfiguration() (config schema.Configuration) {
 	return ctx.Configuration
 }
+
+// Value is a shaded method of context.Context which returns the AutheliaCtx struct if the key is the internal key
+// otherwise it returns the shaded value.
+func (ctx *AutheliaCtx) Value(key any) any {
+	if key == model.CtxKeyAutheliaCtx {
+		return ctx
+	}
+
+	return ctx.RequestCtx.Value(key)
+}

--- a/internal/model/const.go
+++ b/internal/model/const.go
@@ -35,3 +35,9 @@ const (
 	FormatJSONSchemaIdentifier         = "https://www.authelia.com/schemas/%s/json-schema/%s.json"
 	FormatJSONSchemaYAMLLanguageServer = "# yaml-language-server: $schema=" + FormatJSONSchemaIdentifier
 )
+
+type CtxKey int
+
+const (
+	CtxKeyAutheliaCtx CtxKey = iota
+)

--- a/internal/oidc/client.go
+++ b/internal/oidc/client.go
@@ -6,7 +6,7 @@ import (
 
 	oauthelia2 "authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/x/errorsx"
-	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
@@ -19,6 +19,7 @@ func NewClient(config schema.IdentityProvidersOpenIDConnectClient, c *schema.Ide
 	registered := &RegisteredClient{
 		ID:                  config.ID,
 		Name:                config.Name,
+		ClientSecret:        &ClientSecretDigest{PasswordDigest: config.Secret},
 		SectorIdentifierURI: config.SectorIdentifierURI,
 		Public:              config.Public,
 
@@ -58,10 +59,6 @@ func NewClient(config schema.IdentityProvidersOpenIDConnectClient, c *schema.Ide
 
 		JSONWebKeysURI: config.JSONWebKeysURI,
 		JSONWebKeys:    NewPublicJSONWebKeySetFromSchemaJWK(config.JSONWebKeys),
-	}
-
-	if config.Secret != nil && config.Secret.Digest != nil {
-		registered.ClientSecret = &ClientSecretDigest{PasswordDigest: config.Secret}
 	}
 
 	if len(config.Lifespan) != 0 {

--- a/internal/oidc/client_test.go
+++ b/internal/oidc/client_test.go
@@ -25,6 +25,7 @@ func TestNewClient(t *testing.T) {
 	assert.Len(t, client.GetResponseModes(), 0)
 	assert.Len(t, client.GetResponseTypes(), 1)
 	assert.Equal(t, "", client.GetSectorIdentifierURI())
+	assert.False(t, client.GetClientSecret().Valid())
 
 	bclient, ok := client.(*oidc.RegisteredClient)
 	require.True(t, ok)

--- a/internal/oidc/types_test.go
+++ b/internal/oidc/types_test.go
@@ -117,6 +117,14 @@ type TestContext struct {
 	Config        schema.Configuration
 }
 
+func (m *TestContext) Value(key any) any {
+	if key == model.CtxKeyAutheliaCtx {
+		return m
+	}
+
+	return m.Context.Value(key)
+}
+
 func (m *TestContext) GetRandom() (r random.Provider) {
 	return random.NewMathematical()
 }

--- a/internal/storage/sql_provider.go
+++ b/internal/storage/sql_provider.go
@@ -1304,7 +1304,7 @@ func (p *SQLProvider) LoadOAuth2BlacklistedJTI(ctx context.Context, signature st
 	blacklistedJTI = &model.OAuth2BlacklistedJTI{}
 
 	if err = p.db.GetContext(ctx, blacklistedJTI, p.sqlSelectOAuth2BlacklistedJTI, signature); err != nil {
-		return nil, fmt.Errorf("error selecting oauth2 blacklisted JTI with signature '%s': %w", blacklistedJTI.Signature, err)
+		return nil, fmt.Errorf("error selecting oauth2 blacklisted JTI with signature '%s': %w", signature, err)
 	}
 
 	return blacklistedJTI, nil


### PR DESCRIPTION
This fixes an issue where all JWT assertions are strictly checked against the Token URL. RFC7523 Section 3 states that the JWT must contain an 'aud' claim that identifies the authorization server and that the token endpoint URL may be used, not that it must be used. RFC9126 clarifies this that it should be the issuer value, and that both the token endpoint URL and pushed authorization request endpoint URL must also be accepted. This fix facilitate this. In addition it fixes a log message, and an edge case where using a JWT assertion could trigger a handled panic.