### PR TITLE
Adventurelog OIDC integration fixes

### DIFF
--- a/docs/content/integration/openid-connect/adventure-log/index.md
+++ b/docs/content/integration/openid-connect/adventure-log/index.md
@@ -82,7 +82,7 @@ To configure [AdventureLog] to utilize Authelia as an [OpenID Connect 1.0] Provi
    2. Select Settings.
    3. Click Launch Admin Panel.
 3. Scroll down to Social Accounts.
-4. Click Add.
+4. Under Social Applications, click Add.
 5. Configure the following options:
    - Provider: `OpenID Connect`
    - Provider ID: `adventurelog-authelia`
@@ -91,7 +91,8 @@ To configure [AdventureLog] to utilize Authelia as an [OpenID Connect 1.0] Provi
    - Secret Key: `insecure_secret`
    - Settings:
      `{"server_url": "https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}"}`
-   - Sites: Select the sites you want to enable OpenID Connect for.
+   - Sites: Select the sites you want to enable OpenID Connect for.  
+      (By default, you should add the pre-created `example.com` site.)
 6. Press `Save` at the bottom.
 
 Note: the `Provider ID` and `Client ID` configured in step 5 must be identical.

--- a/docs/content/integration/openid-connect/adventure-log/index.md
+++ b/docs/content/integration/openid-connect/adventure-log/index.md
@@ -90,8 +90,8 @@ To configure [AdventureLog] to utilize Authelia as an [OpenID Connect 1.0] Provi
    - Client ID: `adventurelog`
    - Secret Key: `insecure_secret`
    - Settings:
-     - server_url: `https://adventurelog.{{< sitevar name="domain" nojs="example.com" >}}`
-     - Sites: Select the sites you want to enable OpenID Connect for.
+     `{"server_url": "https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}"}`
+   - Sites: Select the sites you want to enable OpenID Connect for.
 6. Press `Save` at the bottom.
 
 

--- a/docs/content/integration/openid-connect/adventure-log/index.md
+++ b/docs/content/integration/openid-connect/adventure-log/index.md
@@ -33,7 +33,7 @@ This example makes the following assumptions:
 
 - __Application Root URL:__ `https://adventurelog.{{< sitevar name="domain" nojs="example.com" >}}/`
 - __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
-- __Client ID:__ `adventurelog`
+- __Client ID:__ `adventurelog-authelia`
 - __Client Secret:__ `insecure_secret`
 
 Some of the values presented in this guide can automatically be replaced with documentation variables.
@@ -53,13 +53,13 @@ identity_providers:
     ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
     ## See: https://www.authelia.com/c/oidc
     clients:
-      - client_id: 'adventurelog'
+      - client_id: 'adventurelog-authelia'
         client_name: 'Adventure Log'
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
         authorization_policy: 'two_factor'
         redirect_uris:
-          - 'https://adventurelog.{{< sitevar name="domain" nojs="example.com" >}}/accounts/oidc/login/callback/'
+          - 'https://adventurelog.{{< sitevar name="domain" nojs="example.com" >}}/accounts/oidc/adventurelog-authelia/login/callback/'
         scopes:
           - 'openid'
           - 'email'
@@ -85,14 +85,17 @@ To configure [AdventureLog] to utilize Authelia as an [OpenID Connect 1.0] Provi
 4. Click Add.
 5. Configure the following options:
    - Provider: `OpenID Connect`
-   - Provider ID: `authelia`
+   - Provider ID: `adventurelog-authelia`
    - Name: `Authelia`
-   - Client ID: `adventurelog`
+   - Client ID: `adventurelog-authelia`
    - Secret Key: `insecure_secret`
    - Settings:
      `{"server_url": "https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}"}`
    - Sites: Select the sites you want to enable OpenID Connect for.
 6. Press `Save` at the bottom.
+
+Note: the `Provider ID` and `Client ID` configured in step 5 must be identical.
+This is a known bug in the Adventurelog frontend, see [Issue 544](https://github.com/seanmorley15/AdventureLog/issues/544) and [PR 556](https://github.com/seanmorley15/AdventureLog/pull/556).
 
 
 ## Linking Existing Accounts


### PR DESCRIPTION
## Changes
Fixed three bugs in the Adventurelog oidc documentation:
 1. Changed the "server_url" in the Adventurelog Web GUI value from the adventurelog url to the authelia url.
 2. Set the `Provider ID` and `Client ID` both equal to `adventurelog-authelia`. They must be identical due to a bug in Adventurelog (https://github.com/seanmorley15/AdventureLog/issues/544 and https://github.com/seanmorley15/AdventureLog/pull/556).
 3. Changed `redirect_uris` in the `configuration.yaml` example to include the `adventurelog-authelia` part which is required.

Also added some clarifications about which `Add` button to click in the Adventurelog Web GUI and what `Sites` to add (which is required for a working configuration).

## Testing
All changes were tested on Authelia v4.39.3 and Adventurelog [v0.9.0](https://github.com/seanmorley15/AdventureLog/releases/tag/v0.9.0) both using docker containers.