### PR TITLE
fix(configuration): cache lifespan scheme case

### DIFF
--- a/internal/configuration/validator/server.go
+++ b/internal/configuration/validator/server.go
@@ -383,7 +383,7 @@ func validateServerEndpointsAuthzStrategies(name, implementation string, strateg
 
 		names = append(names, strategy.Name)
 
-		if strategy.SchemeBasicCacheLifespan > 0 && !utils.IsStringInSlice(schema.SchemeBasic, strategy.Schemes) {
+		if strategy.SchemeBasicCacheLifespan > 0 && !utils.IsStringInSliceFold(schema.SchemeBasic, strategy.Schemes) {
 			validator.Push(fmt.Errorf(errFmtServerEndpointsAuthzStrategySchemeOnlyOption, name, i+1, "scheme_basic_cache_lifespan", schema.SchemeBasic, utils.StringJoinAnd(strategy.Schemes)))
 		}
 

--- a/internal/configuration/validator/server_test.go
+++ b/internal/configuration/validator/server_test.go
@@ -565,6 +565,13 @@ func TestServerAuthzEndpointErrors(t *testing.T) {
 			},
 		},
 		{
+			"ShouldNotErrorOnValidSchemeCase",
+			map[string]schema.ServerEndpointsAuthz{
+				"example": {Implementation: "ForwardAuth", AuthnStrategies: []schema.ServerEndpointsAuthzAuthnStrategy{{Name: "HeaderAuthorization", SchemeBasicCacheLifespan: time.Minute, Schemes: []string{"BASIC"}}}},
+			},
+			[]string{},
+		},
+		{
 			"ShouldErrorOnInvalidChars",
 			map[string]schema.ServerEndpointsAuthz{
 				"/abc":  {Implementation: "ForwardAuth"},


### PR DESCRIPTION
Fix the comparison between the 'basic' scheme and the configured schemes when validating if scheme_basic_cache_lifespan is configured.

Fixes #8981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication configuration validation by making scheme checks case-insensitive, ensuring that valid strategies are recognized consistently.
- **Tests**
  - Introduced a new test case to verify that valid authentication configurations pass without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->