### PR TITLE
docs(oidc): fix immich example config

### DIFF
--- a/docs/content/integration/openid-connect/immich/index.md
+++ b/docs/content/integration/openid-connect/immich/index.md
@@ -67,7 +67,7 @@ identity_providers:
           - 'profile'
           - 'email'
         userinfo_signed_response_alg: 'none'
-        token_endpoint_auth_method: 'client_secret_basic'
+        token_endpoint_auth_method: 'client_secret_post'
 ```
 
 ### Application

--- a/docs/content/integration/openid-connect/immich/index.md
+++ b/docs/content/integration/openid-connect/immich/index.md
@@ -21,9 +21,9 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.38.17](https://github.com/authelia/authelia/releases/tag/v4.38.17)
+  - [v4.39.0](https://github.com/authelia/authelia/releases/tag/v4.39.0)
 - [Immich]
-  - [v1.123.0](https://github.com/immich-app/immich/releases/tag/v1.123.0)
+  - [v1.132.3](https://github.com/immich-app/immich/releases/tag/v1.132.3)
 
 {{% oidc-common %}}
 


### PR DESCRIPTION
Immich [v1.132.3](https://github.com/immich-app/immich/releases/tag/v1.132.3) fixes an issue where the mobile app cannot log in with an instance using Authelia for OAuth. They suggest setting 
```
token_endpoint_auth_method: "client_secret_post"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the OpenID Connect integration guide for Immich to reflect a change in the recommended authentication method for the token endpoint.
  - Updated tested versions of Authelia and Immich in the integration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->