### PR TITLE
docs(oidc): add integrations

### DIFF
--- a/docs/content/integration/openid-connect/argocd/index.md
+++ b/docs/content/integration/openid-connect/argocd/index.md
@@ -70,6 +70,7 @@ identity_providers:
           - 'email'
           - 'profile'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
       - client_id: 'argocd-cli'
         client_name: 'Argo CD (CLI)'
         public: true

--- a/docs/content/integration/openid-connect/audiobookshelf/index.md
+++ b/docs/content/integration/openid-connect/audiobookshelf/index.md
@@ -70,6 +70,8 @@ identity_providers:
           - 'profile'
           - 'groups'
           - 'email'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/beszel/index.md
+++ b/docs/content/integration/openid-connect/beszel/index.md
@@ -1,0 +1,115 @@
+---
+title: "Beszel"
+description: "Integrating Beszel with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2022-06-15T17:51:47+10:00
+draft: false
+images: []
+weight: 620
+toc: true
+support:
+  level: community
+  versions: true
+  integration: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+- [Authelia]
+  - [v4.39.1](https://github.com/authelia/authelia/releases/tag/v4.39.1)
+- [Beszel]
+  - [v0.10.2](https://github.com/henrygd/beszel/releases/tag/v0.10.2)
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+- __Application Root URL:__ `https://beszel.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Client ID:__ `beszel`
+- __Client Secret:__ `insecure_secret`
+
+Some of the values presented in this guide can automatically be replaced with documentation variables.
+
+{{< sitevar-preferences >}}
+
+## Configuration
+
+The following example uses the [OAuth login Extension] which is assumed to be installed when following
+this section of the guide.
+
+To install the [OAuth login Extension] for [Beszel] via the Web GUI:
+
+1. Login to [Beszel].
+2. Navigate to `Extensions`.
+3. Navigate to `Extensions Catalog`.
+4. Search for `OAuth login`.
+5. Click Install.
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Beszel] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'beszel'
+        client_name: 'Beszel'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        redirect_uris:
+          - 'https://beszel.{{< sitevar name="domain" nojs="example.com" >}}/api/oauth2-redirect'
+        scopes:
+          - 'openid'
+          - 'email'
+          - 'profile'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+To configure [Beszel] there is one method, using the [Web GUI](#web-gui).
+
+#### Web GUI
+
+To configure [Beszel] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following instructions:
+
+1. Login to [Beszel].
+2. Navigate to the settings dashboard by going to `https://beszel.{{< sitevar name="domain" nojs="example.com" >}}/_/#/settings`.
+3. Disable the `Hide collection create and edit controls`.
+4. Edit the `users` collection by clicking the cog and selecting `Options`.
+5. Expand OAuth2.
+6. Toggle Enable to the on position.
+7. Click `Add Provider`.
+8. Select `OpenID Connect`.
+9. Configure the following options:
+   - Client ID: `beszel`
+   - Client secret: `insecure_secret`
+   - Display name: `Authelia`
+   - Auth URL: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/authorization`
+   - Token URL: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/token`
+   - Fetch user info from: `User info URL`
+   - User info URL: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/userinfo`
+10. Press `Save` at the bottom.
+
+## See Also
+
+- [Beszel OIDC documentation](https://beszel.dev/guide/oauth)
+
+[Authelia]: https://www.authelia.com
+[Beszel]: https://beszel.dev/
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/chronograf/index.md
+++ b/docs/content/integration/openid-connect/chronograf/index.md
@@ -1,0 +1,121 @@
+---
+title: "Chronograf"
+description: "Integrating Chronograf with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2022-06-15T17:51:47+10:00
+draft: false
+images: []
+weight: 620
+toc: true
+support:
+  level: community
+  versions: true
+  integration: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+- [Authelia]
+  - [v4.38.18](https://github.com/authelia/authelia/releases/tag/v4.38.18)
+- [Chronograf]
+  - [v1.10.7](https://docs.influxdata.com/chronograf/v1/about_the_project/release-notes/#v1107)
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+- __Application Root URL:__ `https://chronograf.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Client ID:__ `chronograf`
+- __Client Secret:__ `insecure_secret`
+
+Some of the values presented in this guide can automatically be replaced with documentation variables.
+
+{{< sitevar-preferences >}}
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Chronograf] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'chronograf'
+        client_name: 'Chronograf'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        redirect_uris:
+          - 'https://chronograf.{{< sitevar name="domain" nojs="example.com" >}}/oauth/authelia/callback'
+        scopes:
+          - 'openid'
+          - 'email'
+          - 'profile'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+To configure [Chronograf] there is one method, using the [Environment Variables](#environment-variables).
+
+#### Environment Variables
+
+To configure [Chronograf] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following environment variables:
+
+##### Standard
+
+```shell {title=".env"}
+PUBLIC_URL=https://chronograf.{{< sitevar name="domain" nojs="example.com" >}}
+TOKEN_SECRET=insecure_random_secret
+GENERIC_CLIENT_ID=chronograf
+GENERIC_CLIENT_SECRET=insecure_secret
+GENERIC_AUTH_URL=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/authorization
+GENERIC_TOKEN_URL=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/token
+JWKS_URL=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/jwks.json
+GENERIC_API_URL=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/userinfo
+GENERIC_API_KEY=email
+GENERIC_SCOPES=openid,email,profile
+GENERIC_NAME=authelia
+```
+
+##### Docker Compose
+
+```yaml {title="compose.yml"}
+services:
+  chronograf:
+    environment:
+      PUBLIC_URL: 'https://chronograf.{{< sitevar name="domain" nojs="example.com" >}}'
+      TOKEN_SECRET: 'insecure_random_secret'
+      GENERIC_CLIENT_ID: 'chronograf'
+      GENERIC_CLIENT_SECRET: 'insecure_secret'
+      GENERIC_AUTH_URL: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/authorization'
+      GENERIC_TOKEN_URL: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/token'
+      JWKS_URL: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/jwks.json'
+      GENERIC_API_URL: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/userinfo'
+      GENERIC_API_KEY: 'email'
+      GENERIC_SCOPES: 'openid,email,profile'
+      GENERIC_NAME: 'authelia'
+```
+
+## See Also
+
+- [Chronograf Security OAuth 2.0 Documentation](https://docs.influxdata.com/chronograf/v1/administration/managing-security/#configure-chronograf-to-use-any-oauth-20-provider)
+
+[Authelia]: https://www.authelia.com
+[Chronograf]: https://www.influxdata.com/time-series-platform/chronograf/
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/cloudflare-zerotrust/index.md
+++ b/docs/content/integration/openid-connect/cloudflare-zerotrust/index.md
@@ -73,6 +73,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/drupal/index.md
+++ b/docs/content/integration/openid-connect/drupal/index.md
@@ -1,8 +1,8 @@
 ---
-title: "RustDesk Server Pro"
-description: "Integrating RustDesk Server Pro with the Authelia OpenID Connect 1.0 Provider."
+title: "Drupal"
+description: "Integrating Drupal with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2025-01-25T10:04:53+11:00
+date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 620
@@ -22,8 +22,8 @@ seo:
 
 - [Authelia]
   - [v4.39.1](https://github.com/authelia/authelia/releases/tag/v4.39.1)
-- [RustDesk Server Pro]
-  - [v1.3.9](https://github.com/rustdesk/rustdesk/releases/tag/1.3.9)
+- [Drupal]
+  - [v10.4.0](https://www.drupal.org/project/drupal/releases/10.4.0)
 
 {{% oidc-common %}}
 
@@ -31,9 +31,9 @@ seo:
 
 This example makes the following assumptions:
 
-- __Application Root URL:__ `https://rustdesk.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Application Root URL:__ `https://drupal.{{< sitevar name="domain" nojs="example.com" >}}/`
 - __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
-- __Client ID:__ `rustdesk`
+- __Client ID:__ `drupal`
 - __Client Secret:__ `insecure_secret`
 
 Some of the values presented in this guide can automatically be replaced with documentation variables.
@@ -44,7 +44,7 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-The following YAML configuration is an example __Authelia__ [client configuration] for use with [RustDesk Server Pro] which will
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Drupal] which will
 operate with the application example:
 
 ```yaml {title="configuration.yml"}
@@ -53,13 +53,13 @@ identity_providers:
     ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
     ## See: https://www.authelia.com/c/oidc
     clients:
-      - client_id: 'rustdesk'
-        client_name: 'RustDesk Server Pro'
+      - client_id: 'drupal'
+        client_name: 'Drupal'
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
         redirect_uris:
-          - 'https://rustdesk.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/callback'
+          - 'https://drupal.{{< sitevar name="domain" nojs="example.com" >}}/openid-connect/generic'
         scopes:
           - 'openid'
           - 'email'
@@ -70,33 +70,29 @@ identity_providers:
 
 ### Application
 
-To configure [RustDesk Server Pro] there is one method, using the [Web GUI](#web-gui).
+To configure [Drupal] there is one method, using the [Web GUI](#web-gui).
 
 #### Web GUI
 
-To configure [RustDesk Server Pro] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following instructions:
+To configure [Drupal] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following instructions:
 
-1. Login to [RustDesk Server Pro].
-2. Navigate to Settings.
-3. Navigate to OIDC.
-4. Click `+ New Auth Provider`.
-5. Configure the following options:
-   - Name: `Authelia`
-   - Client ID: `rustdesk`
+1. Visit `https://drupal.{{< sitevar name="domain" nojs="example.com" >}}/admin/config/services/openid-connect`.
+2. Configure the following options:
+   - Enabled OpenID Connect clients: `Generic`
+   - Client ID: `drupal`
    - Client Secret: `insecure_secret`
-   - Issuer: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}`
    - Authorization Endpoint: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/authorization`
    - Token Endpoint: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/token`
-   - Userinfo Endpoint: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/userinfo`
-   - JWKS Endpoint: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/jwks.json`
-6. Press `Submit` at the bottom.
+   - UserInfo Endpoint: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/userinfo`
+3. Visit `https://drupal.{{< sitevar name="domain" nojs="example.com" >}}/admin/config/people/accounts`.
+4. Configure the following options:
+   - Override registration settings: Enabled
 
 ## See Also
 
-- [RustDesk Server Pro OIDC documentation](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/oidc/)
+- [Drupal OpenID Connect Generic Client Documentation](https://www.drupal.org/node/2274339#toc-5)
 
 [Authelia]: https://www.authelia.com
-[RustDesk Server Pro]: https://rustdesk.com
-[OAuth login Extension]: https://www.rustdesk.com/extensions/oauth/
+[Drupal]: https://drupal.org/
 [OpenID Connect 1.0]: ../../openid-connect/introduction.md
 [client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/firezone/index.md
+++ b/docs/content/integration/openid-connect/firezone/index.md
@@ -71,6 +71,7 @@ identity_providers:
           - 'email'
           - 'profile'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/gatus/index.md
+++ b/docs/content/integration/openid-connect/gatus/index.md
@@ -1,8 +1,8 @@
 ---
-title: "Warpgate"
-description: "Integrating Warpgate with the Authelia OpenID Connect 1.0 Provider."
+title: "Gatus"
+description: "Integrating Gatus with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-12-10T10:52:22+11:00
+date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 620
@@ -21,9 +21,9 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
-- [Warpgate]
-  - [0.9.1](https://github.com/warp-tech/warpgate/releases/tag/v0.9.1)
+  - [v4.38.18](https://github.com/authelia/authelia/releases/tag/v4.38.18)
+- [Gatus]
+  - [v5.17.0](https://github.com/TwiN/gatus/releases/tag/v5.17.0)
 
 {{% oidc-common %}}
 
@@ -31,19 +31,21 @@ seo:
 
 This example makes the following assumptions:
 
-- __Application Root URL:__ `https://warpgate.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Application Root URL:__ `https://gatus.{{< sitevar name="domain" nojs="example.com" >}}/`
 - __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
-- __Client ID:__ `warpgate`
+- __Client ID:__ `gatus`
 - __Client Secret:__ `insecure_secret`
 
 Some of the values presented in this guide can automatically be replaced with documentation variables.
 
 {{< sitevar-preferences >}}
 
+## Configuration
+
 ### Authelia
 
-The following YAML configuration is an example __Authelia__ [client configuration] for use with [Warpgate]
-which will operate with the application example:
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Gatus] which
+will operate with the application example:
 
 ```yaml {title="configuration.yml"}
 identity_providers:
@@ -51,14 +53,16 @@ identity_providers:
     ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
     ## See: https://www.authelia.com/c/oidc
     clients:
-      - client_id: 'warpgate'
-        client_name: 'Warpgate'
+      - client_id: 'gatus'
+        client_name: 'Gatus'
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
         authorization_policy: 'two_factor'
         redirect_uris:
-          - 'https://warpgate.{{< sitevar name="domain" nojs="example.com" >}}/@warpgate/api/sso/return'
+          - 'https://gatus.{{< sitevar name="domain" nojs="example.com" >}}/authorization-code/callback'
         scopes:
           - 'openid'
+          - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'client_secret_basic'
@@ -66,34 +70,32 @@ identity_providers:
 
 ### Application
 
-To configure [Warpgate] there is one method, using the [Configuration File](#configuration-file).
+To configure [Gatus] there are three methods, using the [Configuration File](#configuration-file), using
+[Environment Variables](#environment-variables), or using the [Web GUI](#web-gui).
 
 #### Configuration File
 
 {{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
-Generally the configuration file is named `warpgate.yaml`.
+Generally the configuration file is named `config.yaml`.
 {{< /callout >}}
 
-To configure [Warpgate] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following configuration:
+To configure [Gatus] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following configuration:
 
-```yaml {title="warpgate.yaml"}
-external_host: warpgate.{{< sitevar name="domain" nojs="example.com" >}}
-sso_providers:
-- name: authelia
-  label: Authelia
-  provider:
-    type: custom
-    client_id: warpgate
-    client_secret: insecure_secret
-    issuer_url: https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
-    scopes: ["openid", "email"]
+```yaml {title="config.yaml"}
+security:
+  oidc:
+    issuer-url: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}'
+    client-id: 'gatus'
+    client-secret: 'insecure_secret'
+    redirect-url: 'https://gatus.{{< sitevar name="domain" nojs="example.com" >}}/authorization-code/callback'
+    scopes: ['openid', 'profile', 'email']
 ```
 
 ## See Also
 
-- [Warpgate OpenID Connect Documentation](https://github.com/warp-tech/warpgate/wiki/SSO-Authentication)
+- [Gatus Custom Single Sign-On (SSO) Documentation](https://gatus.io/docs/private-status-page)
 
 [Authelia]: https://www.authelia.com
-[Warpgate]: https://github.com/warp-tech/warpgate
+[Gatus]: https://gatus.io/
 [OpenID Connect 1.0]: ../../openid-connect/introduction.md
 [client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/glitchtip/index.md
+++ b/docs/content/integration/openid-connect/glitchtip/index.md
@@ -1,6 +1,6 @@
 ---
-title: "MeshCentral"
-description: "Integrating MeshCentral with the Authelia OpenID Connect 1.0 Provider."
+title: "Glitchtip"
+description: "Integrating Glitchtip with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
 date: 2022-06-15T17:51:47+10:00
 draft: false
@@ -22,8 +22,8 @@ seo:
 
 - [Authelia]
   - [v4.39.1](https://github.com/authelia/authelia/releases/tag/v4.39.1)
-- [MeshCentral]
-  - [v1.1.44](https://github.com/Ylianst/MeshCentral/releases/tag/1.1.44)
+- [Glitchtip]
+  - [v4.2](https://glitchtip.com/blog/2024-11-01-glitchtip-4-2-release)
 
 {{% oidc-common %}}
 
@@ -31,9 +31,9 @@ seo:
 
 This example makes the following assumptions:
 
-- __Application Root URL:__ `https://meshcentral.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Application Root URL:__ `https://glitchtip.{{< sitevar name="domain" nojs="example.com" >}}/`
 - __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
-- __Client ID:__ `meshcentral`
+- __Client ID:__ `glitchtip`
 - __Client Secret:__ `insecure_secret`
 
 Some of the values presented in this guide can automatically be replaced with documentation variables.
@@ -42,9 +42,12 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ## Configuration
 
+The following instructions assume you've setup a Django Admin / Super User. See the
+[Django Admin](https://glitchtip.com/documentation/install#django-admin) guide for more information.
+
 ### Authelia
 
-The following YAML configuration is an example __Authelia__ [client configuration] for use with [MeshCentral] which will
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Glitchtip] which will
 operate with the application example:
 
 ```yaml {title="configuration.yml"}
@@ -53,51 +56,45 @@ identity_providers:
     ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
     ## See: https://www.authelia.com/c/oidc
     clients:
-      - client_id: 'meshcentral'
-        client_name: 'MeshCentral'
+      - client_id: 'glitchtip'
+        client_name: 'Glitchtip'
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
         redirect_uris:
-          - 'https://meshcentral.{{< sitevar name="domain" nojs="example.com" >}}/auth-oidc-callback'
+          - 'https://glitchtip.{{< sitevar name="domain" nojs="example.com" >}}/accounts/authelia/login/callback/'
         scopes:
           - 'openid'
-          - 'profile'
           - 'email'
+          - 'profile'
         userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application
 
-To configure [MeshCentral] there is one method, using the [Configuration File](#configuration-file).
+To configure [Glitchtip] there is one method, using the [Web GUI](#web-gui).
 
-#### Configuration File
+#### Web GUI
 
-```json {title="config.json"}
-{
-  "domains": {
-    "": {
-      "title": "Example",
-      "title2": "{{< sitevar name="domain" nojs="example.com" >}}",
-      "authStrategies": {
-        "oidc": {
-          "issuer": "https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}",
-          "clientid": "meshcentral",
-          "clientsecret": "insecure_secret",
-          "newAccounts": true
-        }
-      }
-    }
-  }
-}
-```
+To configure [Glitchtip] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following instructions:
+
+1. Visit `https://glitchtip.{{< sitevar name="domain" nojs="example.com" >}}/admin/socialaccount/socialapp/`.
+2. Click `Add Social Application`.
+3. Configure the following options:
+   - Provider: `OpenID Connect`
+   - Provider ID: `authelia`
+   - Provider Name: `Authelia`
+   - Client ID: `glitchtip`
+   - Secret Key: `insecure_secret`
+   - Settings: `{"server_url":"https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/.well-known/openid-configuration"}`
+6. Press `Save` at the bottom.
 
 ## See Also
 
-- [MeshCentral Generic OpenID Connect Setup Guide](https://ylianst.github.io/MeshCentral/meshcentral/#generic-openid-connect-setup)
+- [Glitchtip Configuring OpenID Connect based SSO Documentation](https://glitchtip.com/documentation/install#configuring-openid-connect-based-sso)
 
-[MeshCentral]: https://meshcentral.com/
 [Authelia]: https://www.authelia.com
+[Glitchtip]: https://glitchtip.com/
 [OpenID Connect 1.0]: ../../openid-connect/introduction.md
 [client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/gravitee/index.md
+++ b/docs/content/integration/openid-connect/gravitee/index.md
@@ -1,6 +1,6 @@
 ---
-title: "RustDesk Server Pro"
-description: "Integrating RustDesk Server Pro with the Authelia OpenID Connect 1.0 Provider."
+title: "Gravitee"
+description: "Integrating Gravitee with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
 date: 2025-01-25T10:04:53+11:00
 draft: false
@@ -22,8 +22,8 @@ seo:
 
 - [Authelia]
   - [v4.39.1](https://github.com/authelia/authelia/releases/tag/v4.39.1)
-- [RustDesk Server Pro]
-  - [v1.3.9](https://github.com/rustdesk/rustdesk/releases/tag/1.3.9)
+- [Gravitee]
+  - [v4.7](https://documentation.gravitee.io/apim/overview/release-notes/apim-4.7)
 
 {{% oidc-common %}}
 
@@ -31,9 +31,9 @@ seo:
 
 This example makes the following assumptions:
 
-- __Application Root URL:__ `https://rustdesk.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Application Root URL:__ `https://gravitee.{{< sitevar name="domain" nojs="example.com" >}}/`
 - __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
-- __Client ID:__ `rustdesk`
+- __Client ID:__ `gravitee`
 - __Client Secret:__ `insecure_secret`
 
 Some of the values presented in this guide can automatically be replaced with documentation variables.
@@ -44,7 +44,7 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-The following YAML configuration is an example __Authelia__ [client configuration] for use with [RustDesk Server Pro] which will
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Gravitee] which will
 operate with the application example:
 
 ```yaml {title="configuration.yml"}
@@ -53,36 +53,74 @@ identity_providers:
     ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
     ## See: https://www.authelia.com/c/oidc
     clients:
-      - client_id: 'rustdesk'
-        client_name: 'RustDesk Server Pro'
+      - client_id: 'gravitee'
+        client_name: 'Gravitee'
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
         redirect_uris:
-          - 'https://rustdesk.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/callback'
+          - 'https://gravitee.{{< sitevar name="domain" nojs="example.com" >}}/'
         scopes:
           - 'openid'
           - 'email'
           - 'profile'
+          - 'groups'
         userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application
 
-To configure [RustDesk Server Pro] there is one method, using the [Web GUI](#web-gui).
+To configure [Gravitee] there is one method, using the [Web GUI](#web-gui).
+
+#### Configuration File
+
+{{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
+Generally the configuration file is named `gravitee.yaml`.
+{{< /callout >}}
+
+To configure [Gravitee] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following configuration:
+
+```yaml {title="gravitee.yaml"}
+security:
+  providers:
+    - type: 'oidc'
+      clientId: 'gravitee'
+      clientSecret: 'insecure_secret'
+      tokenIntrospectionEndpoint: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/introspection'
+      tokenEndpoint: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/token'
+      authorizeEndpoint: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/authorization'
+      userInfoEndpoint: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/userinfo'
+      syncMappings: true
+      scopes:
+        - 'openid'
+        - 'email'
+        - 'profile'
+        - 'groups'
+      userMapping:
+        id: 'sub'
+        email: 'email'
+        lastname: 'family_name'
+        firstname: 'given_name'
+        picture: 'photo'
+      roleMapping:
+        - condition: "{(#jsonPath(#profile, '$.groups') matches 'gravitee-admin' )}"
+          roles:
+            - "ORGANIZATION:ADMIN"
+            - "ENVIRONMENT:ADMIN"
+```
 
 #### Web GUI
 
-To configure [RustDesk Server Pro] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following instructions:
+To configure [Gravitee] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following instructions:
 
-1. Login to [RustDesk Server Pro].
+1. Login to [Gravitee].
 2. Navigate to Settings.
 3. Navigate to OIDC.
 4. Click `+ New Auth Provider`.
 5. Configure the following options:
    - Name: `Authelia`
-   - Client ID: `rustdesk`
+   - Client ID: `gravitee`
    - Client Secret: `insecure_secret`
    - Issuer: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}`
    - Authorization Endpoint: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/authorization`
@@ -93,10 +131,10 @@ To configure [RustDesk Server Pro] to utilize Authelia as an [OpenID Connect 1.0
 
 ## See Also
 
-- [RustDesk Server Pro OIDC documentation](https://rustdesk.com/docs/en/self-host/rustdesk-server-pro/oidc/)
+- [Gravitee OpenID Connect Documentation](https://documentation.gravitee.io/apim/administration/authentication/openid-connect)
+- [Gravitee Roles and Groups Mapping](https://documentation.gravitee.io/apim/administration/authentication/roles-and-groups-mapping)
 
 [Authelia]: https://www.authelia.com
-[RustDesk Server Pro]: https://rustdesk.com
-[OAuth login Extension]: https://www.rustdesk.com/extensions/oauth/
+[Gravitee]: https://www.gravitee.io/
 [OpenID Connect 1.0]: ../../openid-connect/introduction.md
 [client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/harbor/index.md
+++ b/docs/content/integration/openid-connect/harbor/index.md
@@ -70,6 +70,7 @@ identity_providers:
           - 'email'
           - 'offline_access'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/hashicorp-vault/index.md
+++ b/docs/content/integration/openid-connect/hashicorp-vault/index.md
@@ -67,6 +67,7 @@ identity_providers:
           - 'groups'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/home-assistant/index.md
+++ b/docs/content/integration/openid-connect/home-assistant/index.md
@@ -73,6 +73,7 @@ identity_providers:
           - 'profile'
           - 'groups'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/immich/index.md
+++ b/docs/content/integration/openid-connect/immich/index.md
@@ -67,6 +67,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/incus/index.md
+++ b/docs/content/integration/openid-connect/incus/index.md
@@ -66,6 +66,7 @@ identity_providers:
           - 'authorization_code'
         access_token_signed_response_alg: 'RS256'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'none'
 ```
 
 ## Application

--- a/docs/content/integration/openid-connect/karakeep/index.md
+++ b/docs/content/integration/openid-connect/karakeep/index.md
@@ -67,6 +67,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/kasm-workspaces/index.md
+++ b/docs/content/integration/openid-connect/kasm-workspaces/index.md
@@ -66,6 +66,7 @@ identity_providers:
           - 'groups'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/komga/index.md
+++ b/docs/content/integration/openid-connect/komga/index.md
@@ -67,6 +67,7 @@ identity_providers:
         grant_types:
           - 'authorization_code'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/librechat/index.md
+++ b/docs/content/integration/openid-connect/librechat/index.md
@@ -69,6 +69,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/mailcow/index.md
+++ b/docs/content/integration/openid-connect/mailcow/index.md
@@ -2,7 +2,7 @@
 title: "Mailcow"
 description: "Integrating Mailcow with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2023-11-12T21:18:09+11:00
 draft: false
 images: []
 weight: 620
@@ -65,6 +65,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/mastodon/index.md
+++ b/docs/content/integration/openid-connect/mastodon/index.md
@@ -65,6 +65,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/mealie/index.md
+++ b/docs/content/integration/openid-connect/mealie/index.md
@@ -67,6 +67,7 @@ identity_providers:
           - 'profile'
           - 'groups'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/miniflux/index.md
+++ b/docs/content/integration/openid-connect/miniflux/index.md
@@ -1,6 +1,6 @@
 ---
-title: "BookStack"
-description: "Integrating BookStack with the Authelia OpenID Connect 1.0 Provider."
+title: "Miniflux"
+description: "Integrating Miniflux with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
 date: 2022-06-15T17:51:47+10:00
 draft: false
@@ -22,8 +22,8 @@ seo:
 
 - [Authelia]
   - [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
-- [BookStack]
-  - 23.02.2
+- [Miniflux]
+  - [v7.42](https://github.com/miniflux/miniflux/releases/tag/v7.42)
 
 {{% oidc-common %}}
 
@@ -31,26 +31,20 @@ seo:
 
 This example makes the following assumptions:
 
-- __Application Root URL:__ `https://bookstack.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Application Root URL:__ `https://miniflux.{{< sitevar name="domain" nojs="example.com" >}}/`
 - __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
-- __Client ID:__ `bookstack`
+- __Client ID:__ `miniflux`
 - __Client Secret:__ `insecure_secret`
 
 Some of the values presented in this guide can automatically be replaced with documentation variables.
 
 {{< sitevar-preferences >}}
 
-{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-[BookStack](https://www.bookstackapp.com/) does not properly URL encode the secret per [RFC6749 Appendix B](https://datatracker.ietf.org/doc/html/rfc6749#appendix-B) at the time this
-article was last modified (noted at the bottom). This means you'll either have to use only alphanumeric characters for
-the secret or URL encode the secret yourself.
-{{< /callout >}}
-
 ## Configuration
 
 ### Authelia
 
-The following YAML configuration is an example __Authelia__ [client configuration] for use with [BookStack] which will
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Miniflux] which will
 operate with the application example:
 
 ```yaml {title="configuration.yml"}
@@ -59,13 +53,13 @@ identity_providers:
     ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
     ## See: https://www.authelia.com/c/oidc
     clients:
-      - client_id: 'bookstack'
-        client_name: 'BookStack'
+      - client_id: 'miniflux'
+        client_name: 'Miniflux'
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
         redirect_uris:
-          - 'https://bookstack.{{< sitevar name="domain" nojs="example.com" >}}/oidc/callback'
+          - 'https://miniflux.{{< sitevar name="domain" nojs="example.com" >}}/oauth2/oidc/callback'
         scopes:
           - 'openid'
           - 'profile'
@@ -76,45 +70,45 @@ identity_providers:
 
 ### Application
 
-To configure [BookStack] there is one method, using the [Environment Variables](#environment-variables).
+To configure [Miniflux] there is one method, using the [Environment Variables](#environment-variables).
 
 #### Environment Variables
 
-To configure [BookStack] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following environment
-variables:
+To configure [Miniflux] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following environment variables:
 
 ##### Standard
 
 ```shell {title=".env"}
-AUTH_METHOD=oidc
-OIDC_ISSUER=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
-OIDC_ISSUER_DISCOVER=true
-OIDC_CLIENT_ID=bookstack
-OIDC_CLIENT_SECRET=insecure_secret
-OIDC_NAME=Authelia
-OIDC_DISPLAY_NAME_CLAIMS=name
+OAUTH2_OIDC_DISCOVERY_ENDPOINT=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
+OAUTH2_CLIENT_ID=miniflux
+OAUTH2_CLIENT_SECRET=insecure_secret
+OAUTH2_OIDC_PROVIDER_NAME=Authelia
+OAUTH2_PROVIDER=oidc
+OAUTH2_REDIRECT_URL=https://miniflux.{{< sitevar name="domain" nojs="example.com" >}}/oauth2/oidc/callback
+OAUTH2_USER_CREATION=1
+
 ```
 
 ##### Docker Compose
 
 ```yaml {title="compose.yml"}
 services:
-  bookstack:
+  miniflux:
     environment:
-      AUTH_METHOD: 'oidc'
-      OIDC_ISSUER: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}'
-      OIDC_ISSUER_DISCOVER: 'true'
-      OIDC_CLIENT_ID: 'bookstack'
-      OIDC_CLIENT_SECRET: 'insecure_secret'
-      OIDC_NAME: 'Authelia'
-      OIDC_DISPLAY_NAME_CLAIMS: 'name'
+      OAUTH2_OIDC_DISCOVERY_ENDPOINT: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}'
+      OAUTH2_CLIENT_ID: 'miniflux'
+      OAUTH2_CLIENT_SECRET: 'insecure_secret'
+      OAUTH2_OIDC_PROVIDER_NAME: 'Authelia'
+      OAUTH2_PROVIDER: 'oidc'
+      OAUTH2_REDIRECT_URL: 'https://miniflux.{{< sitevar name="domain" nojs="example.com" >}}/oauth2/oidc/callback'
+      OAUTH2_USER_CREATION: '1'
 ```
 
 ## See Also
 
-- [BookStack OpenID Connect Documentation](https://www.bookstackapp.com/docs/admin/oidc-auth/)
+- [Miniflux Configuration Documentation](https://miniflux.app/docs/configuration.html#oauth2-oidc-discovery-endpoint)
 
+[Miniflux]: https://miniflux.app/index.html
 [Authelia]: https://www.authelia.com
-[BookStack]: https://www.bookstackapp.com/
 [OpenID Connect 1.0]: ../../openid-connect/introduction.md
 [client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/minio/index.md
+++ b/docs/content/integration/openid-connect/minio/index.md
@@ -66,6 +66,7 @@ identity_providers:
           - 'email'
           - 'groups'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/misago/index.md
+++ b/docs/content/integration/openid-connect/misago/index.md
@@ -71,6 +71,7 @@ identity_providers:
         response_modes:
           - 'query'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/ocis/index.md
+++ b/docs/content/integration/openid-connect/ocis/index.md
@@ -91,6 +91,8 @@ identity_providers:
         grant_types:
           - 'refresh_token'
           - 'authorization_code'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'none'
       - client_id: 'xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69'
         client_name: 'ownCloud Infinite Scale (Desktop Client)'
         client_secret: 'UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh'
@@ -110,6 +112,8 @@ identity_providers:
         grant_types:
           - 'refresh_token'
           - 'authorization_code'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
       - client_id: 'e4rAsNUSIUs0lF4nbv9FmCeUkTlV9GdgTLDH1b5uie7syb90SzEVrbN7HIpmWJeD'
         client_name: 'ownCloud Infinite Scale (Android)'
         client_secret: 'dInFYGV33xKzhbRmpqQltYNdfLdJIfJ9L5ISoKhNoT9qZftpdWSP71VrpGR9pmoD'
@@ -128,6 +132,8 @@ identity_providers:
         grant_types:
           - 'refresh_token'
           - 'authorization_code'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
       - client_id: 'mxd5OQDk6es5LzOzRvidJNfXLUZS2oN3oUFeXPP8LpPrhx3UroJFduGEYIBOxkY1'
         client_name: 'ownCloud Infinite Scale (iOS)'
         client_secret: 'KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx'
@@ -147,6 +153,8 @@ identity_providers:
         grant_types:
           - 'refresh_token'
           - 'authorization_code'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/odoo/index.md
+++ b/docs/content/integration/openid-connect/odoo/index.md
@@ -54,6 +54,8 @@ identity_providers:
         client_name: 'Odoo'
         public: true
         authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://odoo.{{< sitevar name="domain" nojs="example.com" >}}/auth_oauth/signin'
         scopes:

--- a/docs/content/integration/openid-connect/open-webui/index.md
+++ b/docs/content/integration/openid-connect/open-webui/index.md
@@ -68,6 +68,7 @@ identity_providers:
           - 'groups'
           - 'email'
         userinfo_signed_response_alg: 'RS256'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
+++ b/docs/content/integration/openid-connect/openid-connect-1.0-claims.md
@@ -130,6 +130,12 @@ identity_providers:
           - 'scope_name'
 ```
 
+#### Example Integrations
+
+The following integrations leverage all or part of the custom claims functionality:
+
+- [SFTPGo](sftpgo/index.md)
+
 ### Restore Functionality Prior to Claims Parameter
 
 The introduction of the claims parameter has removed most claims from the [ID Token] leaving it with only the claims

--- a/docs/content/integration/openid-connect/openproject/index.md
+++ b/docs/content/integration/openid-connect/openproject/index.md
@@ -2,7 +2,7 @@
 title: "OpenProject"
 description: "Integrating OpenProject with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T18:35:57+10:00
 draft: false
 images: []
 weight: 620
@@ -65,6 +65,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/opkssh/index.md
+++ b/docs/content/integration/openid-connect/opkssh/index.md
@@ -68,6 +68,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/photoprism/index.md
+++ b/docs/content/integration/openid-connect/photoprism/index.md
@@ -66,6 +66,7 @@ identity_providers:
           - 'email'
           - 'address'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/pocketbase/index.md
+++ b/docs/content/integration/openid-connect/pocketbase/index.md
@@ -68,6 +68,7 @@ identity_providers:
           - 'openid'
           - 'profile'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/portainer/index.md
+++ b/docs/content/integration/openid-connect/portainer/index.md
@@ -68,7 +68,7 @@ identity_providers:
           - 'groups'
           - 'email'
         userinfo_signed_response_alg: 'none'
-        token_endpoint_auth_method: client_secret_post
+        token_endpoint_auth_method: 'client_secret_post'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/powerdns/index.md
+++ b/docs/content/integration/openid-connect/powerdns/index.md
@@ -70,6 +70,7 @@ identity_providers:
         grant_types:
           - 'authorization_code'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/proxmox/index.md
+++ b/docs/content/integration/openid-connect/proxmox/index.md
@@ -77,6 +77,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/rocket-chat/index.md
+++ b/docs/content/integration/openid-connect/rocket-chat/index.md
@@ -67,8 +67,8 @@ identity_providers:
           - 'groups'
         grant_types:
           - 'authorization_code'
-        token_endpoint_auth_method: 'client_secret_post'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_post'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/semaphore/index.md
+++ b/docs/content/integration/openid-connect/semaphore/index.md
@@ -1,6 +1,6 @@
 ---
-title: "MeshCentral"
-description: "Integrating MeshCentral with the Authelia OpenID Connect 1.0 Provider."
+title: "Semaphore"
+description: "Integrating Semaphore with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
 date: 2022-06-15T17:51:47+10:00
 draft: false
@@ -22,8 +22,8 @@ seo:
 
 - [Authelia]
   - [v4.39.1](https://github.com/authelia/authelia/releases/tag/v4.39.1)
-- [MeshCentral]
-  - [v1.1.44](https://github.com/Ylianst/MeshCentral/releases/tag/1.1.44)
+- [Semaphore]
+  - [v2.13.14](https://github.com/semaphoreui/semaphore/releases/tag/v2.13.14)
 
 {{% oidc-common %}}
 
@@ -31,9 +31,9 @@ seo:
 
 This example makes the following assumptions:
 
-- __Application Root URL:__ `https://meshcentral.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Application Root URL:__ `https://semaphore.{{< sitevar name="domain" nojs="example.com" >}}/`
 - __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
-- __Client ID:__ `meshcentral`
+- __Client ID:__ `semaphore`
 - __Client Secret:__ `insecure_secret`
 
 Some of the values presented in this guide can automatically be replaced with documentation variables.
@@ -44,7 +44,7 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-The following YAML configuration is an example __Authelia__ [client configuration] for use with [MeshCentral] which will
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Semaphore] which will
 operate with the application example:
 
 ```yaml {title="configuration.yml"}
@@ -53,13 +53,13 @@ identity_providers:
     ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
     ## See: https://www.authelia.com/c/oidc
     clients:
-      - client_id: 'meshcentral'
-        client_name: 'MeshCentral'
+      - client_id: 'semaphore'
+        client_name: 'Semaphore'
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
         redirect_uris:
-          - 'https://meshcentral.{{< sitevar name="domain" nojs="example.com" >}}/auth-oidc-callback'
+          - 'https://semaphore.{{< sitevar name="domain" nojs="example.com" >}}/api/auth/oidc/authelia/redirect'
         scopes:
           - 'openid'
           - 'profile'
@@ -70,24 +70,24 @@ identity_providers:
 
 ### Application
 
-To configure [MeshCentral] there is one method, using the [Configuration File](#configuration-file).
+To configure [Semaphore] there is one method, using the [Configuration File](#configuration-file).
 
 #### Configuration File
 
 ```json {title="config.json"}
 {
-  "domains": {
-    "": {
-      "title": "Example",
-      "title2": "{{< sitevar name="domain" nojs="example.com" >}}",
-      "authStrategies": {
-        "oidc": {
-          "issuer": "https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}",
-          "clientid": "meshcentral",
-          "clientsecret": "insecure_secret",
-          "newAccounts": true
-        }
-      }
+  "oidc_providers":  {
+    "authelia": {
+      "display_name": "Authelia",
+      "provider_url": "https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}",
+      "client_id": "semaphore",
+      "client_secret": "insecure_secret",
+      "redirect_url": "https://semaphore.{{< sitevar name="domain" nojs="example.com" >}}/api/auth/oidc/authelia/redirect",
+      "scopes": ["openid", "profile", "email"],
+      "username_claim": "preferred_username",
+      "email_claim": "email",
+      "name_claim": "name",
+      "order": 1
     }
   }
 }
@@ -95,9 +95,10 @@ To configure [MeshCentral] there is one method, using the [Configuration File](#
 
 ## See Also
 
-- [MeshCentral Generic OpenID Connect Setup Guide](https://ylianst.github.io/MeshCentral/meshcentral/#generic-openid-connect-setup)
+- [Semaphore OpenID Setup Guide](https://docs.semaphoreui.com/administration-guide/openid/)
+  - [Semaphore OpenID Setup Guide (Authelia)](https://docs.semaphoreui.com/administration-guide/openid/authelia/)
 
-[MeshCentral]: https://meshcentral.com/
+[Semaphore]: https://semaphoreui.com/
 [Authelia]: https://www.authelia.com
 [OpenID Connect 1.0]: ../../openid-connect/introduction.md
 [client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/sftpgo/index.md
+++ b/docs/content/integration/openid-connect/sftpgo/index.md
@@ -23,7 +23,7 @@ seo:
 - [Authelia]
   - [v4.38.18](https://github.com/authelia/authelia/releases/tag/v4.38.18)
 - [SFTPGo]
-  - [v25.1.0](https://github.com/actualbudget/actual/releases/tag/v25.1.0)
+  - [v2.6.6](https://github.com/drakkan/sftpgo/releases/tag/v2.6.6)
 
 {{% oidc-common %}}
 
@@ -46,7 +46,7 @@ Some of the values presented in this guide can automatically be replaced with do
 
 {{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
 The `sftpgo_role` user attribute renders the value `admin` if the user is in the `sftpgo_admins` group within Authelia,
-renders the value `maanger` if they are in the "sftpgo_managers" group, otherwise it renders `user`. You can adjust this
+renders the value `manager` if they are in the "sftpgo_managers" group, otherwise it renders `user`. You can adjust this
 to your preference to assign a role to the appropriate user groups.
 {{< /callout >}}
 

--- a/docs/content/integration/openid-connect/sftpgo/index.md
+++ b/docs/content/integration/openid-connect/sftpgo/index.md
@@ -1,0 +1,160 @@
+---
+title: "SFTPGo"
+description: "Integrating SFTPGo with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2022-06-15T17:51:47+10:00
+draft: false
+images: []
+weight: 620
+toc: true
+support:
+  level: community
+  versions: true
+  integration: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+- [Authelia]
+  - [v4.38.18](https://github.com/authelia/authelia/releases/tag/v4.38.18)
+- [SFTPGo]
+  - [v25.1.0](https://github.com/actualbudget/actual/releases/tag/v25.1.0)
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+- __Application Root URL:__ `https://sftpgo.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Client ID:__ `sftpgo`
+- __Client Secret:__ `insecure_secret`
+
+Some of the values presented in this guide can automatically be replaced with documentation variables.
+
+{{< sitevar-preferences >}}
+
+## Configuration
+
+### Authelia
+
+{{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
+The `sftpgo_role` user attribute renders the value `admin` if the user is in the `sftpgo_admins` group within Authelia,
+renders the value `maanger` if they are in the "sftpgo_managers" group, otherwise it renders `user`. You can adjust this
+to your preference to assign a role to the appropriate user groups.
+{{< /callout >}}
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [SFTPGo] which
+will operate with the application example:
+
+```yaml {title="configuration.yml"}
+definitions:
+  user_attributes:
+    sftpgo_role:
+      expression: '"sftpgo_admins" in groups ? "admin" : "sftpgo_managers" in groups ? "manager" : "user"'
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    claims_policies:
+      sftpgo:
+        id_token: ['preferred_username', 'sftpgo_role']
+        custom_claims:
+          sftpgo_role: {}
+    scopes:
+      sftpgo:
+        claims:
+          - 'sftpgo_role'
+    clients:
+      - client_id: 'sftpgo'
+        client_name: 'SFTPGo'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        claims_policy: 'sftpgo'
+        redirect_uris:
+          - 'https://sftpgo.{{< sitevar name="domain" nojs="example.com" >}}/openid/callback'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+          - 'sftpgo'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+To configure [SFTPGo] there are two methods, using the [Configuration File](#configuration-file), or using the
+[Environment Variables](#environment-variables).
+
+#### Configuration File
+
+To configure [SFTPGo] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following configuration:
+
+```json
+{
+  "oidc": {
+    "client_id": "sftpgo",
+    "client_secret": "insecure_secret",
+    "config_url": "https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}",
+    "redirect_base_url": "https://sftpgo.{{< sitevar name="domain" nojs="example.com" >}}",
+    "scopes": [
+      "openid",
+      "profile",
+      "email",
+      "sftpgo"
+    ],
+    "username_field": "preferred_username",
+    "role_field": "sftpgo_role",
+    "implicit_roles": false,
+    "custom_fields": []
+  }
+}
+```
+
+#### Environment Variables
+
+To configure [SFTPGo] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following environment variables:
+
+##### Standard
+
+```shell {title=".env"}
+SFTPGO_HTTPD__BINDINGS__0__OIDC__CLIENT_ID=sftpgo
+SFTPGO_HTTPD__BINDINGS__0__OIDC__CLIENT_SECRET=insecure_secret
+SFTPGO_HTTPD__BINDINGS__0__OIDC__CONFIG_URL=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
+SFTPGO_HTTPD__BINDINGS__0__OIDC__REDIRECT_BASE_URL=https://sftpgo.{{< sitevar name="domain" nojs="example.com" >}}
+SFTPGO_HTTPD__BINDINGS__0__OIDC__SCOPES=openid,profile,email,sftpgo
+SFTPGO_HTTPD__BINDINGS__0__OIDC__USERNAME_FIELD=preferred_username
+SFTPGO_HTTPD__BINDINGS__0__OIDC__ROLE_FIELD=sftpgo_role
+```
+
+##### Docker Compose
+
+```yaml {title="compose.yml"}
+services:
+  sftpgo:
+    environment:
+      SFTPGO_HTTPD__BINDINGS__0__OIDC__CLIENT_ID: 'sftpgo'
+      SFTPGO_HTTPD__BINDINGS__0__OIDC__CLIENT_SECRET: 'insecure_secret'
+      SFTPGO_HTTPD__BINDINGS__0__OIDC__CONFIG_URL: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}'
+      SFTPGO_HTTPD__BINDINGS__0__OIDC__REDIRECT_BASE_URL: 'https://sftpgo.{{< sitevar name="domain" nojs="example.com" >}}'
+      SFTPGO_HTTPD__BINDINGS__0__OIDC__SCOPES: 'openid,profile,email'
+      SFTPGO_HTTPD__BINDINGS__0__OIDC__USERNAME_FIELD: 'preferred_username'
+      SFTPGO_HTTPD__BINDINGS__0__OIDC__ROLE_FIELD: 'sftpgo_role'
+```
+
+## See Also
+
+- [SFTPGo OpenID Connect Documentation](https://docs.sftpgo.com/2.6/oidc/)
+
+[Authelia]: https://www.authelia.com
+[SFTPGo]: https://sftpgo.com/
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/stalwart/index.md
+++ b/docs/content/integration/openid-connect/stalwart/index.md
@@ -2,7 +2,7 @@
 title: "Stalwart"
 description: "Integrating Stalwart with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T18:35:57+10:00
 draft: false
 images: []
 weight: 620
@@ -74,6 +74,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application
@@ -82,10 +83,14 @@ To configure [Stalwart] there are two methods, using the [Configuration File](#c
 
 #### Configuration File
 
+{{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
+Generally the configuration file is named `config.toml`.
+{{< /callout >}}
+
 To configure [Stalwart] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following configuration:
 
-```toml
-[directory."oidc-userinfo"]
+```toml {title="config.toml"}
+[directory."authelia"]
 type = "oidc"
 timeout = "15s"
 endpoint.url = "https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/userinfo"
@@ -105,6 +110,7 @@ To configure [Stalwart] to utilize Authelia as an [OpenID Connect 1.0] Provider,
 4. Navigate to Directories.
 5. Click Create Directory.
 6. Configure the following options:
+   - Directory Id: `authelia`
    - Type: `OpenID Connect`
    - URL: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/userinfo`
    - Type: `OpenID Connect Userinfo`

--- a/docs/content/integration/openid-connect/synapse/index.md
+++ b/docs/content/integration/openid-connect/synapse/index.md
@@ -67,6 +67,7 @@ identity_providers:
           - 'email'
           - 'groups'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/tailscale/index.md
+++ b/docs/content/integration/openid-connect/tailscale/index.md
@@ -63,6 +63,8 @@ identity_providers:
           - 'openid'
           - 'email'
           - 'profile'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/tandoor/index.md
+++ b/docs/content/integration/openid-connect/tandoor/index.md
@@ -1,0 +1,127 @@
+---
+title: "Tandoor"
+description: "Integrating Tandoor with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2022-06-15T17:51:47+10:00
+draft: false
+images: []
+weight: 620
+toc: true
+support:
+  level: community
+  versions: true
+  integration: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+- [Authelia]
+  - [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+- [Tandoor]
+  - [v1.5.34](https://github.com/TandoorRecipes/recipes/releases/tag/1.5.34)
+
+{{% oidc-common %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+- __Application Root URL:__ `https://tandoor.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Client ID:__ `tandoor`
+- __Client Secret:__ `insecure_secret`
+
+Some of the values presented in this guide can automatically be replaced with documentation variables.
+
+{{< sitevar-preferences >}}
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Tandoor] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'tandoor'
+        client_name: 'Tandoor'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        redirect_uris:
+          - 'https://tandoor.{{< sitevar name="domain" nojs="example.com" >}}/accounts/oidc/authelia/login/callback/'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
+```
+
+### Application
+
+To configure [Tandoor] there is one method, using the [Environment Variables](#environment-variables).
+
+#### Environment Variables
+
+For reference purposes, the below `SOCIALACCOUNT_PROVIDERS` environment variable examples are the minified
+format of the following:
+
+```json
+{
+  "openid_connect": {
+    "SCOPE": ["openid", "profile", "email"],
+    "OAUTH_PKCE_ENABLED": true,
+    "APPS": [
+      {
+        "provider_id": "authelia",
+        "name": "Authelia",
+        "client_id": "tandoor",
+        "secret": "insecure_secret",
+        "settings": {
+          "server_url": "https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/.well-known/openid-configuration",
+          "token_auth_method": "client_secret_basic"
+        }
+      }
+    ]
+  }
+}
+```
+
+To configure [Tandoor] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following environment variables:
+
+##### Standard
+
+```shell {title=".env"}
+SOCIAL_PROVIDERS=allauth.socialaccount.providers.openid_connect
+SOCIALACCOUNT_PROVIDERS={"openid_connect":{"SCOPE":["openid","profile","email"],"OAUTH_PKCE_ENABLED":true,"APPS":[{"provider_id":"authelia","name":"Authelia","client_id":"tandoor","secret":"insecure_secret","settings":{"server_url":"https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/.well-known/openid-configuration","token_auth_method":"client_secret_basic"}}]}}
+```
+
+##### Docker Compose
+
+```yaml {title="compose.yml"}
+services:
+  tandoor:
+    environment:
+      SOCIAL_PROVIDERS: 'allauth.socialaccount.providers.openid_connect'
+      SOCIALACCOUNT_PROVIDERS: '{"openid_connect":{"SCOPE":["openid","profile","email"],"OAUTH_PKCE_ENABLED":true,"APPS":[{"provider_id":"authelia","name":"Authelia","client_id":"tandoor","secret":"insecure_secret","settings":{"server_url":"https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/.well-known/openid-configuration","token_auth_method":"client_secret_basic"}}]}}'
+```
+
+## See Also
+
+- [Tandoor Authentication Allauth Documentation](https://docs.tandoor.dev/features/authentication/#allauth)
+
+[Tandoor]: https://tandoor.app/index.html
+[Authelia]: https://www.authelia.com
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/uptime-kuma/index.md
+++ b/docs/content/integration/openid-connect/uptime-kuma/index.md
@@ -106,6 +106,7 @@ identity_providers:
         grant_types:
           - 'client_credentials'
         requested_audience_mode: 'implicit'
+        userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'client_secret_basic'
 ```
 

--- a/docs/content/integration/openid-connect/windmill/index.md
+++ b/docs/content/integration/openid-connect/windmill/index.md
@@ -63,6 +63,7 @@ identity_providers:
           - 'email'
           - 'groups'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ## Application

--- a/docs/content/integration/openid-connect/xen-orchestra/index.md
+++ b/docs/content/integration/openid-connect/xen-orchestra/index.md
@@ -65,6 +65,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/youtrack/index.md
+++ b/docs/content/integration/openid-connect/youtrack/index.md
@@ -66,6 +66,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/zipline/index.md
+++ b/docs/content/integration/openid-connect/zipline/index.md
@@ -63,9 +63,14 @@ identity_providers:
           - 'openid'
           - 'email'
           - 'profile'
-          - offline_access
-        response_types: 'code'
-        token_endpoint_auth_method: 'client_secret_post'
+          - 'offline_access'
+        response_types:
+          - 'code'
+        grant_types:
+          - 'refresh_token'
+          - 'authorization_code'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_basic'
 ```
 
 ### Application


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new integration guides for Beszel, Chronograf, Drupal, Gatus, Glitchtip, Gravitee, Miniflux, Semaphore, SFTPGo, and Tandoor applications with Authelia OpenID Connect provider.

- **Documentation**
  - Updated multiple OpenID Connect client configuration examples to explicitly specify the token endpoint authentication method, primarily setting it to 'client_secret_basic'.
  - Added or clarified parameters such as userinfo response signing algorithm, PKCE enforcement, and grant/response types in various integration guides.
  - Improved and clarified configuration snippets and instructions for several integrations.
  - Updated documentation metadata dates for some pages.

- **Style**
  - Adjusted YAML formatting and ordering of configuration keys in some documentation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->