### PR TITLE
feat: properly set lang attribute for document root

### DIFF
--- a/cmd/authelia-gen/templates/web_i18n_index.ts.tmpl
+++ b/cmd/authelia-gen/templates/web_i18n_index.ts.tmpl
@@ -56,6 +56,16 @@ i18n.use(Backend)
             escapeValue: false,
         },
         debug: false,
+    })
+    .then(() => {
+        const rootElement = document.getElementById("root");
+        if (rootElement) {
+            rootElement.lang = i18n.language;
+
+            i18n.on("languageChanged", (lng) => {
+                rootElement.lang = lng;
+            });
+        }
     });
 
 export default i18n;

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -225,6 +225,16 @@ i18n.use(Backend)
             escapeValue: false,
         },
         debug: false,
+    })
+    .then(() => {
+        const rootElement = document.getElementById("root");
+        if (rootElement) {
+            rootElement.lang = i18n.language;
+
+            i18n.on("languageChanged", (lng) => {
+                rootElement.lang = lng;
+            });
+        }
     });
 
 export default i18n;


### PR DESCRIPTION
Sets root element's lang attribute based on i18n.language and updates it on language changes.

Resolves #8729