### PR TITLE
docs: add missing middleware in traefik example

### DIFF
--- a/docs/content/integration/proxies/traefik.md
+++ b/docs/content/integration/proxies/traefik.md
@@ -230,6 +230,9 @@ services:
       # traefik.http.middlewares.authelia.forwardAuth.address: '{{< sitevar name="tls" nojs="http" >}}://{{< sitevar name="host" nojs="authelia" >}}:{{< sitevar name="port" nojs="9091" >}}/api/authz/forward-auth?authelia_url=https%3A%2F%2F{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}%2F'
       traefik.http.middlewares.authelia.forwardAuth.trustForwardHeader: 'true'
       traefik.http.middlewares.authelia.forwardAuth.authResponseHeaders: 'Remote-User,Remote-Groups,Remote-Email,Remote-Name'
+      traefik.http.middlewares.authelia-basic.forwardAuth.address: '{{< sitevar name="tls" nojs="http" >}}://{{< sitevar name="host" nojs="authelia" >}}:{{< sitevar name="port" nojs="9091" >}}/api/verify?auth=basic'
+      traefik.http.middlewares.authelia-basic.forwardAuth.trustForwardHeader: 'true'
+      traefik.http.middlewares.authelia-basic.forwardAuth.authResponseHeaders: 'Remote-User,Remote-Groups,Remote-Email,Remote-Name'
   nextcloud:
     container_name: 'nextcloud'
     image: 'linuxserver/nextcloud'


### PR DESCRIPTION
The Docker Compose Traefik example references the authelia-basic@docker middleware which is not defined.