### PR TITLE
fix(configuration): oidc enc generated kid invalid chars

### DIFF
--- a/cmd/authelia-gen/cmd_misc.go
+++ b/cmd/authelia-gen/cmd_misc.go
@@ -64,13 +64,14 @@ func newMiscOIDCConformanceCmd() *cobra.Command {
 	cmd.Flags().StringSlice("suites", nil, "names of the plans to generate")
 	cmd.Flags().String("consent", "implicit", "name of the consent mode to use")
 	cmd.Flags().String("policy", "one_factor", "name of the authorization policy to use")
+	cmd.Flags().String("brand", "authelia", "brand name to use")
 
 	return cmd
 }
 
 func miscOIDCConformanceRunE(cmd *cobra.Command, args []string) (err error) {
 	var (
-		rawURL, version, token, consent, policy string
+		rawURL, version, token, consent, policy, brand string
 
 		autheliaURL, suiteURL *url.URL
 
@@ -109,11 +110,15 @@ func miscOIDCConformanceRunE(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	return miscOIDCConformance(version, token, consent, policy, autheliaURL, suiteURL, suiteNames...)
+	if brand, err = cmd.Flags().GetString("brand"); err != nil {
+		return err
+	}
+
+	return miscOIDCConformance(version, token, consent, policy, brand, autheliaURL, suiteURL, suiteNames...)
 }
 
-func miscOIDCConformance(version, token, consent, policy string, autheliaURL, suiteURL *url.URL, suiteNames ...string) (err error) {
-	suites := miscOIDCConformanceBuildSuites(version, consent, policy, suiteURL, autheliaURL, suiteNames...)
+func miscOIDCConformance(version, token, consent, policy, brand string, autheliaURL, suiteURL *url.URL, suiteNames ...string) (err error) {
+	suites := miscOIDCConformanceBuildSuites(version, consent, policy, brand, suiteURL, autheliaURL, suiteNames...)
 
 	clients := &OpenIDConnectClients{}
 
@@ -179,15 +184,15 @@ func miscOIDCConformance(version, token, consent, policy string, autheliaURL, su
 	return nil
 }
 
-func miscOIDCConformanceBuildSuites(version, consent, policy string, suiteURL, autheliaURL *url.URL, suiteNames ...string) (suites []OpenIDConnectConformanceSuite) {
+func miscOIDCConformanceBuildSuites(version, consent, policy, brand string, suiteURL, autheliaURL *url.URL, suiteNames ...string) (suites []OpenIDConnectConformanceSuite) {
 	builders := []*OpenIDConnectConformanceSuiteBuilder{
-		{"config", "Config", true, version, consent, policy, nil, autheliaURL},
-		{"basic", "Basic", true, version, consent, policy, suiteURL, autheliaURL},
-		{suiteNameBasicFormPost, "Basic (Form Post)", true, version, consent, policy, suiteURL, autheliaURL},
-		{"hybrid", "Hybrid", true, version, consent, policy, suiteURL, autheliaURL},
-		{suiteNameHybridFormPost, "Hybrid (Form Post)", true, version, consent, policy, suiteURL, autheliaURL},
-		{"implicit", "Implicit", true, version, consent, policy, suiteURL, autheliaURL},
-		{suiteNameImplicitFormPost, "Implicit (Form Post)", true, version, consent, policy, suiteURL, autheliaURL},
+		{brand, "config", "Config", true, version, consent, policy, nil, autheliaURL},
+		{brand, "basic", "Basic", true, version, consent, policy, suiteURL, autheliaURL},
+		{brand, suiteNameBasicFormPost, "Basic (Form Post)", true, version, consent, policy, suiteURL, autheliaURL},
+		{brand, "hybrid", "Hybrid", true, version, consent, policy, suiteURL, autheliaURL},
+		{brand, suiteNameHybridFormPost, "Hybrid (Form Post)", true, version, consent, policy, suiteURL, autheliaURL},
+		{brand, "implicit", "Implicit", true, version, consent, policy, suiteURL, autheliaURL},
+		{brand, suiteNameImplicitFormPost, "Implicit (Form Post)", true, version, consent, policy, suiteURL, autheliaURL},
 	}
 
 	for _, builder := range builders {

--- a/cmd/authelia-gen/cmd_misc_test.go
+++ b/cmd/authelia-gen/cmd_misc_test.go
@@ -36,7 +36,7 @@ func TestMiscOIDCConformanceBuildSuites(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := miscOIDCConformanceBuildSuites("4.00", "implicit", "one_factor", suiteURL, autheliaURL, tc.have...)
+			actual := miscOIDCConformanceBuildSuites("authelia", "4.00", "implicit", "one_factor", suiteURL, autheliaURL, tc.have...)
 
 			require.Len(t, actual, len(tc.expected))
 

--- a/cmd/authelia-gen/openid_conformance.go
+++ b/cmd/authelia-gen/openid_conformance.go
@@ -14,6 +14,7 @@ import (
 )
 
 type OpenIDConnectConformanceSuiteBuilder struct {
+	brand         string
 	name          string
 	friendly      string
 	certification bool
@@ -39,7 +40,7 @@ func (b *OpenIDConnectConformanceSuiteBuilder) Build() OpenIDConnectConformanceS
 		descriptionSuffix = "Test Profile"
 	}
 
-	aliasSuffix := fmt.Sprintf("%s-%s", strings.ReplaceAll(strings.ToLower(b.name), ".", "-"), strings.ReplaceAll(strings.ToLower(b.version), ".", ""))
+	aliasSuffix := fmt.Sprintf("%s-%s", strings.ReplaceAll(strings.ToLower(b.name), ".", "-"), b.brand+strings.ReplaceAll(strings.ToLower(b.version), ".", ""))
 
 	name := fmt.Sprintf("%s%s", namePrefix, b.name)
 	description := fmt.Sprintf("Authelia %s %s %s", b.version, b.friendly, descriptionSuffix)

--- a/cmd/authelia-gen/openid_conformance_test.go
+++ b/cmd/authelia-gen/openid_conformance_test.go
@@ -36,12 +36,12 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 	}{
 		{
 			"ShouldHandleConfig",
-			&OpenIDConnectConformanceSuiteBuilder{"config", "Config", true, "4.40", "implicit", "one_factor", nil, autheliaURL},
+			&OpenIDConnectConformanceSuiteBuilder{"authelia", "config", "Config", true, "4.40", "implicit", "one_factor", nil, autheliaURL},
 			OpenIDConnectConformanceSuite{
 				Name: "conformance-config",
 				Plan: OpenIDConnectConformanceSuitePlan{
 					Name:        "oidcc-config-certification-test-plan",
-					Alias:       "conformance-config-440",
+					Alias:       "conformance-config-authelia440",
 					Description: "Authelia 4.40 Config Certification Profile",
 					Publish:     "summary",
 					Server: OpenIDConnectConformanceSuitePlanServer{
@@ -52,12 +52,12 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 		},
 		{
 			"ShouldHandleBasic",
-			&OpenIDConnectConformanceSuiteBuilder{"basic", "Basic", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
+			&OpenIDConnectConformanceSuiteBuilder{"authelia", "basic", "Basic", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
 			OpenIDConnectConformanceSuite{
 				Name: "conformance-basic",
 				Plan: OpenIDConnectConformanceSuitePlan{
 					Name:        "oidcc-basic-certification-test-plan",
-					Alias:       "conformance-basic-440",
+					Alias:       "conformance-basic-authelia440",
 					Description: "Authelia 4.40 Basic Certification Profile",
 					Publish:     "summary",
 					Variant: &OpenIDConnectConformanceSuitePlanVariant{
@@ -68,25 +68,25 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
 					},
 					Client: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-basic-440",
+						ID:     "conformance-certification-basic-authelia440",
 						Secret: "present",
 					},
 					ClientAlternate: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-basic-440-alt",
+						ID:     "conformance-certification-basic-authelia440-alt",
 						Secret: "present",
 					},
 					ClientSecretPost: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-basic-440-post",
+						ID:     "conformance-certification-basic-authelia440-post",
 						Secret: "present",
 					},
 				},
 				Clients: []schema.IdentityProvidersOpenIDConnectClient{
 					{
-						ID:     "conformance-certification-basic-440",
+						ID:     "conformance-certification-basic-authelia440",
 						Name:   "Authelia 4.40 Basic Certification Profile",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-basic-440/callback",
+							"https://conformance.example.com/test/a/conformance-basic-authelia440/callback",
 						},
 						ResponseModes:           []string{"query", "query.jwt"},
 						ResponseTypes:           []string{"code"},
@@ -94,11 +94,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-basic-440-alt",
+						ID:     "conformance-certification-basic-authelia440-alt",
 						Name:   "Authelia 4.40 Basic Certification Profile (Alternate)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-basic-440/callback",
+							"https://conformance.example.com/test/a/conformance-basic-authelia440/callback",
 						},
 						ResponseModes:           []string{"query", "query.jwt"},
 						ResponseTypes:           []string{"code"},
@@ -106,11 +106,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-basic-440-post",
+						ID:     "conformance-certification-basic-authelia440-post",
 						Name:   "Authelia 4.40 Basic Certification Profile (Secret Post)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-basic-440/callback",
+							"https://conformance.example.com/test/a/conformance-basic-authelia440/callback",
 						},
 						ResponseModes:           []string{"query", "query.jwt"},
 						ResponseTypes:           []string{"code"},
@@ -122,12 +122,12 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 		},
 		{
 			"ShouldHandleBasicFormPost",
-			&OpenIDConnectConformanceSuiteBuilder{"basic-form-post", "Basic (Form Post)", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
+			&OpenIDConnectConformanceSuiteBuilder{"authelia", "basic-form-post", "Basic (Form Post)", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
 			OpenIDConnectConformanceSuite{
 				Name: "conformance-basic-form-post",
 				Plan: OpenIDConnectConformanceSuitePlan{
 					Name:        "oidcc-basic-form-post-certification-test-plan",
-					Alias:       "conformance-basic-form-post-440",
+					Alias:       "conformance-basic-form-post-authelia440",
 					Description: "Authelia 4.40 Basic (Form Post) Certification Profile",
 					Publish:     "summary",
 					Variant: &OpenIDConnectConformanceSuitePlanVariant{
@@ -138,25 +138,25 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
 					},
 					Client: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-basic-form-post-440",
+						ID:     "conformance-certification-basic-form-post-authelia440",
 						Secret: "present",
 					},
 					ClientAlternate: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-basic-form-post-440-alt",
+						ID:     "conformance-certification-basic-form-post-authelia440-alt",
 						Secret: "present",
 					},
 					ClientSecretPost: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-basic-form-post-440-post",
+						ID:     "conformance-certification-basic-form-post-authelia440-post",
 						Secret: "present",
 					},
 				},
 				Clients: []schema.IdentityProvidersOpenIDConnectClient{
 					{
-						ID:     "conformance-certification-basic-form-post-440",
+						ID:     "conformance-certification-basic-form-post-authelia440",
 						Name:   "Authelia 4.40 Basic (Form Post) Certification Profile",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-basic-form-post-440/callback",
+							"https://conformance.example.com/test/a/conformance-basic-form-post-authelia440/callback",
 						},
 						ResponseModes:           []string{"form_post", "form_post.jwt"},
 						ResponseTypes:           []string{"code"},
@@ -164,11 +164,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-basic-form-post-440-alt",
+						ID:     "conformance-certification-basic-form-post-authelia440-alt",
 						Name:   "Authelia 4.40 Basic (Form Post) Certification Profile (Alternate)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-basic-form-post-440/callback",
+							"https://conformance.example.com/test/a/conformance-basic-form-post-authelia440/callback",
 						},
 						ResponseModes:           []string{"form_post", "form_post.jwt"},
 						ResponseTypes:           []string{"code"},
@@ -176,11 +176,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-basic-form-post-440-post",
+						ID:     "conformance-certification-basic-form-post-authelia440-post",
 						Name:   "Authelia 4.40 Basic (Form Post) Certification Profile (Secret Post)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-basic-form-post-440/callback",
+							"https://conformance.example.com/test/a/conformance-basic-form-post-authelia440/callback",
 						},
 						ResponseModes:           []string{"form_post", "form_post.jwt"},
 						ResponseTypes:           []string{"code"},
@@ -192,12 +192,12 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 		},
 		{
 			"ShouldHandleImplicit",
-			&OpenIDConnectConformanceSuiteBuilder{"implicit", "Implicit", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
+			&OpenIDConnectConformanceSuiteBuilder{"authelia", "implicit", "Implicit", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
 			OpenIDConnectConformanceSuite{
 				Name: "conformance-implicit",
 				Plan: OpenIDConnectConformanceSuitePlan{
 					Name:        "oidcc-implicit-certification-test-plan",
-					Alias:       "conformance-implicit-440",
+					Alias:       "conformance-implicit-authelia440",
 					Description: "Authelia 4.40 Implicit Certification Profile",
 					Publish:     "summary",
 					Variant: &OpenIDConnectConformanceSuitePlanVariant{
@@ -208,25 +208,25 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
 					},
 					Client: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-implicit-440",
+						ID:     "conformance-certification-implicit-authelia440",
 						Secret: "present",
 					},
 					ClientAlternate: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-implicit-440-alt",
+						ID:     "conformance-certification-implicit-authelia440-alt",
 						Secret: "present",
 					},
 					ClientSecretPost: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-implicit-440-post",
+						ID:     "conformance-certification-implicit-authelia440-post",
 						Secret: "present",
 					},
 				},
 				Clients: []schema.IdentityProvidersOpenIDConnectClient{
 					{
-						ID:     "conformance-certification-implicit-440",
+						ID:     "conformance-certification-implicit-authelia440",
 						Name:   "Authelia 4.40 Implicit Certification Profile",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-implicit-440/callback",
+							"https://conformance.example.com/test/a/conformance-implicit-authelia440/callback",
 						},
 						ResponseModes:           []string{"query", "query.jwt"},
 						ResponseTypes:           []string{"code", "id_token", "token", "id_token token"},
@@ -234,11 +234,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-implicit-440-alt",
+						ID:     "conformance-certification-implicit-authelia440-alt",
 						Name:   "Authelia 4.40 Implicit Certification Profile (Alternate)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-implicit-440/callback",
+							"https://conformance.example.com/test/a/conformance-implicit-authelia440/callback",
 						},
 						ResponseModes:           []string{"query", "query.jwt"},
 						ResponseTypes:           []string{"code", "id_token", "token", "id_token token"},
@@ -246,11 +246,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-implicit-440-post",
+						ID:     "conformance-certification-implicit-authelia440-post",
 						Name:   "Authelia 4.40 Implicit Certification Profile (Secret Post)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-implicit-440/callback",
+							"https://conformance.example.com/test/a/conformance-implicit-authelia440/callback",
 						},
 						ResponseModes:           []string{"query", "query.jwt"},
 						ResponseTypes:           []string{"code", "id_token", "token", "id_token token"},
@@ -262,12 +262,12 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 		},
 		{
 			"ShouldHandleImplicitFormPost",
-			&OpenIDConnectConformanceSuiteBuilder{"implicit-form-post", "Implicit (Form Post)", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
+			&OpenIDConnectConformanceSuiteBuilder{"authelia", "implicit-form-post", "Implicit (Form Post)", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
 			OpenIDConnectConformanceSuite{
 				Name: "conformance-implicit-form-post",
 				Plan: OpenIDConnectConformanceSuitePlan{
 					Name:        "oidcc-implicit-form-post-certification-test-plan",
-					Alias:       "conformance-implicit-form-post-440",
+					Alias:       "conformance-implicit-form-post-authelia440",
 					Description: "Authelia 4.40 Implicit (Form Post) Certification Profile",
 					Publish:     "summary",
 					Variant: &OpenIDConnectConformanceSuitePlanVariant{
@@ -278,25 +278,25 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
 					},
 					Client: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-implicit-form-post-440",
+						ID:     "conformance-certification-implicit-form-post-authelia440",
 						Secret: "present",
 					},
 					ClientAlternate: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-implicit-form-post-440-alt",
+						ID:     "conformance-certification-implicit-form-post-authelia440-alt",
 						Secret: "present",
 					},
 					ClientSecretPost: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-implicit-form-post-440-post",
+						ID:     "conformance-certification-implicit-form-post-authelia440-post",
 						Secret: "present",
 					},
 				},
 				Clients: []schema.IdentityProvidersOpenIDConnectClient{
 					{
-						ID:     "conformance-certification-implicit-form-post-440",
+						ID:     "conformance-certification-implicit-form-post-authelia440",
 						Name:   "Authelia 4.40 Implicit (Form Post) Certification Profile",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-implicit-form-post-440/callback",
+							"https://conformance.example.com/test/a/conformance-implicit-form-post-authelia440/callback",
 						},
 						ResponseModes:           []string{"form_post", "form_post.jwt"},
 						ResponseTypes:           []string{"code", "id_token", "token", "id_token token"},
@@ -304,11 +304,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-implicit-form-post-440-alt",
+						ID:     "conformance-certification-implicit-form-post-authelia440-alt",
 						Name:   "Authelia 4.40 Implicit (Form Post) Certification Profile (Alternate)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-implicit-form-post-440/callback",
+							"https://conformance.example.com/test/a/conformance-implicit-form-post-authelia440/callback",
 						},
 						ResponseModes:           []string{"form_post", "form_post.jwt"},
 						ResponseTypes:           []string{"code", "id_token", "token", "id_token token"},
@@ -316,11 +316,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-implicit-form-post-440-post",
+						ID:     "conformance-certification-implicit-form-post-authelia440-post",
 						Name:   "Authelia 4.40 Implicit (Form Post) Certification Profile (Secret Post)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-implicit-form-post-440/callback",
+							"https://conformance.example.com/test/a/conformance-implicit-form-post-authelia440/callback",
 						},
 						ResponseModes:           []string{"form_post", "form_post.jwt"},
 						ResponseTypes:           []string{"code", "id_token", "token", "id_token token"},
@@ -332,12 +332,12 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 		},
 		{
 			"ShouldHandleHybrid",
-			&OpenIDConnectConformanceSuiteBuilder{"hybrid", "Hybrid", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
+			&OpenIDConnectConformanceSuiteBuilder{"authelia", "hybrid", "Hybrid", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
 			OpenIDConnectConformanceSuite{
 				Name: "conformance-hybrid",
 				Plan: OpenIDConnectConformanceSuitePlan{
 					Name:        "oidcc-hybrid-certification-test-plan",
-					Alias:       "conformance-hybrid-440",
+					Alias:       "conformance-hybrid-authelia440",
 					Description: "Authelia 4.40 Hybrid Certification Profile",
 					Publish:     "summary",
 					Variant: &OpenIDConnectConformanceSuitePlanVariant{
@@ -348,25 +348,25 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
 					},
 					Client: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-hybrid-440",
+						ID:     "conformance-certification-hybrid-authelia440",
 						Secret: "present",
 					},
 					ClientAlternate: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-hybrid-440-alt",
+						ID:     "conformance-certification-hybrid-authelia440-alt",
 						Secret: "present",
 					},
 					ClientSecretPost: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-hybrid-440-post",
+						ID:     "conformance-certification-hybrid-authelia440-post",
 						Secret: "present",
 					},
 				},
 				Clients: []schema.IdentityProvidersOpenIDConnectClient{
 					{
-						ID:     "conformance-certification-hybrid-440",
+						ID:     "conformance-certification-hybrid-authelia440",
 						Name:   "Authelia 4.40 Hybrid Certification Profile",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-hybrid-440/callback",
+							"https://conformance.example.com/test/a/conformance-hybrid-authelia440/callback",
 						},
 						ResponseModes:           []string{"query", "query.jwt"},
 						ResponseTypes:           []string{"code", "code id_token", "code token", "code id_token token"},
@@ -374,11 +374,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-hybrid-440-alt",
+						ID:     "conformance-certification-hybrid-authelia440-alt",
 						Name:   "Authelia 4.40 Hybrid Certification Profile (Alternate)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-hybrid-440/callback",
+							"https://conformance.example.com/test/a/conformance-hybrid-authelia440/callback",
 						},
 						ResponseModes:           []string{"query", "query.jwt"},
 						ResponseTypes:           []string{"code", "code id_token", "code token", "code id_token token"},
@@ -386,11 +386,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-hybrid-440-post",
+						ID:     "conformance-certification-hybrid-authelia440-post",
 						Name:   "Authelia 4.40 Hybrid Certification Profile (Secret Post)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-hybrid-440/callback",
+							"https://conformance.example.com/test/a/conformance-hybrid-authelia440/callback",
 						},
 						ResponseModes:           []string{"query", "query.jwt"},
 						ResponseTypes:           []string{"code", "code id_token", "code token", "code id_token token"},
@@ -402,12 +402,12 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 		},
 		{
 			"ShouldHandleHybridFormPost",
-			&OpenIDConnectConformanceSuiteBuilder{"hybrid-form-post", "Hybrid (Form Post)", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
+			&OpenIDConnectConformanceSuiteBuilder{"authelia", "hybrid-form-post", "Hybrid (Form Post)", true, "4.40", "implicit", "one_factor", suiteURL, autheliaURL},
 			OpenIDConnectConformanceSuite{
 				Name: "conformance-hybrid-form-post",
 				Plan: OpenIDConnectConformanceSuitePlan{
 					Name:        "oidcc-hybrid-form-post-certification-test-plan",
-					Alias:       "conformance-hybrid-form-post-440",
+					Alias:       "conformance-hybrid-form-post-authelia440",
 					Description: "Authelia 4.40 Hybrid (Form Post) Certification Profile",
 					Publish:     "summary",
 					Variant: &OpenIDConnectConformanceSuitePlanVariant{
@@ -418,25 +418,25 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
 					},
 					Client: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-hybrid-form-post-440",
+						ID:     "conformance-certification-hybrid-form-post-authelia440",
 						Secret: "present",
 					},
 					ClientAlternate: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-hybrid-form-post-440-alt",
+						ID:     "conformance-certification-hybrid-form-post-authelia440-alt",
 						Secret: "present",
 					},
 					ClientSecretPost: &OpenIDConnectConformanceSuitePlanClient{
-						ID:     "conformance-certification-hybrid-form-post-440-post",
+						ID:     "conformance-certification-hybrid-form-post-authelia440-post",
 						Secret: "present",
 					},
 				},
 				Clients: []schema.IdentityProvidersOpenIDConnectClient{
 					{
-						ID:     "conformance-certification-hybrid-form-post-440",
+						ID:     "conformance-certification-hybrid-form-post-authelia440",
 						Name:   "Authelia 4.40 Hybrid (Form Post) Certification Profile",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-hybrid-form-post-440/callback",
+							"https://conformance.example.com/test/a/conformance-hybrid-form-post-authelia440/callback",
 						},
 						ResponseModes:           []string{"form_post", "form_post.jwt"},
 						ResponseTypes:           []string{"code", "code id_token", "code token", "code id_token token"},
@@ -444,11 +444,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-hybrid-form-post-440-alt",
+						ID:     "conformance-certification-hybrid-form-post-authelia440-alt",
 						Name:   "Authelia 4.40 Hybrid (Form Post) Certification Profile (Alternate)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-hybrid-form-post-440/callback",
+							"https://conformance.example.com/test/a/conformance-hybrid-form-post-authelia440/callback",
 						},
 						ResponseModes:           []string{"form_post", "form_post.jwt"},
 						ResponseTypes:           []string{"code", "code id_token", "code token", "code id_token token"},
@@ -456,11 +456,11 @@ func TestOpenIDConnectConformanceSuiteBuilder_Build(t *testing.T) {
 						TokenEndpointAuthMethod: "client_secret_basic",
 					},
 					{
-						ID:     "conformance-certification-hybrid-form-post-440-post",
+						ID:     "conformance-certification-hybrid-form-post-authelia440-post",
 						Name:   "Authelia 4.40 Hybrid (Form Post) Certification Profile (Secret Post)",
 						Secret: secret,
 						RedirectURIs: []string{
-							"https://conformance.example.com/test/a/conformance-hybrid-form-post-440/callback",
+							"https://conformance.example.com/test/a/conformance-hybrid-form-post-authelia440/callback",
 						},
 						ResponseModes:           []string{"form_post", "form_post.jwt"},
 						ResponseTypes:           []string{"code", "code id_token", "code token", "code id_token token"},

--- a/cmd/dev/authelia
+++ b/cmd/dev/authelia
@@ -2,4 +2,4 @@
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-go run ${ROOT}/../authelia-gen "$@"
+go run ${ROOT}/../authelia "$@"

--- a/cmd/dev/authelia-scripts
+++ b/cmd/dev/authelia-scripts
@@ -2,4 +2,4 @@
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-go run ${ROOT}/../authelia-scripts $*
+go run ${ROOT}/../authelia-scripts "$@"

--- a/cmd/dev/authelia-suites
+++ b/cmd/dev/authelia-suites
@@ -2,4 +2,4 @@
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-go run ${ROOT}/../authelia-suites $*
+go run ${ROOT}/../authelia-suites "$@"

--- a/internal/configuration/validator/util.go
+++ b/internal/configuration/validator/util.go
@@ -227,6 +227,8 @@ func jwkCalculateKID(key schema.CryptographicKey, props *JWKProperties, alg stri
 		alg = props.Algorithm
 	}
 
+	alg = strings.ReplaceAll(alg, "+", ".")
+
 	var thumbprint []byte
 
 	if thumbprint, err = j.Thumbprint(crypto.SHA256); err != nil {


### PR DESCRIPTION
This fixes a case where the auto-generated kid for ECDSA encryption keys contained invalid characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a "brand" when running OpenID Connect conformance suites, affecting suite naming and client IDs.
  - Introduced a new development script for streamlined application execution with argument forwarding.

- **Bug Fixes**
  - Improved algorithm string handling by replacing "+" with "." in key ID calculations for better compatibility.

- **Chores**
  - Updated development scripts to forward command-line arguments correctly, preserving spaces and special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->