### PR TITLE
test(handlers): fix failing webauthn test with regex

### DIFF
--- a/internal/handlers/func_test.go
+++ b/internal/handlers/func_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -29,7 +30,11 @@ func AssertLogEntryMessageAndError(t *testing.T, entry *logrus.Entry, message, e
 		assert.True(t, ok)
 		require.NotNil(t, theErr)
 
-		assert.EqualError(t, theErr, err)
+		if strings.HasPrefix(err, "^") && strings.HasSuffix(err, "$") {
+			assert.Regexp(t, err, theErr.Error())
+		} else {
+			assert.EqualError(t, theErr, err)
+		}
 	}
 }
 

--- a/internal/handlers/handler_sign_webauthn_test.go
+++ b/internal/handlers/handler_sign_webauthn_test.go
@@ -623,7 +623,8 @@ func TestWebAuthnAssertionPOST(t *testing.T) {
 			"",
 			fasthttp.StatusBadRequest,
 			func(t *testing.T, mock *mocks.MockAutheliaCtx) {
-				AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Error occurred validating a WebAuthn authentication challenge for user 'john': error parsing the request body", "Parse error for Assertion (invalid_request): json: cannot unmarshal bool into Go struct field CredentialAssertionResponse.id of type string")
+				AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(),
+					"Error occurred validating a WebAuthn authentication challenge for user 'john': error parsing the request body", "^Parse error for Assertion \\(invalid_request\\): json: cannot unmarshal bool into Go struct field CredentialAssertionResponse(\\.PublicKeyCredential\\.Credential)?\\.id of type string$")
 			},
 		},
 		{


### PR DESCRIPTION
fix test failing due to different call path on local systems vs buildkite