### PR TITLE
fix(webauthn): add conditional mediation

### DIFF
--- a/web/src/services/WebAuthn.ts
+++ b/web/src/services/WebAuthn.ts
@@ -110,7 +110,7 @@ export async function getWebAuthnResult(options: PublicKeyCredentialRequestOptio
     };
 
     try {
-        result.response = await startAuthentication({ optionsJSON: options });
+        result.response = await startAuthentication({ optionsJSON: options, useBrowserAutofill: true });
     } catch (e) {
         const exception = e as DOMException;
         if (exception !== undefined) {

--- a/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
+++ b/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
@@ -258,7 +258,7 @@ const FirstFactorForm = function (props: Props) {
                             onChange={(v) => setUsername(v.target.value)}
                             onFocus={() => setUsernameError(false)}
                             autoCapitalize="none"
-                            autoComplete="username"
+                            autoComplete="username webauthn"
                             onKeyDown={handleUsernameKeyDown}
                         />
                     </Grid>


### PR DESCRIPTION
This PR adds support for conditional mediation in the `LoginPortal` section of authelia. 


Relevant documentation I used, 

1. https://simplewebauthn.dev/docs/packages/browser#browser-autofill-conditional-ui
2. https://simplewebauthn.dev/docs/advanced/passkeys#startauthentication 
3. https://github.com/w3c/webauthn/wiki/Explainer:-WebAuthn-Conditional-UI


It has been tested on Safari on iPadOS and it seems to be working well. 

Fixes #9488 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved browser autofill support during WebAuthn authentication.
  - Enhanced username input field to better support autofill for Web Authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->