### PR TITLE
correct jellyfin oidc documentation

### DIFF
--- a/docs/content/integration/openid-connect/jellyfin/index.md
+++ b/docs/content/integration/openid-connect/jellyfin/index.md
@@ -62,6 +62,7 @@ identity_providers:
         pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://jellyfin.{{< sitevar name="domain" nojs="example.com" >}}/sso/OID/redirect/authelia'
+          - 'https://jellyfin.{{< sitevar name="domain" nojs="example.com" >}}/sso/OID/r/authelia'
         scopes:
           - 'openid'
           - 'profile'


### PR DESCRIPTION
Simple one-line change to the configuration instructions for Jellyfin.

The current instructions provide an incorrect redirect_uri. This change keeps that uri (for backwards compatability) and adds the new, working one. There may be a few other URIs that also need to be included depending on the user's specific setup, but I haven't tested any of them on mine, only the `/sso/OID/r/authelia` one (and the original `/sso/OID/redirect/authelia`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Jellyfin authentication experience by adding an additional redirect option, providing users with more flexibility during the login process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->