### PR TITLE
fix(oidc): select account prompt missing

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -1394,7 +1394,7 @@ paths:
             Authorization Server prompts the End-User for reauthentication and consent.
           required: false
           schema:
-            type: string
+            $ref: '#/components/schemas/openid.spec.Prompt'
         - in: query
           name: max_age
           description: >
@@ -4084,19 +4084,7 @@ components:
         display:
           $ref: '#/components/schemas/openid.spec.DisplayType'
         prompt:
-          description: >
-            Not Supported: Space delimited, case sensitive list of ASCII string values that specifies whether
-            the Authorization Server prompts the End-User for reauthentication and consent.
-          enum:
-            - 'none'
-            - 'login'
-            - 'consent'
-            - 'select_account'
-            - 'login consent'
-            - 'login select_account'
-            - 'consent select_account'
-          example: 'consent'
-          type: string
+          $ref: '#/components/schemas/openid.spec.Prompt'
         max_age:
           description: >
             Maximum Authentication Age. Specifies the allowable elapsed time in seconds since the last time the
@@ -4196,6 +4184,20 @@ components:
         - 'touch'
         - 'wap'
       example: 'page'
+      type: string
+    openid.spec.Prompt:
+      description: >
+        Not Supported: Space delimited, case sensitive list of ASCII string values that specifies whether the
+        Authorization Server prompts the End-User for reauthentication and consent.
+      enum:
+        - 'none'
+        - 'login'
+        - 'consent'
+        - 'select_account'
+        - 'login consent'
+        - 'login select_account'
+        - 'consent select_account'
+      example: 'none'
       type: string
     openid.spec.ResponseType:
       description: The OAuth 2.0 / OpenID Connect 1.0 Response Type.

--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -381,7 +381,7 @@ func (c *Config) LoadHandlers(store *Store) {
 // GetAllowedPrompts returns the allowed prompts.
 func (c *Config) GetAllowedPrompts(ctx context.Context) (prompts []string) {
 	if len(c.AllowedPrompts) == 0 {
-		c.AllowedPrompts = []string{PromptNone, PromptLogin, PromptConsent}
+		c.AllowedPrompts = []string{PromptNone, PromptLogin, PromptConsent, PromptSelectAccount}
 	}
 
 	return c.AllowedPrompts

--- a/internal/oidc/config_test.go
+++ b/internal/oidc/config_test.go
@@ -24,8 +24,8 @@ func TestConfig_GetAllowedPrompts(t *testing.T) {
 	config := &oidc.Config{}
 
 	assert.Equal(t, []string(nil), config.AllowedPrompts)
-	assert.Equal(t, []string{oidc.PromptNone, oidc.PromptLogin, oidc.PromptConsent}, config.GetAllowedPrompts(ctx))
-	assert.Equal(t, []string{oidc.PromptNone, oidc.PromptLogin, oidc.PromptConsent}, config.AllowedPrompts)
+	assert.Equal(t, []string{oidc.PromptNone, oidc.PromptLogin, oidc.PromptConsent, oidc.PromptSelectAccount}, config.GetAllowedPrompts(ctx))
+	assert.Equal(t, []string{oidc.PromptNone, oidc.PromptLogin, oidc.PromptConsent, oidc.PromptSelectAccount}, config.AllowedPrompts)
 
 	config.AllowedPrompts = []string{oidc.PromptNone}
 	assert.Equal(t, []string{oidc.PromptNone}, config.AllowedPrompts)

--- a/internal/oidc/const.go
+++ b/internal/oidc/const.go
@@ -176,9 +176,10 @@ const (
 )
 
 const (
-	PromptNone    = valueNone
-	PromptLogin   = "login"
-	PromptConsent = "consent"
+	PromptConsent       = "consent"
+	PromptLogin         = "login"
+	PromptNone          = valueNone
+	PromptSelectAccount = "select_account"
 	// PromptCreate  = "create" // This prompt value is currently unused.
 )
 

--- a/internal/oidc/discovery.go
+++ b/internal/oidc/discovery.go
@@ -165,8 +165,10 @@ func NewOpenIDConnectWellKnownConfiguration(c *schema.IdentityProvidersOpenIDCon
 		},
 		OpenIDConnectPromptCreateDiscoveryOptions: &OpenIDConnectPromptCreateDiscoveryOptions{
 			PromptValuesSupported: []string{
-				PromptNone,
 				PromptConsent,
+				PromptLogin,
+				PromptNone,
+				PromptSelectAccount,
 			},
 		},
 		OpenIDConnectJWTSecuredAuthorizationResponseModeDiscoveryOptions: &OpenIDConnectJWTSecuredAuthorizationResponseModeDiscoveryOptions{

--- a/internal/oidc/discovery_test.go
+++ b/internal/oidc/discovery_test.go
@@ -244,8 +244,10 @@ func TestNewOpenIDConnectProvider_GetOpenIDConnectWellKnownConfiguration(t *test
 	assert.Contains(t, disco.ClaimsSupported, oidc.ClaimPreferredUsername)
 	assert.Contains(t, disco.ClaimsSupported, oidc.ClaimFullName)
 
-	assert.Len(t, disco.PromptValuesSupported, 2)
+	assert.Len(t, disco.PromptValuesSupported, 4)
 	assert.Contains(t, disco.PromptValuesSupported, oidc.PromptConsent)
+	assert.Contains(t, disco.PromptValuesSupported, oidc.PromptSelectAccount)
+	assert.Contains(t, disco.PromptValuesSupported, oidc.PromptLogin)
 	assert.Contains(t, disco.PromptValuesSupported, oidc.PromptNone)
 }
 


### PR DESCRIPTION
This fixes an issue where the 'select_account' prompt is considered invalid.