### PR TITLE
docs(oidc): fix dokuwiki oidc configuration

### DIFF
--- a/docs/content/integration/openid-connect/dokuwiki/index.md
+++ b/docs/content/integration/openid-connect/dokuwiki/index.md
@@ -68,8 +68,13 @@ identity_providers:
           - 'profile'
           - 'groups'
           - 'offline_access'
+        grant_types:
+          - 'authorization_code'
+          - 'refresh_token'
+        response_types:
+          - 'code'
         userinfo_signed_response_alg: 'none'
-        token_endpoint_auth_method: 'client_secret_basic'
+        token_endpoint_auth_method: 'client_secret_post'
 ```
 
 ### Application


### PR DESCRIPTION
The current documentation leads to DokuWiki outputting the warning after Authelia login:

> Service did not provide a Refresh Token. You will be logged out when the session expires.

Indeed the session will expire rather soon.

Authelia determined client_secret_post for DokuWiki. DokuWiki requests a refresh token, which requires grant_types and response_type code to be configured.

This PR updates the documentation to propose the correct configuration for DokuWiki.

Tested with Authelia v4.38.18 + DokuWiki 55.2 (as already defined in the Authelia DokuWiki docs page).