### PR TITLE
feat: adding the token itself as a template variable for template use

### DIFF
--- a/internal/middlewares/identity_verification.go
+++ b/internal/middlewares/identity_verification.go
@@ -97,6 +97,7 @@ func IdentityVerificationStart(args IdentityVerificationStartArgs, delayFunc Tim
 
 		data := templates.EmailIdentityVerificationJWTValues{
 			Title:              args.MailTitle,
+			Token:              signedToken,
 			LinkURL:            linkURL.String(),
 			LinkText:           args.MailButtonContent,
 			RevocationLinkURL:  revocationLinkURL.String(),

--- a/internal/templates/types.go
+++ b/internal/templates/types.go
@@ -72,6 +72,7 @@ type EmailIdentityVerificationJWTValues struct {
 	DisplayName        string
 	Domain             string
 	RemoteIP           string
+	Token              string
 	LinkURL            string
 	LinkText           string
 	RevocationLinkURL  string


### PR DESCRIPTION
We had an instance when making an override template that we wanted access to the token directly. This exposes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Identity verification emails now include a signed token for improved verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->