### PR TITLE
refactor(webauthn): log all failures for passkeys

### DIFF
--- a/internal/handlers/func_test.go
+++ b/internal/handlers/func_test.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"strings"
+	"regexp"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -12,29 +12,51 @@ import (
 	"github.com/authelia/authelia/v4/internal/middlewares"
 )
 
-func AssertLogEntryMessageAndError(t *testing.T, entry *logrus.Entry, message, err string) {
+func AssertLogEntryMessageAndError(t *testing.T, entry *logrus.Entry, message, err any) {
 	require.NotNil(t, entry)
 
-	assert.Equal(t, message, entry.Message)
+	switch value := message.(type) {
+	case *regexp.Regexp:
+		assert.Regexp(t, value, entry.Message)
+	case string:
+		assert.Equal(t, value, entry.Message)
+	case nil:
+		break
+	default:
+		t.Fatal("Message should be a string, nil, or *regexp.Regex")
+	}
 
 	v, ok := entry.Data["error"]
 
-	if err == "" {
-		assert.False(t, ok)
-		assert.Nil(t, v)
-	} else {
+	switch value := err.(type) {
+	case *regexp.Regexp:
 		assert.True(t, ok)
-		require.NotNil(t, v)
 
 		theErr, ok := v.(error)
 		assert.True(t, ok)
 		require.NotNil(t, theErr)
 
-		if strings.HasPrefix(err, "^") && strings.HasSuffix(err, "$") {
-			assert.Regexp(t, err, theErr.Error())
-		} else {
-			assert.EqualError(t, theErr, err)
+		assert.Regexp(t, value, theErr.Error())
+	case string:
+		if value == "" {
+			assert.False(t, ok)
+			assert.Nil(t, v)
+
+			break
 		}
+
+		assert.True(t, ok)
+
+		theErr, ok := v.(error)
+		assert.True(t, ok)
+		require.NotNil(t, theErr)
+
+		assert.EqualError(t, theErr, value)
+	case nil:
+		assert.False(t, ok)
+		assert.Nil(t, v)
+	default:
+		t.Fatal("Err should be a string, nil, or *regexp.Regex")
 	}
 }
 

--- a/internal/handlers/handler_firstfactor_password.go
+++ b/internal/handlers/handler_firstfactor_password.go
@@ -46,9 +46,9 @@ func FirstFactorPasswordPOST(delayFunc middlewares.TimingAttackDelayFunc) middle
 			return
 		}
 
-		if ban, value, expires, err := ctx.Providers.Regulator.BanCheck(ctx, details.Username); err != nil {
+		if ban, _, expires, err := ctx.Providers.Regulator.BanCheck(ctx, details.Username); err != nil {
 			if errors.Is(err, regulation.ErrUserIsBanned) {
-				doMarkAuthenticationAttempt(ctx, false, regulation.NewBan(ban, value, expires), regulation.AuthType1FA, nil)
+				doMarkAuthenticationAttempt(ctx, false, regulation.NewBan(ban, details.Username, expires), regulation.AuthType1FA, nil)
 
 				respondUnauthorized(ctx, messageAuthenticationFailed)
 

--- a/internal/handlers/handler_sign_webauthn_test.go
+++ b/internal/handlers/handler_sign_webauthn_test.go
@@ -624,7 +624,7 @@ func TestWebAuthnAssertionPOST(t *testing.T) {
 			fasthttp.StatusBadRequest,
 			func(t *testing.T, mock *mocks.MockAutheliaCtx) {
 				AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(),
-					"Error occurred validating a WebAuthn authentication challenge for user 'john': error parsing the request body", "^Parse error for Assertion \\(invalid_request\\): json: cannot unmarshal bool into Go struct field CredentialAssertionResponse(\\.PublicKeyCredential\\.Credential)?\\.id of type string$")
+					"Error occurred validating a WebAuthn authentication challenge for user 'john': error parsing the request body", regexp.MustCompile(`^Parse error for Assertion \(invalid_request\): json: cannot unmarshal bool into Go struct field CredentialAssertionResponse(\.PublicKeyCredential\.Credential)?\.id of type string$`))
 			},
 		},
 		{

--- a/internal/mocks/authelia_ctx.go
+++ b/internal/mocks/authelia_ctx.go
@@ -268,6 +268,18 @@ func (m *MockAutheliaCtx) SetRequestBody(t *testing.T, body interface{}) {
 	m.Ctx.Request.SetBody(bodyBytes)
 }
 
+func (m *MockAutheliaCtx) LogEntryN(i int) *logrus.Entry {
+	entries := m.Hook.AllEntries()
+
+	n := len(entries) - (1 + i)
+
+	if n < 0 {
+		return nil
+	}
+
+	return entries[n]
+}
+
 // AssertKO assert an error response from the service.
 func (m *MockAutheliaCtx) AssertKO(t *testing.T, message string, code int) {
 	assert.Equal(t, code, m.Ctx.Response.StatusCode())

--- a/internal/regulation/regulator_test.go
+++ b/internal/regulation/regulator_test.go
@@ -131,7 +131,7 @@ func (s *RegulatorSuite) TestShouldHandleBanCheckIPBanned() {
 
 	b := regulation.NewBan(ban, value, expires)
 
-	s.Regexp(`expires at \d{2}:\d{2}:\d{2}(AM|PM) on \w+ \d{1,2} \d{4} \(\+\d{2}:\d{2}\)`, b.FormatExpires())
+	s.Regexp(`\d{2}:\d{2}:\d{2}(AM|PM) on \w+ \d{1,2} \d{4} \(\+\d{2}:\d{2}\)`, b.FormatExpires())
 	s.Equal(regulation.BanTypeIP, b.Type())
 	s.Equal("127.0.0.1", b.Value())
 
@@ -430,7 +430,7 @@ func (s *RegulatorSuite) TestShouldHandleBanCheckUserBanned() {
 
 	b := regulation.NewBan(ban, value, expires)
 
-	s.Regexp(`expires at \d{2}:\d{2}:\d{2}(AM|PM) on \w+ \d{1,2} \d{4} \(\+\d{2}:\d{2}\)`, b.FormatExpires())
+	s.Regexp(`\d{2}:\d{2}:\d{2}(AM|PM) on \w+ \d{1,2} \d{4} \(\+\d{2}:\d{2}\)`, b.FormatExpires())
 	s.Equal(regulation.BanTypeUser, b.Type())
 	s.Equal("john", b.Value())
 

--- a/internal/regulation/util.go
+++ b/internal/regulation/util.go
@@ -18,7 +18,7 @@ func FormatExpiresLong(expires *time.Time) string {
 		return "never expires"
 	}
 
-	return expires.Format("expires at 3:04:05PM on January 2 2006 (-07:00)")
+	return expires.Format("3:04:05PM on January 2 2006 (-07:00)")
 }
 
 func FormatExpiresShort(expires sql.NullTime) string {


### PR DESCRIPTION
This includes all failures for passkeys as a logged attempt in the auth logs.