### PR TITLE
docs: add link to reference section on how to generate a secure hmac secret

### DIFF
--- a/docs/content/configuration/identity-validation/reset-password.md
+++ b/docs/content/configuration/identity-validation/reset-password.md
@@ -53,3 +53,7 @@ The JSON Web Token Algorithm used to sign the JWT. Must be HS256, HS384, or HS51
 {{< confkey type="string" required="yes" >}}
 
 The secret used with the HMAC algorithm to sign the JWT.
+
+It's __strongly recommended__ this is a
+[Random Alphanumeric String](../../reference/guides/generating-secure-values.md#generating-a-random-alphanumeric-string) with 64 or more
+characters.


### PR DESCRIPTION
Hi,

this adds a missing link to the docs reference section on how to generate a secure hmac secret.