### PR TITLE
refactor: add debug command for tls verify

### DIFF
--- a/docs/content/reference/cli/authelia/authelia.md
+++ b/docs/content/reference/cli/authelia/authelia.md
@@ -55,6 +55,7 @@ authelia --config /etc/authelia/config/
 * [authelia build-info](authelia_build-info.md)	 - Show the build information of Authelia
 * [authelia config](authelia_config.md)	 - Perform config related actions
 * [authelia crypto](authelia_crypto.md)	 - Perform cryptographic operations
+* [authelia debug](authelia_debug.md)	 - Perform debug functions
 * [authelia storage](authelia_storage.md)	 - Manage the Authelia storage
 * [authelia validate-config](authelia_validate-config.md)	 - Check a configuration against the internal configuration validation mechanisms
 

--- a/docs/content/reference/cli/authelia/authelia_debug.md
+++ b/docs/content/reference/cli/authelia/authelia_debug.md
@@ -1,0 +1,50 @@
+---
+title: "authelia debug"
+description: "Reference for the authelia debug command."
+lead: ""
+date: 2022-06-15T17:51:47+10:00
+draft: false
+images: []
+weight: 905
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia debug
+
+Perform debug functions
+
+### Synopsis
+
+Perform debug related functions.
+
+This subcommand contains other subcommands related to debugging.
+
+### Examples
+
+```
+authelia debug --help
+```
+
+### Options
+
+```
+  -h, --help   help for debug
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config strings                        configuration files or directories to load, for more information run 'authelia -h authelia config' (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information run 'authelia -h authelia filters'
+```
+
+### SEE ALSO
+
+* [authelia](authelia.md)	 - authelia untagged-unknown-dirty (master, unknown)
+* [authelia debug tls](authelia_debug_tls.md)	 - Perform a TLS debug operation
+

--- a/docs/content/reference/cli/authelia/authelia_debug_tls.md
+++ b/docs/content/reference/cli/authelia/authelia_debug_tls.md
@@ -37,7 +37,8 @@ authelia debug tls tcp://smtp.example.com:465
 ### Options
 
 ```
-  -h, --help   help for tls
+  -h, --help              help for tls
+      --hostname string   overrides the hostname to use for the TLS connection which is usually extracted from the address
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/reference/cli/authelia/authelia_debug_tls.md
+++ b/docs/content/reference/cli/authelia/authelia_debug_tls.md
@@ -1,0 +1,53 @@
+---
+title: "authelia debug tls"
+description: "Reference for the authelia debug tls command."
+lead: ""
+date: 2022-06-15T17:51:47+10:00
+draft: false
+images: []
+weight: 905
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia debug tls
+
+Perform a TLS debug operation
+
+### Synopsis
+
+Perform a TLS debug operation.
+
+This subcommand allows checking a remote server's TLS configuration and the ability to validate the certificate.
+
+```
+authelia debug tls [address] [flags]
+```
+
+### Examples
+
+```
+authelia debug tls tcp://smtp.example.com:465
+```
+
+### Options
+
+```
+  -h, --help   help for tls
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config strings                        configuration files or directories to load, for more information run 'authelia -h authelia config' (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information run 'authelia -h authelia filters'
+```
+
+### SEE ALSO
+
+* [authelia debug](authelia_debug.md)	 - Perform debug functions
+

--- a/docs/static/schemas/latest/json-schema/configuration.json
+++ b/docs/static/schemas/latest/json-schema/configuration.json
@@ -4073,9 +4073,13 @@
     "TLSVersion": {
       "type": "string",
       "enum": [
+        "TLS 1.0",
         "TLS1.0",
+        "TLS 1.1",
         "TLS1.1",
+        "TLS 1.2",
         "TLS1.2",
+        "TLS 1.3",
         "TLS1.3"
       ]
     },

--- a/docs/static/schemas/v4.39/json-schema/configuration.json
+++ b/docs/static/schemas/v4.39/json-schema/configuration.json
@@ -4073,9 +4073,13 @@
     "TLSVersion": {
       "type": "string",
       "enum": [
+        "TLS 1.0",
         "TLS1.0",
+        "TLS 1.1",
         "TLS1.1",
+        "TLS 1.2",
         "TLS1.2",
+        "TLS 1.3",
         "TLS1.3"
       ]
     },

--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -661,6 +661,22 @@ This subcommand allows generating an %s key pair.`
 	cmdAutheliaCryptoPairECDSAGenerateExample = `authelia crypto pair ecdsa generate --help`
 
 	cmdAutheliaCryptoPairEd25519GenerateExample = `authelia crypto pair ed25519 generate --help`
+
+	cmdAutheliaDebugShort = "Perform debug functions"
+
+	cmdAutheliaDebugLong = `Perform debug related functions.
+
+This subcommand contains other subcommands related to debugging.`
+
+	cmdAutheliaDebugExample = `authelia debug --help`
+
+	cmdAutheliaDebugTLSShort = "Perform a TLS debug operation"
+
+	cmdAutheliaDebugTLSLong = `Perform a TLS debug operation.
+
+This subcommand allows checking a remote server's TLS configuration and the ability to validate the certificate.`
+
+	cmdAutheliaDebugTLSExample = `authelia debug tls tcp://smtp.example.com:465`
 )
 
 const (

--- a/internal/commands/context.go
+++ b/internal/commands/context.go
@@ -150,6 +150,38 @@ func (ctx *CmdCtx) LoadProviders() (warns, errs []error) {
 	return warns, errs
 }
 
+func (ctx *CmdCtx) LoadTrustedCertificatesRunE(cmd *cobra.Command, args []string) (err error) {
+	var warns, errs []error
+
+	ctx.trusted, warns, errs = utils.NewX509CertPool(ctx.config.CertificatesDirectory)
+
+	if len(warns) != 0 || len(errs) != 0 {
+		for _, e := range warns {
+			if err == nil {
+				err = e
+
+				continue
+			}
+
+			err = fmt.Errorf("%v, %w", err, e)
+		}
+
+		for _, e := range errs {
+			if err == nil {
+				err = e
+
+				continue
+			}
+
+			err = fmt.Errorf("%v, %w", err, e)
+		}
+
+		return fmt.Errorf("failed to load trusted certificates: %w", err)
+	}
+
+	return nil
+}
+
 // ChainRunE runs multiple CobraRunECmd funcs one after the other returning errors.
 func (ctx *CmdCtx) ChainRunE(cmdRunEs ...CobraRunECmd) CobraRunECmd {
 	return func(cmd *cobra.Command, args []string) (err error) {

--- a/internal/commands/debug.go
+++ b/internal/commands/debug.go
@@ -1,0 +1,243 @@
+package commands
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/utils"
+)
+
+func newDebugCmd(ctx *CmdCtx) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:     "debug",
+		Short:   cmdAutheliaDebugShort,
+		Long:    cmdAutheliaDebugLong,
+		Example: cmdAutheliaDebugExample,
+		Args:    cobra.NoArgs,
+
+		DisableAutoGenTag: true,
+	}
+
+	cmd.AddCommand(
+		newDebugTLSCmd(ctx),
+	)
+
+	return cmd
+}
+
+func newDebugTLSCmd(ctx *CmdCtx) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:     "tls [address]",
+		Short:   cmdAutheliaDebugTLSShort,
+		Long:    cmdAutheliaDebugTLSLong,
+		Example: cmdAutheliaDebugTLSExample,
+		Args:    cobra.ExactArgs(1),
+		RunE:    ctx.DebugTLSRunE,
+		PreRunE: ctx.ChainRunE(
+			ctx.HelperConfigLoadRunE,
+			ctx.HelperConfigValidateKeysRunE,
+			ctx.HelperConfigValidateRunE,
+		),
+		DisableAutoGenTag: true,
+	}
+
+	cmd.Flags().String("hostname", "", "overrides the hostname to use for the TLS connection which is usually extracted from the address")
+
+	return cmd
+}
+
+//nolint:gocyclo
+func (ctx *CmdCtx) DebugTLSRunE(cmd *cobra.Command, args []string) (err error) {
+	var (
+		address *schema.Address
+		conn    *tls.Conn
+	)
+
+	if address, err = schema.NewAddress(args[0]); err != nil {
+		return err
+	}
+
+	var hostnameOverride string
+
+	hostname := address.Hostname()
+
+	if hostnameOverride, err = cmd.Flags().GetString("hostname"); err == nil && hostnameOverride != "" {
+		hostname = hostnameOverride
+	} else if err != nil {
+		return err
+	}
+
+	n := len(tls.CipherSuites())
+
+	suites := make([]uint16, n+len(tls.InsecureCipherSuites()))
+
+	for i, suite := range tls.CipherSuites() {
+		suites[i] = suite.ID
+	}
+
+	for i, suite := range tls.InsecureCipherSuites() {
+		suites[i+n] = suite.ID
+	}
+
+	config := &tls.Config{
+		ServerName:         hostname,
+		InsecureSkipVerify: true,             //nolint:gosec // This is used solely to determine the TLS socket information.
+		MinVersion:         tls.VersionSSL30, //nolint:staticcheck // This is used solely to determine the TLS socket information.
+		MaxVersion:         tls.VersionTLS13,
+		CipherSuites:       suites,
+	}
+
+	if conn, err = tls.Dial(address.Network(), address.NetworkAddress(), config); err != nil {
+		return fmt.Errorf("failed to connect to %s: %w", address.NetworkAddress(), err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "General Information:\n")
+	_, _ = fmt.Fprintf(os.Stdout, "\tServer Name: %s\n", conn.ConnectionState().ServerName)
+	_, _ = fmt.Fprintf(os.Stdout, "\tNegotiated Protocol: %s\n", conn.ConnectionState().NegotiatedProtocol)
+	_, _ = fmt.Fprintf(os.Stdout, "\tTLS Version: %s\n", tls.VersionName(conn.ConnectionState().Version))
+
+	if utils.IsInsecureCipherSuite(conn.ConnectionState().CipherSuite) {
+		_, _ = fmt.Fprintf(os.Stdout, "\tCipher Suite: %s (Unsupported and Insecure)\n", tls.CipherSuiteName(conn.ConnectionState().CipherSuite))
+	} else {
+		_, _ = fmt.Fprintf(os.Stdout, "\tCipher Suite: %s (Supported)\n", tls.CipherSuiteName(conn.ConnectionState().CipherSuite))
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "\nCertificate Information:\n")
+
+	opts := x509.VerifyOptions{
+		Roots:         ctx.trusted,
+		Intermediates: x509.NewCertPool(),
+	}
+
+	certs := conn.ConnectionState().PeerCertificates
+
+	for i, cert := range certs {
+		if _, err = cert.Verify(opts); err == nil {
+			if cert.IsCA {
+				opts.Intermediates.AddCert(cert)
+			}
+
+			if i != 0 {
+				if certs[i-1].IsCA {
+					opts.Intermediates.AddCert(certs[i-1])
+				}
+			}
+		}
+	}
+
+	valid := true
+	validHostname := true
+
+	for i, cert := range conn.ConnectionState().PeerCertificates {
+		if _, err = cert.Verify(opts); err != nil {
+			valid = false
+		}
+
+		_, _ = fmt.Fprintf(os.Stdout, "\n\tCertificate #%d:\n", i+1)
+		_, _ = fmt.Fprintf(os.Stdout, "\t\tCertificate Authority: %t\n", cert.IsCA)
+		_, _ = fmt.Fprintf(os.Stdout, "\t\tPublic Key Algorithm: %s\n", cert.PublicKeyAlgorithm)
+		_, _ = fmt.Fprintf(os.Stdout, "\t\tSignature Algorithm: %s\n", cert.SignatureAlgorithm)
+		_, _ = fmt.Fprintf(os.Stdout, "\t\tSubject: %s\n", cert.Subject)
+
+		if len(cert.DNSNames) != 0 {
+			_, _ = fmt.Fprintf(os.Stdout, "\t\tAlternative Names (DNS): %s\n", strings.Join(cert.DNSNames, ", "))
+		}
+
+		if len(cert.IPAddresses) != 0 {
+			ips := make([]string, len(cert.IPAddresses))
+			for j, ip := range cert.IPAddresses {
+				ips[j] = ip.String()
+			}
+
+			_, _ = fmt.Fprintf(os.Stdout, "\t\tAlternative Names (IP): %s\n", strings.Join(ips, ", "))
+		}
+
+		_, _ = fmt.Fprintf(os.Stdout, "\t\tIssuer: %s\n", cert.Issuer)
+		_, _ = fmt.Fprintf(os.Stdout, "\t\tNot Before: %s\n", cert.NotBefore)
+		_, _ = fmt.Fprintf(os.Stdout, "\t\tNot After: %s\n", cert.NotAfter)
+		_, _ = fmt.Fprintf(os.Stdout, "\t\tSerial Number: %s\n", cert.SerialNumber)
+		_, _ = fmt.Fprintf(os.Stdout, "\t\tValid: %t\n", valid)
+
+		if err != nil {
+			var (
+				errUA *x509.UnknownAuthorityError
+				errH  *x509.HostnameError
+				errCI *x509.CertificateInvalidError
+			)
+
+			switch {
+			case errors.As(err, &errUA):
+				_, _ = fmt.Fprintf(os.Stdout, "\t\tValidation Hint: Certificate signed by unknown authority\n")
+			case errors.As(err, &errH):
+				_, _ = fmt.Fprintf(os.Stdout, "\t\tValidation Hint: Certificate hostname mismatch\n")
+			case errors.As(err, &errCI):
+				_, _ = fmt.Fprintf(os.Stdout, "\t\tValidation Hint: Certificate is invalid\n")
+			default:
+				_, _ = fmt.Fprintf(os.Stdout, "\t\tValidation Hint: Unknown Error (%T)\n", err)
+			}
+
+			_, _ = fmt.Fprintf(os.Stdout, "\t\tValidation Error: %v\n", err)
+		}
+
+		if i == 0 {
+			if err = cert.VerifyHostname(hostname); err != nil {
+				validHostname = false
+
+				_, _ = fmt.Fprintf(os.Stdout, "\t\tHostname Verification Error: %v\n", err)
+			} else {
+				_, _ = fmt.Fprintf(os.Stdout, "\t\tHostname Verification: pass\n")
+			}
+		}
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "\n\tTrusted: %t\n", valid)
+
+	c := struct {
+		TLS schema.TLS `yaml:"tls"`
+	}{
+		TLS: schema.TLS{
+			ServerName:     conn.ConnectionState().ServerName,
+			SkipVerify:     false,
+			MinimumVersion: schema.TLSVersion{Value: conn.ConnectionState().Version},
+			MaximumVersion: schema.TLSVersion{Value: tls.VersionTLS13},
+		},
+	}
+
+	if !validHostname && len(certs[0].DNSNames) != 0 {
+		c.TLS.ServerName = certs[0].DNSNames[0]
+	} else if validHostname && hostnameOverride != "" {
+		c.TLS.ServerName = hostnameOverride
+	}
+
+	data, err := yaml.Marshal(&c)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stdout, "\nError marshaling suggested config: %v\n", err)
+	} else {
+		_, _ = fmt.Fprintf(os.Stdout, "\nSuggested Configuration:\n\n")
+		_, _ = fmt.Fprintf(os.Stdout, "%s\n", string(data))
+	}
+
+	if !valid {
+		_, _ = fmt.Fprintf(os.Stdout, "\nWARNING: The certificate is not valid for one reason or another. You may need to configure Authelia to trust certificate below.\n\n")
+
+		block := &pem.Block{
+			Type:  utils.BlockTypeCertificate,
+			Bytes: conn.ConnectionState().PeerCertificates[0].Raw,
+		}
+
+		if err = pem.Encode(os.Stdout, block); err != nil {
+			_, _ = fmt.Fprintf(os.Stdout, "Error writing certificate to stdout: %v\n", err)
+		}
+	}
+
+	return conn.Close()
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -50,6 +50,7 @@ func NewRootCmd() (cmd *cobra.Command) {
 		newStorageCmd(ctx),
 		newConfigCmd(ctx),
 		newConfigValidateLegacyCmd(ctx),
+		newDebugCmd(ctx),
 
 		newHelpTopic("config", "Help for the config file/directory paths", helpTopicConfig),
 		newHelpTopic("filters", "help topic for the config filters", helpTopicConfigFilters),

--- a/internal/configuration/schema/types.go
+++ b/internal/configuration/schema/types.go
@@ -186,15 +186,15 @@ func NewX509CertificateChainFromCerts(in []*x509.Certificate) (chain X509Certifi
 // NewTLSVersion returns a new TLSVersion given a string.
 func NewTLSVersion(input string) (version *TLSVersion, err error) {
 	switch strings.ReplaceAll(strings.ToUpper(input), " ", "") {
-	case TLSVersion13, Version13:
+	case TLSVersion13, Version13, tls.VersionName(tls.VersionTLS13):
 		return &TLSVersion{tls.VersionTLS13}, nil
-	case TLSVersion12, Version12:
+	case TLSVersion12, Version12, tls.VersionName(tls.VersionTLS12):
 		return &TLSVersion{tls.VersionTLS12}, nil
-	case TLSVersion11, Version11:
+	case TLSVersion11, Version11, tls.VersionName(tls.VersionTLS11):
 		return &TLSVersion{tls.VersionTLS11}, nil
-	case TLSVersion10, Version10:
+	case TLSVersion10, Version10, tls.VersionName(tls.VersionTLS10):
 		return &TLSVersion{tls.VersionTLS10}, nil
-	case SSLVersion30:
+	case SSLVersion30, strings.ToUpper(tls.VersionName(tls.VersionSSL30)): //nolint:staticcheck
 		return &TLSVersion{tls.VersionSSL30}, nil //nolint:staticcheck
 	}
 
@@ -211,9 +211,13 @@ func (TLSVersion) JSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
 		Type: jsonschema.TypeString,
 		Enum: []any{
+			"TLS 1.0",
 			"TLS1.0",
+			"TLS 1.1",
 			"TLS1.1",
+			"TLS 1.2",
 			"TLS1.2",
+			"TLS 1.3",
 			"TLS1.3",
 		},
 	}
@@ -239,20 +243,15 @@ func (v *TLSVersion) MinVersion() uint16 {
 
 // String provides the Stringer.
 func (v *TLSVersion) String() string {
-	switch v.Value {
-	case tls.VersionTLS10:
-		return TLSVersion10
-	case tls.VersionTLS11:
-		return TLSVersion11
-	case tls.VersionTLS12:
-		return TLSVersion12
-	case tls.VersionTLS13:
-		return TLSVersion13
-	case tls.VersionSSL30: //nolint:staticcheck
-		return SSLVersion30
-	default:
-		return ""
+	if name := tls.VersionName(v.Value); !strings.HasPrefix(name, "0x") {
+		return name
 	}
+
+	return ""
+}
+
+func (v TLSVersion) MarshalYAML() (any, error) {
+	return v.String(), nil
 }
 
 // CryptographicPrivateKey represents the actual crypto.PrivateKey interface.

--- a/internal/configuration/schema/types_test.go
+++ b/internal/configuration/schema/types_test.go
@@ -137,6 +137,12 @@ func TestNewTLSVersion(t *testing.T) {
 			"",
 		},
 		{
+			"ShouldParseTLS_1.3",
+			"TLS 1.3",
+			&TLSVersion{Value: tls.VersionTLS13},
+			"",
+		},
+		{
 			"ShouldParse1.3",
 			"1.3",
 			&TLSVersion{Value: tls.VersionTLS13},
@@ -145,6 +151,12 @@ func TestNewTLSVersion(t *testing.T) {
 		{
 			"ShouldParseTLS1.2",
 			"TLS1.2",
+			&TLSVersion{Value: tls.VersionTLS12},
+			"",
+		},
+		{
+			"ShouldParseTLS_1.2",
+			"TLS 1.2",
 			&TLSVersion{Value: tls.VersionTLS12},
 			"",
 		},
@@ -161,6 +173,12 @@ func TestNewTLSVersion(t *testing.T) {
 			"",
 		},
 		{
+			"ShouldParseTLS_1.1",
+			"TLS 1.1",
+			&TLSVersion{Value: tls.VersionTLS11},
+			"",
+		},
+		{
 			"ShouldParse1.1",
 			"1.1",
 			&TLSVersion{Value: tls.VersionTLS11},
@@ -173,6 +191,12 @@ func TestNewTLSVersion(t *testing.T) {
 			"",
 		},
 		{
+			"ShouldParseTLS_1.0",
+			"TLS 1.0",
+			&TLSVersion{Value: tls.VersionTLS10},
+			"",
+		},
+		{
 			"ShouldParse1.0",
 			"1.0",
 			&TLSVersion{Value: tls.VersionTLS10},
@@ -181,6 +205,12 @@ func TestNewTLSVersion(t *testing.T) {
 		{
 			"ShouldParseSSL3.0",
 			"SSL3.0",
+			&TLSVersion{Value: tls.VersionSSL30}, //nolint:staticcheck
+			"",
+		},
+		{
+			"ShouldParseSSLv3",
+			"SSLv3",
 			&TLSVersion{Value: tls.VersionSSL30}, //nolint:staticcheck
 			"",
 		},
@@ -233,7 +263,7 @@ func TestTLSVersion_Functions(t *testing.T) {
 			expected{
 				tls.VersionTLS13,
 				tls.VersionTLS13,
-				"TLS1.3",
+				"TLS 1.3",
 			},
 		},
 		{
@@ -242,7 +272,7 @@ func TestTLSVersion_Functions(t *testing.T) {
 			expected{
 				tls.VersionTLS12,
 				tls.VersionTLS12,
-				"TLS1.2",
+				"TLS 1.2",
 			},
 		},
 		{
@@ -251,7 +281,7 @@ func TestTLSVersion_Functions(t *testing.T) {
 			expected{
 				tls.VersionTLS11,
 				tls.VersionTLS11,
-				"TLS1.1",
+				"TLS 1.1",
 			},
 		},
 		{
@@ -260,7 +290,7 @@ func TestTLSVersion_Functions(t *testing.T) {
 			expected{
 				tls.VersionTLS10,
 				tls.VersionTLS10,
-				"TLS1.0",
+				"TLS 1.0",
 			},
 		},
 		{
@@ -269,7 +299,7 @@ func TestTLSVersion_Functions(t *testing.T) {
 			expected{
 				tls.VersionSSL30, //nolint:staticcheck
 				tls.VersionSSL30, //nolint:staticcheck
-				"SSL3.0",
+				"SSLv3",
 			},
 		},
 	}

--- a/internal/configuration/validator/authentication_test.go
+++ b/internal/configuration/validator/authentication_test.go
@@ -965,7 +965,7 @@ func (suite *LDAPAuthenticationBackendSuite) TestShouldNotAllowTLSVerMinGreaterT
 	suite.Len(suite.validator.Warnings(), 0)
 	suite.Require().Len(suite.validator.Errors(), 1)
 
-	suite.EqualError(suite.validator.Errors()[0], "authentication_backend: ldap: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS1.3 is greater than the maximum version TLS1.2")
+	suite.EqualError(suite.validator.Errors()[0], "authentication_backend: ldap: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS 1.3 is greater than the maximum version TLS 1.2")
 }
 
 func TestLDAPAuthenticationBackend(t *testing.T) {

--- a/internal/configuration/validator/notifier_test.go
+++ b/internal/configuration/validator/notifier_test.go
@@ -185,7 +185,7 @@ func (suite *NotifierSuite) TestSMTPShouldErrorOnTLSMinVerGreaterThanMaxVer() {
 	suite.Len(suite.validator.Warnings(), 0)
 	suite.Require().Len(suite.validator.Errors(), 1)
 
-	suite.EqualError(suite.validator.Errors()[0], "notifier: smtp: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS1.3 is greater than the maximum version TLS1.0")
+	suite.EqualError(suite.validator.Errors()[0], "notifier: smtp: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS 1.3 is greater than the maximum version TLS 1.0")
 }
 
 func (suite *NotifierSuite) TestSMTPShouldWarnOnDisabledSTARTTLS() {

--- a/internal/configuration/validator/session_test.go
+++ b/internal/configuration/validator/session_test.go
@@ -708,7 +708,7 @@ func TestShouldRaiseErrorOnBadRedisTLSOptionsMinVerGreaterThanMax(t *testing.T) 
 	assert.Len(t, validator.Warnings(), 0)
 	require.Len(t, validator.Errors(), 1)
 
-	assert.EqualError(t, validator.Errors()[0], "session: redis: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS1.3 is greater than the maximum version TLS1.0")
+	assert.EqualError(t, validator.Errors()[0], "session: redis: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS 1.3 is greater than the maximum version TLS 1.0")
 }
 
 func TestShouldRaiseErrorWhenHaveDuplicatedDomainName(t *testing.T) {

--- a/internal/configuration/validator/storage_test.go
+++ b/internal/configuration/validator/storage_test.go
@@ -178,7 +178,7 @@ func (suite *StorageSuite) TestShouldRaiseErrorOnInvalidMySQLTLSMinVersionGreate
 	suite.Len(suite.val.Warnings(), 0)
 	suite.Require().Len(suite.val.Errors(), 1)
 
-	suite.EqualError(suite.val.Errors()[0], "storage: mysql: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS1.3 is greater than the maximum version TLS1.1")
+	suite.EqualError(suite.val.Errors()[0], "storage: mysql: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS 1.3 is greater than the maximum version TLS 1.1")
 }
 
 func (suite *StorageSuite) TestShouldValidatePostgreSQLHostUsernamePasswordAndDatabaseAreProvided() {
@@ -330,7 +330,7 @@ func (suite *StorageSuite) TestShouldValidatePostgresServers() {
 	suite.Require().Len(errors, 3)
 	suite.EqualError(errors[0], "storage: postgres: servers: #1: option 'address' with value 'udp://server1:4321' is invalid: scheme must be one of 'tcp', 'tcp4', 'tcp6', 'unix', or 'fd' but is configured as 'udp'")
 	suite.EqualError(errors[1], "storage: postgres: servers: #2: option 'address' is required")
-	suite.EqualError(errors[2], "storage: postgres: servers: #5: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS1.3 is greater than the maximum version TLS1.0")
+	suite.EqualError(errors[2], "storage: postgres: servers: #5: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS 1.3 is greater than the maximum version TLS 1.0")
 }
 
 func (suite *StorageSuite) TestShouldValidatePostgresServersTLSMinMaxFromPrimary() {
@@ -479,7 +479,7 @@ func (suite *StorageSuite) TestShouldRaiseErrorOnInvalidPostgreSQLMinVersionGrea
 	suite.Len(suite.val.Warnings(), 0)
 	suite.Require().Len(suite.val.Errors(), 1)
 
-	suite.EqualError(suite.val.Errors()[0], "storage: postgres: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS1.3 is greater than the maximum version TLS1.1")
+	suite.EqualError(suite.val.Errors()[0], "storage: postgres: tls: option combination of 'minimum_version' and 'maximum_version' is invalid: minimum version TLS 1.3 is greater than the maximum version TLS 1.1")
 }
 
 func (suite *StorageSuite) TestShouldValidatePostgresSSLDefaults() {

--- a/internal/suites/CLI/compose.yml
+++ b/internal/suites/CLI/compose.yml
@@ -3,11 +3,13 @@ services:
   authelia-backend:
     volumes:
       - './CLI/configuration.yml:/config/configuration.yml'
+      - './CLI/configuration.nocerts.yml:/config/configuration.nocerts.yml'
       - './CLI/storage.yml:/config/configuration.storage.yml'
       - './CLI/users.yml:/config/users.yml'
       - './CLI/exports:/exports'
       - './common/pki:/pki'
       - './common/pki/public.crt:/certs/public.crt'
+      - './common/pki/ca/ca.public.crt:/certs/ca.public.crt'
       - '/tmp:/tmp'
     user: '${USER_ID}:${GROUP_ID}'
 ...

--- a/internal/suites/CLI/configuration.nocerts.yml
+++ b/internal/suites/CLI/configuration.nocerts.yml
@@ -1,5 +1,5 @@
 ---
-certificates_directory: '/certs/'
+certificates_directory: ''
 
 server:
   address: 'tcp://:9091'

--- a/internal/suites/example/compose/nginx/cli/compose.yml
+++ b/internal/suites/example/compose/nginx/cli/compose.yml
@@ -1,0 +1,15 @@
+---
+services:
+  nginx-cli:
+    image: nginx:1.27.5-alpine
+    volumes:
+      - ./example/compose/nginx/cli/nginx.conf:/etc/nginx/nginx.conf
+      - ./common/pki:/pki
+    networks:
+      authelianet:
+        aliases:
+          - public.example.com
+          - secure.example.com
+        # Set the IP to be able to query on port 443
+        ipv4_address: 192.168.240.100
+...

--- a/internal/suites/example/compose/nginx/cli/nginx.conf
+++ b/internal/suites/example/compose/nginx/cli/nginx.conf
@@ -1,0 +1,57 @@
+#
+# You can find a documented example of configuration in ./docs/proxies/nginx.md.
+#
+worker_processes  1;
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen 8081;
+        server_name ~^[a-z]+\.example([0-9])*\.com$;
+
+        resolver 127.0.0.11 ipv6=off;
+
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
+
+        # Serves a stub application.
+        location / {
+            add_header X-Content-Type-Options "nosniff";
+            add_header Referrer-Policy "strict-origin-when-cross-origin";
+            add_header X-Frame-Options "DENY";
+            add_header Permissions-Policy "accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), sync-xhr=(), xr-spatial-tracking=(), interest-cohort=()";
+            add_header X-DNS-Prefetch-Control "off";
+            add_header Cross-Origin-Opener-Policy "same-origin";
+            add_header Cross-Origin-Embedder-Policy "require-corp";
+            add_header Cross-Origin-Resource-Policy "same-origin";
+
+            return 200;
+        }
+    }
+    server {
+        listen 8080 ssl;
+        server_name ~^[a-z]+\.example([0-9])*\.com$;
+
+        resolver 127.0.0.11 ipv6=off;
+
+        ssl_certificate     /pki/public.chain.pem;
+        ssl_certificate_key /pki/private.pem;
+
+        error_page 497 301 =307 https://$host:$server_port$request_uri;
+
+        # Serves a stub application.
+        location / {
+            add_header X-Content-Type-Options "nosniff";
+            add_header Referrer-Policy "strict-origin-when-cross-origin";
+            add_header X-Frame-Options "DENY";
+            add_header Permissions-Policy "accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), screen-wake-lock=(), sync-xhr=(), xr-spatial-tracking=(), interest-cohort=()";
+            add_header X-DNS-Prefetch-Control "off";
+            add_header Cross-Origin-Opener-Policy "same-origin";
+            add_header Cross-Origin-Embedder-Policy "require-corp";
+            add_header Cross-Origin-Resource-Policy "same-origin";
+
+            return 200;
+        }
+    }
+}

--- a/internal/suites/suite_cli.go
+++ b/internal/suites/suite_cli.go
@@ -12,6 +12,7 @@ func init() {
 		"internal/suites/compose.yml",
 		"internal/suites/CLI/compose.yml",
 		"internal/suites/example/compose/authelia/compose.backend.{}.yml",
+		"internal/suites/example/compose/nginx/cli/compose.yml",
 	})
 
 	setup := func(suitePath string) (err error) {

--- a/internal/utils/crypto.go
+++ b/internal/utils/crypto.go
@@ -721,3 +721,13 @@ func TLSVersionFromBytesString(input string) (version int, err error) {
 		return -1, fmt.Errorf("tls version 0x%x is unknown", version)
 	}
 }
+
+func IsInsecureCipherSuite(cipherSuite uint16) bool {
+	for _, suite := range tls.InsecureCipherSuites() {
+		if suite.ID == cipherSuite {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/utils/crypto.go
+++ b/internal/utils/crypto.go
@@ -731,3 +731,38 @@ func IsInsecureCipherSuite(cipherSuite uint16) bool {
 
 	return false
 }
+
+// UnsafeGetIntermediatesFromPeerCertificates attempts to find valid intermediates from the provided peer certificates.
+//
+// CRITICAL: This function should not be used for production code as it may not produce the correct output to properly
+// verify the chain. This function is intended to be used for testing purposes only.
+func UnsafeGetIntermediatesFromPeerCertificates(certs []*x509.Certificate, roots, ints *x509.CertPool) (intermediates *x509.CertPool) {
+	var err error
+
+	n := len(certs) - 1
+
+	opts := x509.VerifyOptions{
+		Roots:         roots.Clone(),
+		Intermediates: ints.Clone(),
+	}
+
+	for i := n; i >= 0; i-- {
+		if _, err = certs[i].Verify(opts); err == nil {
+			continue
+		}
+
+		if i == n {
+			// No certs in the chain are valid.
+			break
+		}
+
+		// Intentionally only add the certificates within the trust chain.
+		if certs[i+1].IsCA {
+			if _, err = certs[i+1].Verify(opts); err == nil {
+				opts.Intermediates.AddCert(certs[i+1])
+			}
+		}
+	}
+
+	return opts.Intermediates
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI command: `authelia debug`, with a `tls` subcommand for diagnosing remote server TLS configurations and validating certificates.
  - Added a method to load trusted certificates with detailed error handling in the CLI context.

- **Documentation**
  - Added documentation for the new `authelia debug` and `authelia debug tls` CLI commands, including usage examples and options.
  - Updated CLI reference to include the new debug command.

- **Style**
  - Updated TLS version strings in error messages and documentation to use spaced formats (e.g., "TLS 1.3" instead of "TLS1.3").

- **Tests**
  - Enhanced test cases to cover new TLS version string formats and updated expected error messages to match the new formatting.
  - Added CLI tests for the `authelia debug tls` command covering connection diagnostics and certificate validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->