### PR TITLE
docs: update ssf links

### DIFF
--- a/docs/content/blog/technical-oidc-nuances/index.md
+++ b/docs/content/blog/technical-oidc-nuances/index.md
@@ -182,15 +182,15 @@ So some astute readers may be thinking. Why do these _Claims_[^1] exist in the f
 primary functions. Obviously these functions are not an exhaustive list, but it should be enough to explain the
 principles.
 
-The first function of these _Claims_[^1] is to provide helpful information or hints to the Relying Party during a
+The first function of these _Claims_[^1] is to provide helpful information or hints to the _Relying Party_[^13] during a
 Registration Flow, or in some instances an Identity Binding Flow (i.e. binding the `sub` and `iss` _Claims_[^1] to an
 identity that already exists) when they're not already logged in. For example they may prefill a form.
 
-The second function of these _Claims_[^1] is to provide the Relying Party with information about a _Resource Owner_[^8]
+The second function of these _Claims_[^1] is to provide the _Relying Party_[^13] with information about a _Resource Owner_[^8]
 with an already bound identity that they may not want to store themselves; such as they may perform a Authorization Flow
 to temporarily obtain the _Resource Owners_[^8] address information for a purchase.
 
-The third function of these _Claims_[^1] is to provide the Relying Party a way to obtain updated details about a
+The third function of these _Claims_[^1] is to provide the _Relying Party_[^13] a way to obtain updated details about a
 _Resource Owner_[^8] who already has a bound identity. For example updating their contact details. This leads naturally
 into the next concept.
 
@@ -199,12 +199,22 @@ into the next concept.
 ## Claims Availability
 
 There are various ways to request and grant _Claims_[^1] in the [OpenID Connect 1.0] specification. Many assume that the
-_Claims_[^1] are either exclusively available in the _ID Token_[^3], will always be in the _ID Token_[^3], or even worse as we've
-previously found out in the _Access Token_[^2]. The assumption stems from the fact certain scopes grant the Relying Party
-access to certain sets of _Claims_[^1]. But what does the specification really intend?
+_Claims_[^1] are either exclusively available in the _ID Token_[^3], will always be in the _ID Token_[^3], or even worse
+as we've previously found out in the _Access Token_[^2]. The assumption stems from the fact certain scopes grant the
+_Relying Party_[^13] access to certain sets of _Claims_[^1]. But what does the specification really intend?
 
-Well if we dive into the _Claims_[^1] that are standard in the _ID Token_[^3], it has a very minimal set of _Claims_[^1]
-by default. It can contain more, and in some scenarios it should contain a lot of _Claims_[^1].
+> An identity token represents the outcome of an authentication process. It contains at a bare minimum an identifier for
+> the user (called the sub aka subject claim) and information about how and when the user authenticated. It can contain
+> additional identity data.
+
+This comes directly from the
+[OpenID Foundations "How OpenID Connect Works" article](https://openid.net/developers/how-connect-works/). This clearly
+indicates the _ID Token_[^3] contains a bare minimum information to identify a user as well as information about _how_
+and _when_ the user authenticated, and that it **_can_** contain additional identity data.
+
+If we dive into the _Claims_[^1] that are standard in the _ID Token_[^3], it has a very minimal set of _Claims_[^1]
+by default, and it's clear the ways in which a _Relying Party_[^13] may request additional _Claims_[^1] and in which
+scenarios it must contain additional _Claims_[^1].
 
 ### Scope Parameter
 
@@ -240,7 +250,7 @@ surrounding Claim Stability and Uniqueness, and then extrapolate that the reques
 _User Information Endpoint_[^10] could realistically have the most up-to-date information about the user; I feel like
 it all just makes complete sense.
 
-The question is if a Relying Party is not intending on using the _Access Token_[^2] to access the
+The question is if a _Relying Party_[^13] is not intending on using the _Access Token_[^2] to access the
 _User Information Endpoint_[^10] why are they not using the _Implicit Flow_[^16] with the _Response Mode_[^17] `form_post`
 since this flow is intended specifically to identify the user. Since they will not be issued an _Access Token_[^2], and
 only the _ID Token_[^3], and it's performed over `form_post`, and the _ID Token_[^3] is signed and potentially encrypted
@@ -264,11 +274,11 @@ _Implicit Flow_[^16] which only returns an _ID Token_[^3] can obtain additional 
 
 This is done via the [Claims Parameter]. The [Claims Parameter] allows requesting specific _Claims_[^1] be present in the
 _ID Token_[^3]. In addition it has the added benefit of allowing granular requests for specific _Claims_[^1] rather than
-granting an entire _Scope_[^14] which may have many useless _Claims_[^1] to the Relying Party.
+granting an entire _Scope_[^14] which may have many useless _Claims_[^1] to the _Relying Party_[^13].
 
 This clearly has several impactful elements to security, privacy, and usability. This is also the parameter that is used
 to indicate elements which are optional to consent to. I suspect most users have seen these dialogs which ask the user
-what properties they want to allow the Relying Party to be able to access, even if they were not fully conscious of it.
+what properties they want to allow the _Relying Party_[^13] to be able to access, even if they were not fully conscious of it.
 
 The advantages of using the _Claims_[^1] parameter makes it quite a desirable feature. You can specifically request the
 `openid` scope, and request the specific _Claims_[^1] you need access to, and you can request that these _Claims_[^1] are made
@@ -286,7 +296,7 @@ _Resource Owner_[^8]. This is also specifically defined in the [OpenID Connect 1
 which is either completely proprietary or described in [RFC9068](https://datatracker.ietf.org/doc/html/rfc9068). The
 Access Token is used to access resources.
 
-[^3]: An ID Token is a _JSON Web Token_[^4] which is described ing
+[^3]: An ID Token otherwise known as an Identity Token is a _JSON Web Token_[^4] which is described in
 [ID Token Section of OpenID Connect 1.0 Core](https://openid.net/specs/openid-connect-core-1_0.html). The ID Token is
 intentionally designed to identify a unique user and has a strictly defined format and contents.
 This is also specifically defined in the [OpenID Connect 1.0 Core Terminology].

--- a/docs/content/integration/openid-connect/introduction.md
+++ b/docs/content/integration/openid-connect/introduction.md
@@ -454,57 +454,59 @@ The advantages of this approach are as follows:
 The following support chart is a list of various specifications in the OpenID Connect 1.0 and OAuth 2.0 space that we've
 either implemented, have our eye on, or are refusing to implement.
 
-|                                                        Name                                                        |  Support  |                                       Additional Documentation                                       |
-|:------------------------------------------------------------------------------------------------------------------:|:---------:|:----------------------------------------------------------------------------------------------------:|
-|                                             [OpenID Connect Core 1.0]                                              | Certified |                                                 N/A                                                  |
-|                                           [OpenID Connect Discovery 1.0]                                           | Certified |                                                 N/A                                                  |
-|                                        [OAuth 2.0 Multiple Response Types]                                         | Certified |                                                 N/A                                                  |
-|                                        [OAuth 2.0 Form Post Response Mode]                                         | Certified |                                                 N/A                                                  |
-|                                  [OpenID Connect Dynamic Client Registration 1.0]                                  |   None    |                                                 N/A                                                  |
-|                                      [OpenID Connect RP-Initiated Logout 1.0]                                      |   None    |                                                 N/A                                                  |
-|                                      [OpenID Connect Session Management 1.0]                                       |   None    |                                                 N/A                                                  |
-|                                     [OpenID Connect Front-Channel Logout 1.0]                                      |   None    |                                                 N/A                                                  |
-|                                      [OpenID Connect Back-Channel Logout 1.0]                                      |   None    |                                                 N/A                                                  |
-|                                       [OpenID Connect 1.0 User Registration]                                       |   None    |                                                 N/A                                                  |
-|                [OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0] (CIBA)                 |   None    |                                                 N/A                                                  |
-|                                    [OpenID Shared Signals Framework 1.0] (SSF)                                     |   None    |                                                 N/A                                                  |
-|                                             [Proof Key Code Exchange]                                              | Certified |            [RFC7636], [OAuth 2.0 Simplified](https://www.oauth.com/oauth2-servers/pkce/)             |
-|                                                  [OAuth 2.0 Core]                                                  | Certified |                                              [RFC6749]                                               |
-|                                            [OAuth 2.0 Token Revocation]                                            | Complete  |                                              [RFC7009]                                               |
-|                                          [OAuth 2.0 Token Introspection]                                           | Complete  |                                              [RFC7662]                                               |
-|                                   JWT Response for OAuth 2.0 Token Introspection                                   | Complete  |                                              [RFC9701]                                               |
-|                                             [OAuth 2.0 Token Exchange]                                             |   None    |                                              [RFC8693]                                               |
-|                                      [OAuth 2.0 Dynamic Client Registration]                                       |   None    |                                              [RFC7591]                                               |
-|                                 [OAuth 2.0 Dynamic Client Registration Management]                                 |   None    |                                              [RFC7592]                                               |
-|                                   OAuth 2.0 Resource Owner Password Credentials                                    | None[^3]  |         [RFC6749 Section 1.3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-1.3.3)         |
-|                                     [OAuth 2.0 Authorization Server Metadata]                                      | Complete  |                                              [RFC8414]                                               |
-|                                     [OAuth 2.0 Pushed Authorization Requests]                                      | Complete  |                                              [RFC9126]                                               |
-|                                  [OAuth 2.0 Demonstrating of Proof of Possession]                                  |   None    |                                              [RFC9449]                                               |
-|                  [OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens]                  |   None    |                                              [RFC8705]                                               |
-|                                            [OAuth 2.0 for Native Apps]                                             | Complete  |                                              [RFC8252]                                               |
-|                           [OAuth 2.0 Device Flow / OAuth 2.0 Device Authorization Grant]                           | Complete  |                                              [RFC8628]                                               |
-|                                     [OAuth 2.0 JWT Profile for Access Tokens]                                      | Complete  |                                              [RFC9068]                                               |
-|                                      [OAuth 2.0 Rich Authorization Requests]                                       |   None    |                                              [RFC9396]                                               |
-|                      OAuth 2.0 JWT Profile for Client Authentication and Authorization Grants                      | Complete  |                                              [RFC7523]                                               |
-|                                OAuth 2.0 Step-up Authentication Challenge Protocol                                 |   None    |                                              [RFC9470]                                               |
-|                                          OAuth 2.0 for Browser-Based Apps                                          | Complete  |       [IETF Draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps)        |
-|                                  SD-JWT-based Verifiable Credentials (SD-JWT VC)                                   |   None    |            [IETF Draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc)            |
-|                                       Selective Disclosure for JWTs (SD-JWT)                                       |   None    |    [IETF Draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt)     |
-|                                         Resource Indicators for OAuth 2.0                                          |   None    |                                              [RFC8707]                                               |
-|                                             [OAuth 2.0 Bearer Tokens]                                              | Complete  |                                              [RFC6750]                                               |
-|                 [OAuth 2.0 Assertion Framework for Client Authentication and Authorization Grants]                 | Complete  |                                              [RFC7521]                                               |
-|                                            [OAuth 2.0 Private Key JWT]                                             | Complete  |                                              [RFC7521]                                               |
-|                                    OAuth 2.0 JWT-Secured Authorization Request                                     |   None    |                                              [RFC9101]                                               |
-|                                OAuth 2.0 Authorization Server Issuer Identification                                | Complete  |                                              [RFC9207]                                               |
-|                                       OAuth 2.0 Protected Resource Metadata                                        |   None    |                                              [RFC9728]                                               |
-|                                           OAuth 2.0 Resource Indicators                                            |   None    |                                              [RFC8707]                                               |
-|                                 OAuth 2.0 JWT Secured Authorization Response Mode                                  | Complete  |                                          [OpenID 1.0 JARM]                                           |
-|                                            [FAPI 2.0] Security Profile                                             |  Partial  |                                [OpenID 1.0 FAPI 2.0 Security Profile]                                |
-|                                             [FAPI 2.0] Message Signing                                             |  Partial  |                                [OpenID 1.0 FAPI 2.0 Message Signing]                                 |
-|                                             [FAPI 2.0] Attacker Model                                              |  Partial  |                                 [OpenID 1.0 FAPI 2.0 Attacker Model]                                 |
-|                                       Authentication Method Reference Values                                       | Complete  |                                              [RFC8176]                                               |
-| Security Assertion Markup Language (SAML) 2.0 Profile for OAuth 2.0 Client Authentication and Authorization Grants |   None    |                                              [RFC7522]                                               |
-|                                                JSON Web Token (JWT)                                                | Complete  |                                              [RFC7519]                                               |
+|                                                        Name                                                        |    Support    |                                   Additional Documentation                                    |
+|:------------------------------------------------------------------------------------------------------------------:|:-------------:|:---------------------------------------------------------------------------------------------:|
+|                                             [OpenID Connect Core 1.0]                                              |   Certified   |                                              N/A                                              |
+|                                           [OpenID Connect Discovery 1.0]                                           |   Certified   |                                              N/A                                              |
+|                                        [OAuth 2.0 Multiple Response Types]                                         |   Certified   |                                              N/A                                              |
+|                                        [OAuth 2.0 Form Post Response Mode]                                         |   Certified   |                                              N/A                                              |
+|                                  [OpenID Connect Dynamic Client Registration 1.0]                                  |     None      |                                              N/A                                              |
+|                                      [OpenID Connect RP-Initiated Logout 1.0]                                      |     None      |                                              N/A                                              |
+|                                      [OpenID Connect Session Management 1.0]                                       |     None      |                                              N/A                                              |
+|                                     [OpenID Connect Front-Channel Logout 1.0]                                      |     None      |                                              N/A                                              |
+|                                      [OpenID Connect Back-Channel Logout 1.0]                                      |     None      |                                              N/A                                              |
+|                                       [OpenID Connect 1.0 User Registration]                                       |     None      |                                              N/A                                              |
+|                [OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0] (CIBA)                 |     None      |                                              N/A                                              |
+|                                    [OpenID Shared Signals Framework 1.0] (SSF)                                     |     None      |                                              N/A                                              |
+|                           [OpenID Continuous Access Evaluation Profile 1.0] (CAEP - SSF)                           |     None      |                                              N/A                                              |
+|                                     [CAEP Interoperability Profile 1.0] (SSF)                                      |     None      |                                              N/A                                              |
+|                                             [Proof Key Code Exchange]                                              | Certified[^3] |         [RFC7636], [OAuth 2.0 Simplified](https://www.oauth.com/oauth2-servers/pkce/)         |
+|                                                  [OAuth 2.0 Core]                                                  | Certified[^3] |                                           [RFC6749]                                           |
+|                                            [OAuth 2.0 Token Revocation]                                            |   Complete    |                                           [RFC7009]                                           |
+|                                          [OAuth 2.0 Token Introspection]                                           |   Complete    |                                           [RFC7662]                                           |
+|                                   JWT Response for OAuth 2.0 Token Introspection                                   |   Complete    |                                           [RFC9701]                                           |
+|                                             [OAuth 2.0 Token Exchange]                                             |     None      |                                           [RFC8693]                                           |
+|                                      [OAuth 2.0 Dynamic Client Registration]                                       |     None      |                                           [RFC7591]                                           |
+|                                 [OAuth 2.0 Dynamic Client Registration Management]                                 |     None      |                                           [RFC7592]                                           |
+|                                   OAuth 2.0 Resource Owner Password Credentials                                    |   None[^4]    |     [RFC6749 Section 1.3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-1.3.3)      |
+|                                     [OAuth 2.0 Authorization Server Metadata]                                      |   Complete    |                                           [RFC8414]                                           |
+|                                     [OAuth 2.0 Pushed Authorization Requests]                                      |   Complete    |                                           [RFC9126]                                           |
+|                                  [OAuth 2.0 Demonstrating of Proof of Possession]                                  |     None      |                                           [RFC9449]                                           |
+|                  [OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens]                  |     None      |                                           [RFC8705]                                           |
+|                                            [OAuth 2.0 for Native Apps]                                             |   Complete    |                                           [RFC8252]                                           |
+|                           [OAuth 2.0 Device Flow / OAuth 2.0 Device Authorization Grant]                           |   Complete    |                                           [RFC8628]                                           |
+|                                     [OAuth 2.0 JWT Profile for Access Tokens]                                      |   Complete    |                                           [RFC9068]                                           |
+|                                      [OAuth 2.0 Rich Authorization Requests]                                       |     None      |                                           [RFC9396]                                           |
+|                      OAuth 2.0 JWT Profile for Client Authentication and Authorization Grants                      |   Complete    |                                           [RFC7523]                                           |
+|                                OAuth 2.0 Step-up Authentication Challenge Protocol                                 |     None      |                                           [RFC9470]                                           |
+|                                          OAuth 2.0 for Browser-Based Apps                                          |   Complete    |    [IETF Draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps)    |
+|                                  SD-JWT-based Verifiable Credentials (SD-JWT VC)                                   |     None      |        [IETF Draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc)         |
+|                                       Selective Disclosure for JWTs (SD-JWT)                                       |     None      | [IETF Draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt) |
+|                                         Resource Indicators for OAuth 2.0                                          |     None      |                                           [RFC8707]                                           |
+|                                             [OAuth 2.0 Bearer Tokens]                                              |   Complete    |                                           [RFC6750]                                           |
+|                 [OAuth 2.0 Assertion Framework for Client Authentication and Authorization Grants]                 |   Complete    |                                           [RFC7521]                                           |
+|                                            [OAuth 2.0 Private Key JWT]                                             |   Complete    |                                           [RFC7521]                                           |
+|                                    OAuth 2.0 JWT-Secured Authorization Request                                     |     None      |                                           [RFC9101]                                           |
+|                                OAuth 2.0 Authorization Server Issuer Identification                                |   Complete    |                                           [RFC9207]                                           |
+|                                       OAuth 2.0 Protected Resource Metadata                                        |     None      |                                           [RFC9728]                                           |
+|                                           OAuth 2.0 Resource Indicators                                            |     None      |                                           [RFC8707]                                           |
+|                                 OAuth 2.0 JWT Secured Authorization Response Mode                                  |   Complete    |                                       [OpenID 1.0 JARM]                                       |
+|                                            [FAPI 2.0] Security Profile                                             |    Partial    |                            [OpenID 1.0 FAPI 2.0 Security Profile]                             |
+|                                             [FAPI 2.0] Message Signing                                             |    Partial    |                             [OpenID 1.0 FAPI 2.0 Message Signing]                             |
+|                                             [FAPI 2.0] Attacker Model                                              |    Partial    |                             [OpenID 1.0 FAPI 2.0 Attacker Model]                              |
+|                                       Authentication Method Reference Values                                       |   Complete    |                                           [RFC8176]                                           |
+| Security Assertion Markup Language (SAML) 2.0 Profile for OAuth 2.0 Client Authentication and Authorization Grants |     None      |                                           [RFC7522]                                           |
+|                                                JSON Web Token (JWT)                                                |   Complete    |                                           [RFC7519]                                           |
 
 ## Footnotes
 
@@ -512,7 +514,10 @@ either implemented, have our eye on, or are refusing to implement.
       secret, which means the client secret itself must be stored using a plaintext format.
 [^2]: This algorithm is strongly discouraged due to concerns about its security and it is only supported for the purpose
       of compatibility.
-[^3]: The Resource Owner Password Grant is currently
+[^3]: This is [OpenID Certified™] by it being used within one or more conformance suites which have been
+      [OpenID Certified™]. This specification may not have a direct certification process but reasonable should be
+      assumed to be certified by the requirements of another certification process.
+[^4]: The Resource Owner Password Grant is currently
       [heavily discouraged and deprecated](https://oauth.net/2/grant-types/password/) by the OAuth 2.0 specifications
       body, disallowed by
       [OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/html/rfc9700#name-resource-owner-password-cre),
@@ -581,7 +586,9 @@ either implemented, have our eye on, or are refusing to implement.
 [OpenID Connect Front-Channel Logout 1.0]: https://openid.net/specs/openid-connect-frontchannel-1_0.html
 [OpenID Connect Back-Channel Logout 1.0]: https://openid.net/specs/openid-connect-backchannel-1_0.html
 [OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0]: https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html
-[OpenID Shared Signals Framework 1.0]: https://openid.net/specs/openid-sharedsignals-framework-1_0-ID3.html#name-management-api-for-set-even
+[OpenID Shared Signals Framework 1.0]: https://openid.net/specs/openid-sharedsignals-framework-1_0-ID3.html
+[OpenID Continuous Access Evaluation Profile 1.0]: https://openid.net/specs/openid-caep-1_0-ID2.html
+[CAEP Interoperability Profile 1.0]: https://openid.net/specs/openid-caep-interoperability-profile-1_0-ID1.html
 [OAuth 2.0 Multiple Response Types]: https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html
 [OAuth 2.0 Form Post Response Mode]: https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html
 [OAuth 2.0 Core]: https://oauth.net/2/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved formatting and clarity of the OpenID Connect and OAuth 2.0 support chart.
  - Added new entries for Continuous Access Evaluation Profile (CAEP) and its Interoperability Profile, including documentation links.
  - Updated certification notes and expanded footnotes for deprecated grant types.
  - Corrected and added relevant reference links.
  - Made minor adjustments to whitespace and capitalization for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->