### PR TITLE
refactor(handlers): log policy and debug info for oidc authorization

### DIFF
--- a/internal/handlers/handler_oidc_authorization_consent.go
+++ b/internal/handlers/handler_oidc_authorization_consent.go
@@ -57,15 +57,13 @@ func handleOIDCAuthorizationConsent(ctx *middlewares.AutheliaCtx, issuer *url.UR
 
 			return nil, true
 		}
+	case level == authorization.Denied:
+		ctx.Logger.Errorf("Authorization Request with id '%s' on client with id '%s' using policy '%s' could not be processed: the user '%s' is not authorized to use this client", requester.GetID(), client.GetID(), policy.Name, userSession.Username)
+
+		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrClientAuthorizationUserAccessDenied)
+
+		return nil, true
 	default:
-		if level == authorization.Denied {
-			ctx.Logger.Errorf("Authorization Request with id '%s' on client with id '%s' using policy '%s' could not be processed: the user '%s' is not authorized to use this client", requester.GetID(), client.GetID(), policy.Name, userSession.Username)
-
-			ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrClientAuthorizationUserAccessDenied)
-
-			return nil, true
-		}
-
 		if subject, err = ctx.Providers.OpenIDConnect.GetSubject(ctx, client.GetSectorIdentifierURI(), userSession.Username); err != nil {
 			ctx.Logger.Errorf(logFmtErrConsentCantGetSubject, requester.GetID(), client.GetID(), client.GetConsentPolicy(), userSession.Username, client.GetSectorIdentifierURI(), err)
 

--- a/internal/totp/totp.go
+++ b/internal/totp/totp.go
@@ -23,7 +23,7 @@ func NewTimeBasedProvider(config schema.TOTP) (provider *TimeBased) {
 	}
 
 	if config.Skew != nil && *config.Skew >= 0 {
-		provider.skew = uint(*config.Skew) //nolint:gosec // This input is checked.
+		provider.skew = uint(*config.Skew)
 	} else {
 		provider.skew = 1
 	}


### PR DESCRIPTION
This change provides additional information as part of the OIDC authorization requests, this allows simpler debugging if custom authorization policies are being utilised for OIDC clients.