### PR TITLE
fix(oidc): ensure stateful userinfo token use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	authelia.com/provider/oauth2 v0.2.5
+	authelia.com/provider/oauth2 v0.2.6
 	github.com/Gurpartap/logrus-stack v0.0.0-20170710170904-89c00d8a28f4
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/authelia/jsonschema v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-authelia.com/provider/oauth2 v0.2.5 h1:xQWBz0KUxDWGW1wajXWp25GP+vf3dyDRNclNHR/iYkI=
-authelia.com/provider/oauth2 v0.2.5/go.mod h1:ZePmlvzmhUoX0ZX/syjuI7oxFdqU63kTuFIFxhoQgUU=
+authelia.com/provider/oauth2 v0.2.6 h1:93fQ0uPO+ZyuTeNgSWB0bwwd9oiFwxpoRGJQhTSIALQ=
+authelia.com/provider/oauth2 v0.2.6/go.mod h1:fntoRMJONoUzQxby7/84FCST8SDDeprSFuMrtiUdyXM=
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=

--- a/internal/handlers/handler_oauth2_oidc_userinfo.go
+++ b/internal/handlers/handler_oauth2_oidc_userinfo.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	oauthelia2 "authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/handler/oauth2"
 	"authelia.com/provider/oauth2/token/jwt"
 	"authelia.com/provider/oauth2/x/errorsx"
 	"github.com/google/uuid"
@@ -39,7 +40,7 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 
 	ctx.Logger.Debugf("User Info Request with id '%s' is being processed", requestID)
 
-	if tokenType, requester, err = ctx.Providers.OpenIDConnect.IntrospectToken(r.Context(), oauthelia2.AccessTokenFromRequest(r), oauthelia2.AccessToken, session); err != nil {
+	if tokenType, requester, err = ctx.Providers.OpenIDConnect.IntrospectToken(oauth2.SetSkipStatelessIntrospection(r.Context()), oauthelia2.AccessTokenFromRequest(r), oauthelia2.AccessToken, session); err != nil {
 		ctx.Logger.Errorf("User Info Request with id '%s' failed with error: %s", requestID, oauthelia2.ErrorToDebugRFC6749Error(err))
 
 		if rfc := oauthelia2.ErrorToRFC6749Error(err); rfc.StatusCode() == http.StatusUnauthorized {

--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -228,6 +228,11 @@ type ProofKeyCodeExchangeConfig struct {
 	AllowPlainChallengeMethod bool
 }
 
+type StatelessJWTStrategy struct {
+	jwt.Strategy
+	oauth2.CoreStrategy
+}
+
 // LoadHandlers reloads the handlers based on the current configuration.
 func (c *Config) LoadHandlers(store *Store) {
 	validator := openid.NewOpenIDConnectRequestValidator(c.Strategy.JWT, c)
@@ -236,8 +241,11 @@ func (c *Config) LoadHandlers(store *Store) {
 
 	if c.JWTAccessToken.Enable && c.JWTAccessToken.EnableStatelessIntrospection {
 		statelessJWT = &oauth2.StatelessJWTValidator{
-			Strategy: c.Strategy.JWT,
-			Config:   c,
+			StatelessJWTStrategy: &StatelessJWTStrategy{
+				Strategy:     c.Strategy.JWT,
+				CoreStrategy: c.Strategy.Core,
+			},
+			Config: c,
 		}
 	}
 


### PR DESCRIPTION
This ensures the userinfo endpoint can be used properly when stateless introspection is enabled and the provided Access Token is a JWT Profile Access Token. Previously this caused an error which is due to the fact the session type when performing stateless introspection is arbitrary from the JWT claims.

Fixes #9382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved stateless JWT access token validation with enhanced strategy handling.

- **Refactor**
	- Updated token introspection to better support stateless validation using a combined JWT and core strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->