### PR TITLE
fix(configuration): jwk without required key startup panic

### DIFF
--- a/internal/configuration/provider_test.go
+++ b/internal/configuration/provider_test.go
@@ -527,6 +527,26 @@ func TestShouldLoadURLList(t *testing.T) {
 	assert.Equal(t, "https://example.com", config.IdentityProviders.OIDC.CORS.AllowedOrigins[1].String())
 }
 
+func TestShouldNotPanicJWKNilKey(t *testing.T) {
+	val := schema.NewStructValidator()
+	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc_empty_jwk_key.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)
+
+	assert.NoError(t, err)
+
+	validator.ValidateKeys(keys, GetMultiKeyMappedDeprecationKeys(), DefaultEnvPrefix, val)
+
+	assert.Len(t, val.Errors(), 0)
+	assert.Len(t, val.Warnings(), 0)
+
+	validator.ValidateIdentityProviders(validator.NewValidateCtx(), &config.IdentityProviders, val)
+
+	assert.Len(t, val.Errors(), 2)
+	require.Len(t, val.Warnings(), 1)
+
+	assert.EqualError(t, val.Errors()[0], "identity_providers: oidc: jwks: key #1 with key id 'abc': option 'key' must be provided")
+	assert.EqualError(t, val.Errors()[1], "identity_providers: oidc: clients: client 'abc': jwks: key #1 with key id 'client_abc': option 'key' must be provided")
+}
+
 func TestShouldDisableOIDCEntropy(t *testing.T) {
 	val := schema.NewStructValidator()
 	keys, config, err := Load(val, NewDefaultSources([]string{"./test_resources/config_oidc_disable_entropy.yml"}, DefaultEnvPrefix, DefaultEnvDelimiter)...)

--- a/internal/configuration/provider_test.go
+++ b/internal/configuration/provider_test.go
@@ -541,11 +541,15 @@ func TestShouldNotPanicJWKNilKey(t *testing.T) {
 	require.NotPanics(t, func() {
 		validator.ValidateIdentityProviders(validator.NewValidateCtx(), &config.IdentityProviders, val)
 	})
-	assert.Len(t, val.Errors(), 2)
+
+	assert.Len(t, val.Errors(), 5)
 	require.Len(t, val.Warnings(), 1)
 
 	assert.EqualError(t, val.Errors()[0], "identity_providers: oidc: jwks: key #1 with key id 'abc': option 'key' must be provided")
-	assert.EqualError(t, val.Errors()[1], "identity_providers: oidc: clients: client 'abc': jwks: key #1 with key id 'client_abc': option 'key' must be provided")
+	assert.EqualError(t, val.Errors()[1], "identity_providers: oidc: jwks: key #2: option 'key' must be provided")
+	assert.EqualError(t, val.Errors()[2], "identity_providers: oidc: clients: client 'abc': jwks: key #1 with key id 'client_abc': option 'key' must be provided")
+	assert.EqualError(t, val.Errors()[3], "identity_providers: oidc: clients: client 'abc': jwks: key #2: option 'key_id' must be provided")
+	assert.EqualError(t, val.Errors()[4], "identity_providers: oidc: clients: client 'abc': jwks: key #2: option 'key' must be provided")
 }
 
 func TestShouldDisableOIDCEntropy(t *testing.T) {

--- a/internal/configuration/provider_test.go
+++ b/internal/configuration/provider_test.go
@@ -538,8 +538,9 @@ func TestShouldNotPanicJWKNilKey(t *testing.T) {
 	assert.Len(t, val.Errors(), 0)
 	assert.Len(t, val.Warnings(), 0)
 
-	validator.ValidateIdentityProviders(validator.NewValidateCtx(), &config.IdentityProviders, val)
-
+	require.NotPanics(t, func() {
+		validator.ValidateIdentityProviders(validator.NewValidateCtx(), &config.IdentityProviders, val)
+	})
 	assert.Len(t, val.Errors(), 2)
 	require.Len(t, val.Warnings(), 1)
 

--- a/internal/configuration/test_resources/config_oidc_empty_jwk_key.yml
+++ b/internal/configuration/test_resources/config_oidc_empty_jwk_key.yml
@@ -131,6 +131,7 @@ identity_providers:
     jwks:
       - key_id: 'abc'
         use: 'sig'
+      - use: 'sig'
     clients:
       - client_id: 'abc'
         client_secret: '123'
@@ -139,4 +140,5 @@ identity_providers:
         jwks:
           - key_id: 'client_abc'
             use: 'sig'
+          - use: 'sig'
 ...

--- a/internal/configuration/test_resources/config_oidc_empty_jwk_key.yml
+++ b/internal/configuration/test_resources/config_oidc_empty_jwk_key.yml
@@ -1,0 +1,142 @@
+---
+default_redirection_url: 'https://home.example.com:8080/'
+
+server:
+  address: 'tcp://127.0.0.1:9091'
+
+log:
+  level: 'debug'
+
+totp:
+  issuer: 'authelia.com'
+
+duo_api:
+  hostname: 'api-123456789.example.com'
+  integration_key: 'ABCDEF'
+
+authentication_backend:
+  ldap:
+    address: 'ldap://127.0.0.1'
+    base_dn: 'dc=example,dc=com'
+    additional_users_dn: 'ou=users'
+    users_filter: '(&({username_attribute}={input})(objectCategory=person)(objectClass=user))'
+    additional_groups_dn: 'ou=groups'
+    groups_filter: '(&(member={dn})(objectClass=groupOfNames))'
+    user: 'cn=admin,dc=example,dc=com'
+    attributes:
+      username: 'uid'
+      group_name: 'cn'
+      mail: 'mail'
+
+access_control:
+  default_policy: 'deny'
+
+  rules:
+    # Rules applied to everyone
+    - domain: 'public.example.com'
+      policy: 'bypass'
+
+    - domain: 'secure.example.com'
+      policy: 'one_factor'
+      # Network based rule, if not provided any network matches.
+      networks:
+        - '192.168.1.0/24'
+    - domain: 'secure.example.com'
+      policy: 'two_factor'
+
+    - domain: ['singlefactor.example.com', 'onefactor.example.com']
+      policy: 'one_factor'
+
+    # Rules applied to 'admins' group
+    - domain: 'mx2.mail.example.com'
+      subject: 'group:admins'
+      policy: 'deny'
+    - domain: '*.example.com'
+      subject: 'group:admins'
+      policy: 'two_factor'
+
+    # Rules applied to 'dev' group
+    - domain: 'dev.example.com'
+      resources:
+        - '^/groups/dev/.*$'
+      subject: 'group:dev'
+      policy: 'two_factor'
+
+    # Rules applied to user 'john'
+    - domain: 'dev.example.com'
+      resources:
+        - '^/users/john/.*$'
+      subject: 'user:john'
+      policy: 'two_factor'
+
+    # Rules applied to 'dev' group and user 'john'
+    - domain: 'dev.example.com'
+      resources:
+        - '^/deny-all.*$'
+      subject: ['group:dev', 'user:john']
+      policy: 'deny'
+
+    # Rules applied to user 'harry'
+    - domain: 'dev.example.com'
+      resources:
+        - '^/users/harry/.*$'
+      subject: 'user:harry'
+      policy: 'two_factor'
+
+    # Rules applied to user 'bob'
+    - domain: '*.mail.example.com'
+      subject: 'user:bob'
+      policy: 'two_factor'
+    - domain: 'dev.example.com'
+      resources:
+        - '^/users/bob/.*$'
+      subject: 'user:bob'
+      policy: 'two_factor'
+
+session:
+  name: 'authelia_session'
+  expiration: '1h'  # 1 hour
+  inactivity: '5m'  # 5 minutes
+  domain: 'example.com'
+  redis:
+    host: '127.0.0.1'
+    port: 6379
+    high_availability:
+      sentinel_name: 'test'
+
+regulation:
+  max_retries: 3
+  find_time: '2m'
+  ban_time: '5m'
+
+storage:
+  mysql:
+    address: 'tcp://127.0.0.1:3306'
+    database: 'authelia'
+    username: 'authelia'
+
+notifier:
+  smtp:
+    address: 'smtp://127.0.0.1:1025'
+    username: 'test'
+    sender: 'admin@example.com'
+    disable_require_tls: true
+
+identity_providers:
+  oidc:
+    cors:
+      allowed_origins:
+        - 'https://google.com'
+        - 'https://example.com'
+    jwks:
+      - key_id: 'abc'
+        use: 'sig'
+    clients:
+      - client_id: 'abc'
+        client_secret: '123'
+        consent_mode: 'explicit'
+        userinfo_signed_response_alg: 'none'
+        jwks:
+          - key_id: 'client_abc'
+            use: 'sig'
+...

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -174,6 +174,8 @@ const (
 	errFmtOIDCProviderInsecureDisabledParameterEntropy = errFmtOIDCProviderInsecureParameterEntropy +
 		"disabled which is considered unsafe and insecure"
 	errFmtOIDCProviderPrivateKeysInvalid                 = "identity_providers: oidc: jwks: key #%d: option 'key' must be a valid private key but the provided data is malformed as it's missing the public key bits"
+	errFmtOIDCProviderPrivateKeysMissing                 = "identity_providers: oidc: jwks: key #%d: option 'key' must be provided"
+	errFmtOIDCProviderPrivateKeysWithKeyID               = "identity_providers: oidc: jwks: key #%d with key id '%s': option 'key' must be provided"
 	errFmtOIDCProviderPrivateKeysCalcThumbprint          = "identity_providers: oidc: jwks: key #%d: option 'key' failed to calculate thumbprint to configure key id value: %w"
 	errFmtOIDCProviderPrivateKeysKeyIDLength             = "identity_providers: oidc: jwks: key #%d with key id '%s': option `key_id` must be 100 characters or less"
 	errFmtOIDCProviderPrivateKeysAttributeNotUnique      = "identity_providers: oidc: jwks: key #%d with key id '%s': option '%s' must be unique"
@@ -286,17 +288,18 @@ const (
 	errFmtOIDCClientInvalidRefreshTokenOptionWithoutCodeResponseType = errFmtOIDCClientOption +
 		"'%s' should only have the values %s if the client is also configured with a 'response_type' such as %s which respond with authorization codes"
 
-	errFmtOIDCClientPublicKeysBothURIAndValuesConfigured  = "identity_providers: oidc: clients: client '%s': option 'jwks_uri' must not be defined at the same time as option 'jwks'"
-	errFmtOIDCClientPublicKeysURIInvalidScheme            = "identity_providers: oidc: clients: client '%s': option 'jwks_uri' must have the 'https' scheme but the scheme is '%s'"
-	errFmtOIDCClientPublicKeysProperties                  = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'key' failed to get key properties: %w"
-	errFmtOIDCClientPublicKeysInvalidOptionOneOf          = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option '%s' must be one of %s but it's configured as '%s'"
-	errFmtOIDCClientPublicKeysInvalidOptionMissingOneOf   = "identity_providers: oidc: clients: client '%s': jwks: key #%d: option '%s' must be provided"
-	errFmtOIDCClientPublicKeysKeyMalformed                = "identity_providers: oidc: clients: client '%s': jwks: key #%d: option 'key' option 'key' must be a valid private key but the provided data is malformed as it's missing the public key bits"
-	errFmtOIDCClientPublicKeysRSAKeyLessThan2048Bits      = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'key' is an RSA %d bit private key but it must at minimum be a RSA 2048 bit private key"
-	errFmtOIDCClientPublicKeysKeyNotRSAOrECDSA            = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'key' must be a RSA public key or ECDSA public key but it's type is %T"
-	errFmtOIDCClientPublicKeysCertificateChainKeyMismatch = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'certificate_chain' does not appear to contain the public key for the public key provided by option 'key'"
-	errFmtOIDCClientPublicKeysCertificateChainInvalid     = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'certificate_chain' produced an error during validation of the chain: %w"
-	errFmtOIDCClientPublicKeysROSAMissingAlgorithm        = errFmtOIDCClientOption + "'request_object_signing_alg' must be one of %s configured in the client option 'jwks'"
+	errFmtOIDCClientPublicKeysBothURIAndValuesConfigured      = "identity_providers: oidc: clients: client '%s': option 'jwks_uri' must not be defined at the same time as option 'jwks'"
+	errFmtOIDCClientPublicKeysURIInvalidScheme                = "identity_providers: oidc: clients: client '%s': option 'jwks_uri' must have the 'https' scheme but the scheme is '%s'"
+	errFmtOIDCClientPublicKeysProperties                      = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'key' failed to get key properties: %w"
+	errFmtOIDCClientPublicKeysInvalidOptionOneOf              = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option '%s' must be one of %s but it's configured as '%s'"
+	errFmtOIDCClientPublicKeysInvalidOptionMissingOneOf       = "identity_providers: oidc: clients: client '%s': jwks: key #%d: option '%s' must be provided"
+	errFmtOIDCClientPublicKeysWithIDInvalidOptionMissingOneOf = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option '%s' must be provided"
+	errFmtOIDCClientPublicKeysKeyMalformed                    = "identity_providers: oidc: clients: client '%s': jwks: key #%d: option 'key' option 'key' must be a valid private key but the provided data is malformed as it's missing the public key bits"
+	errFmtOIDCClientPublicKeysRSAKeyLessThan2048Bits          = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'key' is an RSA %d bit private key but it must at minimum be a RSA 2048 bit private key"
+	errFmtOIDCClientPublicKeysKeyNotRSAOrECDSA                = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'key' must be a RSA public key or ECDSA public key but it's type is %T"
+	errFmtOIDCClientPublicKeysCertificateChainKeyMismatch     = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'certificate_chain' does not appear to contain the public key for the public key provided by option 'key'"
+	errFmtOIDCClientPublicKeysCertificateChainInvalid         = "identity_providers: oidc: clients: client '%s': jwks: key #%d with key id '%s': option 'certificate_chain' produced an error during validation of the chain: %w"
+	errFmtOIDCClientPublicKeysROSAMissingAlgorithm            = errFmtOIDCClientOption + "'request_object_signing_alg' must be one of %s configured in the client option 'jwks'"
 )
 
 // WebAuthn Error constants.

--- a/internal/configuration/validator/identity_providers.go
+++ b/internal/configuration/validator/identity_providers.go
@@ -175,6 +175,18 @@ func validateOIDCIssuerJSONWebKeys(config *schema.IdentityProvidersOpenIDConnect
 	config.Discovery.DefaultKeyIDs = map[string]string{}
 
 	for i := 0; i < len(config.JSONWebKeys); i++ {
+
+		if config.JSONWebKeys[i].Key == nil {
+			if len(config.JSONWebKeys[i].KeyID) != 0 {
+				validator.Push(fmt.Errorf(errFmtOIDCProviderPrivateKeysWithKeyID, i+1, config.JSONWebKeys[i].KeyID))
+			} else {
+				validator.Push(fmt.Errorf(errFmtOIDCProviderPrivateKeysMissing, i+1))
+
+			}
+
+			continue
+		}
+
 		if key, ok := config.JSONWebKeys[i].Key.(*rsa.PrivateKey); ok && key.PublicKey.N == nil {
 			validator.Push(fmt.Errorf(errFmtOIDCProviderPrivateKeysInvalid, i+1))
 
@@ -510,13 +522,21 @@ func validateOIDCClientJSONWebKeysList(c int, config *schema.IdentityProvidersOp
 			continue
 		}
 
+		if config.Clients[c].JSONWebKeys[i].Key == nil {
+			if len(config.Clients[c].JSONWebKeys[i].KeyID) != 0 {
+				validator.Push(fmt.Errorf(errFmtOIDCClientPublicKeysWithIDInvalidOptionMissingOneOf, config.Clients[c].ID, i+1, config.Clients[c].JSONWebKeys[i].KeyID, attrOIDCKey))
+			} else {
+				validator.Push(fmt.Errorf(errFmtOIDCClientPublicKeysInvalidOptionMissingOneOf, config.Clients[c].ID, i+1, attrOIDCKey))
+			}
+
+			continue
+		}
+
 		validateOIDCClientJSONWebKeysListKeyUseAlg(c, i, props, config, validator)
 
 		var checkEqualKey bool
 
 		switch key := config.Clients[c].JSONWebKeys[i].Key.(type) {
-		case nil:
-			validator.Push(fmt.Errorf(errFmtOIDCClientPublicKeysInvalidOptionMissingOneOf, config.Clients[c].ID, i+1, attrOIDCKey))
 		case *rsa.PublicKey:
 			checkEqualKey = true
 

--- a/internal/configuration/validator/identity_providers.go
+++ b/internal/configuration/validator/identity_providers.go
@@ -181,7 +181,6 @@ func validateOIDCIssuerJSONWebKeys(config *schema.IdentityProvidersOpenIDConnect
 				validator.Push(fmt.Errorf(errFmtOIDCProviderPrivateKeysWithKeyID, i+1, config.JSONWebKeys[i].KeyID))
 			} else {
 				validator.Push(fmt.Errorf(errFmtOIDCProviderPrivateKeysMissing, i+1))
-
 			}
 
 			continue

--- a/internal/configuration/validator/identity_providers.go
+++ b/internal/configuration/validator/identity_providers.go
@@ -175,7 +175,6 @@ func validateOIDCIssuerJSONWebKeys(config *schema.IdentityProvidersOpenIDConnect
 	config.Discovery.DefaultKeyIDs = map[string]string{}
 
 	for i := 0; i < len(config.JSONWebKeys); i++ {
-
 		if config.JSONWebKeys[i].Key == nil {
 			if len(config.JSONWebKeys[i].KeyID) != 0 {
 				validator.Push(fmt.Errorf(errFmtOIDCProviderPrivateKeysWithKeyID, i+1, config.JSONWebKeys[i].KeyID))

--- a/internal/configuration/validator/identity_providers_test.go
+++ b/internal/configuration/validator/identity_providers_test.go
@@ -3202,7 +3202,7 @@ func TestValidateOIDCClientJWKS(t *testing.T) {
 			nil,
 			nil,
 			[]string{
-				"identity_providers: oidc: clients: client 'test': jwks: key #1: option 'key' must be provided",
+				"identity_providers: oidc: clients: client 'test': jwks: key #1 with key id 'test': option 'key' must be provided",
 			},
 		},
 		{

--- a/internal/configuration/validator/identity_providers_test.go
+++ b/internal/configuration/validator/identity_providers_test.go
@@ -3206,6 +3206,19 @@ func TestValidateOIDCClientJWKS(t *testing.T) {
 			},
 		},
 		{
+			"ShouldFailOnEmptyKeyNoKeyID",
+			nil,
+			[]schema.JWK{
+				{KeyID: "", Use: oidc.KeyUseSignature, Algorithm: oidc.SigningAlgRSAUsingSHA256, Key: nil},
+			},
+			nil,
+			nil,
+			[]string{
+				"identity_providers: oidc: clients: client 'test': jwks: key #1: option 'key_id' must be provided",
+				"identity_providers: oidc: clients: client 'test': jwks: key #1: option 'key' must be provided",
+			},
+		},
+		{
 			"ShouldFailOnMalformedKey",
 			nil,
 			[]schema.JWK{
@@ -3550,6 +3563,44 @@ func TestValidateOIDCIssuer(t *testing.T) {
 			[]string{
 				"identity_providers: oidc: jwks: key #1 with key id 'c4c7ca-invalid': option 'algorithm' must be one of 'RS256', 'PS256', 'ES256', 'RS384', 'PS384', 'ES384', 'RS512', 'PS512', or 'ES512' but it's configured as 'invalid'",
 				"identity_providers: oidc: jwks: keys: must at least have one key supporting the 'RS256' algorithm but only has 'invalid'",
+			},
+		},
+		{
+			"ShouldErrorNilKeyWithoutKID",
+			&schema.IdentityProvidersOpenIDConnect{
+				JSONWebKeys: []schema.JWK{
+					{Key: nil, Algorithm: oidc.SigningAlgRSAUsingSHA256, Use: oidc.KeyUseSignature},
+				},
+			},
+			schema.IdentityProvidersOpenIDConnect{
+				JSONWebKeys: []schema.JWK{
+					{Algorithm: oidc.SigningAlgRSAUsingSHA256, Use: oidc.KeyUseSignature},
+				},
+				Discovery: schema.IdentityProvidersOpenIDConnectDiscovery{
+					DefaultKeyIDs: map[string]string{},
+				},
+			},
+			[]string{
+				"identity_providers: oidc: jwks: key #1: option 'key' must be provided",
+			},
+		},
+		{
+			"ShouldErrorNilKey",
+			&schema.IdentityProvidersOpenIDConnect{
+				JSONWebKeys: []schema.JWK{
+					{Key: nil, KeyID: "example", Algorithm: oidc.SigningAlgRSAUsingSHA256, Use: oidc.KeyUseSignature},
+				},
+			},
+			schema.IdentityProvidersOpenIDConnect{
+				JSONWebKeys: []schema.JWK{
+					{KeyID: "example", Algorithm: oidc.SigningAlgRSAUsingSHA256, Use: oidc.KeyUseSignature},
+				},
+				Discovery: schema.IdentityProvidersOpenIDConnectDiscovery{
+					DefaultKeyIDs: map[string]string{},
+				},
+			},
+			[]string{
+				"identity_providers: oidc: jwks: key #1 with key id 'example': option 'key' must be provided",
 			},
 		},
 		{


### PR DESCRIPTION
This fixes an issue where not defining the required key for a JSON Web Key would cause a panic.

Fixes #8020