### PR TITLE
fix(notifier): smtp log fails to serialize

### DIFF
--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -82,7 +82,6 @@ func NewSMTPNotifier(config *schema.NotifierSMTP, certPool *x509.CertPool) *SMTP
 		"port":    config.Address.Port(),
 		"helo":    config.Identifier,
 		"timeout": config.Timeout.Seconds(),
-		"tls":     tlsconfig,
 		"domain":  domain,
 	}).Trace("Configuring Provider")
 


### PR DESCRIPTION
This fixes an issue where the SMTP logging fails to serialize a log message with the TLS config in the fields.

Fixes #8569