### PR TITLE
docs:  fix outdated redirect_uris in Immich integration

### DIFF
--- a/docs/content/integration/openid-connect/immich/index.md
+++ b/docs/content/integration/openid-connect/immich/index.md
@@ -21,9 +21,9 @@ seo:
 ## Tested Versions
 
 * [Authelia]
-  * [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+  * [v4.38.16](https://github.com/authelia/authelia/releases/tag/v4.38.16)
 * [immich]
-  * [v1.101.0](https://github.com/immich-app/immich/releases/tag/v1.101.0)
+  * [v1.117.0](https://github.com/immich-app/immich/releases/tag/v1.117.0)
 
 {{% oidc-common %}}
 
@@ -61,7 +61,7 @@ identity_providers:
         redirect_uris:
           - 'https://immich.{{< sitevar name="domain" nojs="example.com" >}}/auth/login'
           - 'https://immich.{{< sitevar name="domain" nojs="example.com" >}}/user-settings'
-          - 'app.immich:/'
+          - 'app.immich:///oauth-callback'
         scopes:
           - 'openid'
           - 'profile'


### PR DESCRIPTION
Some recent version of Immich changed its callback URL for mobile devices, which breaks OAuth.

The [guide](https://immich.app/docs/administration/oauth/) from Immich said that the redirect URIs are,

- app.immich:///oauth-callback - for logging in with OAuth from the [Mobile App](https://immich.app/docs/features/mobile-app)
- ...