### PR TITLE
fix malformed redirect uri

### DIFF
--- a/docs/content/integration/openid-connect/minio/index.md
+++ b/docs/content/integration/openid-connect/minio/index.md
@@ -23,7 +23,7 @@ seo:
 - [Authelia]
   - [v4.39.2](https://github.com/authelia/authelia/releases/tag/v4.39.2)
 - [MinIO]
-  - [2025-03-12T18-04-18Z](https://github.com/minio/minio/releases/tag/RELEASE.2025-03-12T18-04-18Z)
+  - [2025-04-22T22-12-26Z](https://github.com/minio/minio/releases/tag/RELEASE.2025-04-22T22-12-26Z)
 
 {{% oidc-common %}}
 
@@ -85,7 +85,7 @@ MINIO_IDENTITY_OPENID_CONFIG_URL=https://{{< sitevar name="subdomain-authelia" n
 MINIO_IDENTITY_OPENID_CLIENT_ID=minio
 MINIO_IDENTITY_OPENID_CLIENT_SECRET=insecure_secret
 MINIO_IDENTITY_OPENID_SCOPES=openid,profile,email,groups
-MINIO_IDENTITY_OPENID_REDIRECT_URI=https://minio.{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/oauth_callback
+MINIO_IDENTITY_OPENID_REDIRECT_URI=https://minio.{{< sitevar name="domain" nojs="example.com" >}}/oauth_callback
 MINIO_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC=off
 MINIO_IDENTITY_OPENID_DISPLAY_NAME=Authelia
 MINIO_IDENTITY_OPENID_CLAIM_NAME=groups
@@ -102,7 +102,7 @@ services:
       MINIO_IDENTITY_OPENID_CLIENT_ID: 'minio'
       MINIO_IDENTITY_OPENID_CLIENT_SECRET: 'insecure_secret'
       MINIO_IDENTITY_OPENID_SCOPES: 'openid,profile,email,groups'
-      MINIO_IDENTITY_OPENID_REDIRECT_URI: 'https://minio.{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/oauth_callback'
+      MINIO_IDENTITY_OPENID_REDIRECT_URI: 'https://minio.{{< sitevar name="domain" nojs="example.com" >}}/oauth_callback'
       MINIO_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC: 'off'
       MINIO_IDENTITY_OPENID_DISPLAY_NAME: 'Authelia'
       MINIO_IDENTITY_OPENID_CLAIM_NAME: 'groups'


### PR DESCRIPTION
small, probably copy-paste related error regarding the redirect uri which led to the environment variable:

MINIO_IDENTITY_OPENID_REDIRECT_URI=https://minio.<subdomain-authelia>.<domain>/oauth_callback

The subdomain-authelia part is wrong at that point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated MinIO integration guide to reference the April 22, 2025 release.
  - Simplified example redirect URI in environment variable and Docker Compose configurations by removing the subdomain prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->