### PR TITLE
Add missing parameter in express integration

### DIFF
--- a/docs/content/integration/openid-connect/expressjs/index.md
+++ b/docs/content/integration/openid-connect/expressjs/index.md
@@ -105,6 +105,7 @@ app.use(
     issuerBaseURL: process.env.OIDC_ISSUER || 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}',
     pushedAuthorizationRequests: true,
     authorizationParams: {
+      redirect_uri: `${process.env.APP_BASE_URL}/callback`,
       response_type: 'code',
       scope: 'openid profile email groups',
     },


### PR DESCRIPTION
I copied the example as minimum example and redirect_url param is required. Also, this parameter is not super understandable for a beginner so I think it is relevant to add it in the example.