### PR TITLE
refactor: debug oidc claims hydration

### DIFF
--- a/docs/content/reference/cli/authelia/authelia_debug_expression.md
+++ b/docs/content/reference/cli/authelia/authelia_debug_expression.md
@@ -2,7 +2,7 @@
 title: "authelia debug expression"
 description: "Reference for the authelia debug expression command."
 lead: ""
-date: 2025-05-10T13:16:45+10:00
+date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 905

--- a/docs/content/reference/cli/authelia/authelia_debug_oidc.md
+++ b/docs/content/reference/cli/authelia/authelia_debug_oidc.md
@@ -1,8 +1,8 @@
 ---
-title: "authelia debug"
-description: "Reference for the authelia debug command."
+title: "authelia debug oidc"
+description: "Reference for the authelia debug oidc command."
 lead: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-05-10T14:27:29+10:00
 draft: false
 images: []
 weight: 905
@@ -14,26 +14,26 @@ seo:
   noindex: false # false (default) or true
 ---
 
-## authelia debug
+## authelia debug oidc
 
-Perform debug functions
+Perform a OpenID Connect 1.0 debug operation
 
 ### Synopsis
 
-Perform debug related functions.
+Perform a OpenID Connect 1.0 debug operation.
 
-This subcommand contains other subcommands related to debugging.
+This subcommand allows checking certain OpenID Connect 1.0 scenarios.
 
 ### Examples
 
 ```
-authelia debug --help
+authelia debug oidc --help
 ```
 
 ### Options
 
 ```
-  -h, --help   help for debug
+  -h, --help   help for oidc
 ```
 
 ### Options inherited from parent commands
@@ -45,8 +45,6 @@ authelia debug --help
 
 ### SEE ALSO
 
-* [authelia](authelia.md)	 - authelia untagged-unknown-dirty (master, unknown)
-* [authelia debug expression](authelia_debug_expression.md)	 - Perform a user attribute expression debug operation
-* [authelia debug oidc](authelia_debug_oidc.md)	 - Perform a OpenID Connect 1.0 debug operation
-* [authelia debug tls](authelia_debug_tls.md)	 - Perform a TLS debug operation
+* [authelia debug](authelia_debug.md)	 - Perform debug functions
+* [authelia debug oidc claims](authelia_debug_oidc_claims.md)	 - Perform a OpenID Connect 1.0 claims hydration debug operation
 

--- a/docs/content/reference/cli/authelia/authelia_debug_oidc_claims.md
+++ b/docs/content/reference/cli/authelia/authelia_debug_oidc_claims.md
@@ -1,0 +1,59 @@
+---
+title: "authelia debug oidc claims"
+description: "Reference for the authelia debug oidc claims command."
+lead: ""
+date: 2025-05-10T14:27:29+10:00
+draft: false
+images: []
+weight: 905
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia debug oidc claims
+
+Perform a OpenID Connect 1.0 claims hydration debug operation
+
+### Synopsis
+
+Perform a OpenID Connect 1.0 claims hydration debug operation.
+
+This subcommand allows checking an OpenID Connect 1.0 claims hydration scenario by providing certain information about a request.
+
+```
+authelia debug oidc claims [username] [flags]
+```
+
+### Examples
+
+```
+authelia debug oidc claims --help
+```
+
+### Options
+
+```
+      --claims strings         granted claims to use for this request
+      --client-id string       arbitrary client id for the client (default "example")
+      --grant-type string      grant type to use for this request (default "authorization_code")
+  -h, --help                   help for claims
+      --policy string          claims policy name to use
+      --response-type string   response type to use for this request (default "code")
+      --scopes strings         granted scopes to use for this request (default [openid,profile,email,phone,address,groups])
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config strings                        configuration files or directories to load, for more information run 'authelia -h authelia config' (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information run 'authelia -h authelia filters'
+```
+
+### SEE ALSO
+
+* [authelia debug oidc](authelia_debug_oidc.md)	 - Perform a OpenID Connect 1.0 debug operation
+

--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -685,6 +685,22 @@ This subcommand allows checking a remote server's TLS configuration and the abil
 This subcommand allows checking a user attribute expression against a specific user.`
 
 	cmdAutheliaDebugExpressionExample = `authelia debug expression username "'abc' in groups"`
+
+	cmdAutheliaDebugOIDCShort = "Perform a OpenID Connect 1.0 debug operation"
+
+	cmdAutheliaDebugOIDCLong = `Perform a OpenID Connect 1.0 debug operation.
+
+This subcommand allows checking certain OpenID Connect 1.0 scenarios.`
+
+	cmdAutheliaDebugOIDCExample = `authelia debug oidc --help`
+
+	cmdAutheliaDebugOIDCClaimsShort = "Perform a OpenID Connect 1.0 claims hydration debug operation"
+
+	cmdAutheliaDebugOIDCClaimsLong = `Perform a OpenID Connect 1.0 claims hydration debug operation.
+
+This subcommand allows checking an OpenID Connect 1.0 claims hydration scenario by providing certain information about a request.`
+
+	cmdAutheliaDebugOIDCClaimsExample = `authelia debug oidc claims --help`
 )
 
 const (

--- a/internal/oidc/claims_test.go
+++ b/internal/oidc/claims_test.go
@@ -59,7 +59,7 @@ func TestClaimValidate(t *testing.T) {
 		},
 	}
 
-	strategy := oidc.NewCustomClaimsStrategy(config.Clients[0], config.Scopes, config.ClaimsPolicies)
+	strategy := oidc.NewCustomClaimsStrategyFromClient(config.Clients[0], config.Scopes, config.ClaimsPolicies)
 
 	client := &oidc.RegisteredClient{
 		ID:     config.Clients[0].ID,
@@ -252,7 +252,7 @@ func TestNewClaimRequestsMatcher(t *testing.T) {
 
 	client := &oidc.RegisteredClient{
 		ID:             config.Clients[0].ID,
-		ClaimsStrategy: oidc.NewCustomClaimsStrategy(config.Clients[0], config.Scopes, config.ClaimsPolicies),
+		ClaimsStrategy: oidc.NewCustomClaimsStrategyFromClient(config.Clients[0], config.Scopes, config.ClaimsPolicies),
 		Scopes:         config.Clients[0].Scopes,
 	}
 
@@ -1472,7 +1472,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 
 			client := &oidc.RegisteredClient{
 				ID:             tc.config.Clients[0].ID,
-				ClaimsStrategy: oidc.NewCustomClaimsStrategy(tc.config.Clients[0], tc.config.Scopes, tc.config.ClaimsPolicies),
+				ClaimsStrategy: oidc.NewCustomClaimsStrategyFromClient(tc.config.Clients[0], tc.config.Scopes, tc.config.ClaimsPolicies),
 				Scopes:         tc.config.Clients[0].Scopes,
 			}
 

--- a/internal/oidc/client.go
+++ b/internal/oidc/client.go
@@ -32,7 +32,7 @@ func NewClient(config schema.IdentityProvidersOpenIDConnectClient, c *schema.Ide
 		ResponseTypes: config.ResponseTypes,
 		ResponseModes: []oauthelia2.ResponseModeType{},
 
-		ClaimsStrategy: NewCustomClaimsStrategy(config, c.Scopes, c.ClaimsPolicies),
+		ClaimsStrategy: NewCustomClaimsStrategyFromClient(config, c.Scopes, c.ClaimsPolicies),
 
 		RequirePKCE:                config.RequirePKCE || config.PKCEChallengeMethod != "",
 		RequirePKCEChallengeMethod: config.PKCEChallengeMethod != "",

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -222,6 +222,13 @@ type Context interface {
 	context.Context
 }
 
+// ClaimsStrategyContext is a context used for the CustomClaimsStrategy implementation.
+type ClaimsStrategyContext interface {
+	GetProviderUserAttributeResolver() expression.UserAttributeResolver
+
+	context.Context
+}
+
 type ClientContext interface {
 	GetHTTPClient() *http.Client
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new CLI debug command to simulate and output OpenID Connect (OIDC) ID token and user info claims for a specified user, with support for various flags and subcommands.
- **Documentation**
  - Updated documentation to include the new OIDC debug subcommand and made minor metadata corrections.
- **Refactor**
  - Improved internal handling of claims strategies for OIDC, enhancing type specificity and decoupling strategy construction from client objects.
- **Tests**
  - Updated tests to use the new claims strategy initialization method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->