### PR TITLE
fix(oidc): consent semantics not enforced

### DIFF
--- a/docs/content/configuration/identity-providers/openid-connect/clients.md
+++ b/docs/content/configuration/identity-providers/openid-connect/clients.md
@@ -390,10 +390,25 @@ Configures the consent mode. The following table describes the different modes:
 |:--------------:|:----------------------------------------------------------------------------------------------------------------------------------------------:|
 |      auto      | Automatically determined (default). Uses `explicit` unless [pre_configured_consent_duration] is specified in which case uses `pre-configured`. |
 |    explicit    |                                   Requires the user provide unique explicit consent for every authorization.                                   |
-|    implicit    |                   Automatically assumes consent for every authorization, never asking the user if they wish to give consent.                   |
+|    implicit    |    Automatically assumes consent for every authorization, never asking the user if they wish to give consent. See the specific notes below.    |
 | pre-configured |                            Allows the end-user to remember their consent for the [pre_configured_consent_duration].                            |
 
 [pre_configured_consent_duration]: #pre_configured_consent_duration
+
+#### implicit
+
+The `implicit` consent mode is largely unsupported and in various cases either revert to `explicit`, silently not
+perform certain expected actions, or outright fail. This mode is intended for development and testing, and should
+not be used in production.
+
+The following specific and intentional limitations exist:
+
+1. The Authorization Code Flow will not mint and grant a Refresh Token unless the user either provides explicit consent
+   or has previously provided explicit consent and requested their consent is remembered.
+2. If the client requests the user is prompted to provide consent the mode will automatically be `explicit` regardless
+   of client configuration.
+3. If the client requests the `offline_access` or `offline` scope the mode will automatically be `explicit` regardless
+   of client configuration.
 
 ### pre_configured_consent_duration
 

--- a/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
+++ b/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
@@ -220,9 +220,9 @@ issued token credentials via the [Refresh FLow], effectively it allows the Relyi
 periodically minted and granted.
 
 As per [OpenID Connect 1.0] Section 11 [Offline Access] can only be granted during the [Authorization Code Flow] or a
-[Hybrid Flow]. The [Refresh Token] will only ever be returned at the [Token Endpoint] when all the following are
+As per [OpenID Connect 1.0] Section 11, [Offline Access] can only be granted during the [Authorization Code Flow] or a
+[Hybrid Flow]. The [Refresh Token] will only ever be returned by the [Token Endpoint] when all the following are
 true:
-
 1. The client is exchanging a [OAuth 2.0 Authorization Code].
 2. The client is permitted to request [Offline Access], i.e., it is explicitly configured with the `offline_access` scope.
 3. The client is permitted to use [Refresh Tokens] i.e. it is explicitly configured with the `refresh_token`

--- a/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
+++ b/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
@@ -224,7 +224,7 @@ As per [OpenID Connect 1.0] Section 11 [Offline Access] can only be granted duri
 true:
 
 1. The client is exchanging a [OAuth 2.0 Authorization Code].
-2. The client is permitted to request [Offline Access] i.e. it is explicitly configured with the `offiline_access` scope.
+2. The client is permitted to request [Offline Access], i.e., it is explicitly configured with the `offline_access` scope.
 3. The client is permitted to use [Refresh Tokens] i.e. it is explicitly configured with the `refresh_token`
    [Grant Type](introduction.md#grant-types).
 4. The resource owner has explicitly provided consent in one of the following scenarios:

--- a/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
+++ b/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
@@ -235,10 +235,10 @@ true:
 Generally unless an application supports this and actively requests this scope they should not be granted this scope via
 the client configuration.
 
-It is also important to note that we treat a [Refresh Token] as single use and we mint and grant a new [Refresh Token]
-during the [Refresh Flow] i.e. [Refresh Token] Rotation. This is in accordance with the
+It is also important to note that we treat a [Refresh Token] as single-use, and we mint and grant a new [Refresh Token]
+during the [Refresh Flow] (i.e., [Refresh Token] Rotation). This aligns with the
 [Refresh Token Protection](https://datatracker.ietf.org/doc/html/rfc9700#refresh_token_protection) recommendations
-from [RFC9700](https://datatracker.ietf.org/doc/html/rfc9700).
+from [RFC9700].
 
 ### profile
 

--- a/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
+++ b/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
@@ -224,7 +224,10 @@ As per [OpenID Connect 1.0] Section 11 [Offline Access] can only be granted duri
 true:
 
 1. The client is exchanging a [OAuth 2.0 Authorization Code].
-2. The resource owner has explicitly provided consent in one of the following scenarios:
+2. The client is permitted to request [Offline Access] i.e. it is explicitly configured with the `offiline_access` scope.
+3. The client is permitted to use [Refresh Tokens] i.e. it is explicitly configured with the `refresh_token`
+   [Grant Type](introduction.md#grant-types).
+4. The resource owner has explicitly provided consent in one of the following scenarios:
    1. During the process of completing the current flow.
    2. During the process of completing a previous flow and requested that this decision is remembered, and the decision
       is still relevant (i.e. not expired and matches the access level requested).

--- a/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
+++ b/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
@@ -216,7 +216,7 @@ the [OpenID Connect 1.0](https://openid.net/connect/) specification.
 
 This scope is a special scope designed to allow applications to obtain a [Refresh Token] which allows extended access to
 an application on behalf of a user. A [Refresh Token] is a special [Access Token] that allows refreshing previously
-issued token credentials via the [Refresh FLow], effectively it allows the Relying Party to request new tokens are
+issued token credentials via the [Refresh Flow], effectively allowing the relying party to request that new tokens be
 periodically minted and granted.
 
 As per [OpenID Connect 1.0] Section 11 [Offline Access] can only be granted during the [Authorization Code Flow] or a

--- a/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
+++ b/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
@@ -202,7 +202,7 @@ the [OpenID Connect 1.0](https://openid.net/connect/) specification.
 |    sub    | string(uuid)  |     opaque id      |    [ID Token]    |    A [RFC4122] UUID V4 linked to the user who logged in     |
 |    aud    | array[string] |       *N/A*        |    [ID Token]    |                          Audience                           |
 |    exp    |    number     |       *N/A*        |    [ID Token]    |                           Expires                           |
-|    iat    |    number     |       *N/A*        |    [ID Token]    |             The time when the token was issued              |
+|    iat    |    number     |       *N/A*        |    [ID Token]    |             The time when the token was minted              |
 | auth_time |    number     |       *N/A*        |    [ID Token]    |        The time the user authenticated with Authelia        |
 |   nonce   |    string     |       *N/A*        |    [ID Token]    |        The time the user authenticated with Authelia        |
 |    amr    | array[string] |       *N/A*        |    [ID Token]    | An [RFC8176] list of authentication method reference values |
@@ -216,17 +216,26 @@ the [OpenID Connect 1.0](https://openid.net/connect/) specification.
 
 This scope is a special scope designed to allow applications to obtain a [Refresh Token] which allows extended access to
 an application on behalf of a user. A [Refresh Token] is a special [Access Token] that allows refreshing previously
-issued token credentials, effectively it allows the Relying Party to obtain new tokens periodically.
+issued token credentials via the [Refresh FLow], effectively it allows the Relying Party to request new tokens are
+periodically minted and granted.
 
 As per [OpenID Connect 1.0] Section 11 [Offline Access] can only be granted during the [Authorization Code Flow] or a
-[Hybrid Flow]. The [Refresh Token] will only ever be returned at the [Token Endpoint] when the client is exchanging
-their [OAuth 2.0 Authorization Code].
+[Hybrid Flow]. The [Refresh Token] will only ever be returned at the [Token Endpoint] when all the following are
+true:
+
+1. The client is exchanging a [OAuth 2.0 Authorization Code].
+2. The resource owner has explicitly provided consent in one of the following scenarios:
+   1. During the process of completing the current flow.
+   2. During the process of completing a previous flow and requested that this decision is remembered, and the decision
+      is still relevant (i.e. not expired and matches the access level requested).
 
 Generally unless an application supports this and actively requests this scope they should not be granted this scope via
 the client configuration.
 
-It is also important to note that we treat a [Refresh Token] as single use and reissue a new [Refresh Token] during the
-refresh flow.
+It is also important to note that we treat a [Refresh Token] as single use and we mint and grant a new [Refresh Token]
+during the [Refresh Flow] i.e. [Refresh Token] Rotation. This is in accordance with the
+[Refresh Token Protection](https://datatracker.ietf.org/doc/html/rfc9700#refresh_token_protection) recommendations
+from [RFC9700](https://datatracker.ietf.org/doc/html/rfc9700).
 
 ### profile
 
@@ -237,7 +246,7 @@ This scope allows the client to access the profile information the authenticatio
 |        name        |  string  |    display_name    |    [UserInfo]    |          The users display name          |
 |    family_name     |  string  |    family_name     |    [UserInfo]    |          The users family name           |
 |     given_name     |  string  |     given_name     |    [UserInfo]    |           The users given name           |
-|    	middle_name    |  string  |    	middle_name    |    [UserInfo]    |          The users middle name           |
+|    middle_name     |  string  |    middle_name     |    [UserInfo]    |          The users middle name           |
 |      nickname      |  string  |      nickname      |    [UserInfo]    |            The users nickname            |
 | preferred_username |  string  |      username      |    [UserInfo]    | The username the user used to login with |
 |      profile       |  string  |      profile       |    [UserInfo]    |          The users profile URL           |
@@ -327,6 +336,7 @@ guide.
 
 [Authorization Code Flow]: https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
 [Hybrid Flow]: https://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth
+[Refresh Flow]: https://datatracker.ietf.org/doc/html/rfc6749#section-1.5
 
 [Token Endpoint]: https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
 [UserInfo]: https://openid.net/specs/openid-connect-core-1_0.html#UserInfo

--- a/internal/handlers/handler_oauth2_authorization_consent_core.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_core.go
@@ -47,6 +47,20 @@ func handleOAuth2AuthorizationConsent(ctx *middlewares.AutheliaCtx, issuer *url.
 		case oidc.ClientConsentModeExplicit:
 			handler = handleOAuth2AuthorizationConsentModeExplicit
 		case oidc.ClientConsentModeImplicit:
+			if requester.GetRequestForm().Get(oidc.FormParameterPrompt) == oidc.PromptConsent {
+				handler = handleOAuth2AuthorizationConsentModeExplicit
+
+				break
+			}
+
+			if requester.GetRequestedScopes().Has(oidc.ScopeOfflineAccess) || requester.GetRequestedScopes().Has(oidc.ScopeOffline) {
+				if ar, ok := requester.(oauthelia2.AuthorizeRequester); ok && ar.GetResponseTypes().Has(oidc.ResponseTypeAuthorizationCodeFlow) {
+					handler = handleOAuth2AuthorizationConsentModeExplicit
+
+					break
+				}
+			}
+
 			handler = handleOAuth2AuthorizationConsentModeImplicit
 		case oidc.ClientConsentModePreConfigured:
 			handler = handleOAuth2AuthorizationConsentModePreConfigured

--- a/internal/handlers/handler_oauth2_authorization_consent_implicit.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_implicit.go
@@ -87,9 +87,9 @@ func handleOAuth2AuthorizationConsentModeImplicitWithID(ctx *middlewares.Autheli
 	var requests *oidc.ClaimsRequests
 
 	if requests, err = oidc.NewClaimRequests(requester.GetRequestForm()); err == nil && requests != nil {
-		consent.GrantWithClaims(requests.ToSlice())
+		oidc.ConsentGrant(consent, false, requests.ToSlice())
 	} else {
-		consent.Grant()
+		oidc.ConsentGrant(consent, false, nil)
 	}
 
 	consent.SetRespondedAt(ctx.Clock.Now(), 0)
@@ -149,9 +149,9 @@ func handleOAuth2AuthorizationConsentModeImplicitWithoutID(ctx *middlewares.Auth
 	var requests *oidc.ClaimsRequests
 
 	if requests, err = oidc.NewClaimRequests(requester.GetRequestForm()); err == nil && requests != nil {
-		consent.GrantWithClaims(requests.ToSlice())
+		oidc.ConsentGrant(consent, false, requests.ToSlice())
 	} else {
-		consent.Grant()
+		oidc.ConsentGrant(consent, false, nil)
 	}
 
 	consent.SetRespondedAt(ctx.Clock.Now(), 0)

--- a/internal/handlers/handler_oauth2_authorization_consent_implicit.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_implicit.go
@@ -60,7 +60,7 @@ func handleOAuth2AuthorizationConsentModeImplicitWithID(ctx *middlewares.Autheli
 		return nil, true
 	}
 
-	if subject != consent.Subject.UUID {
+	if (consent.Subject.UUID != uuid.Nil && subject != consent.Subject.UUID) || subject == uuid.Nil {
 		ctx.Logger.Errorf(logFmtErrConsentSessionSubjectNotAuthorized, requester.GetID(), client.GetID(), client.GetConsentPolicy(), consent.ChallengeID, userSession.Username, subject, consent.Subject.UUID)
 
 		ctx.Providers.OpenIDConnect.WriteDynamicAuthorizeError(ctx, rw, requester, oidc.ErrConsentCouldNotLookup)
@@ -87,12 +87,10 @@ func handleOAuth2AuthorizationConsentModeImplicitWithID(ctx *middlewares.Autheli
 	var requests *oidc.ClaimsRequests
 
 	if requests, err = oidc.NewClaimRequests(requester.GetRequestForm()); err == nil && requests != nil {
-		oidc.ConsentGrant(consent, false, requests.ToSlice())
+		oidc.ConsentGrantImplicit(consent, requests.ToSlice(), subject, ctx.Clock.Now())
 	} else {
-		oidc.ConsentGrant(consent, false, nil)
+		oidc.ConsentGrantImplicit(consent, nil, subject, ctx.Clock.Now())
 	}
-
-	consent.SetRespondedAt(ctx.Clock.Now(), 0)
 
 	if err = ctx.Providers.StorageProvider.SaveOAuth2ConsentSessionResponse(ctx, consent, false); err != nil {
 		ctx.Logger.Errorf(logFmtErrConsentSaveSessionResponse, requester.GetID(), client.GetID(), client.GetConsentPolicy(), consent.ChallengeID, err)
@@ -149,12 +147,10 @@ func handleOAuth2AuthorizationConsentModeImplicitWithoutID(ctx *middlewares.Auth
 	var requests *oidc.ClaimsRequests
 
 	if requests, err = oidc.NewClaimRequests(requester.GetRequestForm()); err == nil && requests != nil {
-		oidc.ConsentGrant(consent, false, requests.ToSlice())
+		oidc.ConsentGrantImplicit(consent, requests.ToSlice(), subject, ctx.Clock.Now())
 	} else {
-		oidc.ConsentGrant(consent, false, nil)
+		oidc.ConsentGrantImplicit(consent, nil, subject, ctx.Clock.Now())
 	}
-
-	consent.SetRespondedAt(ctx.Clock.Now(), 0)
 
 	if err = ctx.Providers.StorageProvider.SaveOAuth2ConsentSessionResponse(ctx, consent, false); err != nil {
 		ctx.Logger.Errorf(logFmtErrConsentSaveSessionResponse, requester.GetID(), client.GetID(), client.GetConsentPolicy(), consent.ChallengeID, err)

--- a/internal/handlers/handler_oauth2_authorization_consent_preconfigured.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_preconfigured.go
@@ -103,7 +103,7 @@ func handleOAuth2AuthorizationConsentModePreConfiguredWithID(ctx *middlewares.Au
 	}
 
 	if config != nil {
-		consent.GrantWithClaims(config.GrantedClaims)
+		oidc.ConsentGrant(consent, true, config.GrantedClaims)
 
 		consent.SetRespondedAt(ctx.Clock.Now(), config.ID)
 
@@ -203,7 +203,7 @@ func handleOAuth2AuthorizationConsentModePreConfiguredWithoutID(ctx *middlewares
 		ctx.Logger.WithFields(map[string]any{"requested_at": consent.RequestedAt, "authenticated_at": userSession.LastAuthenticatedTime(), "prompt": requester.GetRequestForm().Get("prompt")}).Debugf("Authorization Request with id '%s' on client with id '%s' is not being redirected for reauthentication", requester.GetID(), client.GetID())
 	}
 
-	consent.Grant()
+	oidc.ConsentGrant(consent, true, config.GrantedClaims)
 
 	consent.SetRespondedAt(ctx.Clock.Now(), config.ID)
 

--- a/internal/handlers/handler_oauth2_consent.go
+++ b/internal/handlers/handler_oauth2_consent.go
@@ -125,7 +125,7 @@ func OAuth2ConsentPOST(ctx *middlewares.AutheliaCtx) {
 	}
 
 	if bodyJSON.Consent {
-		consent.GrantWithClaims(bodyJSON.Claims)
+		oidc.ConsentGrant(consent, true, bodyJSON.Claims)
 
 		if bodyJSON.PreConfigure {
 			if client.GetConsentPolicy().Mode == oidc.ClientConsentModePreConfigured {

--- a/internal/model/oidc.go
+++ b/internal/model/oidc.go
@@ -283,16 +283,28 @@ func (s *OAuth2ConsentSession) SetRespondedAt(t time.Time, preconf int64) {
 	}
 }
 
-// Grant grants the requested scopes and audience.
-func (s *OAuth2ConsentSession) Grant() {
+// GrantScopes grants all of the requested scopes.
+func (s *OAuth2ConsentSession) GrantScopes() {
 	s.GrantedScopes = s.RequestedScopes
-	s.GrantedAudience = s.RequestedAudience
 }
 
-func (s *OAuth2ConsentSession) GrantWithClaims(claims []string) {
-	s.Grant()
+// GrantScope grants the specified scope.
+func (s *OAuth2ConsentSession) GrantScope(scope string) {
+	s.GrantedScopes = append(s.GrantedScopes, scope)
+}
+
+// GrantClaims grants the specified claims.
+func (s *OAuth2ConsentSession) GrantClaims(claims []string) {
+	if len(claims) == 0 {
+		return
+	}
 
 	s.GrantedClaims = claims
+}
+
+// GrantAudience grants all of the requested audiences.
+func (s *OAuth2ConsentSession) GrantAudience() {
+	s.GrantedAudience = s.RequestedAudience
 }
 
 // HasExactGrants returns true if the granted audience and scopes of this consent matches exactly with another

--- a/internal/model/oidc.go
+++ b/internal/model/oidc.go
@@ -274,6 +274,11 @@ type OAuth2ConsentSession struct {
 	PreConfiguration sql.NullInt64
 }
 
+// SetSubject sets the subject value.
+func (s *OAuth2ConsentSession) SetSubject(subject uuid.UUID) {
+	s.Subject = uuid.NullUUID{UUID: subject, Valid: subject != uuid.Nil}
+}
+
 // SetRespondedAt sets the responded at value.
 func (s *OAuth2ConsentSession) SetRespondedAt(t time.Time, preconf int64) {
 	s.RespondedAt = sql.NullTime{Time: t, Valid: true}

--- a/internal/model/oidc_test.go
+++ b/internal/model/oidc_test.go
@@ -559,7 +559,7 @@ func TestOAuth2ConsentSession(t *testing.T) {
 	session.GrantedScopes = nil
 	session.GrantedAudience = nil
 
-	session.Grant()
+	oidc.ConsentGrant(session, true, nil)
 
 	assert.Nil(t, session.GrantedScopes)
 	session.HasExactGrantedAudience([]string{"a-client"})
@@ -567,7 +567,7 @@ func TestOAuth2ConsentSession(t *testing.T) {
 	session.RequestedScopes = []string{oidc.ScopeOpenID}
 	session.RequestedAudience = []string{"abc"}
 
-	session.Grant()
+	oidc.ConsentGrant(session, true, nil)
 
 	session.HasExactGrantedScopes([]string{oidc.ScopeOpenID})
 	session.HasExactGrantedAudience([]string{"abc", "a-client"})

--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -195,3 +195,23 @@ func (s *Session) Clone() oauthelia2.Session {
 
 	return deepcopy.Copy(s).(oauthelia2.Session)
 }
+
+// ConsentGrant is a helper function to perform specific consent granting functionality. In particular in honors the
+// requirements around consent like not allowing access to a refresh token unless the user has explicitly consented.
+func ConsentGrant(consent *model.OAuth2ConsentSession, explicit bool, claims []string) {
+	consent.GrantAudience()
+	consent.GrantClaims(claims)
+
+	if explicit {
+		consent.GrantScopes()
+	} else {
+		for _, scope := range consent.RequestedScopes {
+			switch scope {
+			case ScopeOffline, ScopeOfflineAccess:
+				continue
+			default:
+				consent.GrantScope(scope)
+			}
+		}
+	}
+}

--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -196,6 +196,15 @@ func (s *Session) Clone() oauthelia2.Session {
 	return deepcopy.Copy(s).(oauthelia2.Session)
 }
 
+// ConsentGrantImplicit that handles the implicit consent flow assigning the subject and responded at values then
+// allows ConsentGrant to finalize the grant mechanics.
+func ConsentGrantImplicit(consent *model.OAuth2ConsentSession, claims []string, subject uuid.UUID, respondedAt time.Time) {
+	consent.SetRespondedAt(respondedAt, 0)
+	consent.SetSubject(subject)
+
+	ConsentGrant(consent, false, claims)
+}
+
 // ConsentGrant is a helper function to perform specific consent granting functionality. In particular in honors the
 // requirements around consent like not allowing access to a refresh token unless the user has explicitly consented.
 func ConsentGrant(consent *model.OAuth2ConsentSession, explicit bool, claims []string) {


### PR DESCRIPTION
This fixes an issue where certain consent semantics were not properly enforced. Specifically requests with prompt consent should always show consent, and refresh tokens should only be issued when a resource owner has explicitly provided consent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the behavior and limitations of the "implicit" consent mode for OpenID Connect clients, including new guidance on its use and fallback behaviors.
  - Updated documentation for the "offline_access" scope to specify conditions for receiving a Refresh Token and improved formatting for claim entries.

- **Refactor**
  - Streamlined consent granting logic by introducing new helper functions that centralize how scopes, audience, and claims are granted during OAuth2 consent flows.
  - Refactored internal methods to separate and clarify the granting of scopes, audiences, and claims.

- **Bug Fixes**
  - Improved handling of consent modes to ensure explicit consent is required for certain scopes and prompt parameters, enhancing compliance with consent requirements.

- **Tests**
  - Updated tests to align with the new consent granting logic and helper functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->