### PR TITLE
docs(oidc): fix type of authorization_policies subject

### DIFF
--- a/docs/content/configuration/identity-providers/openid-connect/provider.md
+++ b/docs/content/configuration/identity-providers/openid-connect/provider.md
@@ -427,7 +427,7 @@ The policy which is applied if this rule matches. Valid values are `one_factor`,
 
 ##### subject
 
-{{< confkey type="list(string(string))" required="yes" >}}
+{{< confkey type="list(list(string))" required="yes" >}}
 
 The subjects criteria as per the [Access Control Configuration](../../security/access-control.md#subject). This must be
 included for the rule to be considered valid.


### PR DESCRIPTION
The type was incorrectly set as `list(string(string))`, and has been updated to `list(list(string))` to match the access control documentation.