### PR TITLE
ci: include musl binaries in build process

### DIFF
--- a/.buildkite/annotations/artifacts
+++ b/.buildkite/annotations/artifacts
@@ -5,6 +5,8 @@
     <dd>
       <a href="artifact://authelia-linux-amd64.tar.gz">authelia-linux-amd64.tar.gz</a><br>
       <a href="artifact://authelia-linux-amd64.tar.gz.sha256">authelia-linux-amd64.tar.gz.sha256</a><br>
+      <a href="artifact://authelia-linux-amd64-musl.tar.gz">authelia-linux-amd64-musl.tar.gz</a><br>
+      <a href="artifact://authelia-linux-amd64-musl.tar.gz.sha256">authelia-linux-amd64-musl.tar.gz.sha256</a><br>
       <a href="artifact://authelia-freebsd-amd64.tar.gz">authelia-freebsd-amd64.tar.gz</a><br>
       <a href="artifact://authelia-freebsd-amd64.tar.gz.sha256">authelia-freebsd-amd64.tar.gz.sha256</a><br>
       <a href="artifact://authelia_amd64.deb">authelia_amd64.deb</a><br>
@@ -16,6 +18,8 @@
     <dd>
       <a href="artifact://authelia-linux-arm.tar.gz">authelia-linux-arm.tar.gz</a><br>
       <a href="artifact://authelia-linux-arm.tar.gz.sha256">authelia-linux-arm.tar.gz.sha256</a><br>
+      <a href="artifact://authelia-linux-arm-musl.tar.gz">authelia-linux-arm-musl.tar.gz</a><br>
+      <a href="artifact://authelia-linux-arm-musl.tar.gz.sha256">authelia-linux-arm-musl.tar.gz.sha256</a><br>
       <a href="artifact://authelia_armhf.deb">authelia_armhf.deb</a><br>
       <a href="artifact://authelia_armhf.deb.sha256">authelia_armhf.deb.sha256</a>
     </dd>
@@ -25,6 +29,8 @@
     <dd>
       <a href="artifact://authelia-linux-arm64.tar.gz">authelia-linux-arm64.tar.gz</a><br>
       <a href="artifact://authelia-linux-arm64.tar.gz.sha256">authelia-linux-arm64.tar.gz.sha256</a><br>
+      <a href="artifact://authelia-linux-arm64-musl.tar.gz">authelia-linux-arm64-musl.tar.gz</a><br>
+      <a href="artifact://authelia-linux-arm64-musl.tar.gz.sha256">authelia-linux-arm64-musl.tar.gz.sha256</a><br>
       <a href="artifact://authelia_arm64.deb">authelia_arm64.deb</a><br>
       <a href="artifact://authelia_arm64.deb.sha256">authelia_arm64.deb.sha256</a>
     </dd>

--- a/.buildkite/hooks/pre-artifact
+++ b/.buildkite/hooks/pre-artifact
@@ -2,7 +2,7 @@
 
 set +u
 
-declare -A BUILDS=(["linux"]="amd64 arm arm64" ["freebsd"]="amd64")
+declare -A BUILDS=(["linux"]="amd64 arm arm64 amd64-musl arm-musl arm64-musl" ["freebsd"]="amd64")
 DOCKER_IMAGE=authelia:dist
 
 if [[ "${BUILDKITE_LABEL}" == ":hammer_and_wrench: Unit Test" ]]; then

--- a/.buildkite/steps/ghartifacts.sh
+++ b/.buildkite/steps/ghartifacts.sh
@@ -7,6 +7,9 @@ for FILE in \
   authelia-linux-amd64.tar.gz authelia-linux-amd64.tar.gz.sha256 \
   authelia-linux-arm.tar.gz authelia-linux-arm.tar.gz.sha256 \
   authelia-linux-arm64.tar.gz authelia-linux-arm64.tar.gz.sha256 \
+  authelia-linux-amd64-musl.tar.gz authelia-linux-amd64-musl.tar.gz.sha256 \
+  authelia-linux-arm-musl.tar.gz authelia-linux-arm-musl.tar.gz.sha256 \
+  authelia-linux-arm64-musl.tar.gz authelia-linux-arm64-musl.tar.gz.sha256 \
   authelia-freebsd-amd64.tar.gz authelia-freebsd-amd64.tar.gz.sha256 \
   authelia-public_html.tar.gz authelia-public_html.tar.gz.sha256;
 do

--- a/cmd/authelia-scripts/cmd/build.go
+++ b/cmd/authelia-scripts/cmd/build.go
@@ -77,7 +77,22 @@ func buildAutheliaBinaryGOX(xflags []string) {
 
 	s := time.Now()
 
-	wg.Add(1)
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		cmd := utils.CommandWithStdout("gox", "-output={{.Dir}}-{{.OS}}-{{.Arch}}-musl", "-buildmode=pie", "-trimpath", "-cgo", "-ldflags=-linkmode=external -s -w "+strings.Join(xflags, " "), "-osarch=linux/amd64 linux/arm linux/arm64", "./cmd/authelia/")
+
+		cmd.Env = append(os.Environ(),
+			"GOEXPERIMENT=nosynchashtriemap", "CGO_CPPFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong", "CGO_LDFLAGS=-Wl,-z,relro,-z,now",
+			"GOX_LINUX_ARM_CC=arm-linux-musleabihf-gcc", "GOX_LINUX_ARM64_CC=aarch64-linux-musl-gcc")
+
+		err := cmd.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
This change adds musl binaries back into our CI/CD process.

Fixes #9033.