### PR TITLE
Remove docker containers after generating secrets

### DIFF
--- a/docs/content/integration/openid-connect/frequently-asked-questions.md
+++ b/docs/content/integration/openid-connect/frequently-asked-questions.md
@@ -51,7 +51,7 @@ separately.
 {{< envTabs "Generate a Random Client ID" >}}
 {{< envTab "Docker" >}}
 ```bash
-docker run authelia/authelia:latest authelia crypto rand --length 72 --charset rfc3986
+docker run --rm authelia/authelia:latest authelia crypto rand --length 72 --charset rfc3986
 ```
 {{< /envTab >}}
 {{< envTab "Bare-Metal" >}}
@@ -77,7 +77,7 @@ separately.
 {{< envTabs "Generate a Random Client Secret" >}}
 {{< envTab "Docker" >}}
 ```bash
-docker run authelia/authelia:latest authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72 --random.charset rfc3986
+docker run --rm authelia/authelia:latest authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72 --random.charset rfc3986
 ```
 {{< /envTab >}}
 {{< envTab "Bare-Metal" >}}

--- a/docs/content/reference/guides/generating-secure-values.md
+++ b/docs/content/reference/guides/generating-secure-values.md
@@ -30,7 +30,7 @@ more information on all available options and algorithms.
 {{< envTabs "Generate Random Password" >}}
 {{< envTab "Docker" >}}
 ```bash
-docker run authelia/authelia:latest authelia crypto hash generate argon2 --random --random.length 64 --random.charset alphanumeric
+docker run --rm authelia/authelia:latest authelia crypto hash generate argon2 --random --random.length 64 --random.charset alphanumeric
 ```
 {{< /envTab >}}
 {{< envTab "Bare-Metal" >}}
@@ -55,7 +55,7 @@ all available options.
 {{< envTabs "Generate Random String" >}}
 {{< envTab "Docker" >}}
 ```bash
-docker run authelia/authelia:latest authelia crypto rand --length 64 --charset alphanumeric
+docker run --rm authelia/authelia:latest authelia crypto rand --length 64 --charset alphanumeric
 ```
 {{< /envTab >}}
 {{< envTab "Bare-Metal" >}}
@@ -102,7 +102,7 @@ information on all available options.
 {{< envTabs "Generate RSA Key Pair" >}}
 {{< envTab "Docker" >}}
 ```bash
-docker run -u "$(id -u):$(id -g)" -v "$(pwd)":/keys authelia/authelia:latest authelia crypto pair rsa generate --directory /keys
+docker run --rm -u "$(id -u):$(id -g)" -v "$(pwd)":/keys authelia/authelia:latest authelia crypto pair rsa generate --directory /keys
 ```
 {{< /envTab >}}
 {{< envTab "Bare-Metal" >}}
@@ -144,7 +144,7 @@ information on all available options.
 {{< envTabs "Generate RSA Key Pair" >}}
 {{< envTab "Docker" >}}
 ```bash
-docker run -u "$(id -u):$(id -g)" -v "$(pwd)":/keys authelia/authelia:latest authelia crypto certificate rsa generate --common-name example.com --directory /keys
+docker run --rm -u "$(id -u):$(id -g)" -v "$(pwd)":/keys authelia/authelia:latest authelia crypto certificate rsa generate --common-name example.com --directory /keys
 ```
 {{< /envTab >}}
 {{< envTab "Bare-Metal" >}}


### PR DESCRIPTION
Current docker commands won't remove the containers after the secrets are generated. I added the `--rm` argument so that the containers will be removed after the secret gets generated.
https://docs.docker.com/reference/cli/docker/container/run/#rm