### PR TITLE
Add NEXTAUTH_URL for homarr config, needed in revese proxy setup

### DIFF
--- a/docs/content/integration/openid-connect/homarr/index.md
+++ b/docs/content/integration/openid-connect/homarr/index.md
@@ -88,6 +88,7 @@ AUTH_OIDC_CLIENT_ID=homarr
 AUTH_OIDC_CLIENT_NAME=Authelia
 AUTH_OIDC_ADMIN_GROUP=homarr-admins
 AUTH_OIDC_OWNER_GROUP=homarr-owners
+NEXTAUTH_URL=https://homarr.{{< sitevar name="domain" nojs="example.com" >}}
 ```
 
 ## See Also


### PR DESCRIPTION
Without it the redirect goes to localhost:7575 instead of to the correct domain and the flow fails.

More details in https://github.com/ajnart/homarr/issues/1909
