### PR TITLE
perf(configuration): decode hooks improvements

### DIFF
--- a/internal/configuration/provider.go
+++ b/internal/configuration/provider.go
@@ -61,10 +61,7 @@ func LoadDefinitions(val *schema.StructValidator, sources ...Source) (definition
 
 	c := koanf.UnmarshalConf{
 		DecoderConfig: &mapstructure.DecoderConfig{
-			DecodeHook: mapstructure.ComposeDecodeHookFunc(
-				mapstructure.StringToSliceHookFunc(","),
-				StringToIPNetworksHookFunc(nil),
-			),
+			DecodeHook:       DecodeHooksComposeDefinitions(),
 			Metadata:         nil,
 			Result:           legacy,
 			WeaklyTypedInput: true,
@@ -138,24 +135,7 @@ func unmarshal(ko *koanf.Koanf, val *schema.StructValidator, path string, o any,
 
 	c := koanf.UnmarshalConf{
 		DecoderConfig: &mapstructure.DecoderConfig{
-			DecodeHook: mapstructure.ComposeDecodeHookFunc(
-				mapstructure.StringToSliceHookFunc(","),
-				StringToMailAddressHookFunc(),
-				StringToURLHookFunc(),
-				StringToRegexpHookFunc(),
-				StringToAddressHookFunc(),
-				StringToX509CertificateHookFunc(),
-				StringToX509CertificateChainHookFunc(),
-				StringToPrivateKeyHookFunc(),
-				StringToCryptoPrivateKeyHookFunc(),
-				StringToCryptographicKeyHookFunc(),
-				StringToTLSVersionHookFunc(),
-				StringToPasswordDigestHookFunc(),
-				StringToIPNetworksHookFunc(definitions.Network),
-				StringToUUIDHookFunc(),
-				ToTimeDurationHookFunc(),
-				ToRefreshIntervalDurationHookFunc(),
-			),
+			DecodeHook:       DecodeHooksComposeAll(definitions),
 			Metadata:         nil,
 			Result:           o,
 			WeaklyTypedInput: true,

--- a/internal/expression/user_attributes.go
+++ b/internal/expression/user_attributes.go
@@ -11,11 +11,7 @@ import (
 )
 
 func NewUserAttributes(config *schema.Configuration) (ua UserAttributeResolver) {
-	if config == nil {
-		return &UserAttributes{}
-	}
-
-	if len(config.Definitions.UserAttributes) == 0 {
+	if config == nil || len(config.Definitions.UserAttributes) == 0 {
 		return &UserAttributes{}
 	}
 


### PR DESCRIPTION
This improves the way decode hooks function by ensuring where possible reflection only occurs once rather than once per configuration item. It's possible go is able to figure out this on its own but this doesn't leave it up to chance and clearly expresses the intent behind the function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal code structure for type declarations in configuration decoding, reducing redundancy.
  - Simplified conditional logic for user attribute initialization to streamline code flow.
  - Centralized decoding logic into reusable functions to enhance maintainability.

No changes to user-facing features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->