### PR TITLE
fix(cmd): allow bootstrap to handle modified lines

### DIFF
--- a/cmd/authelia-scripts/cmd/bootstrap.go
+++ b/cmd/authelia-scripts/cmd/bootstrap.go
@@ -233,21 +233,25 @@ func prepareHostsFile() {
 		domainInHostFile := false
 
 		for i, line := range lines {
+			trimmedLine := strings.TrimSpace(line)
+			if trimmedLine == "" {
+				continue
+			}
+
 			domainFound := strings.Contains(line, entry.Domain)
-			ipFound := strings.Contains(line, entry.IP)
 
 			if domainFound {
 				domainInHostFile = true
 
-				// The IP is not up to date.
-				if ipFound {
-					break
-				} else {
-					lines[i] = entry.IP + " " + entry.Domain
-					modified = true
+				expectedEntry := entry.IP + " " + entry.Domain
+				isCommented := trimmedLine[0] == '#'
 
-					break
+				if isCommented || !strings.Contains(line, expectedEntry) {
+					lines[i] = expectedEntry
+					modified = true
 				}
+
+				break
 			}
 		}
 


### PR DESCRIPTION
This allows bootstrap to fix malformed or commented hosts records which may cause tests to fail or other weird interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty and commented lines in the hosts file to ensure accurate updates and formatting of domain entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->