### PR TITLE
release: v4.39.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -34,6 +34,7 @@ body:
         What version(s) of Authelia can you reproduce this bug on?
       multiple: true
       options:
+        - 'v4.39.4'
         - 'v4.39.3'
         - 'v4.39.2'
         - 'v4.39.1'

--- a/docs/content/integration/openid-connect/adventure-log/index.md
+++ b/docs/content/integration/openid-connect/adventure-log/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [AdventureLog]
   - [v0.9.0](https://github.com/seanmorley15/AdventureLog/releases/tag/v0.9.0)
 

--- a/docs/content/integration/openid-connect/apache-guacamole/index.md
+++ b/docs/content/integration/openid-connect/apache-guacamole/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Apache Guacamole]
   - [v1.5.5](https://guacamole.apache.org/releases/1.5.5/)
 

--- a/docs/content/integration/openid-connect/beszel/index.md
+++ b/docs/content/integration/openid-connect/beszel/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Beszel]
   - [v0.10.2](https://github.com/henrygd/beszel/releases/tag/v0.10.2)
 

--- a/docs/content/integration/openid-connect/chronograf/index.md
+++ b/docs/content/integration/openid-connect/chronograf/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Chronograf]
   - [v1.10.7](https://docs.influxdata.com/chronograf/v1/about_the_project/release-notes/#v1107)
 

--- a/docs/content/integration/openid-connect/drupal/index.md
+++ b/docs/content/integration/openid-connect/drupal/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Drupal]
   - [v10.4.0](https://www.drupal.org/project/drupal/releases/10.4.0)
 

--- a/docs/content/integration/openid-connect/gatus/index.md
+++ b/docs/content/integration/openid-connect/gatus/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Gatus]
   - [v5.17.0](https://github.com/TwiN/gatus/releases/tag/v5.17.0)
 

--- a/docs/content/integration/openid-connect/glitchtip/index.md
+++ b/docs/content/integration/openid-connect/glitchtip/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Glitchtip]
   - [v4.2](https://glitchtip.com/blog/2024-11-01-glitchtip-4-2-release)
 

--- a/docs/content/integration/openid-connect/gravitee/index.md
+++ b/docs/content/integration/openid-connect/gravitee/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Gravitee]
   - [v4.7](https://documentation.gravitee.io/apim/overview/release-notes/apim-4.7)
 

--- a/docs/content/integration/openid-connect/home-assistant/index.md
+++ b/docs/content/integration/openid-connect/home-assistant/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Home Assistant]
   - Application:
     - [v2025.4.2](https://github.com/home-assistant/core/releases/tag/2025.4.2)

--- a/docs/content/integration/openid-connect/komodo/index.md
+++ b/docs/content/integration/openid-connect/komodo/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Komodo]
   - [v1.17.5](https://github.com/moghtech/komodo/releases/tag/v1.17.5)
 

--- a/docs/content/integration/openid-connect/mailcow/index.md
+++ b/docs/content/integration/openid-connect/mailcow/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Mailcow]
   - [v2025-03](https://github.com/mailcow/mailcow-dockerized/releases/tag/2025-03)
 

--- a/docs/content/integration/openid-connect/meshcentral/index.md
+++ b/docs/content/integration/openid-connect/meshcentral/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [MeshCentral]
   - [v1.1.44](https://github.com/Ylianst/MeshCentral/releases/tag/1.1.44)
 

--- a/docs/content/integration/openid-connect/miniflux/index.md
+++ b/docs/content/integration/openid-connect/miniflux/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Miniflux]
   - [v2.2.8](https://github.com/miniflux/v2/releases/tag/2.2.8)
 

--- a/docs/content/integration/openid-connect/minio/index.md
+++ b/docs/content/integration/openid-connect/minio/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [MinIO]
   - [2025-04-22T22-12-26Z](https://github.com/minio/minio/releases/tag/RELEASE.2025-04-22T22-12-26Z)
 

--- a/docs/content/integration/openid-connect/openid-connect-playground/index.md
+++ b/docs/content/integration/openid-connect/openid-connect-playground/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [OpenID Connect Playground]
   - Not Applicable
 

--- a/docs/content/integration/openid-connect/openproject/index.md
+++ b/docs/content/integration/openid-connect/openproject/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [OpenProject]
   - [v15.4.2](https://www.openproject.org/docs/release-notes/#1550)
 

--- a/docs/content/integration/openid-connect/opkssh/index.md
+++ b/docs/content/integration/openid-connect/opkssh/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [opkssh]
   - [v0.4.0](https://github.com/openpubkey/opkssh/releases/tag/v0.4.0)
 

--- a/docs/content/integration/openid-connect/pangolin/index.md
+++ b/docs/content/integration/openid-connect/pangolin/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Pangolin]
   - [v1.3.1](https://github.com/fosrl/pangolin/releases/tag/1.3.1)
 

--- a/docs/content/integration/openid-connect/plesk/index.md
+++ b/docs/content/integration/openid-connect/plesk/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Plesk]
   - [v18.0.69](https://docs.plesk.com/release-notes/obsidian/change-log/#plesk-18069)
 

--- a/docs/content/integration/openid-connect/rustdesk-server-pro/index.md
+++ b/docs/content/integration/openid-connect/rustdesk-server-pro/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [RustDesk Server Pro]
   - [v1.3.9](https://github.com/rustdesk/rustdesk/releases/tag/1.3.9)
 

--- a/docs/content/integration/openid-connect/semaphore/index.md
+++ b/docs/content/integration/openid-connect/semaphore/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Semaphore]
   - [v2.13.14](https://github.com/semaphoreui/semaphore/releases/tag/v2.13.14)
 

--- a/docs/content/integration/openid-connect/sftpgo/index.md
+++ b/docs/content/integration/openid-connect/sftpgo/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [SFTPGo]
   - [v2.6.6](https://github.com/drakkan/sftpgo/releases/tag/v2.6.6)
 

--- a/docs/content/integration/openid-connect/stalwart/index.md
+++ b/docs/content/integration/openid-connect/stalwart/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Stalwart]
   - [v0.11.7](https://github.com/stalwartlabs/mail-server/releases/tag/v0.11.7)
 

--- a/docs/content/integration/openid-connect/synapse/index.md
+++ b/docs/content/integration/openid-connect/synapse/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Synapse]
   - [v1.127.1](https://github.com/element-hq/synapse/releases/tag/v1.127.1)
 

--- a/docs/content/integration/openid-connect/tandoor/index.md
+++ b/docs/content/integration/openid-connect/tandoor/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Tandoor]
   - [v1.5.34](https://github.com/TandoorRecipes/recipes/releases/tag/1.5.34)
 

--- a/docs/content/integration/openid-connect/xen-orchestra/index.md
+++ b/docs/content/integration/openid-connect/xen-orchestra/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [Xen Orchestra]
   - [v5.105](https://xen-orchestra.com/blog/xen-orchestra-5-105/)
 

--- a/docs/content/integration/openid-connect/youtrack/index.md
+++ b/docs/content/integration/openid-connect/youtrack/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.3](https://github.com/authelia/authelia/releases/tag/v4.39.3)
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [YouTrack]
   - 2025.1
 

--- a/docs/data/misc.json
+++ b/docs/data/misc.json
@@ -4,7 +4,7 @@
         "development": "default-src 'self' 'unsafe-eval'; frame-src 'none'; object-src 'none'; style-src 'self' 'nonce-${NONCE}'; frame-ancestors 'none'; base-uri 'self'",
         "nonce": "${NONCE}"
     },
-    "latest": "4.39.3",
+    "latest": "4.39.4",
     "support": {
         "traefik": [
             "v3.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authelia",
-  "version": "4.39.3",
+  "version": "4.39.4",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documented tested version of Authelia from v4.39.3 to v4.39.4 across multiple OpenID Connect integration guides. No other content or configuration details were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->