### PR TITLE
docs: unset image width to prevent overflow

### DIFF
--- a/docs/assets/scss/common/_custom.scss
+++ b/docs/assets/scss/common/_custom.scss
@@ -5,6 +5,10 @@ figure.figure-blog {
   justify-content: center;
 }
 
+img[data-sizes="auto"] {
+  width: unset !important;
+}
+
 .text-orange {
   --bs-text-opacity: 1;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the image styling to provide a more natural display for pictures marked for automatic sizing. With this change, images now use their intrinsic width rather than a fixed size, leading to a more consistent and improved layout presentation across different views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->