### PR TITLE
docs(oidc): fix home assistant example config

### DIFF
--- a/docs/content/integration/openid-connect/home-assistant/index.md
+++ b/docs/content/integration/openid-connect/home-assistant/index.md
@@ -73,7 +73,7 @@ identity_providers:
           - 'profile'
           - 'groups'
         userinfo_signed_response_alg: 'none'
-        token_endpoint_auth_method: 'client_secret_basic'
+        token_endpoint_auth_method: 'client_secret_post'
 ```
 
 ### Application


### PR DESCRIPTION
change incorrect `token_endpoint_auth_method` value from `client_secret_basic` to `client_secret_post` based on documentation from integration repo:  
see https://github.com/christiaangoossens/hass-oidc-auth/blob/main/docs/provider-configurations/authelia.md#confidential-client-configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the configuration example for integrating Home Assistant with Authelia OpenID Connect to use a different token endpoint authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->