### PR TITLE
fix(oidc): missing grant handlers

### DIFF
--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -269,7 +269,6 @@ func (c *Config) LoadHandlers(store *Store) {
 			TokenRevocationStorage: store,
 			Config:                 c,
 		},
-
 		&rfc8628.DeviceAuthorizeHandler{
 			Storage:  store,
 			Strategy: c.Strategy.Core,
@@ -279,6 +278,20 @@ func (c *Config) LoadHandlers(store *Store) {
 			Storage:  store,
 			Strategy: c.Strategy.Core,
 			Config:   c,
+		},
+		&rfc8628.DeviceAuthorizeTokenEndpointHandler{
+			GenericCodeTokenEndpointHandler: oauth2.GenericCodeTokenEndpointHandler{
+				CodeTokenEndpointHandler: &rfc8628.DeviceCodeTokenHandler{
+					Strategy: c.Strategy.Core,
+					Storage:  store,
+					Config:   c,
+				},
+				AccessTokenStrategy:    c.Strategy.Core,
+				RefreshTokenStrategy:   c.Strategy.Core,
+				CoreStorage:            store,
+				TokenRevocationStorage: store,
+				Config:                 c,
+			},
 		},
 
 		&openid.OpenIDConnectExplicitHandler{
@@ -326,6 +339,19 @@ func (c *Config) LoadHandlers(store *Store) {
 				IDTokenStrategy: c.Strategy.OpenID,
 			},
 			Config: c,
+		},
+		&openid.OpenIDConnectDeviceAuthorizeHandler{
+			OpenIDConnectRequestStorage:   store,
+			OpenIDConnectRequestValidator: validator,
+			CodeTokenEndpointHandler: &rfc8628.DeviceCodeTokenHandler{
+				Strategy: c.Strategy.Core,
+				Storage:  store,
+				Config:   c,
+			},
+			Config: c,
+			IDTokenHandleHelper: &openid.IDTokenHandleHelper{
+				IDTokenStrategy: c.Strategy.OpenID,
+			},
 		},
 
 		statelessJWT,


### PR DESCRIPTION
This fixes the missing grant handlers for the OAuth 2.0 Device Code Flow, and accompanies the fixes to the specific flow handlers for this flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for device authorization flows, including RFC 8628 Device Authorization Grant and OpenID Connect Device Authorization.

- **Chores**
  - Minor cleanup of blank lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->