### PR TITLE
fix: swagger-ui csp and cleanup unnecessary files

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -5,40 +5,18 @@
     <meta charset="UTF-8">
     <title>Swagger UI</title>
     <link rel="stylesheet" type="text/css" href="{{ .Base }}/api/swagger-ui.css" />
+    <link rel="stylesheet" type="text/css" href="{{ .Base }}/api/index.css" />
     <link rel="icon" type="image/png" href="{{ .Base }}/api/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="{{ .Base }}/api/favicon-16x16.png" sizes="16x16" />
-    <style nonce="{{ .CSPNonce }}">
-      html
-      {
-        box-sizing: border-box;
-        overflow: -moz-scrollbars-vertical;
-        overflow-y: scroll;
-      }
-
-      *,
-      *:before,
-      *:after
-      {
-        box-sizing: inherit;
-      }
-
-      body
-      {
-        margin:0;
-        background: #fafafa;
-      }
-    </style>
   </head>
 
   <body>
     <div id="swagger-ui"></div>
-
     <script src="{{ .Base }}/api/swagger-ui-bundle.js" charset="UTF-8"> </script>
     <script src="{{ .Base }}/api/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
     <script nonce="{{ .CSPNonce }}">
-    window.onload = function() {
-      // Begin Swagger UI call region
-      const ui = SwaggerUIBundle({
+    window.onload = () => {
+      window.ui = SwaggerUIBundle({
         url: "{{ .Base }}/api/openapi.yml",
         dom_id: '#swagger-ui',
         deepLinking: true,
@@ -51,9 +29,6 @@
         ],
         layout: "StandaloneLayout"
       });
-      // End Swagger UI call region
-
-      window.ui = ui;
     };
   </script>
   </body>

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -14,7 +14,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
   version: 1.0.0
 servers:
-  - url: '{{ .BaseURL }}api/'
+  - url: '{{ .BaseURL }}'
     description: Authelia API
 tags:
   - name: State

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -1,5 +1,5 @@
 ---
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: Authelia API
   description: >
@@ -14,7 +14,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0
   version: 1.0.0
 servers:
-  - url: '{{ .BaseURL }}'
+  - url: '{{ .BaseURL }}api/'
     description: Authelia API
 tags:
   - name: State

--- a/cmd/authelia-scripts/cmd/build.go
+++ b/cmd/authelia-scripts/cmd/build.go
@@ -160,7 +160,7 @@ func buildSwagger() {
 		log.Fatal(err)
 	}
 
-	cmd = utils.CommandWithStdout("tar", "-C", "internal/server/public_html/api", "--exclude=index.html", "--strip-components=2", "-xf", "v"+versionSwaggerUI+extTarballGzip, "swagger-ui-"+versionSwaggerUI+"/dist")
+	cmd = utils.CommandWithStdout("tar", "-C", "internal/server/public_html/api", "--exclude=index.html", "--exclude=*.map", "--exclude=*-es-*", "--exclude=swagger-{ui,initializer}.js", "--strip-components=2", "-xf", "v"+versionSwaggerUI+extTarballGzip, "swagger-ui-"+versionSwaggerUI+"/dist")
 
 	err = cmd.Run()
 	if err != nil {

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -59,6 +59,7 @@ var (
 	headerValueZero            = []byte("0")
 	headerValueCSPNone         = []byte("default-src 'none'")
 	headerValueCSPNoneFormPost = []byte("default-src 'none'; script-src 'sha256-skflBqA90WuHvoczvimLdj49ExKdizFjX2Itd6xKZdU='")
+	headerValueCSPSelf         = []byte("default-src 'self'")
 
 	headerValueNoSniff                 = []byte("nosniff")
 	headerValueStrictOriginCrossOrigin = []byte("strict-origin-when-cross-origin")

--- a/internal/middlewares/headers.go
+++ b/internal/middlewares/headers.go
@@ -91,6 +91,11 @@ func SecurityHeadersCSPSelf(next fasthttp.RequestHandler) fasthttp.RequestHandle
 	}
 }
 
+// SetSecurityHeadersCSPNone function adds the Content-Security-Policy header with the value "default-src 'none';".
+func SetSecurityHeadersCSPNone(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.SetBytesKV(headerContentSecurityPolicy, headerValueCSPNone)
+}
+
 // SecurityHeadersNoStore middleware adds the Pragma no-cache and Cache-Control no-store headers.
 func SecurityHeadersNoStore(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {

--- a/internal/middlewares/headers.go
+++ b/internal/middlewares/headers.go
@@ -82,6 +82,15 @@ func SecurityHeadersCSPNoneOpenIDConnect(next fasthttp.RequestHandler) fasthttp.
 	}
 }
 
+// SecurityHeadersCSPSelf middleware adds the Content-Security-Policy header with the value "default-src 'self';".
+func SecurityHeadersCSPSelf(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		ctx.Response.Header.SetBytesKV(headerContentSecurityPolicy, headerValueCSPSelf)
+
+		next(ctx)
+	}
+}
+
 // SecurityHeadersNoStore middleware adds the Pragma no-cache and Cache-Control no-store headers.
 func SecurityHeadersNoStore(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {

--- a/internal/server/asset.go
+++ b/internal/server/asset.go
@@ -60,6 +60,7 @@ func newPublicHTMLEmbeddedHandler() fasthttp.RequestHandler {
 		}
 
 		middlewares.SetBaseSecurityHeaders(ctx)
+		middlewares.SetSecurityHeadersCSPNone(ctx)
 
 		contentType := mime.TypeByExtension(path.Ext(p))
 		if len(contentType) == 0 {
@@ -192,6 +193,7 @@ func newLocalesEmbeddedHandler() (handler fasthttp.RequestHandler) {
 		}
 
 		middlewares.SetBaseSecurityHeaders(ctx)
+		middlewares.SetSecurityHeadersCSPNone(ctx)
 		middlewares.SetContentTypeApplicationJSON(ctx)
 
 		switch {

--- a/internal/server/const.go
+++ b/internal/server/const.go
@@ -12,6 +12,7 @@ const (
 	fileLogo = "logo.png"
 
 	extHTML = ".html"
+	extJS   = ".js"
 	extJSON = ".json"
 	extYML  = ".yml"
 )
@@ -29,19 +30,9 @@ var (
 		"favicon-32x32.png",
 		"index.css",
 		"oauth2-redirect.html",
-		"swagger-initializer.js",
 		"swagger-ui-bundle.js",
-		"swagger-ui-bundle.js.map",
-		"swagger-ui-es-bundle-core.js",
-		"swagger-ui-es-bundle-core.js.map",
-		"swagger-ui-es-bundle.js",
-		"swagger-ui-es-bundle.js.map",
 		"swagger-ui-standalone-preset.js",
-		"swagger-ui-standalone-preset.js.map",
 		"swagger-ui.css",
-		"swagger-ui.css.map",
-		"swagger-ui.js",
-		"swagger-ui.js.map",
 	}
 
 	// Directories excluded from the not found handler proceeding to the next() handler.
@@ -91,8 +82,7 @@ const (
 )
 
 const (
-	tmplCSPSwaggerNonce = "default-src 'self'; img-src 'self' https://validator.swagger.io data:; object-src 'none'; script-src 'self' 'unsafe-inline' 'nonce-%s'; style-src 'self' 'nonce-%s'; base-uri 'self'"
-	tmplCSPSwagger      = "default-src 'self'; img-src 'self' https://validator.swagger.io data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self'; base-uri 'self'"
+	tmplCSPSwagger = "default-src 'self'; img-src 'self' https://validator.swagger.io data:; object-src 'none'; script-src 'self' 'nonce-%s'; style-src 'self' 'sha256-RL3ie0nH+Lzz2YNqQN83mnU0J1ot4QL7b99vMdIX99w='; base-uri 'self'"
 )
 
 var (

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -129,7 +129,7 @@ func handleRouter(config *schema.Configuration, providers middlewares.Providers)
 		WithPreMiddlewares(middlewares.SecurityHeadersBase).Build()
 
 	bridgeSwagger := middlewares.NewBridgeBuilder(*config, providers).
-		WithPreMiddlewares(middlewares.SecurityHeadersRelaxed).Build()
+		WithPreMiddlewares(middlewares.SecurityHeadersRelaxed, middlewares.SecurityHeadersCSPSelf).Build()
 
 	policyCORSPublicGET := middlewares.NewCORSPolicyBuilder().
 		WithAllowedMethods(fasthttp.MethodOptions, fasthttp.MethodGet).

--- a/internal/server/template_test.go
+++ b/internal/server/template_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"io/fs"
-	"net/url"
 	"os"
 	"testing"
 
@@ -56,8 +55,6 @@ func TestShouldTemplateOpenAPI(t *testing.T) {
 		Cookies: []schema.SessionCookie{
 			{
 				Domain: "example.com",
-
-				AutheliaURL: &url.URL{Scheme: "https", Host: "auth.example.com", Path: "/"},
 			},
 		},
 	}
@@ -69,7 +66,7 @@ func TestShouldTemplateOpenAPI(t *testing.T) {
 	handler := ServeTemplatedOpenAPI(provider.GetAssetOpenAPISpecTemplate(), opts)
 
 	mock.Ctx.Request.Header.Set(fasthttp.HeaderXForwardedProto, "https")
-	mock.Ctx.Request.Header.Set(fasthttp.HeaderXForwardedHost, "example.com")
+	mock.Ctx.Request.Header.Set(fasthttp.HeaderXForwardedHost, "auth.example.com")
 	mock.Ctx.Request.Header.Set("X-Forwarded-URI", "/api/openapi.yml")
 
 	handler(mock.Ctx)


### PR DESCRIPTION
This change fixes CSP errors when browsing Swagger and cuts down the binary/image size 10%+ by keeping only required files from the swagger-ui package.