### PR TITLE
fix(web): include privacy policy when remember me is enabled

### DIFF
--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -336,6 +336,8 @@ func (options *TemplatedFileOptions) commonDataWithRememberMe(base, baseURL, dom
 		RememberMe:             rememberMe,
 		ResetPassword:          options.ResetPassword,
 		ResetPasswordCustomURL: options.ResetPasswordCustomURL,
+		PrivacyPolicyURL:       options.PrivacyPolicyURL,
+		PrivacyPolicyAccept:    options.PrivacyPolicyAccept,
 		Session:                options.Session,
 		Theme:                  options.Theme,
 	}


### PR DESCRIPTION
This change fixes the rendering of the privacy policy when administrators also have the remember me option enabled in their Authelia instance.

Fixes #8537.