### PR TITLE
fix: notifier startup check ignored

### DIFF
--- a/internal/middlewares/startup.go
+++ b/internal/middlewares/startup.go
@@ -22,7 +22,7 @@ func (p *Providers) StartupChecks(ctx Context, log bool) (err error) {
 	provider, disable = ctx.GetProviders().UserProvider, false
 	doStartupCheck(ctx, ProviderNameUser, provider, disable, log, e.errors)
 
-	provider, disable = ctx.GetProviders().Notifier, false
+	provider, disable = ctx.GetProviders().Notifier, ctx.GetConfiguration().Notifier.DisableStartupCheck
 	doStartupCheck(ctx, ProviderNameNotification, provider, disable, log, e.errors)
 
 	provider, disable = ctx.GetProviders().NTP, ctx.GetConfiguration().NTP.DisableStartupCheck


### PR DESCRIPTION
Fix an issue where the disable startup check option is ignored.

Fixes #8975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configuration-driven control for the notification service’s startup process, allowing users to optionally disable its automatic checks via settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->