### PR TITLE
fix(oidc): claims nil value not checked

### DIFF
--- a/internal/handlers/handler_oidc_consent.go
+++ b/internal/handlers/handler_oidc_consent.go
@@ -138,6 +138,9 @@ func OpenIDConnectConsentPOST(ctx *middlewares.AutheliaCtx) {
 					ctx.Logger.WithError(err).Debug("Error occurred resolving the actual form from the consent form")
 				} else if requests, err = oidc.NewClaimRequests(actualForm); err != nil {
 					ctx.Logger.WithError(err).Debug("Error occurred parsing claims parameter from request form for claims signature")
+				} else if requests == nil {
+					config.RequestedClaims = sql.NullString{Valid: false}
+					config.SignatureClaims = sql.NullString{Valid: false}
 				} else if config.RequestedClaims.String, config.SignatureClaims.String, err = requests.Serialized(); err != nil {
 					ctx.Logger.WithError(err).Debug("Error occurred calculating claims signature")
 				} else {


### PR DESCRIPTION
This fixes an issue where the claims nil state of the claims parameter is not checked when saving pre-configured consent.

Fixes #8979

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the consent process to clearly handle cases with missing information, ensuring a more robust configuration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->