### PR TITLE
fix(oidc): missing device code handlers

### DIFF
--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -14,6 +14,7 @@ import (
 	"authelia.com/provider/oauth2/handler/openid"
 	"authelia.com/provider/oauth2/handler/par"
 	"authelia.com/provider/oauth2/handler/pkce"
+	"authelia.com/provider/oauth2/handler/rfc8628"
 	"authelia.com/provider/oauth2/i18n"
 	"authelia.com/provider/oauth2/token/jwt"
 	"github.com/hashicorp/go-retryablehttp"
@@ -267,6 +268,17 @@ func (c *Config) LoadHandlers(store *Store) {
 			RefreshTokenStrategy:   c.Strategy.Core,
 			TokenRevocationStorage: store,
 			Config:                 c,
+		},
+
+		&rfc8628.DeviceAuthorizeHandler{
+			Storage:  store,
+			Strategy: c.Strategy.Core,
+			Config:   c,
+		},
+		&rfc8628.UserAuthorizeHandler{
+			Storage:  store,
+			Strategy: c.Strategy.Core,
+			Config:   c,
 		},
 
 		&openid.OpenIDConnectExplicitHandler{


### PR DESCRIPTION
This addresses part of an issue with the Device Code Flow where the appropriate handlers were not registered. This was caused by a lost commit, of which also had some adjustments to the frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for device authorization and user authorization endpoints, enhancing OpenID Connect compatibility with RFC 8628. This enables improved device-based authentication flows for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->