### PR TITLE
Remove domain variable from about page

### DIFF
--- a/docs/content/information/about.md
+++ b/docs/content/information/about.md
@@ -18,8 +18,6 @@ seo:
 
 ## What is Authelia?
 
-{{< sitevar name="domain" nojs="example.com" >}}
-
 Authelia is a project with several open source developers who contribute to the project in their free time. We are not
 a company or another type of incorporated entity, and do not have any monetization model. Individuals and Organizations
 are free to contribute [financially](../contributing/prologue/financial.md) or with their time to the


### PR DESCRIPTION
The `{{< sitevar name="domain" nojs="example.com" >}}` domain variable doesn't seem to have any practical value in the [about page of the site.](https://www.authelia.com/information/about/#what-is-authelia) In my opinion it should be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed a shortcode reference from the "What is Authelia?" section for improved clarity. No other content changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->