### PR TITLE
docs: remove pkcs1

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -495,9 +495,9 @@ identity_validation:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
     ## Connection Pooling configuration.
     # pooling:
@@ -941,9 +941,9 @@ session:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
     ## The Redis HA configuration options.
     ## This provides specific options to Redis Sentinel, sentinel_name must be defined (Master Name).
@@ -1070,9 +1070,9 @@ session:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
   ##
   ## PostgreSQL (Storage Provider)
@@ -1104,9 +1104,9 @@ session:
             # ...
             # -----END CERTIFICATE-----
           # private_key: |
-            # -----BEGIN RSA PRIVATE KEY-----
+            # -----BEGIN PRIVATE KEY-----
             # ...
-            # -----END RSA PRIVATE KEY-----
+            # -----END PRIVATE KEY-----
 
     ## The database name to use.
     # database: 'authelia'
@@ -1157,9 +1157,9 @@ session:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
 ##
 ## Notification Provider
@@ -1255,9 +1255,9 @@ session:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
 ##
 ## Identity Providers
@@ -1290,9 +1290,9 @@ session:
 
       ## Required Private Key in PEM DER form.
       # key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
 
       ## Optional matching certificate chain in PEM DER form that matches the key. All certificates within the chain

--- a/docs/content/blog/release-notes-4.38/index.md
+++ b/docs/content/blog/release-notes-4.38/index.md
@@ -254,9 +254,9 @@ template filter example. To use this example you'll need to enable the `template
 identity_providers:
   oidc:
     issuer_private_key: |
-      -----BEGIN RSA PRIVATE KEY-----
+      -----BEGIN PRIVATE KEY-----
       ...
-      -----END RSA PRIVATE KEY-----
+      -----END PRIVATE KEY-----
     issuer_certificate_chain: |
       -----BEGIN CERTIFICATE-----
       ...
@@ -270,9 +270,9 @@ identity_providers:
   oidc:
     jwks:
       - key: |
-          -----BEGIN RSA PRIVATE KEY-----
+          -----BEGIN PRIVATE KEY-----
           ...
-          -----END RSA PRIVATE KEY-----
+          -----END PRIVATE KEY-----
         certificate_chain: |
           -----BEGIN CERTIFICATE-----
           ...

--- a/docs/content/configuration/first-factor/ldap.md
+++ b/docs/content/configuration/first-factor/ldap.md
@@ -47,9 +47,9 @@ authentication_backend:
         ...
         -----END CERTIFICATE-----
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
     pooling:
       enable: false
       count: 5

--- a/docs/content/configuration/identity-providers/openid-connect/provider.md
+++ b/docs/content/configuration/identity-providers/openid-connect/provider.md
@@ -52,9 +52,9 @@ identity_providers:
         algorithm: 'RS256'
         use: 'sig'
         key: |
-          -----BEGIN RSA PRIVATE KEY-----
+          -----BEGIN PRIVATE KEY-----
           ...
-          -----END RSA PRIVATE KEY-----
+          -----END PRIVATE KEY-----
         certificate_chain: |
           -----BEGIN CERTIFICATE-----
           ...
@@ -143,9 +143,9 @@ identity_providers:
         algorithm: 'RS256'
         use: 'sig'
         key: |
-          -----BEGIN RSA PRIVATE KEY-----
+          -----BEGIN PRIVATE KEY-----
           ...
-          -----END RSA PRIVATE KEY-----
+          -----END PRIVATE KEY-----
         certificate_chain: |
           -----BEGIN CERTIFICATE-----
           ...

--- a/docs/content/configuration/notifications/smtp.md
+++ b/docs/content/configuration/notifications/smtp.md
@@ -54,9 +54,9 @@ notifier:
         ...
         -----END CERTIFICATE-----
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
 ```
 
 ## Options

--- a/docs/content/configuration/prologue/common.md
+++ b/docs/content/configuration/prologue/common.md
@@ -308,9 +308,9 @@ tls:
     ...
     -----END CERTIFICATE-----
   private_key: |
-    -----BEGIN RSA PRIVATE KEY-----
+    -----BEGIN PRIVATE KEY-----
     ...
-    -----END RSA PRIVATE KEY-----
+    -----END PRIVATE KEY-----
 ```
 
 #### server_name

--- a/docs/content/configuration/session/redis.md
+++ b/docs/content/configuration/session/redis.md
@@ -49,9 +49,9 @@ session:
         ...
         -----END CERTIFICATE-----
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
     high_availability:
       sentinel_name: 'mysentinel'
       # If `sentinel_username` is supplied, Authelia will connect using ACL-based

--- a/docs/content/configuration/storage/mysql.md
+++ b/docs/content/configuration/storage/mysql.md
@@ -54,9 +54,9 @@ storage:
         ...
         -----END CERTIFICATE-----
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
 ```
 
 ## Options

--- a/docs/content/configuration/storage/postgres.md
+++ b/docs/content/configuration/storage/postgres.md
@@ -55,9 +55,9 @@ storage:
         ...
         -----END CERTIFICATE-----
       private_key: |
-        -----BEGIN RSA PRIVATE KEY-----
+        -----BEGIN PRIVATE KEY-----
         ...
-        -----END RSA PRIVATE KEY-----
+        -----END PRIVATE KEY-----
 ```
 
 ## Options

--- a/docs/content/integration/kubernetes/secrets.md
+++ b/docs/content/integration/kubernetes/secrets.md
@@ -69,8 +69,8 @@ stringData:
     d4ypk2UQXxuo86s7vJ2rYWPa5KoxDfU9JQWgEqtANiBaJVQSG8PJbD9U24eiVuPC
   OIDC_HMAC_SECRET: >-
     eSopMjbiuCMhEbXGFsm5B8KWKszxV3CJWSLYrWnBJja4rFNvDxti388WyBjdrsHb
-  OIDC_ISSUER_PRIVATE_KEY:
-    -----BEGIN RSA PRIVATE KEY-----
+  OIDC_ISSUER_PRIVATE_KEY: |
+    -----BEGIN PRIVATE KEY-----
     MXIEogIB$AKCAQEAxZVJP3WF//PG2fLQoEC9DtdiFG/+00vqlbVzz47nyxKONIPI
     lmL3UdmqpGTKMe/5Brqse4ZAKlQHiDbwzK9ypnfigtHuvh/JO0S7ChP70RC67ed1
     HV1nyfz5eW3llbtGJPrlYLqITNgctHp6zmRUFtSzPj9qFvozI93LJi492yL1+vu8
@@ -96,7 +96,7 @@ stringData:
     P1dZAoGASGcGnTMkmeSXP8ux+dvQJAiJskn/sJIgBZ5uq5GRCeLBUosRSVxM75UK
     vAh/c/RBj+pYXVKuPuHGZCQJxsdcRXzXNGouUtgbaYML5Me/Hagt20QzDRBfuGBg
     qeZBJaXhjElvw6PUWtg4x+LYRCBpq/bS3LK3ozZrSTukVkKDegw=
-    -----END RSA PRIVATE KEY-----
+    -----END PRIVATE KEY-----
 ...
 ```
 

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -495,9 +495,9 @@ identity_validation:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
     ## Connection Pooling configuration.
     # pooling:
@@ -941,9 +941,9 @@ session:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
     ## The Redis HA configuration options.
     ## This provides specific options to Redis Sentinel, sentinel_name must be defined (Master Name).
@@ -1070,9 +1070,9 @@ session:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
   ##
   ## PostgreSQL (Storage Provider)
@@ -1104,9 +1104,9 @@ session:
             # ...
             # -----END CERTIFICATE-----
           # private_key: |
-            # -----BEGIN RSA PRIVATE KEY-----
+            # -----BEGIN PRIVATE KEY-----
             # ...
-            # -----END RSA PRIVATE KEY-----
+            # -----END PRIVATE KEY-----
 
     ## The database name to use.
     # database: 'authelia'
@@ -1157,9 +1157,9 @@ session:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
 ##
 ## Notification Provider
@@ -1255,9 +1255,9 @@ session:
       ## The private key used with the certificate_chain if the server requests TLS Client Authentication
       ## i.e. Mutual TLS.
       # private_key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
 ##
 ## Identity Providers
@@ -1290,9 +1290,9 @@ session:
 
       ## Required Private Key in PEM DER form.
       # key: |
-        # -----BEGIN RSA PRIVATE KEY-----
+        # -----BEGIN PRIVATE KEY-----
         # ...
-        # -----END RSA PRIVATE KEY-----
+        # -----END PRIVATE KEY-----
 
 
       ## Optional matching certificate chain in PEM DER form that matches the key. All certificates within the chain


### PR DESCRIPTION
This removes all PKCS#1 references from documentation and instead references PKCS#8 key types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all example configuration snippets to use the generic "-----BEGIN PRIVATE KEY-----" and "-----END PRIVATE KEY-----" PEM headers and footers instead of the RSA-specific format.
  - Applied these changes across documentation for OpenID Connect, LDAP, SMTP, TLS, Redis, MySQL, PostgreSQL, and Kubernetes secrets.
  - No changes were made to configuration structure or explanatory content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->