### PR TITLE
feat(web): add theme changer

### DIFF
--- a/docs/content/configuration/miscellaneous/introduction.md
+++ b/docs/content/configuration/miscellaneous/introduction.md
@@ -79,11 +79,12 @@ default_2fa_method: totp
 
 {{< confkey type="string " default="light" required="no" >}}
 
-There are currently 3 available themes for Authelia:
+There are currently 4 available themes for Authelia:
 
 * light (default)
 * dark
 * grey
+* oled
 
 To enable automatic switching between themes, you can set `theme` to `auto`. The theme will be set to either `dark` or
 `light` depending on the user's system preference which is determined using media queries. To read more technical

--- a/internal/configuration/schema/configuration.go
+++ b/internal/configuration/schema/configuration.go
@@ -6,7 +6,7 @@ import (
 
 // Configuration object extracted from YAML configuration file.
 type Configuration struct {
-	Theme                 string `koanf:"theme" json:"theme" jsonschema:"default=light,enum=auto,enum=light,enum=dark,enum=grey,title=Theme Name" jsonschema_description:"The name of the theme to apply to the web UI."`
+	Theme                 string `koanf:"theme" json:"theme" jsonschema:"default=light,enum=auto,enum=light,enum=dark,enum=grey,enum=oled,title=Theme Name" jsonschema_description:"The name of the theme to apply to the web UI."`
 	CertificatesDirectory string `koanf:"certificates_directory" json:"certificates_directory" jsonschema:"title=Certificates Directory Path" jsonschema_description:"The path to a directory which is used to determine the certificates that are trusted."`
 	Default2FAMethod      string `koanf:"default_2fa_method" json:"default_2fa_method" jsonschema:"enum=totp,enum=webauthn,enum=mobile_push,title=Default 2FA method" jsonschema_description:"When a user logs in for the first time this is the 2FA method configured for them."`
 

--- a/web/src/components/ThemeChanger.tsx
+++ b/web/src/components/ThemeChanger.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+
+import { Brightness4, Brightness5, Brightness6, BrightnessAuto, BrightnessHigh } from "@mui/icons-material";
+import { IconButton, Menu, MenuItem, useTheme } from "@mui/material";
+
+import { useThemeContext } from "@contexts/ThemeContext";
+import { ThemeNameAuto, ThemeNameDark, ThemeNameGrey, ThemeNameLight, ThemeNameOled } from "@themes/index";
+
+const ThemeChanger: React.FC = () => {
+    const { themeName, setThemeName } = useThemeContext();
+    const theme = useTheme();
+    const [anchorElement, setAnchorElement] = useState<null | HTMLElement>(null);
+
+    const themes = [
+        { name: "Auto", value: ThemeNameAuto, icon: BrightnessAuto },
+        { name: "Light", value: ThemeNameLight, icon: BrightnessHigh },
+        { name: "Grey", value: ThemeNameGrey, icon: Brightness6 },
+        { name: "Dark", value: ThemeNameDark, icon: Brightness4 },
+        { name: "Oled", value: ThemeNameOled, icon: Brightness5 },
+    ];
+
+    const CurrentIcon = themes.find((t) => t.value === themeName)?.icon || BrightnessAuto;
+
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        setAnchorElement(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorElement(null);
+    };
+
+    const handleThemeChange = (newTheme: string) => {
+        setThemeName(newTheme);
+        handleClose();
+    };
+
+    return (
+        <>
+            <IconButton
+                onClick={handleClick}
+                aria-label="change theme"
+                aria-controls="theme-menu"
+                aria-haspopup="true"
+                sx={{
+                    color: theme.palette.text.primary,
+                }}
+            >
+                <CurrentIcon />
+            </IconButton>
+            <Menu
+                id="theme-menu"
+                anchorEl={anchorElement}
+                keepMounted
+                open={Boolean(anchorElement)}
+                onClose={handleClose}
+            >
+                {themes.map((t) => (
+                    <MenuItem key={t.value} onClick={() => handleThemeChange(t.value)} selected={themeName === t.value}>
+                        <t.icon sx={{ mr: 1 }} />
+                        {t.name}
+                    </MenuItem>
+                ))}
+            </Menu>
+        </>
+    );
+};
+
+export default ThemeChanger;

--- a/web/src/contexts/ThemeContext.tsx
+++ b/web/src/contexts/ThemeContext.tsx
@@ -128,6 +128,8 @@ function ThemeFromName(name: string) {
             return themes.Dark;
         case themes.ThemeNameGrey:
             return themes.Grey;
+        case themes.ThemeNameOled:
+            return themes.Oled;
         case themes.ThemeNameAuto:
             return window.matchMedia(MediaQueryDarkMode).matches ? themes.Dark : themes.Light;
         default:

--- a/web/src/layouts/LoginLayout.tsx
+++ b/web/src/layouts/LoginLayout.tsx
@@ -9,6 +9,7 @@ import UserSvg from "@assets/images/user.svg?react";
 import AccountSettingsMenu from "@components/AccountSettingsMenu";
 import Brand from "@components/Brand";
 import PrivacyPolicyDrawer from "@components/PrivacyPolicyDrawer";
+import ThemeChanger from "@components/ThemeChanger";
 import TypographyWithTooltip from "@components/TypographyWithTooltip";
 import { UserInfo } from "@models/UserInfo";
 import { getLogoOverride } from "@utils/Configuration";
@@ -43,6 +44,7 @@ const LoginLayout = function (props: Props) {
             <AppBar position="static" color="transparent" elevation={0}>
                 <Toolbar variant="regular">
                     <Typography style={{ flexGrow: 1 }} />
+                    <ThemeChanger />
                     {props.userInfo ? <AccountSettingsMenu userInfo={props.userInfo} /> : null}
                 </Toolbar>
             </AppBar>

--- a/web/src/themes/Oled.ts
+++ b/web/src/themes/Oled.ts
@@ -1,0 +1,87 @@
+import { createTheme } from "@mui/material/styles";
+
+const Oled = createTheme({
+    custom: {
+        icon: "#fff",
+        loadingBar: "#fff",
+    },
+    palette: {
+        mode: "dark",
+        primary: {
+            main: "#1976d2",
+        },
+        secondary: {
+            light: "#ff4081",
+            main: "#f50057",
+            dark: "#c51162",
+            contrastText: "#ffffff",
+        },
+        error: {
+            light: "#e57373",
+            main: "#f44336",
+            dark: "#d32f2f",
+            contrastText: "#ffffff",
+        },
+        warning: {
+            light: "#ffb74d",
+            main: "#ff9800",
+            dark: "#f57c00",
+            contrastText: "rgba(255, 255, 255, 0.87)",
+        },
+        info: {
+            light: "#64b5f6",
+            main: "#2196f3",
+            dark: "#1976d2",
+            contrastText: "#ffffff",
+        },
+        success: {
+            light: "#81c784",
+            main: "#4caf50",
+            dark: "#388e3c",
+            contrastText: "rgba(255, 255, 255, 0.87)",
+        },
+        grey: {
+            "50": "#fafafa",
+            "100": "#f5f5f5",
+            "200": "#eeeeee",
+            "300": "#e0e0e0",
+            "400": "#bdbdbd",
+            "500": "#9e9e9e",
+            "600": "#757575",
+            "700": "#616161",
+            "800": "#424242",
+            "900": "#212121",
+            A100: "#d5d5d5",
+            A200: "#aaaaaa",
+            A400: "#303030",
+            A700: "#616161",
+        },
+        contrastThreshold: 3,
+        tonalOffset: 0.2,
+        text: {
+            primary: "#ffffff",
+            secondary: "rgba(255, 255, 255, 0.7)",
+            disabled: "rgba(255, 255, 255, 0.5)",
+        },
+        divider: "rgba(255, 255, 255, 0.12)",
+        background: {
+            paper: "#000000",
+            default: "#000000",
+        },
+        action: {
+            active: "#ffffff",
+            hover: "rgba(255, 255, 255, 0.08)",
+            hoverOpacity: 0.08,
+            selected: "rgba(255, 255, 255, 0.16)",
+            selectedOpacity: 0.16,
+            disabled: "rgba(255, 255, 255, 0.3)",
+            disabledBackground: "rgba(255, 255, 255, 0.12)",
+            disabledOpacity: 0.38,
+            focus: "rgba(255, 255, 255, 0.12)",
+            focusOpacity: 0.12,
+            activatedOpacity: 0.24,
+        },
+    },
+});
+
+export default Oled;

--- a/web/src/themes/index.ts
+++ b/web/src/themes/index.ts
@@ -27,7 +27,9 @@ export const ThemeNameAuto = "auto";
 export const ThemeNameLight = "light";
 export const ThemeNameDark = "dark";
 export const ThemeNameGrey = "grey";
+export const ThemeNameOled = "oled";
 
 export { default as Light } from "@themes/Light";
 export { default as Dark } from "@themes/Dark";
 export { default as Grey } from "@themes/Grey";
+export { default as Oled } from "@themes/Oled";


### PR DESCRIPTION
Add a theme changer drop down to Login Portal and Authenticated Pages, allowing users to easily set their current device's theme.

Additionally added a new OLED theme.