### PR TITLE
docs: add supported items to certificates_directory docs

### DIFF
--- a/docs/content/configuration/miscellaneous/introduction.md
+++ b/docs/content/configuration/miscellaneous/introduction.md
@@ -34,7 +34,7 @@ This section describes the individual configuration options.
 ### certificates_directory
 
 This option defines the location of additional certificates to load into the trust chain specifically for Authelia.
-This currently affects both the SMTP notifier and the LDAP authentication backend. The certificates should all be in the
+This currently affects both the [SMTP](../notifications/smtp.md#tls) notifier, the [LDAP](../first-factor/ldap.md#tls) authentication backend, [PostgreSQL](../storage/postgres.md#tls) and [MySQL](../storage/mysql.md#tls) storage backends, and [Redis](../session/redis.md#tls). The certificates should all be in the
 PEM format and end with the extension `.pem`, `.crt`, or `.cer`. You can either add the individual certificates public
 key or the CA public key which signed them (don't add the private key).
 

--- a/docs/content/configuration/miscellaneous/introduction.md
+++ b/docs/content/configuration/miscellaneous/introduction.md
@@ -34,7 +34,7 @@ This section describes the individual configuration options.
 ### certificates_directory
 
 This option defines the location of additional certificates to load into the trust chain specifically for Authelia.
-This currently affects both the [SMTP](../notifications/smtp.md#tls) notifier, the [LDAP](../first-factor/ldap.md#tls) authentication backend, [PostgreSQL](../storage/postgres.md#tls) and [MySQL](../storage/mysql.md#tls) storage backends, and [Redis](../session/redis.md#tls). The certificates should all be in the
+This currently affects any service that Authelia connects to over TLS. The certificates should all be in the
 PEM format and end with the extension `.pem`, `.crt`, or `.cer`. You can either add the individual certificates public
 key or the CA public key which signed them (don't add the private key).
 


### PR DESCRIPTION
It is unclear if adding root certificates to the certificates_directory will allow verification for self-signed certificates for things other than SMTP and LDAP.

This change aims to improve clarity in that regard.