### PR TITLE
fix(configuration): allow unix socket ports

### DIFF
--- a/internal/configuration/schema/types_address.go
+++ b/internal/configuration/schema/types_address.go
@@ -478,6 +478,16 @@ func (a *Address) validate() (err error) {
 		if err = a.validateUnixSocket(); err != nil {
 			return err
 		}
+
+		host := a.url.Host != ""
+
+		if err = a.validateTCPUDP(); err != nil {
+			return err
+		}
+
+		if !host {
+			a.url.Host = ""
+		}
 	case AddressSchemeTCP, AddressSchemeTCP4, AddressSchemeTCP6, AddressSchemeUDP, AddressSchemeUDP4, AddressSchemeUDP6:
 		if err = a.validateTCPUDP(); err != nil {
 			return err
@@ -548,8 +558,8 @@ func (a *Address) validateUnixSocket() (err error) {
 	switch {
 	case a.url.Path == "" && a.url.Scheme != AddressSchemeLDAPI:
 		return fmt.Errorf("error validating the unix socket address: could not determine path from '%s'", a.url.String())
-	case a.url.Host != "":
-		return fmt.Errorf("error validating the unix socket address: the url '%s' appears to have a host but this is not valid for unix sockets: this may occur if you omit the leading forward slash from the socket path", a.url.String())
+	case a.url.Hostname() != "":
+		return fmt.Errorf("error validating the unix socket address: the url '%s' appears to have a hostname but this is not valid for unix sockets: this may occur if you omit the leading forward slash from the socket path", a.url.String())
 	}
 
 	if a.url.Query().Has(addressQueryParamUmask) {

--- a/internal/storage/const.go
+++ b/internal/storage/const.go
@@ -70,7 +70,8 @@ const (
 )
 
 var (
-	reMigration = regexp.MustCompile(`^V(?P<Version>\d{4})\.(?P<Name>[^.]+)\.(?P<Direction>(up|down))\.sql$`)
+	reMigration                  = regexp.MustCompile(`^V(?P<Version>\d{4})\.(?P<Name>[^.]+)\.(?P<Direction>(up|down))\.sql$`)
+	rePostgreSQLUnixDomainSocket = regexp.MustCompile(`^\.s\.PGSQL\.(\d+)$`)
 )
 
 const (

--- a/internal/storage/sql_provider_backend_postgres_test.go
+++ b/internal/storage/sql_provider_backend_postgres_test.go
@@ -1,0 +1,305 @@
+package storage
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
+)
+
+func TestNewPostgreSQLProvider(t *testing.T) {
+	address, err := schema.NewAddress("tcp://localhost:5432")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name string
+		have *schema.Configuration
+	}{
+		{
+			"ShouldHandleSimple",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleTLS",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						TLS: &schema.TLS{
+							MinimumVersion: schema.TLSVersion{Value: tls.VersionTLS12},
+							MaximumVersion: schema.TLSVersion{Value: tls.VersionTLS13},
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSVerifyFull",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode: "verify-full",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSVerifyCA",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode: "verify-ca",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSRequire",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode: "require",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSDisabled",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode: "disable",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSVerifyCARootCA",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode:            "verify-ca",
+							RootCertificate: "../configuration/test_resources/crypto/ca.rsa.2048.crt",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSVerifyCAAllCertificates",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode:            "verify-ca",
+							RootCertificate: "../configuration/test_resources/crypto/ca.rsa.2048.crt",
+							Certificate:     "../configuration/test_resources/crypto/rsa.2048.crt",
+							Key:             "../configuration/test_resources/crypto/rsa.2048.pem",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSVerifyCAAllCertificatesFailReadFileCA",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode:            "verify-ca",
+							RootCertificate: "../configuration/test_resources/crypto/ca.rsa.2048.cert",
+							Certificate:     "../configuration/test_resources/crypto/rsa.2048.crt",
+							Key:             "../configuration/test_resources/crypto/rsa.2048.pem",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSVerifyCAAllCertificatesFailReadFileKey",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode:            "verify-ca",
+							RootCertificate: "../configuration/test_resources/crypto/ca.rsa.2048.crt",
+							Certificate:     "../configuration/test_resources/crypto/rsa.2048.crt",
+							Key:             "../configuration/test_resources/crypto/rsa.2048.key",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSVerifyCAAllCertificatesFailReadFileCertificate",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode:            "verify-ca",
+							RootCertificate: "../configuration/test_resources/crypto/ca.rsa.2048.crt",
+							Certificate:     "../configuration/test_resources/crypto/rsa.2048.cert",
+							Key:             "../configuration/test_resources/crypto/rsa.2048.pem",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSVerifyCAAllCertificatesFailPair",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode:            "verify-ca",
+							RootCertificate: "../configuration/test_resources/crypto/ca.rsa.2048.crt",
+							Certificate:     "../configuration/test_resources/crypto/rsa.2048.crt",
+							Key:             "../configuration/test_resources/crypto/rsa.4096.pem",
+						},
+					},
+				},
+			},
+		},
+		{
+			"ShouldHandleLegacyTLSVerifyCAAllCertificatesFailReadCACertificateFromPrivateKey",
+			&schema.Configuration{
+				Storage: schema.Storage{
+					PostgreSQL: &schema.StoragePostgreSQL{
+						StorageSQL: schema.StorageSQL{
+							Address: &schema.AddressTCP{Address: *address},
+						},
+						SSL: &schema.StoragePostgreSQLSSL{
+							Mode:            "verify-ca",
+							RootCertificate: "../configuration/test_resources/crypto/ca.rsa.2048.pem",
+							Certificate:     "../configuration/test_resources/crypto/rsa.2048.crt",
+							Key:             "../configuration/test_resources/crypto/rsa.2048.pem",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Parallel()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := NewPostgreSQLProvider(tc.have, x509.NewCertPool())
+
+			assert.NotNil(t, provider)
+		})
+	}
+}
+
+func TestDSNConfigPostgreSQLHostPort(t *testing.T) {
+	testCases := []struct {
+		name      string
+		have      string
+		hexpected string
+		pexpected uint16
+	}{
+		{
+			"ShouldParseDirectoryDefaultPort",
+			"unix:///tmp",
+			"/tmp",
+			5432,
+		},
+		{
+			"ShouldParseURLPort",
+			"unix://:255/tmp",
+			"/tmp",
+			255,
+		},
+		{
+			"ShouldParseAbsolutePort",
+			"unix:///tmp/.s.PGSQL.25432",
+			"/tmp",
+			25432,
+		},
+		{
+			"ShouldParseAbsolutePortWithURLPort",
+			"unix://:2455/tmp/.s.PGSQL.25432",
+			"/tmp",
+			25432,
+		},
+		{
+			"ShouldParseAbsolutePortInvalidWithURLPort",
+			"unix://:2455/tmp/.s.PGSQL.233335432",
+			"/tmp/.s.PGSQL.233335432",
+			2455,
+		},
+		{
+			"ShouldParseAbsolutePortInvalid",
+			"unix:///tmp/.s.PGSQL.233335432",
+			"/tmp/.s.PGSQL.233335432",
+			5432,
+		},
+	}
+
+	t.Parallel()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			address, err := schema.NewAddress(tc.have)
+			require.NotNil(t, address)
+			require.NoError(t, err)
+
+			host, port := dsnPostgreSQLHostPort(&schema.AddressTCP{Address: *address})
+			assert.Equal(t, tc.hexpected, host)
+			assert.Equal(t, tc.pexpected, port)
+		})
+	}
+}


### PR DESCRIPTION
This allows unix sockets to include ports in the address URL. In addition allows for a absolute path for the PostgreSQL socket type. Both options are only used by PostgreSQL but other unix sockets will not expressly error if this is included.

Fixes #8509