### PR TITLE
Update Jellyfin SSO documentation

### DIFF
--- a/docs/content/integration/openid-connect/jellyfin/index.md
+++ b/docs/content/integration/openid-connect/jellyfin/index.md
@@ -61,6 +61,7 @@ identity_providers:
         require_pkce: true
         pkce_challenge_method: 'S256'
         redirect_uris:
+          - 'https://jellyfin.{{< sitevar name="domain" nojs="example.com" >}}/sso/OID/r/authelia'
           - 'https://jellyfin.{{< sitevar name="domain" nojs="example.com" >}}/sso/OID/redirect/authelia'
         scopes:
           - 'openid'


### PR DESCRIPTION
Integration with Jellyfin SSO requires a `/r/<provider>/` redirect URI in addition to the `/redirect/<provider>` URI (docs source: https://github.com/9p4/jellyfin-plugin-sso#examples). This PR adds the other URI to the `required_uris` field of the Authelia configuration.

Edit: You may also want to update the URIs to use `/Authelia` (capitalized) because it needs to match the name in Jellyfin and the docs use "Authelia" as the example.