### PR TITLE
fix(oidc): rfc9068 jwt strategy not configured

### DIFF
--- a/internal/configuration/validator/identity_providers.go
+++ b/internal/configuration/validator/identity_providers.go
@@ -1408,6 +1408,12 @@ func validateOIDDClientSigningAlg(c int, config *schema.IdentityProvidersOpenIDC
 
 	key := fmt.Sprintf("%s_signed_response_alg", attribute)
 
+	if !config.Discovery.JWTResponseAccessTokens && attribute == attrOIDCAccessTokenPrefix {
+		if utils.IsStringInSlice(outAlg, validOIDCIssuerJWKSigningAlgs) {
+			config.Discovery.JWTResponseAccessTokens = true
+		}
+	}
+
 	switch outKID {
 	case "":
 		switch outAlg {

--- a/internal/configuration/validator/identity_providers_test.go
+++ b/internal/configuration/validator/identity_providers_test.go
@@ -3047,6 +3047,8 @@ func TestValidateOIDCClients(t *testing.T) {
 				assert.Equal(t, oidc.EncryptionEncA128CBCHS256, have.Clients[0].UserinfoEncryptedResponseEnc)
 				assert.Equal(t, oidc.EncryptionEncA128CBCHS256, have.Clients[0].IntrospectionEncryptedResponseEnc)
 				assert.Equal(t, oidc.EncryptionEncA128CBCHS256, have.Clients[0].AccessTokenEncryptedResponseEnc)
+
+				assert.True(t, have.Discovery.JWTResponseAccessTokens)
 			},
 			tcv{
 				nil,


### PR DESCRIPTION
This fixes an issue where the JWT Profile Access Token Strategy isn't configured when the user configures this kind of response type for one or more clients.

Fixes #9478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the JWT response access tokens flag in OpenID Connect provider configuration to ensure it is correctly updated based on signing algorithm validation.

- **Tests**
  - Enhanced test coverage to verify that the JWT response access tokens flag is set as expected in relevant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->