### PR TITLE
ci(buildkite): re-enable kubernetes suite

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -7,9 +7,6 @@ git fetch -q
 if [[ ! "${BUILDKITE_COMMAND}" =~ "buildkite-agent pipeline upload" ]] || \
 [[ "${BUILDKITE_COMMAND}" == ".buildkite/steps/e2etests.sh | buildkite-agent pipeline upload" ]]; then
   echo "--- :buildkite: Setting up Build environment"
-  if [[ "${BUILDKITE_LABEL}" == ":hammer_and_wrench: Unit Test" ]]; then
-    nohup docker pull authelia/crossbuild -q &
-  fi
   source bootstrap.sh
   if [[ "${BUILDKITE_LABEL}" == ":hammer_and_wrench: Unit Test" ]] || [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
     go mod download

--- a/.buildkite/steps/e2etests.sh
+++ b/.buildkite/steps/e2etests.sh
@@ -2,9 +2,6 @@
 set -eu
 
 for SUITE_NAME in $(authelia-scripts suites list); do
-if [[ "${SUITE_NAME}" = "Kubernetes" ]]; then
-  continue
-fi
 cat << EOF
   - label: ":selenium: ${SUITE_NAME} Suite"
     command: "authelia-scripts --log-level debug suites test ${SUITE_NAME} --failfast --headless"


### PR DESCRIPTION
This change re-enables the Kubernetes suite and also removes the early pull of the `crossbuild` container as this has now moved up into the agent `environment` hook for earlier priming.

Closes #7923.