### PR TITLE
Update example lite configuration.yml

### DIFF
--- a/examples/compose/lite/authelia/configuration.yml
+++ b/examples/compose/lite/authelia/configuration.yml
@@ -69,6 +69,6 @@ notifier:
     username: 'test'
     # This secret can also be set using the env variables AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE
     password: 'password'
-    address: 'smtp://mail.exmaple.com:25'
+    address: 'smtp://mail.example.com:25'
     sender: 'admin@example.com'
 ...


### PR DESCRIPTION
The mail domain was initialized as "exmaple.com", which is an actual domain owned by someone. It's better practice to use example.com, a reserved second-level domain