### PR TITLE
docs: fix references in callouts & align overview

### DIFF
--- a/docs/content/configuration/first-factor/file.md
+++ b/docs/content/configuration/first-factor/file.md
@@ -260,8 +260,8 @@ Permitted values `standard`, `sha256`.
 {{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
 The `sha256` variant is a special variant designed by
 [Passlib](https://passlib.readthedocs.io/en/stable/lib/passlib.hash.bcrypt_sha256.html). This variant passes the
-password through a SHA256 HMAC before passing it to the [Bcrypt] algorithm, effectively bypassing the 72 byte password
-truncation that [Bcrypt] does. It is not supported by many other systems.
+password through a SHA256 HMAC before passing it to the [Bcrypt](https://en.wikipedia.org/wiki/Bcrypt) algorithm, effectively bypassing the 72 byte password
+truncation that [Bcrypt](https://en.wikipedia.org/wiki/Bcrypt) does. It is not supported by many other systems.
 {{< /callout >}}
 
 #### cost

--- a/docs/content/configuration/first-factor/ldap.md
+++ b/docs/content/configuration/first-factor/ldap.md
@@ -254,7 +254,7 @@ The only known support at this time is with Active Directory.
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
 This option is technically required however the [implementation](#implementation) option can implicitly set a
-default negating this requirement. Refer to the [attribute defaults] for more information.
+default negating this requirement. Refer to the [attribute defaults](../../reference/guides/ldap.md#attribute-defaults) for more information.
 {{< /callout >}}
 
 The directory server attribute that maps to the username in *Authelia*. This must contain the `{username_attribute}` [placeholder].
@@ -265,7 +265,7 @@ The directory server attribute that maps to the username in *Authelia*. This mus
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
 This option is technically required however the [implementation](#implementation) option can implicitly set a
-default negating this requirement. Refer to the [attribute defaults] for more information.
+default negating this requirement. Refer to the [attribute defaults](../../reference/guides/ldap.md#attribute-defaults) for more information.
 {{< /callout >}}
 
 The directory server attribute to retrieve which is shown on the Web UI to the user when they log in.
@@ -276,7 +276,7 @@ The directory server attribute to retrieve which is shown on the Web UI to the u
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
 This option is technically required however the [implementation](#implementation) option can implicitly set a
-default negating this requirement. Refer to the [attribute defaults] for more information.
+default negating this requirement. Refer to the [attribute defaults](../../reference/guides/ldap.md#attribute-defaults) for more information.
 {{< /callout >}}
 
 The directory server attribute to retrieve which contains the users email addresses. This is important for the device
@@ -289,7 +289,7 @@ identity verification when a user attempts to reset their password or register a
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
 This option is technically required however the [implementation](#implementation) option can implicitly set a
-default negating this requirement. Refer to the [attribute defaults] for more information.
+default negating this requirement. Refer to the [attribute defaults](../../reference/guides/ldap.md#attribute-defaults) for more information.
 {{< /callout >}}
 
 The directory server attribute which contains the groups a user is a member of. This is currently only used for the
@@ -301,7 +301,7 @@ The directory server attribute which contains the groups a user is a member of. 
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
 This option is technically required however the [implementation](#implementation) option can implicitly set a
-default negating this requirement. Refer to the [attribute defaults] for more information.
+default negating this requirement. Refer to the [attribute defaults](../../reference/guides/ldap.md#attribute-defaults) for more information.
 {{< /callout >}}
 
 The directory server attribute that is used by Authelia to determine the group name.

--- a/docs/content/configuration/second-factor/duo.md
+++ b/docs/content/configuration/second-factor/duo.md
@@ -23,7 +23,7 @@ instructions on how to set up push notifications in Authelia.
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
 The configuration options in the following sections are noted as required. They are however only required when
-you have this section defined. i.e. if you don't wish to use the [Duo] push notifications, you can just not define this
+you have this section defined. i.e. if you don't wish to use the [Duo](https://duo.com/) push notifications, you can just not define this
 section of the configuration.
 {{< /callout >}}
 

--- a/docs/content/configuration/session/introduction.md
+++ b/docs/content/configuration/session/introduction.md
@@ -119,7 +119,7 @@ configurations with individual settings.
 
 {{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
 Browsers have rules regarding which cookie domains a website can write. In particular the
-[Public Suffix List] usually contains domains which are not permitted.
+[Public Suffix List](https://publicsuffix.org/list/) usually contains domains which are not permitted.
 {{< /callout >}}
 
 The domain the session cookie is assigned to protect. This must be the same as the domain Authelia is served on or the

--- a/docs/content/integration/proxies/support.md
+++ b/docs/content/integration/proxies/support.md
@@ -71,8 +71,8 @@ More information about [Kubernetes] deployments of Authelia can be read in the
 ### XHR Redirect
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
-The XHR is a deprecated web feature and applications should be using the new [Fetch API] which does not have
-the same issues regarding redirects (the [Fetch API] allows developers to
+The XHR is a deprecated web feature and applications should be using the new [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) which does not have
+the same issues regarding redirects (the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) allows developers to
 [control how to handle them](https://developer.mozilla.org/en-US/docs/Web/API/Request/redirect)). As such the fact
 a proxy does not support it should only be seen as a means to communicate a feature not that the proxy should not be
 used.
@@ -129,5 +129,3 @@ contribution.
 [IIS]: https://www.iis.net/
 [Kubernetes]: https://kubernetes.io/
 [Ingress Controller]: https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/
-
-[Fetch API]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API

--- a/docs/content/integration/proxies/swag.md
+++ b/docs/content/integration/proxies/swag.md
@@ -305,3 +305,4 @@ server {
 [SWAG]: https://docs.linuxserver.io/general/swag
 [NGINX]: https://www.nginx.com/
 [Forwarded Headers]: forwarded-headers
+[linuxserver.io]: https://www.linuxserver.io/

--- a/docs/content/overview/authentication/introduction.md
+++ b/docs/content/overview/authentication/introduction.md
@@ -6,7 +6,7 @@ date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 210
-toc: false
+toc: true
 aliases:
   - /docs/features/2fa/
 seo:

--- a/docs/content/overview/authorization/access-control.md
+++ b/docs/content/overview/authorization/access-control.md
@@ -6,7 +6,7 @@ date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 310
-toc: false
+toc: true
 aliases:
   - /docs/features/access-control.html
 seo:

--- a/docs/content/overview/authorization/openid-connect-1.0.md
+++ b/docs/content/overview/authorization/openid-connect-1.0.md
@@ -6,7 +6,7 @@ date: 2022-11-27T16:07:08+11:00
 draft: false
 images: []
 weight: 330
-toc: false
+toc: true
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)

--- a/docs/content/overview/authorization/regulation.md
+++ b/docs/content/overview/authorization/regulation.md
@@ -6,7 +6,7 @@ date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 320
-toc: false
+toc: true
 aliases:
   - /docs/features/regulation.html
 seo:

--- a/docs/content/overview/authorization/statelessness.md
+++ b/docs/content/overview/authorization/statelessness.md
@@ -6,7 +6,7 @@ date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 390
-toc: false
+toc: true
 aliases:
   - /t/statelessness
   - /docs/features/statelessness.html

--- a/docs/content/overview/authorization/trusted-headers.md
+++ b/docs/content/overview/authorization/trusted-headers.md
@@ -6,7 +6,7 @@ date: 2022-11-27T16:07:08+11:00
 draft: false
 images: []
 weight: 340
-toc: false
+toc: true
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)

--- a/docs/content/overview/prologue/architecture/index.md
+++ b/docs/content/overview/prologue/architecture/index.md
@@ -6,7 +6,7 @@ date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 120
-toc: false
+toc: true
 aliases:
   - /docs/home/architecture.html
 seo:

--- a/docs/content/overview/prologue/introduction.md
+++ b/docs/content/overview/prologue/introduction.md
@@ -6,7 +6,7 @@ date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 110
-toc: false
+toc: true
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)

--- a/docs/content/overview/prologue/supported-proxies.md
+++ b/docs/content/overview/prologue/supported-proxies.md
@@ -6,7 +6,7 @@ date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 130
-toc: false
+toc: true
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)

--- a/docs/content/overview/security/introduction.md
+++ b/docs/content/overview/security/introduction.md
@@ -6,7 +6,7 @@ date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 410
-toc: false
+toc: true
 aliases:
   - /docs/security/
 seo:

--- a/docs/content/overview/security/measures.md
+++ b/docs/content/overview/security/measures.md
@@ -6,7 +6,7 @@ date: 2018-08-26T23:46:15+02:00
 draft: false
 images: []
 weight: 420
-toc: false
+toc: true
 aliases:
   - /docs/security/measures.html
 seo:

--- a/docs/content/overview/security/threat-model.md
+++ b/docs/content/overview/security/threat-model.md
@@ -6,7 +6,7 @@ date: 2020-04-16T18:12:41+10:00
 draft: false
 images: []
 weight: 430
-toc: false
+toc: true
 aliases:
   - /o/threatmodel
   - /docs/security/threat-model.html

--- a/docs/content/reference/guides/passwords.md
+++ b/docs/content/reference/guides/passwords.md
@@ -147,7 +147,7 @@ all algorithms. The main cost type measurements are:
 * Memory
 
 {{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-When using algorithms that use a memory cost like [Argon2](https://datatracker.ietf.org/doc/html/rfc9106) and[Scrypt](https://en.wikipedia.org/wiki/Scrypt) it should be noted that
+When using algorithms that use a memory cost like [Argon2](https://datatracker.ietf.org/doc/html/rfc9106) and [Scrypt](https://en.wikipedia.org/wiki/Scrypt) it should be noted that
 this memory is released by Go after the hashing process completes, however the operating system may not reclaim the
 memory until a later time such as when the system is experiencing memory pressure which may cause the appearance of more
 memory being in use than Authelia is actually actively using. Authelia will typically reuse this memory if it has not be

--- a/docs/content/reference/guides/passwords.md
+++ b/docs/content/reference/guides/passwords.md
@@ -147,7 +147,7 @@ all algorithms. The main cost type measurements are:
 * Memory
 
 {{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-When using algorithms that use a memory cost like [Argon2] and [Scrypt] it should be noted that
+When using algorithms that use a memory cost like [Argon2](https://datatracker.ietf.org/doc/html/rfc9106) and[Scrypt](https://en.wikipedia.org/wiki/Scrypt) it should be noted that
 this memory is released by Go after the hashing process completes, however the operating system may not reclaim the
 memory until a later time such as when the system is experiencing memory pressure which may cause the appearance of more
 memory being in use than Authelia is actually actively using. Authelia will typically reuse this memory if it has not be

--- a/docs/content/reference/guides/proxy-authorization.md
+++ b/docs/content/reference/guides/proxy-authorization.md
@@ -130,9 +130,9 @@ This is the implementation which supports [NGINX] via the [auth_request HTTP mod
 | Authelia URL [^1] | Session Cookie Configuration |      `authelia_url`      |
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
-This endpoint does not support automatic redirection. This is because there is no support on [NGINX]'s side
-to achieve this with `ngx_http_auth_request_module` and the redirection must be performed within the [NGINX]
-configuration. However we return the appropriate URL to redirect users to with the `Location` header which
+This endpoint does not support automatic redirection. This is because there is no support on [NGINX](https://www.nginx.com/)'s side
+to achieve this with `ngx_http_auth_request_module` and the redirection must be performed within the [NGINX](https://www.nginx.com/)
+configuration. However, we return the appropriate URL to redirect users to with the `Location` header which
 simplifies this process especially for multi-cookie domain deployments.
 {{< /callout >}}
 

--- a/docs/content/reference/guides/server-asset-overrides.md
+++ b/docs/content/reference/guides/server-asset-overrides.md
@@ -44,7 +44,7 @@ to make a PR. We also encourage people to make PR's for variants where the diffe
 
 {{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
 Users wishing to override the locales files should be aware that we do not provide any guarantee
-that the file will not change in a breaking way between releases as per our [Versioning Policy]. Users who planning to
+that the file will not change in a breaking way between releases as per our [Versioning Policy](../../policies/versioning.md). Users who planning to
 utilize these overrides should either check for changes to the files in the
 [en](https://github.com/authelia/authelia/tree/master/internal/server/locales/en) translation prior to upgrading or
 [Contribute](../../contributing/prologue/translations.md) their translation to ensure it is maintained.
@@ -81,5 +81,3 @@ List of supported languages and variants:
 {{% table-i18n-overrides %}}
 
 More information may be available from the [Internationalization Reference Guide](./internationalization.md).
-
-[Versioning Policy]: ../../policies/versioning.md

--- a/docs/content/reference/guides/server-asset-overrides.md
+++ b/docs/content/reference/guides/server-asset-overrides.md
@@ -44,7 +44,7 @@ to make a PR. We also encourage people to make PR's for variants where the diffe
 
 {{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
 Users wishing to override the locales files should be aware that we do not provide any guarantee
-that the file will not change in a breaking way between releases as per our [Versioning Policy](../../policies/versioning.md). Users who planning to
+that the file will not change in a breaking way between releases as per our [Versioning Policy](../../policies/versioning.md). Users who are planning to
 utilize these overrides should either check for changes to the files in the
 [en](https://github.com/authelia/authelia/tree/master/internal/server/locales/en) translation prior to upgrading or
 [Contribute](../../contributing/prologue/translations.md) their translation to ensure it is maintained.

--- a/docs/content/reference/integrations/cache-integrations.md
+++ b/docs/content/reference/integrations/cache-integrations.md
@@ -35,8 +35,9 @@ When it comes to [Redis Sentinel] we support the versions supported by [Redis] t
 version.
 
 {{< callout context="note" title="Note" icon="outline/info-circle" >}}
-Currently we only support [Redis Sentinel] version 6.x due to a breaking change to [Redis Sentinel] in
-version 7.x. This will be resolved in the near future.
+Currently we only support [Redis Sentinel](https://redis.io/docs/management/sentinel/) version 6.x due to a breaking
+change to [Redis Sentinel](https://redis.io/docs/management/sentinel/) in version 7.x. This will be resolved in the near
+future.
 {{< /callout >}}
 
 [Redis]: https://redis.io/


### PR DESCRIPTION
Hi,

this further extends on #8047. Hopefully, I’ve covered everything now.

I also noticed that the content in some sections of the overview is centered instead of left-aligned. 
To fix this, I enabled the table of contents for all sections in the overview to be consistent with the rest of the documentation.

The missing link [here](https://github.com/authelia/authelia/blob/239fe2d9c3da1ff7f21ee614816d6d3ead994d66/docs/content/overview/security/introduction.md?plain=1#L24) should probably be added by the team to provide a fitting source for authelia.