### PR TITLE
Update integration docs for FreshRSS

### DIFF
--- a/docs/content/integration/openid-connect/freshrss/index.md
+++ b/docs/content/integration/openid-connect/freshrss/index.md
@@ -42,12 +42,6 @@ Some of the values presented in this guide can automatically be replaced with do
 
 {{< sitevar-preferences >}}
 
-### Special Notes
-
-1. The [FreshRSS] implementation seems to always include the port in the requested `redirect_uri`. As Authelia strictly
-   conforms to the specifications this means the client registration **_MUST_** include the port for the requested
-   `redirect_uri` to match.
-
 ## Configuration
 
 ### Authelia
@@ -67,7 +61,7 @@ identity_providers:
         public: false
         authorization_policy: 'two_factor'
         redirect_uris:
-          - 'https://freshrss.{{< sitevar name="domain" nojs="example.com" >}}:443/i/oidc/'
+          - 'https://freshrss.{{< sitevar name="domain" nojs="example.com" >}}/i/oidc/'
         scopes:
           - 'openid'
           - 'groups'


### PR DESCRIPTION
The port 443 is no longer required - see https://freshrss.github.io/FreshRSS/en/admins/16_OpenID-Connect.html, where their instructions do not include the port. In fact, for me it _only_ works _without_ the port.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated integration guide for FreshRSS by removing notes about port requirements in redirect URIs.
  - Adjusted example client configuration to exclude the explicit port from the redirect URI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->