### PR TITLE
docs: update grafana attribute path to reference groups properly

### DIFF
--- a/docs/content/integration/openid-connect/grafana/index.md
+++ b/docs/content/integration/openid-connect/grafana/index.md
@@ -163,10 +163,13 @@ The role attribute path configuration is optional but allows mapping Authelia gr
 you do not wish to automatically do this you can just omit the `role_attribute_path` configuration option or
 `GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH` environment variable.
 
-The ways you can configure this rule value is vast as an examle if you wanted a default role of `Viewer`, but also
-wanted everyone in the `admin` Authelia group to be in the `Admin` role, and everyone in the `editor` Authelia group to
-be in the `Editor` role, a rule similar to
-`contains(groups, 'admin') && 'Admin' || contains(groups, 'editor') && 'Editor' || 'Viewer'` would be needed.
+The ways you can configure this rule value is vast, here is a simple example:
+- User's with the authelia group `admin` should be a member of the Grafana group `Admin`
+- User's with the authelia group `editor` should be a member of the Grafana group `Editor`
+- Everyone else should be a member of the Grafana group 'Viewer'
+
+To achieve the above structure you would use the following `role_attribute_path`:
+`contains(groups[*], 'admin') && 'Admin' || contains(groups[*], 'editor') && 'Editor' || 'Viewer'`
 
 See [Grafana Generic OAuth2 Documentation: Configure role mapping] for more information.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved the explanation and example for configuring `role_attribute_path` in the Grafana integration guide, making role mapping rules clearer and easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->