### PR TITLE
docs(oidc): add grafana conformance bug note

### DIFF
--- a/docs/content/integration/openid-connect/grafana/index.md
+++ b/docs/content/integration/openid-connect/grafana/index.md
@@ -44,6 +44,8 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
+{{% oidc-conformance-claims claims="email,name,groups,preferred_username" %}}
+
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [Grafana] which will
 operate with the application example:
 


### PR DESCRIPTION
This adds the OpenID Connect 1.0 conformance bug note for claims to Grafana.