### PR TITLE
docs: update gmail example

### DIFF
--- a/docs/content/configuration/notifications/smtp.md
+++ b/docs/content/configuration/notifications/smtp.md
@@ -186,10 +186,9 @@ You need to generate an app password in order to use Gmail SMTP servers. The pro
 ```yaml {title="configuration.yml"}
 notifier:
   smtp:
+    address: 'smtp://smtp.gmail.com:587'
     username: 'myaccount@gmail.com'
     # Password can also be set using a secret: https://www.authelia.com/configuration/methods/secrets/
     password: 'yourapppassword'
     sender: 'admin@{{< sitevar name="domain" nojs="example.com" >}}'
-    host: 'smtp.gmail.com'
-    port: 587
 ```

--- a/docs/content/configuration/notifications/smtp.md
+++ b/docs/content/configuration/notifications/smtp.md
@@ -186,7 +186,7 @@ You need to generate an app password in order to use Gmail SMTP servers. The pro
 ```yaml {title="configuration.yml"}
 notifier:
   smtp:
-    address: 'smtp://smtp.gmail.com:587'
+    address: 'submission://smtp.gmail.com:587'
     username: 'myaccount@gmail.com'
     # Password can also be set using a secret: https://www.authelia.com/configuration/methods/secrets/
     password: 'yourapppassword'

--- a/docs/content/configuration/notifications/smtp.md
+++ b/docs/content/configuration/notifications/smtp.md
@@ -192,3 +192,5 @@ notifier:
     password: 'yourapppassword'
     sender: 'admin@{{< sitevar name="domain" nojs="example.com" >}}'
 ```
+
+[security]: ../../overview/security/measures.md#notifier-security-measures-smtp


### PR DESCRIPTION
Hi,

this updates the Gmail example to use the new address scheme.
The reference to [security] was also missing. I hope I linked it as intended.