### PR TITLE
fix(web): adjust contrast for iv buttons and text input

### DIFF
--- a/web/src/components/OneTimeCodeTextField.tsx
+++ b/web/src/components/OneTimeCodeTextField.tsx
@@ -6,14 +6,17 @@ const OneTimeCodeTextField = function (props: TextFieldProps) {
     return (
         <TextField
             {...props}
-            inputProps={{
-                style: {
-                    textTransform: "uppercase",
-                    textAlign: "center",
-                    letterSpacing: ".5rem",
+            slotProps={{
+                htmlInput: {
+                    style: {
+                        textTransform: "uppercase",
+                        textAlign: "center",
+                        letterSpacing: ".5rem",
+                    },
                 },
             }}
             variant={"outlined"}
+            color={"info"}
             spellCheck={false}
         />
     );

--- a/web/src/views/Settings/Common/IdentityVerificationDialog.tsx
+++ b/web/src/views/Settings/Common/IdentityVerificationDialog.tsx
@@ -215,7 +215,7 @@ const IdentityVerificationDialog = function (props: Props) {
                 <DialogActions>
                     <Button
                         id={"dialog-cancel"}
-                        variant={"outlined"}
+                        variant={"contained"}
                         color={"error"}
                         disabled={loading}
                         onClick={handleCancelled}
@@ -224,8 +224,8 @@ const IdentityVerificationDialog = function (props: Props) {
                     </Button>
                     <Button
                         id={"dialog-verify"}
-                        variant={"outlined"}
-                        color={"primary"}
+                        variant={"contained"}
+                        color={"info"}
                         disabled={loading}
                         startIcon={loading ? <CircularProgress color="inherit" size={20} /> : undefined}
                         onClick={handleSubmit}

--- a/web/src/views/Settings/TwoFactorAuthentication/OneTimePasswordRegisterDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/OneTimePasswordRegisterDialog.tsx
@@ -477,8 +477,10 @@ const OneTimePasswordRegisterDialog = function (props: Props) {
                                         className={classes.secret}
                                         value={secretURL === null ? "" : secretURL}
                                         multiline={true}
-                                        InputProps={{
-                                            readOnly: true,
+                                        slotProps={{
+                                            input: {
+                                                readOnly: true,
+                                            },
                                         }}
                                     />
                                 </Grid>

--- a/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialEditDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialEditDialog.tsx
@@ -109,7 +109,11 @@ const WebAuthnCredentialEditDialog = function (props: Props) {
                     error={errorDescription}
                     fullWidth
                     disabled={false}
-                    inputProps={{ maxLength: 30 }}
+                    slotProps={{
+                        htmlInput: {
+                            maxLength: 30,
+                        },
+                    }}
                     onChange={(v) => {
                         setCredentialDescription(v.target.value.substring(0, 30));
                         setErrorDescription(false);


### PR DESCRIPTION
This pr also moves a couple components to the new `slotProps` from the depreciated `inputProps`.

This is the current format for the identity verification dialog with harder to see buttons and text field.
![old identity verification dialog with hard to see buttons](https://github.com/user-attachments/assets/f98b6731-e2cf-4725-852f-790c8278952f)

This is the new one with a different color used for the text box and a different variant for the button.
The color used for the "verify button" was changed to 'info' to ensure the color is consistent across themes.
![new identity verification image with better button contrast](https://github.com/user-attachments/assets/431ce099-3976-443f-875d-87fe95922ab0)
