### PR TITLE
fix(suites): container dependencies for redis stack in ha suite

### DIFF
--- a/internal/suites/example/compose/redis-sentinel/docker-compose.yml
+++ b/internal/suites/example/compose/redis-sentinel/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     command: /entrypoint.sh master
     expose:
       - "6379"
+    healthcheck: &node-health
+      test: ["CMD-SHELL", "redis-cli ping || exit 1"]
+      interval: 3s
+      timeout: 5s
+      retries: 5
     volumes:
       - ./example/compose/redis/templates:/templates
       - ./example/compose/redis/users.acl:/data/users.acl
@@ -17,10 +22,12 @@ services:
   redis-node-1:
     image: redis:7.4-alpine
     command: /entrypoint.sh slave
-    depends_on:
-      - redis-node-0
+    depends_on: &deps
+      redis-node-0:
+        condition: service_healthy
     expose:
       - "6379"
+    healthcheck: *node-health
     volumes:
       - ./example/compose/redis/templates:/templates
       - ./example/compose/redis/users.acl:/data/users.acl
@@ -33,10 +40,10 @@ services:
   redis-node-2:
     image: redis:7.4-alpine
     command: /entrypoint.sh slave
-    depends_on:
-      - redis-node-0
+    depends_on: *deps
     expose:
       - "6379"
+    healthcheck: *node-health
     volumes:
       - ./example/compose/redis/templates:/templates
       - ./example/compose/redis/users.acl:/data/users.acl
@@ -49,11 +56,19 @@ services:
   redis-sentinel-0:
     image: redis:7.4-alpine
     command: /entrypoint.sh sentinel
-    depends_on:
-      - redis-node-1
-      - redis-node-2
+    depends_on: &deps-sentinel
+      <<: *deps
+      redis-node-1:
+        condition: service_healthy
+      redis-node-2:
+        condition: service_healthy
     expose:
       - "26379"
+    healthcheck: &sentinel-health
+      test: [ "CMD-SHELL", "redis-cli -p 26379 -a sentinel-server-password ping || exit 1" ]
+      interval: 3s
+      timeout: 5s
+      retries: 5
     volumes:
       - ./example/compose/redis/templates:/templates
       - ./example/compose/redis/entrypoint.sh:/entrypoint.sh
@@ -65,11 +80,10 @@ services:
   redis-sentinel-1:
     image: redis:7.4-alpine
     command: /entrypoint.sh sentinel
-    depends_on:
-      - redis-node-1
-      - redis-node-2
+    depends_on: *deps-sentinel
     expose:
       - "26379"
+    healthcheck: *sentinel-health
     volumes:
       - ./example/compose/redis/templates:/templates
       - ./example/compose/redis/entrypoint.sh:/entrypoint.sh
@@ -81,11 +95,10 @@ services:
   redis-sentinel-2:
     image: redis:7.4-alpine
     command: /entrypoint.sh sentinel
-    depends_on:
-      - redis-node-1
-      - redis-node-2
+    depends_on: *deps-sentinel
     expose:
       - "26379"
+    healthcheck: *sentinel-health
     volumes:
       - ./example/compose/redis/templates:/templates
       - ./example/compose/redis/entrypoint.sh:/entrypoint.sh

--- a/internal/suites/suite_high_availability_test.go
+++ b/internal/suites/suite_high_availability_test.go
@@ -125,11 +125,11 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrim
 		s.Require().NoError(err)
 	}()
 
-	err = haDockerEnvironment.Stop("redis-node-2")
+	err = haDockerEnvironment.Stop("redis-node-0")
 	s.Require().NoError(err)
 
 	defer func() {
-		err = haDockerEnvironment.Start("redis-node-2")
+		err = haDockerEnvironment.Start("redis-node-0")
 		s.Require().NoError(err)
 	}()
 


### PR DESCRIPTION
This change adds in appropriate healthchecks and dependencies for the HighAvailability suite and also ensures that the correct node (master) is brought down during integration tests.