### PR TITLE
fix(embed): unable to run services

### DIFF
--- a/experimental/embed/context.go
+++ b/experimental/embed/context.go
@@ -2,12 +2,60 @@ package embed
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/authelia/authelia/v4/experimental/embed/provider"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/middlewares"
 )
+
+// New creates a new instance of the embedded Authelia context. This can later be used with embed.ServiceRunAll.
+func New(paths []string, filterNames []string) (ctx Context, val *schema.StructValidator, err error) {
+	if len(paths) == 0 {
+		return nil, nil, fmt.Errorf("no paths provided")
+	}
+
+	filters, err := NewNamedConfigFileFilters(filterNames...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keys, config, val, err := NewConfiguration(paths, filters)
+	if err != nil {
+		return nil, val, err
+	}
+
+	ValidateConfigurationAndKeys(config, keys, val)
+
+	if val.HasErrors() {
+		return nil, val, fmt.Errorf("configuration validation errors")
+	}
+
+	providers, warns, errs := provider.New(config, nil)
+
+	for _, warn := range warns {
+		val.PushWarning(warn)
+	}
+
+	for _, err = range errs {
+		val.Push(err)
+	}
+
+	if val.HasErrors() {
+		return nil, val, fmt.Errorf("provider validation errors")
+	}
+
+	ctx = &ctxEmbed{
+		Configuration:      (*Configuration)(config),
+		ConfigurationPaths: paths,
+		Logger:             logrus.NewEntry(logrus.StandardLogger()),
+		Providers:          Providers(providers),
+	}
+
+	return ctx, nil, err
+}
 
 // Context is an interface used in various areas of Authelia to simplify access to important elements like the
 // configuration, providers, and logger.
@@ -15,20 +63,27 @@ type Context interface {
 	GetLogger() *logrus.Entry
 	GetProviders() middlewares.Providers
 	GetConfiguration() *schema.Configuration
+	GetConfigurationPaths() (paths []string)
 
 	context.Context
 }
 
 type ctxEmbed struct {
-	Configuration *Configuration
-	Providers     Providers
-	Logger        *logrus.Entry
+	Configuration      *Configuration
+	ConfigurationPaths []string
+
+	Providers Providers
+	Logger    *logrus.Entry
 
 	context.Context
 }
 
 func (c *ctxEmbed) GetConfiguration() *schema.Configuration {
 	return c.Configuration.ToInternal()
+}
+
+func (c *ctxEmbed) GetConfigurationPaths() (paths []string) {
+	return c.ConfigurationPaths
 }
 
 func (c *ctxEmbed) GetProviders() middlewares.Providers {
@@ -41,4 +96,5 @@ func (c *ctxEmbed) GetLogger() *logrus.Entry {
 
 var (
 	_ middlewares.Context = (*ctxEmbed)(nil)
+	_ Context             = (*ctxEmbed)(nil)
 )

--- a/experimental/embed/embed.go
+++ b/experimental/embed/embed.go
@@ -1,7 +1,30 @@
 package embed
 
+import (
+	"fmt"
+
+	"github.com/authelia/authelia/v4/internal/service"
+)
+
 func ProvidersStartupCheck(ctx Context, log bool) (err error) {
 	providers := ctx.GetProviders()
 
 	return providers.StartupChecks(ctx, log)
+}
+
+// ServiceRunAll runs all services given a context.
+func ServiceRunAll(ctx Context) (err error) {
+	if ctx == nil {
+		return fmt.Errorf("no context provided")
+	}
+
+	if ctx.GetConfiguration() == nil {
+		return fmt.Errorf("no configuration provided")
+	}
+
+	if ctx.GetLogger() == nil {
+		return fmt.Errorf("no logger provided")
+	}
+
+	return service.RunAll(ctx)
 }


### PR DESCRIPTION
This fixes an issue where there is no way to run the embedded Authelia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to create an embedded context instance from configuration file paths, with enhanced validation and error reporting.
  - Introduced a method to retrieve the configuration file paths used for context creation.
  - Added a new function to run all services with improved validation of context and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->