### PR TITLE
ci: temporarily skip k8s suite

### DIFF
--- a/.buildkite/steps/e2etests.sh
+++ b/.buildkite/steps/e2etests.sh
@@ -2,6 +2,9 @@
 set -eu
 
 for SUITE_NAME in $(authelia-scripts suites list); do
+if [[ "${SUITE_NAME}" = "Kubernetes" ]]; then
+  continue
+fi
 cat << EOF
   - label: ":selenium: ${SUITE_NAME} Suite"
     command: "authelia-scripts --log-level debug suites test ${SUITE_NAME} --failfast --headless"


### PR DESCRIPTION
While we debug causes for this suites failure solely on agents we're suspending this suite.