### PR TITLE
docs(configuration): update pgAdmin OAuth2 Documentation link's version

### DIFF
--- a/docs/content/integration/openid-connect/pgadmin/index.md
+++ b/docs/content/integration/openid-connect/pgadmin/index.md
@@ -102,7 +102,7 @@ OAUTH2_CONFIG = [{
 
 ## See Also
 
-- [pgAdmin OAuth2 Documentation](https://www.pgadmin.org/docs/pgadmin4/8.4/oauth2.html)
+- [pgAdmin OAuth2 Documentation](https://www.pgadmin.org/docs/pgadmin4/9.2/oauth2.html)
 
 [pgAdmin]: https://www.pgadmin.org/
 [Authelia]: https://www.authelia.com


### PR DESCRIPTION
Update of pgAdmin OAuth2 Documentation link's version from 8.4 to 9.2 as 8.4 version of documentation have been removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the pgAdmin OAuth2 documentation link in the "See Also" section to reference version 9.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->