### PR TITLE
amend the wrong userinfo_signed_response_alg for the correct id_token…

### DIFF
--- a/docs/content/integration/openid-connect/home-assistant/index.md
+++ b/docs/content/integration/openid-connect/home-assistant/index.md
@@ -69,7 +69,7 @@ identity_providers:
           - 'openid'
           - 'profile'
           - 'groups'
-        userinfo_signed_response_alg: 'none'
+        id_token_signed_response_alg: 'none'
 ```
 
 ### Application


### PR DESCRIPTION
userinfo_signed_response_alg is the wrong configuration for Home Assistant, id_token_signed_response_alg is the right one.
Spent some time troubleshooting this and thought would be good to get a PR to amend this on Authelia's docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Home Assistant integration guide to use the correct OpenID Connect parameter for configuring the ID token signature algorithm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->