### PR TITLE
feat(metrics): record passkey logins separately

### DIFF
--- a/docs/content/reference/guides/metrics.md
+++ b/docs/content/reference/guides/metrics.md
@@ -43,12 +43,13 @@ when configured. If metrics are enabled the metrics listener listens on `:9959` 
 
 ##### Vectored Counters
 
-|        Name         |           Vectors           |     Description      |
-|:-------------------:|:---------------------------:|:--------------------:|
-|       request       |      `code`, `method`       |     All Requests     |
-|        authz        |           `code`            |    Authz Requests    |
-|        authn        |     `success`, `banned`     | Authn Requests (1FA) |
-| authn_second_factor | `success`, `banned`, `type` | Authn Requests (2FA) |
+|        Name         |           Vectors           |       Description        |
+|:-------------------:|:---------------------------:|:------------------------:|
+|       request       |      `code`, `method`       |       All Requests       |
+|        authz        |           `code`            |      Authz Requests      |
+|        authn        |     `success`, `banned`     |   Authn Requests (1FA)   |
+|    authn_passkey    |          `success`          | Authn Requests (Passkey) |
+| authn_second_factor | `success`, `banned`, `type` |   Authn Requests (2FA)   |
 
 ##### Vectored Histograms
 


### PR DESCRIPTION
This adjusts the passkey logins to have a wholly unique metric.