### PR TITLE
docs: fix karakeep missing sitevar

### DIFF
--- a/docs/content/integration/openid-connect/karakeep/index.md
+++ b/docs/content/integration/openid-connect/karakeep/index.md
@@ -81,7 +81,7 @@ To configure [karakeep] to utilize Authelia as an [OpenID Connect 1.0] Provider,
 ##### Standard
 
 ```shell {title=".env"}
-OAUTH_WELLKNOWN_URL=https://auth.{{< sitevar name="domain" nojs="example.com" >}}/.well-known/openid-configuration
+OAUTH_WELLKNOWN_URL=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/.well-known/openid-configuration
 OAUTH_CLIENT_ID=karakeep
 OAUTH_CLIENT_SECRET=insecure_secret
 OAUTH_PROVIDER_NAME=Authelia


### PR DESCRIPTION
Use the `subdomain-authelia` site variable instead of a hard coded value, similar to how it's done a few lines below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example environment variable for configuring Karakeep with Authelia as an OpenID Connect provider to use a configurable subdomain, ensuring consistency and flexibility in setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->