### PR TITLE
feat(configuration): reload

### DIFF
--- a/cmd/authelia/main.go
+++ b/cmd/authelia/main.go
@@ -1,13 +1,27 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/authelia/authelia/v4/internal/commands"
+	"github.com/authelia/authelia/v4/internal/service"
 )
 
 func main() {
-	if err := commands.NewRootCmd().Execute(); err != nil {
-		os.Exit(1)
+	cmd := commands.NewRootCmd()
+
+	for {
+		reload := service.IsConfigFileWatcherEnabled()
+
+		if err := cmd.Execute(); err != nil {
+			if reload && errors.Is(err, service.ErrApplicationReload) {
+				continue
+			}
+
+			os.Exit(1)
+		}
+
+		break
 	}
 }

--- a/cmd/authelia/main.go
+++ b/cmd/authelia/main.go
@@ -10,15 +10,24 @@ import (
 	"os"
 
 	"github.com/authelia/authelia/v4/internal/commands"
+	"github.com/authelia/authelia/v4/internal/service"
 )
 
 func main() {
-	if err := commands.NewRootCmd().Execute(); err != nil {
-		switch {
-		case errors.Is(err, commands.ErrConfigCreated):
-			os.Exit(0)
-		default:
-			os.Exit(1)
+	for {
+		// A new root command is built for every iteration as the reload must not reuse any state from the previous
+		// run, most notably the loaded configuration and the provisioned providers.
+		if err := commands.NewRootCmd().Execute(); err != nil {
+			switch {
+			case errors.Is(err, service.ErrApplicationReload):
+				continue
+			case errors.Is(err, commands.ErrConfigCreated):
+				os.Exit(0)
+			default:
+				os.Exit(1)
+			}
 		}
+
+		return
 	}
 }

--- a/docs/content/configuration/methods/files.md
+++ b/docs/content/configuration/methods/files.md
@@ -18,10 +18,12 @@ seo:
 
 There are several options which affect the loading of files:
 
-|           Name           |            Argument             |    Environment Variable     |                                    Description                                     |
-|:------------------------:|:-------------------------------:|:---------------------------:|:----------------------------------------------------------------------------------:|
-|   Configuration Paths    |        `--config`, `-c`         |     `X_AUTHELIA_CONFIG`     | A list of file or directory (non-recursive) paths to load configuration files from |
-| [Filters](#file-filters) | `--config.experimental.filters` | `X_AUTHELIA_CONFIG_FILTERS` |   A list of filters applied to every file from the Files or Directories options    |
+|                 Name                  |            Argument             |       Environment Variable       |                                    Description                                     |
+|:-------------------------------------:|:-------------------------------:|:--------------------------------:|:----------------------------------------------------------------------------------:|
+|          Configuration Paths          |        `--config`, `-c`         |       `X_AUTHELIA_CONFIG`        | A list of file or directory (non-recursive) paths to load configuration files from |
+|         Configuration Reload          |               N/A               |    `X_AUTHELIA_CONFIG_RELOAD`    | Enables reloading Authelia on the modification of one of the defined config paths  |
+| Configuration Reload Additional Paths |               N/A               | `X_AUTHELIA_CONFIG_RELOAD_PATHS` |    A list of additional paths to the watcher which are not configuration paths     |
+|       [Filters](#file-filters)        | `--config.experimental.filters` |   `X_AUTHELIA_CONFIG_FILTERS`    |   A list of filters applied to every file from the Files or Directories options    |
 
 ### Configuration Paths
 
@@ -41,6 +43,30 @@ Configuration options can be discovered via either the Argument or Environment V
 If both are specified the Argument takes precedence and the Environment Variable is ignored. It is generally recommended
 that if you're using a container that you use the Environment Variable as this will allow you to execute other commands
 from the context of the container more easily.
+
+### Configuration Reload
+
+{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
+If the configuration reload fails to validate the configuration or a provider fails to initialize this will cause an
+intentional crash of Authelia. This is expected behaviour and will not be changed. Users are expected to validate their
+configuration before writing the changes to disk.
+
+Changing a path that used to be a file into a directory is also not supported. Performing this action could result in
+unexpected and undesirable behaviour.
+{{< /callout >}}
+
+In the instance of a file system notify event being observed that is a file path defined in the
+[Configuration Paths](#configuration-paths), this will trigger a reload.
+
+In the instance of a file system change being
+observed that is a file within a directory path defined in the [Configuration Paths](#configuration-paths) this will
+also cause a reload, regardless if the file is effectively a configuration file or not, and regardless of the type of
+file system notify event that was observed.
+
+In addition to the configuration paths you can define additional paths which will cause a reload with the
+`X_AUTHELIA_CONFIG_RELOAD_PATHS` environment variable. These paths are not included in the configuration, and this makes
+this option useful for folders that include secrets. This value is a comma separated list of paths which can either be
+a file or a directory.
 
 ## Formats
 

--- a/docs/content/configuration/methods/files.md
+++ b/docs/content/configuration/methods/files.md
@@ -22,10 +22,12 @@ seo:
 
 There are several options which affect the loading of files:
 
-|           Name           |            Argument             |    Environment Variable     |                                    Description                                     |
-| :----------------------: | :-----------------------------: | :-------------------------: | :--------------------------------------------------------------------------------: |
-|   Configuration Paths    |        `--config`, `-c`         |     `X_AUTHELIA_CONFIG`     | A list of file or directory (non-recursive) paths to load configuration files from |
-| [Filters](#file-filters) | `--config.experimental.filters` | `X_AUTHELIA_CONFIG_FILTERS` |   A list of filters applied to every file from the Files or Directories options    |
+|                 Name                  |            Argument             |       Environment Variable       |                                    Description                                     |
+| :-----------------------------------: | :-----------------------------: | :------------------------------: | :--------------------------------------------------------------------------------: |
+|          Configuration Paths          |        `--config`, `-c`         |       `X_AUTHELIA_CONFIG`        | A list of file or directory (non-recursive) paths to load configuration files from |
+|         Configuration Reload          |               N/A               |    `X_AUTHELIA_CONFIG_RELOAD`    | Enables reloading Authelia on the modification of one of the defined config paths  |
+| Configuration Reload Additional Paths |               N/A               | `X_AUTHELIA_CONFIG_RELOAD_PATHS` |    A list of additional paths to the watcher which are not configuration paths     |
+|       [Filters](#file-filters)        | `--config.experimental.filters` |   `X_AUTHELIA_CONFIG_FILTERS`    |   A list of filters applied to every file from the Files or Directories options    |
 
 ### Configuration Paths
 
@@ -45,6 +47,38 @@ Configuration options can be discovered via either the Argument or Environment V
 If both are specified the Argument takes precedence and the Environment Variable is ignored. It is generally recommended
 that if you're using a container that you use the Environment Variable as this will allow you to execute other commands
 from the context of the container more easily.
+
+### Configuration Reload
+
+{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
+If the configuration reload fails to validate the configuration or a provider fails to initialize this will cause an
+intentional crash of Authelia. This is expected behavior and will not be changed. Users are expected to validate their
+configuration before writing the changes to disk.
+
+Changing a path that used to be a file into a directory is also not supported. Performing this action could result in
+unexpected and undesirable behavior.
+{{< /callout >}}
+
+In the instance of a file system notify event being observed that is a file path defined in the
+[Configuration Paths](#configuration-paths), this will trigger a reload.
+
+In the instance of a file system change being
+observed that is a file within a directory path defined in the [Configuration Paths](#configuration-paths) this will
+also cause a reload, regardless if the file is effectively a configuration file or not, and regardless of the type of
+file system notify event that was observed.
+
+In addition to the configuration paths you can define additional paths which will cause a reload with the
+`X_AUTHELIA_CONFIG_RELOAD_PATHS` environment variable. These paths are not included in the configuration, and this makes
+this option useful for folders that include secrets. This value is a comma separated list of paths which can either be
+a file or a directory.
+
+A reload can also be triggered manually at any time, regardless of whether the `X_AUTHELIA_CONFIG_RELOAD` environment
+variable is enabled, by sending the `SIGHUP` signal to the Authelia process.
+
+{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
+Prior to v4.40.0 the `SIGHUP` signal caused the log file to be reopened. This behavior has moved to the `SIGUSR1`
+signal, and log rotation configurations which send `SIGHUP` must be updated accordingly.
+{{< /callout >}}
 
 ## Formats
 

--- a/docs/content/configuration/miscellaneous/logging.md
+++ b/docs/content/configuration/miscellaneous/logging.md
@@ -90,9 +90,14 @@ default uses the [RFC3339] layout, but optionally can be suffixed with the
 [Go Layout](https://pkg.go.dev/time#pkg-constants) semantics in the format of `{datetime:<layout>}` where `<layout>` is
 the layout supported by Go.
 
-When using a log file sending the Authelia process a SIGHUP will cause it to close and reopen the current log file and
-truncate it. This is useful for log rotation services which can force a reopen so the file descriptor open does not
+When using a log file sending the Authelia process a `SIGUSR1` will cause it to close and reopen the current log file
+and truncate it. This is useful for log rotation services which can force a reopen so the file descriptor open does not
 continue to append to the old log file.
+
+{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
+Prior to v4.40.0 this behavior was triggered by the `SIGHUP` signal. The `SIGHUP` signal now reloads the entire
+application, so log rotation configurations must be updated to send `SIGUSR1` instead.
+{{< /callout >}}
 
 #### File Path Examples
 

--- a/experimental/embed/context.go
+++ b/experimental/embed/context.go
@@ -70,6 +70,7 @@ type Context interface {
 	GetLogger() *logrus.Entry
 	GetProviders() middlewares.Providers
 	GetConfiguration() *schema.Configuration
+	GetConfigurationPaths() (paths []string)
 	GetClock() (clock clock.Provider)
 	GetRandom() (random random.Provider)
 	RemoteIP() net.IP

--- a/internal/commands/context.go
+++ b/internal/commands/context.go
@@ -88,6 +88,10 @@ func (ctx *CmdCtx) GetConfiguration() *schema.Configuration {
 	return ctx.config
 }
 
+func (ctx *CmdCtx) GetConfigurationPaths() (paths []string) {
+	return ctx.cconfig.files
+}
+
 func (ctx *CmdCtx) CheckSchemaVersion() (err error) {
 	if ctx.providers.StorageProvider == nil {
 		return fmt.Errorf("storage not loaded")

--- a/internal/commands/context.go
+++ b/internal/commands/context.go
@@ -52,6 +52,7 @@ type CmdCtx struct {
 	trusted   *x509.CertPool
 
 	cconfig *CmdCtxConfig
+	cpaths  []string
 
 	factoryX509SystemCertPool utils.X509SystemCertPoolFactory
 }
@@ -100,6 +101,12 @@ func (ctx *CmdCtx) GetRandom() (random random.Provider) {
 // GetConfiguration returns *schema.Configuration satisfying part of the ServiceCtx.
 func (ctx *CmdCtx) GetConfiguration() *schema.Configuration {
 	return ctx.config
+}
+
+// GetConfigurationPaths returns the configuration file and directory paths which were loaded, satisfying part of the
+// ServiceCtx. The paths are retained separately to the CmdCtxConfig as it's discarded prior to the services running.
+func (ctx *CmdCtx) GetConfigurationPaths() (paths []string) {
+	return ctx.cpaths
 }
 
 // CheckSchemaVersion returns an error if the storage schema is not at the latest version.
@@ -433,6 +440,8 @@ func (ctx *CmdCtx) HelperConfigLoadRunE(cmd *cobra.Command, _ []string) (err err
 	if ctx.cconfig.files, filters, err = loadXEnvCLIConfigValues(cmd); err != nil {
 		return err
 	}
+
+	ctx.cpaths = ctx.cconfig.files
 
 	ctx.cconfig.filters = make([]string, len(filters))
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -65,7 +65,7 @@ func NewRootCmd() (cmd *cobra.Command) {
 }
 
 // RootRunE is the RunE for the authelia root command.
-func (ctx *CmdCtx) RootRunE(_ *cobra.Command, _ []string) (err error) {
+func (ctx *CmdCtx) RootRunE(cmd *cobra.Command, _ []string) (err error) {
 	ctx.log.Infof("Authelia %s is starting", utils.Version())
 
 	if utils.Dev {
@@ -105,5 +105,14 @@ func (ctx *CmdCtx) RootRunE(_ *cobra.Command, _ []string) (err error) {
 
 	ctx.log.Trace("Starting Services")
 
-	return service.RunAll(ctx)
+	if err = service.RunAll(ctx); err != nil {
+		if errors.Is(err, service.ErrApplicationReload) {
+			// The reload error is handled by the caller of the command, it's not a usage or reportable error.
+			cmd.SilenceErrors, cmd.SilenceUsage = true, true
+		}
+
+		return err
+	}
+
+	return nil
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -60,6 +60,16 @@ func ConfigureLogger(config schema.Log, log bool) (err error) {
 
 	var writers []io.Writer
 
+	// Close any log file opened by a previous invocation, otherwise the file descriptor is leaked as the writer is
+	// replaced below. This occurs when the application is reloaded.
+	if logFile != nil {
+		if err = logFile.Close(); err != nil {
+			return err
+		}
+
+		logFile = nil
+	}
+
 	switch {
 	case config.FilePath != "":
 		writers = []io.Writer{}
@@ -68,11 +78,14 @@ func ConfigureLogger(config schema.Log, log bool) (err error) {
 			writers = append(writers, os.Stdout)
 		}
 
-		logFile = NewFile(config.FilePath)
+		file := NewFile(config.FilePath)
 
-		if err = logFile.Open(); err != nil {
+		if err = file.Open(); err != nil {
 			return err
 		}
+
+		// Only assigned once open so logFile is never non-nil while closed.
+		logFile = file
 
 		if config.Format != FormatJSON {
 			logrus.SetFormatter(&logrus.TextFormatter{

--- a/internal/service/const.go
+++ b/internal/service/const.go
@@ -1,5 +1,7 @@
 package service
 
+import "errors"
+
 const (
 	fmtLogServerListening = "Listening for %s connections on '%s' path '%s'"
 )
@@ -12,4 +14,10 @@ const (
 	serviceTypeServer  = "server"
 	serviceTypeWatcher = "watcher"
 	serviceTypeSignal  = "signal"
+)
+
+var (
+	// ErrApplicationReload is emitted when the application is being reloaded. This effectively starts Authelia again
+	// instead of doing a full exit.
+	ErrApplicationReload = errors.New("application reload")
 )

--- a/internal/service/const.go
+++ b/internal/service/const.go
@@ -4,6 +4,8 @@
 
 package service
 
+import "errors"
+
 const (
 	fmtLogServerListening = "Listening for %s connections on '%s' path '%s'"
 )
@@ -19,4 +21,18 @@ const (
 	serviceTypeWatcher = "watcher"
 	serviceTypeSignal  = "signal"
 	serviceTypeGC      = "gc"
+)
+
+const (
+	// environmentVariableConfigReload enables reloading the application when the configuration changes.
+	environmentVariableConfigReload = "X_AUTHELIA_CONFIG_RELOAD"
+
+	// environmentVariableConfigReloadPaths is a comma delimited list of additional paths to watch for changes.
+	environmentVariableConfigReloadPaths = "X_AUTHELIA_CONFIG_RELOAD_PATHS"
+)
+
+var (
+	// ErrApplicationReload is emitted when the application is being reloaded. This effectively starts Authelia again
+	// instead of doing a full exit.
+	ErrApplicationReload = errors.New("application reload")
 )

--- a/internal/service/file_watcher.go
+++ b/internal/service/file_watcher.go
@@ -9,12 +9,52 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
+	"github.com/authelia/authelia/v4/internal/utils"
 )
+
+// ProvisionConfigFileWatcher returns a Provider which watches the configuration for changes and reloads the
+// application when a change occurs. It's only provisioned when the relevant environment variable is enabled.
+func ProvisionConfigFileWatcher(ctx Context) (service Provider, err error) {
+	if !IsConfigFileWatcherEnabled() {
+		return nil, nil
+	}
+
+	// The context paths are copied as they must not be mutated by the append below.
+	paths := slices.Clone(ctx.GetConfigurationPaths())
+
+	if additional := utils.StringSplitClean(os.Getenv(environmentVariableConfigReloadPaths), ","); len(additional) != 0 {
+		paths = append(paths, additional...)
+	}
+
+	if len(paths) == 0 {
+		ctx.GetLogger().WithFields(map[string]any{logFieldService: serviceTypeWatcher, serviceTypeWatcher: "configuration"}).
+			Warn("Configuration reloading was enabled but no configuration paths are available to watch")
+
+		return nil, nil
+	}
+
+	action := func(log *logrus.Entry, event fsnotify.Event) (bubble bool, err error) {
+		if event.Has(fsnotify.Create) || event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) || event.Has(fsnotify.Write) {
+			log.Info("Configuration change detected, reloading the application")
+
+			return true, ErrApplicationReload
+		}
+
+		return false, nil
+	}
+
+	if service, err = NewFileWatcher("configuration", nil, action, ctx.GetLogger(), paths...); err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}
 
 // ProvisionUsersFileWatcher returns a Provider which watches the file based user database for changes.
 func ProvisionUsersFileWatcher(ctx Context) (service Provider, err error) {
@@ -28,7 +68,7 @@ func ProvisionUsersFileWatcher(ctx Context) (service Provider, err error) {
 			return nil, errors.New("error occurred asserting user provider")
 		}
 
-		if service, err = NewFileWatcher("users", config.AuthenticationBackend.File.Path, provider, ctx.GetLogger()); err != nil {
+		if service, err = NewFileWatcher("users", provider, nil, ctx.GetLogger(), config.AuthenticationBackend.File.Path); err != nil {
 			return nil, err
 		}
 	}
@@ -36,27 +76,17 @@ func ProvisionUsersFileWatcher(ctx Context) (service Provider, err error) {
 	return service, nil
 }
 
-// NewFileWatcher creates a new FileWatcher with the appropriate logger etc.
-func NewFileWatcher(name, path string, reload ReloadableProvider, log *logrus.Entry) (service *FileWatcher, err error) {
-	if path == "" {
+// NewFileWatcher creates a new FileWatcher with the appropriate logger etc. Either a ReloadableProvider or a
+// FileWatcherAction must be provided to handle the relevant events.
+func NewFileWatcher(name string, reload ReloadableProvider, action FileWatcherAction, log *logrus.Entry, paths ...string) (service *FileWatcher, err error) {
+	if len(paths) == 0 {
 		return nil, fmt.Errorf("error initializing file watcher: path must be specified")
 	}
 
-	if path, err = filepath.Abs(path); err != nil {
-		return nil, fmt.Errorf("error initializing file watcher: could not determine the absolute path of file '%s': %w", path, err)
-	}
+	var fwp FileWatcherPaths
 
-	var info os.FileInfo
-
-	if info, err = os.Stat(path); err != nil {
-		switch {
-		case os.IsNotExist(err):
-			return nil, fmt.Errorf("error initializing file watcher: error stating file '%s': file does not exist", path)
-		case os.IsPermission(err):
-			return nil, fmt.Errorf("error initializing file watcher: error stating file '%s': permission denied trying to read the file", path)
-		default:
-			return nil, fmt.Errorf("error initializing file watcher: error stating file '%s': %w", path, err)
-		}
+	if fwp, err = newFileWatcherPaths(paths); err != nil {
+		return nil, fmt.Errorf("error initializing file watcher: %w", err)
 	}
 
 	var watcher *fsnotify.Watcher
@@ -67,31 +97,23 @@ func NewFileWatcher(name, path string, reload ReloadableProvider, log *logrus.En
 
 	entry := log.WithFields(map[string]any{logFieldService: serviceTypeWatcher, serviceTypeWatcher: name})
 
-	if info.IsDir() {
-		service = &FileWatcher{
-			name:      name,
-			watcher:   watcher,
-			reload:    reload,
-			log:       entry,
-			directory: filepath.Clean(path),
-		}
-	} else {
-		service = &FileWatcher{
-			name:      name,
-			watcher:   watcher,
-			reload:    reload,
-			log:       entry,
-			directory: filepath.Dir(path),
-			file:      filepath.Base(path),
-		}
+	service = &FileWatcher{
+		name:    name,
+		watcher: watcher,
+		reload:  reload,
+		action:  action,
+		log:     entry,
+		paths:   fwp,
 	}
 
-	if err = service.watcher.Add(service.directory); err != nil {
-		if errClose := service.watcher.Close(); errClose != nil {
-			entry.WithError(errClose).Error("Error occurred closing the file watcher")
-		}
+	for _, path := range fwp {
+		if err = service.watcher.Add(path.Directory); err != nil {
+			if errClose := service.watcher.Close(); errClose != nil {
+				entry.WithError(errClose).Error("Error occurred closing the file watcher")
+			}
 
-		return nil, fmt.Errorf("failed to add path '%s' to watch list: %w", path, err)
+			return nil, fmt.Errorf("failed to add path '%s' to watch list: %w", path.Directory, err)
+		}
 	}
 
 	return service, nil
@@ -102,11 +124,39 @@ type FileWatcher struct {
 	name string
 
 	watcher *fsnotify.Watcher
-	reload  ReloadableProvider
 
-	log       *logrus.Entry
-	file      string
-	directory string
+	reload ReloadableProvider
+	action FileWatcherAction
+
+	log   *logrus.Entry
+	paths FileWatcherPaths
+}
+
+// FileWatcherPath describes a path being checked by a FileWatcher.
+type FileWatcherPath struct {
+	File      string
+	Directory string
+	Info      os.FileInfo
+}
+
+// FileWatcherPaths is a composite type that describes a slice of FileWatcherPath.
+type FileWatcherPaths []FileWatcherPath
+
+// IsMatch returns true if a fsnotify.Event matches any FileWatcherPath.
+func (fwp FileWatcherPaths) IsMatch(event fsnotify.Event) (match bool) {
+	directory, file := filepath.Dir(event.Name), filepath.Base(event.Name)
+
+	for _, path := range fwp {
+		if directory != path.Directory {
+			continue
+		}
+
+		if path.Info.IsDir() || file == path.File {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ServiceType returns the service type for this service, which is always 'watcher'.
@@ -127,7 +177,9 @@ func (service *FileWatcher) Run() (err error) {
 		}
 	}()
 
-	service.log.WithField(logFieldFile, filepath.Join(service.directory, service.file)).Info("Watching file for changes")
+	for _, path := range service.paths {
+		service.log.WithField(logFieldFile, filepath.Join(path.Directory, path.File)).Info("Watching file for changes")
+	}
 
 	for {
 		select {
@@ -136,7 +188,9 @@ func (service *FileWatcher) Run() (err error) {
 				return nil
 			}
 
-			service.handleEvent(event)
+			if err = service.handleEvent(event); err != nil {
+				return err
+			}
 		case errWatch, ok := <-service.watcher.Errors:
 			if !ok {
 				return nil
@@ -147,15 +201,39 @@ func (service *FileWatcher) Run() (err error) {
 	}
 }
 
-func (service *FileWatcher) handleEvent(event fsnotify.Event) {
+// handleEvent handles a single fsnotify.Event. A non-nil error indicates the FileWatcher should terminate and the
+// error should be returned to the caller.
+func (service *FileWatcher) handleEvent(event fsnotify.Event) (err error) {
 	log := service.log.WithFields(map[string]any{logFieldFile: event.Name, logFieldOP: event.Op})
 
-	if service.file != "" && service.file != filepath.Base(event.Name) {
+	if !service.paths.IsMatch(event) {
 		log.Trace("File modification detected to irrelevant file")
 
-		return
+		return nil
 	}
 
+	switch {
+	case service.reload != nil:
+		service.handleEventReload(log, event)
+	case service.action != nil:
+		var bubble bool
+
+		switch bubble, err = service.action(log, event); {
+		case err != nil && bubble:
+			return err
+		case err != nil:
+			log.WithError(err).Error("Error occurred during action")
+		default:
+			log.Debug("Action triggered successfully")
+		}
+	default:
+		log.Debug("File event was detected")
+	}
+
+	return nil
+}
+
+func (service *FileWatcher) handleEventReload(log *logrus.Entry, event fsnotify.Event) {
 	switch {
 	case event.Op&fsnotify.Write == fsnotify.Write, event.Op&fsnotify.Create == fsnotify.Create:
 		log.Debug("File modification was detected")

--- a/internal/service/file_watcher_test.go
+++ b/internal/service/file_watcher_test.go
@@ -109,7 +109,7 @@ func TestNewFileWatcher(t *testing.T) {
 	f, err := os.Create(filepath.Join(dir, "test.log"))
 	require.NoError(t, err)
 
-	service, err := NewFileWatcher("example", filepath.Join(dir, "test.log"), reloader, logrus.NewEntry(logging.Logger()))
+	service, err := NewFileWatcher("example", reloader, nil, logrus.NewEntry(logging.Logger()), filepath.Join(dir, "test.log"))
 
 	require.NoError(t, err)
 
@@ -141,7 +141,7 @@ func TestNewFileWatcherDirectory(t *testing.T) {
 
 	reloader := &testReloader{reload: true}
 
-	service, err := NewFileWatcher("example", dir, reloader, logrus.NewEntry(logging.Logger()))
+	service, err := NewFileWatcher("example", reloader, nil, logrus.NewEntry(logging.Logger()), dir)
 
 	require.NoError(t, err)
 
@@ -176,7 +176,7 @@ func TestNewFileWatcherBadPath(t *testing.T) {
 
 	reloader := &testReloader{reload: true}
 
-	service, err := NewFileWatcher("example", filepath.Join(dir, "test.log"), reloader, logrus.NewEntry(logging.Logger()))
+	service, err := NewFileWatcher("example", reloader, nil, logrus.NewEntry(logging.Logger()), filepath.Join(dir, "test.log"))
 
 	require.Error(t, err)
 	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf(`^error initializing file watcher: error stating file '%s/test.log': file does not exist$`, dir)), err.Error())
@@ -198,7 +198,7 @@ func TestNewFileWatcherBadPermission(t *testing.T) {
 
 	require.NoError(t, os.Chmod(filepath.Join(dir, "tmp"), 0o000))
 
-	service, err := NewFileWatcher("example", filepath.Join(dir, "tmp", "test.log"), reloader, logrus.NewEntry(logging.Logger()))
+	service, err := NewFileWatcher("example", reloader, nil, logrus.NewEntry(logging.Logger()), filepath.Join(dir, "tmp", "test.log"))
 
 	require.Error(t, err)
 	assert.Regexp(t, regexp.MustCompile(fmt.Sprintf(`^error initializing file watcher: error stating file '%s/tmp/test.log': permission denied trying to read the file$`, dir)), err.Error())
@@ -258,7 +258,7 @@ func TestFileWatcherRunShouldHandleReloadOutcomes(t *testing.T) {
 			logger, hook := test.NewNullLogger()
 			logger.SetLevel(logrus.TraceLevel)
 
-			service, err := NewFileWatcher("example", path, tc.reloader, logrus.NewEntry(logger))
+			service, err := NewFileWatcher("example", tc.reloader, nil, logrus.NewEntry(logger), path)
 			require.NoError(t, err)
 
 			errCh := make(chan error, 1)
@@ -292,19 +292,25 @@ func TestFileWatcherHandleEventShouldIgnoreIrrelevantEvents(t *testing.T) {
 	}{
 		{
 			name:     "ShouldIgnoreEventsForOtherFiles",
-			event:    fsnotify.Event{Name: "other.log", Op: fsnotify.Write},
+			event:    fsnotify.Event{Name: "/tmp/other.log", Op: fsnotify.Write},
+			level:    logrus.TraceLevel,
+			expected: "File modification detected to irrelevant file",
+		},
+		{
+			name:     "ShouldIgnoreEventsForOtherDirectories",
+			event:    fsnotify.Event{Name: "/var/tmp/test.log", Op: fsnotify.Write},
 			level:    logrus.TraceLevel,
 			expected: "File modification detected to irrelevant file",
 		},
 		{
 			name:     "ShouldIgnoreRemovalOfTheWatchedFile",
-			event:    fsnotify.Event{Name: "test.log", Op: fsnotify.Remove},
+			event:    fsnotify.Event{Name: "/tmp/test.log", Op: fsnotify.Remove},
 			level:    logrus.DebugLevel,
 			expected: "File remove was detected",
 		},
 		{
 			name:  "ShouldIgnoreChmodOfTheWatchedFile",
-			event: fsnotify.Event{Name: "test.log", Op: fsnotify.Chmod},
+			event: fsnotify.Event{Name: "/tmp/test.log", Op: fsnotify.Chmod},
 		},
 	}
 
@@ -316,14 +322,15 @@ func TestFileWatcherHandleEventShouldIgnoreIrrelevantEvents(t *testing.T) {
 			reloader := &testReloader{reload: true}
 
 			service := &FileWatcher{
-				name:      "example",
-				reload:    reloader,
-				log:       logrus.NewEntry(logger),
-				directory: "/tmp",
-				file:      "test.log",
+				name:   "example",
+				reload: reloader,
+				log:    logrus.NewEntry(logger),
+				paths: FileWatcherPaths{
+					{File: "test.log", Directory: "/tmp", Info: testFileInfo{}},
+				},
 			}
 
-			service.handleEvent(tc.event)
+			require.NoError(t, service.handleEvent(tc.event))
 
 			assert.Equal(t, int32(0), reloader.count.Load())
 
@@ -339,11 +346,12 @@ func TestFileWatcherHandleErrorShouldLogTheError(t *testing.T) {
 	logger.SetLevel(logrus.TraceLevel)
 
 	service := &FileWatcher{
-		name:      "example",
-		reload:    &testReloader{reload: true},
-		log:       logrus.NewEntry(logger),
-		directory: "/tmp",
-		file:      "test.log",
+		name:   "example",
+		reload: &testReloader{reload: true},
+		log:    logrus.NewEntry(logger),
+		paths: FileWatcherPaths{
+			{File: "test.log", Directory: "/tmp", Info: testFileInfo{}},
+		},
 	}
 
 	service.handleError(errors.New("failed to watch"))
@@ -363,7 +371,7 @@ func TestFileWatcherRunShouldNotReturnStaleReloadErrors(t *testing.T) {
 
 	reloader := &testReloader{err: errors.New("failed to reload"), panic: true, panicAfter: 1}
 
-	service, err := NewFileWatcher("example", path, reloader, logrus.NewEntry(logger))
+	service, err := NewFileWatcher("example", reloader, nil, logrus.NewEntry(logger), path)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 1)
@@ -402,7 +410,7 @@ func TestFileWatcherRunShouldRecoverFromPanics(t *testing.T) {
 	logger, hook := test.NewNullLogger()
 	logger.SetLevel(logrus.TraceLevel)
 
-	service, err := NewFileWatcher("example", path, &testReloader{panic: true}, logrus.NewEntry(logger))
+	service, err := NewFileWatcher("example", &testReloader{panic: true}, nil, logrus.NewEntry(logger), path)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 1)
@@ -462,7 +470,7 @@ func TestNewFileWatcherShouldNotLeakTheWatcherOnFailureToAddPath(t *testing.T) {
 	reloader := &testReloader{reload: true}
 	log := logrus.NewEntry(logging.Logger())
 
-	service, err := NewFileWatcher("example", path, reloader, log)
+	service, err := NewFileWatcher("example", reloader, nil, log, path)
 	if err == nil {
 		service.Shutdown()
 
@@ -475,13 +483,183 @@ func TestNewFileWatcherShouldNotLeakTheWatcherOnFailureToAddPath(t *testing.T) {
 	before := testCountOpenFileDescriptors(t)
 
 	for i := 0; i < 20; i++ {
-		service, err = NewFileWatcher("example", path, reloader, log)
+		service, err = NewFileWatcher("example", reloader, nil, log, path)
 
 		require.Error(t, err)
 		require.Nil(t, service)
 	}
 
 	assert.Less(t, testCountOpenFileDescriptors(t)-before, 20)
+}
+
+func TestProvisionConfigFileWatcher(t *testing.T) {
+	dir := t.TempDir()
+
+	file := filepath.Join(dir, "configuration.yml")
+
+	require.NoError(t, os.WriteFile(file, []byte("theme: 'dark'"), 0600))
+
+	newCtx := func(paths []string) *testCtx {
+		return &testCtx{
+			Context:            context.Background(),
+			Configuration:      &schema.Configuration{},
+			ConfigurationPaths: paths,
+			Providers:          middlewares.NewProvidersBasic(),
+			Logger:             logrus.NewEntry(logging.Logger()),
+		}
+	}
+
+	t.Run("ShouldNotProvisionWhenDisabled", func(t *testing.T) {
+		service, err := ProvisionConfigFileWatcher(newCtx([]string{file}))
+
+		assert.NoError(t, err)
+		assert.Nil(t, service)
+	})
+
+	t.Run("ShouldNotProvisionWithoutPaths", func(t *testing.T) {
+		t.Setenv(environmentVariableConfigReload, "true")
+
+		service, err := ProvisionConfigFileWatcher(newCtx(nil))
+
+		assert.NoError(t, err)
+		assert.Nil(t, service)
+	})
+
+	t.Run("ShouldProvisionWhenEnabled", func(t *testing.T) {
+		t.Setenv(environmentVariableConfigReload, "true")
+
+		service, err := ProvisionConfigFileWatcher(newCtx([]string{file}))
+
+		require.NoError(t, err)
+		require.NotNil(t, service)
+
+		assert.Equal(t, "configuration", service.ServiceName())
+		assert.Equal(t, "watcher", service.ServiceType())
+
+		service.Shutdown()
+	})
+
+	t.Run("ShouldIncludeAdditionalPaths", func(t *testing.T) {
+		other := t.TempDir()
+
+		t.Setenv(environmentVariableConfigReload, "true")
+		t.Setenv(environmentVariableConfigReloadPaths, fmt.Sprintf(" %s , ", other))
+
+		service, err := ProvisionConfigFileWatcher(newCtx([]string{file}))
+
+		require.NoError(t, err)
+		require.NotNil(t, service)
+
+		watcher, ok := service.(*FileWatcher)
+		require.True(t, ok)
+
+		assert.Len(t, watcher.paths, 2)
+
+		service.Shutdown()
+	})
+
+	t.Run("ShouldErrorOnInvalidAdditionalPaths", func(t *testing.T) {
+		t.Setenv(environmentVariableConfigReload, "true")
+		t.Setenv(environmentVariableConfigReloadPaths, filepath.Join(dir, "missing.yml"))
+
+		service, err := ProvisionConfigFileWatcher(newCtx([]string{file}))
+
+		assert.Error(t, err)
+		assert.Nil(t, service)
+	})
+}
+
+func TestFileWatcherShouldReturnApplicationReloadOnConfigurationChange(t *testing.T) {
+	dir := t.TempDir()
+
+	path := filepath.Join(dir, "configuration.yml")
+
+	require.NoError(t, os.WriteFile(path, []byte("theme: 'dark'"), 0600))
+
+	t.Setenv(environmentVariableConfigReload, "true")
+
+	ctx := &testCtx{
+		Context:            context.Background(),
+		Configuration:      &schema.Configuration{},
+		ConfigurationPaths: []string{path},
+		Providers:          middlewares.NewProvidersBasic(),
+		Logger:             logrus.NewEntry(logging.Logger()),
+	}
+
+	service, err := ProvisionConfigFileWatcher(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, service)
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- service.Run()
+	}()
+
+	require.NoError(t, os.WriteFile(path, []byte("theme: 'light'"), 0600))
+
+	select {
+	case err = <-errCh:
+		assert.ErrorIs(t, err, ErrApplicationReload)
+	case <-time.After(time.Second * 5):
+		t.Fatal("service did not return the reload error within timeout")
+	}
+
+	service.Shutdown()
+}
+
+func TestFileWatcherPathsIsMatch(t *testing.T) {
+	paths := FileWatcherPaths{
+		{File: "configuration.yml", Directory: "/etc/authelia", Info: testFileInfo{}},
+		{Directory: "/etc/authelia.d", Info: testFileInfo{dir: true}},
+	}
+
+	testCases := []struct {
+		name     string
+		event    string
+		expected bool
+	}{
+		{"ShouldMatchTheWatchedFile", "/etc/authelia/configuration.yml", true},
+		{"ShouldNotMatchAnotherFileInTheSameDirectory", "/etc/authelia/users.yml", false},
+		{"ShouldNotMatchTheSameFileInAnotherDirectory", "/etc/other/configuration.yml", false},
+		{"ShouldMatchAnyFileInTheWatchedDirectory", "/etc/authelia.d/anything.yml", true},
+		{"ShouldNotMatchASubdirectoryOfTheWatchedDirectory", "/etc/authelia.d/nested/anything.yml", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, paths.IsMatch(fsnotify.Event{Name: tc.event, Op: fsnotify.Write}))
+		})
+	}
+}
+
+type testFileInfo struct {
+	dir bool
+}
+
+func (i testFileInfo) Name() string       { return "" }
+func (i testFileInfo) Size() int64        { return 0 }
+func (i testFileInfo) Mode() os.FileMode  { return 0 }
+func (i testFileInfo) ModTime() time.Time { return time.Time{} }
+func (i testFileInfo) IsDir() bool        { return i.dir }
+func (i testFileInfo) Sys() any           { return nil }
+
+type testReloader struct {
+	count      atomic.Int32
+	reload     bool
+	panic      bool
+	panicAfter int32
+	err        error
+}
+
+func (r *testReloader) Reload() (bool, error) {
+	count := r.count.Add(1)
+
+	if r.panic && count > r.panicAfter {
+		panic("failed to reload")
+	}
+
+	return r.reload, r.err
 }
 
 func testCountOpenFileDescriptors(t *testing.T) int {
@@ -506,22 +684,4 @@ func testCountOpenFileDescriptors(t *testing.T) int {
 	}
 
 	return len(names)
-}
-
-type testReloader struct {
-	count      atomic.Int32
-	reload     bool
-	panic      bool
-	panicAfter int32
-	err        error
-}
-
-func (r *testReloader) Reload() (bool, error) {
-	count := r.count.Add(1)
-
-	if r.panic && count > r.panicAfter {
-		panic("failed to reload")
-	}
-
-	return r.reload, r.err
 }

--- a/internal/service/provider.go
+++ b/internal/service/provider.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
@@ -32,6 +33,9 @@ type ReloadableProvider interface {
 	Reload() (reloaded bool, err error)
 }
 
+// FileWatcherAction represents an action to perform when this watcher is triggered.
+type FileWatcherAction func(log *logrus.Entry, event fsnotify.Event) (bubble bool, err error)
+
 type Provisioner func(ctx Context) (provider Provider, err error)
 
 func GetProvisioners() []Provisioner {
@@ -39,14 +43,17 @@ func GetProvisioners() []Provisioner {
 		ProvisionServer,
 		ProvisionServerMetrics,
 		ProvisionUsersFileWatcher,
+		ProvisionConfigFileWatcher,
 		ProvisionLoggingSignal,
+		ProvisionApplicationReloadSignal,
 	}
 }
 
 type Context interface {
-	GetLogger() *logrus.Entry
-	GetProviders() middlewares.Providers
-	GetConfiguration() *schema.Configuration
+	GetLogger() (logger *logrus.Entry)
+	GetProviders() (providers middlewares.Providers)
+	GetConfiguration() (config *schema.Configuration)
+	GetConfigurationPaths() (paths []string)
 
 	context.Context
 }

--- a/internal/service/provider.go
+++ b/internal/service/provider.go
@@ -5,6 +5,7 @@
 package service
 
 import (
+	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 )
 
@@ -31,6 +32,10 @@ type ReloadableProvider interface {
 	Reload() (reloaded bool, err error)
 }
 
+// FileWatcherAction represents an action to perform when a FileWatcher is triggered. A bubble return value of true
+// causes the returned error to terminate the service and be returned to the caller rather than just being logged.
+type FileWatcherAction func(log *logrus.Entry, event fsnotify.Event) (bubble bool, err error)
+
 // Provisioner is a function which provisions a Provider.
 type Provisioner func(ctx Context) (provider Provider, err error)
 
@@ -40,7 +45,9 @@ func GetProvisioners() []Provisioner {
 		ProvisionServer,
 		ProvisionServerMetrics,
 		ProvisionUsersFileWatcher,
+		ProvisionConfigFileWatcher,
 		ProvisionLoggingSignal,
+		ProvisionApplicationReloadSignal,
 		ProvisionGarbageCollector,
 	}
 }

--- a/internal/service/provider_test.go
+++ b/internal/service/provider_test.go
@@ -9,5 +9,5 @@ import (
 func TestGetProvisioners(t *testing.T) {
 	provisioners := GetProvisioners()
 
-	assert.Len(t, provisioners, 4)
+	assert.Len(t, provisioners, 6)
 }

--- a/internal/service/provider_test.go
+++ b/internal/service/provider_test.go
@@ -13,5 +13,5 @@ import (
 func TestGetProvisioners(t *testing.T) {
 	provisioners := GetProvisioners()
 
-	assert.Len(t, provisioners, 5)
+	assert.Len(t, provisioners, 7)
 }

--- a/internal/service/server.go
+++ b/internal/service/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/authelia/authelia/v4/internal/server"
 )
 
+// ProvisionServer initializes the main listener.
 func ProvisionServer(ctx Context) (service Provider, err error) {
 	var (
 		s        *fasthttp.Server
@@ -32,6 +33,7 @@ func ProvisionServer(ctx Context) (service Provider, err error) {
 	return service, nil
 }
 
+// ProvisionServerMetrics initializes the metrics listener.
 func ProvisionServerMetrics(ctx Context) (service Provider, err error) {
 	var (
 		s        *fasthttp.Server

--- a/internal/service/server_test.go
+++ b/internal/service/server_test.go
@@ -204,9 +204,10 @@ func (l *testListener) Addr() net.Addr {
 }
 
 type testCtx struct {
-	Configuration *schema.Configuration
-	Providers     middlewares.Providers
-	Logger        *logrus.Entry
+	Configuration      *schema.Configuration
+	ConfigurationPaths []string
+	Providers          middlewares.Providers
+	Logger             *logrus.Entry
 
 	context.Context
 }
@@ -221,4 +222,8 @@ func (c *testCtx) GetProviders() middlewares.Providers {
 
 func (c *testCtx) GetLogger() *logrus.Entry {
 	return c.Logger
+}
+
+func (c *testCtx) GetConfigurationPaths() []string {
+	return c.ConfigurationPaths
 }

--- a/internal/service/sever_test.go
+++ b/internal/service/sever_test.go
@@ -29,13 +29,13 @@ func TestNewMainServer(t *testing.T) {
 		},
 	}
 
-	ctx := &testCtx{
-		Context:       context.Background(),
-		Configuration: config,
-		Providers: middlewares.Providers{
+	ctx := &testContext{
+		Context: t.Context(),
+		config:  config,
+		providers: middlewares.Providers{
 			Templates: tx,
 		},
-		Logger: logrus.NewEntry(logging.Logger()),
+		logger: logrus.NewEntry(logging.Logger()),
 	}
 
 	server, err := ProvisionServer(ctx)
@@ -72,14 +72,14 @@ func TestNewMetricsServer(t *testing.T) {
 		},
 	}
 
-	ctx := &testCtx{
-		Context:       context.Background(),
-		Configuration: config,
-		Providers: middlewares.Providers{
+	ctx := &testContext{
+		Context: context.Background(),
+		config:  config,
+		providers: middlewares.Providers{
 			Templates: tx,
 			Metrics:   metrics.NewPrometheus(),
 		},
-		Logger: logrus.NewEntry(logging.Logger()),
+		logger: logrus.NewEntry(logging.Logger()),
 	}
 
 	server, err := ProvisionServerMetrics(ctx)
@@ -98,24 +98,4 @@ func TestNewMetricsServer(t *testing.T) {
 	assert.NotNil(t, server.Log())
 
 	server.Shutdown()
-}
-
-type testCtx struct {
-	Configuration *schema.Configuration
-	Providers     middlewares.Providers
-	Logger        *logrus.Entry
-
-	context.Context
-}
-
-func (c *testCtx) GetConfiguration() *schema.Configuration {
-	return c.Configuration
-}
-
-func (c *testCtx) GetProviders() middlewares.Providers {
-	return c.Providers
-}
-
-func (c *testCtx) GetLogger() *logrus.Entry {
-	return c.Logger
 }

--- a/internal/service/signal.go
+++ b/internal/service/signal.go
@@ -25,11 +25,28 @@ func ProvisionLoggingSignal(ctx Context) (service Provider, err error) {
 
 	return &Signal{
 		name:    "log-reload",
+		signals: []os.Signal{syscall.SIGUSR1},
+		action: func() (bubble bool, err error) {
+			return false, logging.Reopen()
+		},
+		log:    ctx.GetLogger().WithFields(map[string]any{logFieldService: serviceTypeSignal, serviceTypeSignal: "log-reload"}),
+		notify: make(chan os.Signal, 1),
+		quit:   make(chan struct{}),
+	}, nil
+}
+
+// ProvisionApplicationReloadSignal returns a Provider which performs an effective application reload when the relevant
+// signal is received.
+func ProvisionApplicationReloadSignal(ctx Context) (service Provider, err error) {
+	return &Signal{
+		name:    "application-reload",
 		signals: []os.Signal{syscall.SIGHUP},
-		action:  logging.Reopen,
-		log:     ctx.GetLogger().WithFields(map[string]any{logFieldService: serviceTypeSignal, serviceTypeSignal: "log-reload"}),
-		notify:  make(chan os.Signal, 1),
-		quit:    make(chan struct{}),
+		action: func() (bubble bool, err error) {
+			return true, ErrApplicationReload
+		},
+		log:    ctx.GetLogger().WithFields(map[string]any{logFieldService: serviceTypeSignal, serviceTypeSignal: "application-reload"}),
+		notify: make(chan os.Signal, 1),
+		quit:   make(chan struct{}),
 	}, nil
 }
 
@@ -37,7 +54,7 @@ func ProvisionLoggingSignal(ctx Context) (service Provider, err error) {
 type Signal struct {
 	name    string
 	signals []os.Signal
-	action  func() (err error)
+	action  func() (bubble bool, err error)
 	log     *logrus.Entry
 
 	notify chan os.Signal
@@ -64,10 +81,17 @@ func (service *Signal) Run() (err error) {
 	for {
 		select {
 		case s := <-service.notify:
-			if err = service.action(); err != nil {
-				service.log.WithError(err).Error("Error occurred executing service action.")
-			} else {
-				service.log.WithFields(map[string]any{"signal-received": s.String()}).Debug("Successfully executed service action.")
+			log := service.log.WithFields(map[string]any{"signal-received": s.String()})
+
+			var bubble bool
+
+			switch bubble, err = service.action(); {
+			case err != nil && bubble:
+				return err
+			case err != nil:
+				log.WithError(err).Error("Error occurred executing service action.")
+			default:
+				log.Debug("Successfully executed service action.")
 			}
 		case <-service.quit:
 			return nil

--- a/internal/service/signal_test.go
+++ b/internal/service/signal_test.go
@@ -25,6 +25,7 @@ import (
 type mockServiceCtx struct {
 	ctx       context.Context
 	config    *schema.Configuration
+	cpaths    []string
 	logger    *logrus.Entry
 	providers middlewares.Providers
 }
@@ -39,6 +40,10 @@ func (m *mockServiceCtx) GetProviders() middlewares.Providers {
 
 func (m *mockServiceCtx) GetConfiguration() *schema.Configuration {
 	return m.config
+}
+
+func (m *mockServiceCtx) GetConfigurationPaths() []string {
+	return m.cpaths
 }
 
 func (m *mockServiceCtx) Deadline() (deadline time.Time, ok bool) {
@@ -95,9 +100,9 @@ func TestSignalService_Run(t *testing.T) {
 			logger.SetLevel(logrus.TraceLevel)
 
 			actionCalled := false
-			action := func() error {
+			action := func() (bubble bool, err error) {
 				actionCalled = true
-				return tc.actionError
+				return false, tc.actionError
 			}
 
 			service := &Signal{
@@ -233,7 +238,7 @@ func TestLogReopenFiles(t *testing.T) {
 	p, err := os.FindProcess(os.Getpid())
 	require.NoError(t, err)
 
-	err = p.Signal(syscall.SIGHUP)
+	err = p.Signal(syscall.SIGUSR1)
 	require.NoError(t, err)
 
 	time.Sleep(100 * time.Millisecond)
@@ -254,10 +259,10 @@ func TestSignalRunShouldNotReturnStaleActionError(t *testing.T) {
 	service := &Signal{
 		name:    "test",
 		signals: []os.Signal{syscall.SIGHUP},
-		action: func() error {
+		action: func() (bubble bool, err error) {
 			called <- struct{}{}
 
-			return errors.New("action failed")
+			return false, errors.New("action failed")
 		},
 		log:    logrus.New().WithFields(map[string]any{logFieldService: serviceTypeSignal, serviceTypeSignal: "test"}),
 		notify: make(chan os.Signal, 1),
@@ -316,7 +321,7 @@ func TestSignalShutdownShouldNotBlock(t *testing.T) {
 			service := &Signal{
 				name:    "test",
 				signals: []os.Signal{syscall.SIGHUP},
-				action:  func() error { return nil },
+				action:  func() (bubble bool, err error) { return false, nil },
 				log:     logrus.New().WithFields(map[string]any{logFieldService: serviceTypeSignal, serviceTypeSignal: "test"}),
 				notify:  make(chan os.Signal, 1),
 				quit:    make(chan struct{}),
@@ -360,7 +365,7 @@ func TestSignalShutdownShouldNotBlock(t *testing.T) {
 
 func TestSignalService_Shutdown(t *testing.T) {
 	logger := logrus.New()
-	action := func() error { return nil }
+	action := func() (bubble bool, err error) { return false, nil }
 	service := &Signal{
 		name:    "test",
 		signals: []os.Signal{syscall.SIGHUP},
@@ -387,4 +392,40 @@ func TestSignalService_Shutdown(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("service did not shut down within timeout")
 	}
+}
+
+func TestProvisionApplicationReloadSignal(t *testing.T) {
+	ctx := newMockServiceCtx()
+
+	service, err := ProvisionApplicationReloadSignal(ctx)
+
+	require.NoError(t, err)
+	require.NotNil(t, service)
+
+	assert.Equal(t, "application-reload", service.ServiceName())
+	assert.Equal(t, "signal", service.ServiceType())
+	assert.NotNil(t, service.Log())
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- service.Run()
+	}()
+
+	// Give the service a moment to start.
+	time.Sleep(100 * time.Millisecond)
+
+	p, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+
+	require.NoError(t, p.Signal(syscall.SIGHUP))
+
+	select {
+	case err = <-errCh:
+		assert.ErrorIs(t, err, ErrApplicationReload)
+	case <-time.After(time.Second * 5):
+		t.Fatal("service did not return the reload error within timeout")
+	}
+
+	service.Shutdown()
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -18,6 +18,7 @@ type Context interface {
 	GetLogger() *logrus.Entry
 	GetProviders() middlewares.Providers
 	GetConfiguration() *schema.Configuration
+	GetConfigurationPaths() []string
 
 	context.Context
 }
@@ -47,4 +48,8 @@ func (c *runContext) GetProviders() middlewares.Providers {
 
 func (c *runContext) GetConfiguration() *schema.Configuration {
 	return c.base.GetConfiguration()
+}
+
+func (c *runContext) GetConfigurationPaths() []string {
+	return c.base.GetConfigurationPaths()
 }

--- a/internal/service/util.go
+++ b/internal/service/util.go
@@ -6,9 +6,12 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strconv"
 	"sync"
 	"syscall"
 
@@ -24,7 +27,8 @@ func RunAll(ctx Context) (err error) {
 }
 
 // Run provisions and runs the services from the given provisioners until the context is cancelled, a SIGINT or
-// SIGTERM signal is received, or a service terminates.
+// SIGTERM signal is received, or a service terminates. It returns ErrApplicationReload if a service requested that the
+// application be reloaded rather than shut down.
 func Run(ctx Context, provisioners ...Provisioner) (err error) {
 	cctx, cancel := context.WithCancel(ctx)
 
@@ -83,11 +87,21 @@ func Run(ctx Context, provisioners ...Provisioner) (err error) {
 		log.WithError(err).Error("Error occurred closing database connections")
 	}
 
+	var reload bool
+
 	if err = group.Wait(); err != nil {
-		log.WithError(err).Error("Error occurred waiting for shutdown")
+		if errors.Is(err, ErrApplicationReload) {
+			reload = true
+		} else {
+			log.WithError(err).Error("Error occurred waiting for shutdown")
+		}
 	}
 
 	log.Info("Shutdown complete")
+
+	if reload {
+		return ErrApplicationReload
+	}
 
 	return nil
 }
@@ -114,6 +128,13 @@ func shutdown(log *logrus.Entry, services []Provider) {
 	wg.Wait()
 }
 
+// IsConfigFileWatcherEnabled determines if a configuration change will cause the Authelia application to reload.
+func IsConfigFileWatcherEnabled() (enabled bool) {
+	value, err := strconv.ParseBool(os.Getenv(environmentVariableConfigReload))
+
+	return err == nil && value
+}
+
 func connectionType(isTLS bool) string {
 	if isTLS {
 		return "TLS"
@@ -133,4 +154,46 @@ func recoverErr(i any) error {
 	default:
 		return fmt.Errorf("recovered panic with unknown type: %v", v)
 	}
+}
+
+func newFileWatcherPaths(in []string) (paths FileWatcherPaths, err error) {
+	paths = make(FileWatcherPaths, len(in))
+
+	for i, path := range in {
+		if path == "" {
+			return nil, fmt.Errorf("path must be specified")
+		}
+
+		if path, err = filepath.Abs(path); err != nil {
+			return nil, fmt.Errorf("could not determine the absolute path of file '%s': %w", path, err)
+		}
+
+		var info os.FileInfo
+
+		if info, err = os.Stat(path); err != nil {
+			switch {
+			case os.IsNotExist(err):
+				return nil, fmt.Errorf("error stating file '%s': file does not exist", path)
+			case os.IsPermission(err):
+				return nil, fmt.Errorf("error stating file '%s': permission denied trying to read the file", path)
+			default:
+				return nil, fmt.Errorf("error stating file '%s': %w", path, err)
+			}
+		}
+
+		if info.IsDir() {
+			paths[i] = FileWatcherPath{
+				Directory: path,
+				Info:      info,
+			}
+		} else {
+			paths[i] = FileWatcherPath{
+				File:      filepath.Base(path),
+				Directory: filepath.Dir(path),
+				Info:      info,
+			}
+		}
+	}
+
+	return paths, nil
 }

--- a/internal/service/util_test.go
+++ b/internal/service/util_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/middlewares"
+)
+
+// testContext implements service.Context for testing.
+type testContext struct {
+	context.Context
+
+	config    *schema.Configuration
+	logger    *logrus.Entry
+	providers middlewares.Providers
+	paths     []string
+}
+
+func (m *testContext) GetLogger() *logrus.Entry {
+	return m.logger
+}
+
+func (m *testContext) GetProviders() middlewares.Providers {
+	return m.providers
+}
+
+func (m *testContext) GetConfiguration() *schema.Configuration {
+	return m.config
+}
+
+func (m *testContext) GetConfigurationPaths() []string {
+	return m.paths
+}
+
+func newMockServiceCtx(t *testing.T) *testContext {
+	logger := logrus.New()
+	logger.SetLevel(logrus.TraceLevel)
+
+	config := &schema.Configuration{}
+
+	return &testContext{
+		Context:   t.Context(),
+		config:    config,
+		logger:    logrus.NewEntry(logger),
+		providers: middlewares.Providers{},
+	}
+}

--- a/internal/service/util_test.go
+++ b/internal/service/util_test.go
@@ -7,7 +7,9 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -412,4 +414,111 @@ func (s *testServiceProvider) Shutdown() {
 	s.stop.Do(func() {
 		close(s.quit)
 	})
+}
+
+func TestIsConfigFileWatcherEnabled(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		set      bool
+		expected bool
+	}{
+		{"ShouldNotBeEnabledWhenUnset", "", false, false},
+		{"ShouldNotBeEnabledWhenEmpty", "", true, false},
+		{"ShouldNotBeEnabledWhenInvalid", "abc", true, false},
+		{"ShouldNotBeEnabledWhenFalse", "false", true, false},
+		{"ShouldNotBeEnabledWhenZero", "0", true, false},
+		{"ShouldBeEnabledWhenTrue", "true", true, true},
+		{"ShouldBeEnabledWhenOne", "1", true, true},
+		{"ShouldBeEnabledWhenUpperCase", "TRUE", true, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv(environmentVariableConfigReload, tc.value)
+			}
+
+			assert.Equal(t, tc.expected, IsConfigFileWatcherEnabled())
+		})
+	}
+}
+
+func TestNewFileWatcherPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	file := filepath.Join(dir, "configuration.yml")
+
+	require.NoError(t, os.WriteFile(file, []byte("theme: 'dark'"), 0600))
+
+	t.Run("ShouldHandleFile", func(t *testing.T) {
+		paths, err := newFileWatcherPaths([]string{file})
+		require.NoError(t, err)
+		require.Len(t, paths, 1)
+
+		assert.Equal(t, "configuration.yml", paths[0].File)
+		assert.Equal(t, dir, paths[0].Directory)
+		assert.False(t, paths[0].Info.IsDir())
+	})
+
+	t.Run("ShouldHandleDirectory", func(t *testing.T) {
+		paths, err := newFileWatcherPaths([]string{dir})
+		require.NoError(t, err)
+		require.Len(t, paths, 1)
+
+		assert.Equal(t, "", paths[0].File)
+		assert.Equal(t, dir, paths[0].Directory)
+		assert.True(t, paths[0].Info.IsDir())
+	})
+
+	t.Run("ShouldHandleMultiplePaths", func(t *testing.T) {
+		paths, err := newFileWatcherPaths([]string{file, dir})
+		require.NoError(t, err)
+		assert.Len(t, paths, 2)
+	})
+
+	t.Run("ShouldErrorOnEmptyPath", func(t *testing.T) {
+		paths, err := newFileWatcherPaths([]string{""})
+		assert.EqualError(t, err, "path must be specified")
+		assert.Nil(t, paths)
+	})
+
+	t.Run("ShouldErrorOnMissingPath", func(t *testing.T) {
+		paths, err := newFileWatcherPaths([]string{filepath.Join(dir, "missing.yml")})
+		assert.EqualError(t, err, fmt.Sprintf("error stating file '%s': file does not exist", filepath.Join(dir, "missing.yml")))
+		assert.Nil(t, paths)
+	})
+}
+
+func TestRunShouldReturnApplicationReloadWhenAServiceRequestsIt(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected error
+	}{
+		{"ShouldReturnApplicationReload", ErrApplicationReload, ErrApplicationReload},
+		{"ShouldReturnApplicationReloadWhenWrapped", fmt.Errorf("service failed: %w", ErrApplicationReload), ErrApplicationReload},
+		{"ShouldNotReturnOtherErrors", errors.New("a bad thing happened"), nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := newTestServiceCtx()
+
+			defer cancel()
+
+			testWithProviderMocks(t, ctx, nil, nil)
+
+			service := newTestServiceProvider("reload")
+			service.err = tc.err
+
+			err := Run(ctx, testProvisionerOf(service))
+
+			if tc.expected == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.expected)
+			}
+		})
+	}
 }

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -303,3 +303,23 @@ func StringJoinBuild(sep, sepFinal, quote string, items []string) string {
 
 	return b.String()
 }
+
+// StringSplitClean splits a string by the sep after trimming all leading and trailing whitespace. It then removes any
+// elements from the slice which when trimmed of any leading and trailing whitespace are an empty string.
+func StringSplitClean(s string, sep string) []string {
+	split := strings.Split(strings.TrimSpace(s), sep)
+
+	if len(split) == 0 || (len(split) == 1 && split[0] == "") {
+		return nil
+	}
+
+	result := make([]string, 0, len(split))
+	for _, item := range split {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			result = append(result, item)
+		}
+	}
+
+	return result
+}

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -323,3 +323,24 @@ func StringHasSuffixFold(s, suffix string) bool {
 func StringHasPrefixFold(s, prefix string) bool {
 	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
 }
+
+// StringSplitClean splits a string by the sep after trimming all leading and trailing whitespace. It then removes any
+// elements from the slice which when trimmed of any leading and trailing whitespace are an empty string.
+func StringSplitClean(s string, sep string) []string {
+	split := strings.Split(strings.TrimSpace(s), sep)
+
+	if len(split) == 0 || (len(split) == 1 && split[0] == "") {
+		return nil
+	}
+
+	result := make([]string, 0, len(split))
+
+	for _, item := range split {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			result = append(result, item)
+		}
+	}
+
+	return result
+}

--- a/internal/utils/strings_test.go
+++ b/internal/utils/strings_test.go
@@ -426,3 +426,24 @@ func TestStringJoinBuild(t *testing.T) {
 		})
 	}
 }
+
+func TestStringSplitClean(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"ShouldSplitStandardScenario", "apple,banana,cherry", []string{"apple", "banana", "cherry"}},
+		{"ShouldSplitLeadingTrailingScenario", " apple,banana,cherry ", []string{"apple", "banana", "cherry"}},
+		{"ShouldTrimEmptyItems", "apple,,banana", []string{"apple", "banana"}},
+		{"ShouldHandleOnlyWhiteSpace", "   ", nil},
+		{"ShouldHandleEmptyString", "", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := StringSplitClean(tc.input, ",")
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/internal/utils/strings_test.go
+++ b/internal/utils/strings_test.go
@@ -480,3 +480,24 @@ func TestStringHasSuffixFold(t *testing.T) {
 		})
 	}
 }
+
+func TestStringSplitClean(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"ShouldSplitStandardScenario", "apple,banana,cherry", []string{"apple", "banana", "cherry"}},
+		{"ShouldSplitLeadingTrailingScenario", " apple,banana,cherry ", []string{"apple", "banana", "cherry"}},
+		{"ShouldTrimEmptyItems", "apple,,banana", []string{"apple", "banana"}},
+		{"ShouldHandleOnlyWhiteSpace", "   ", nil},
+		{"ShouldHandleEmptyString", "", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := StringSplitClean(tc.input, ",")
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Adds the ability to reload Authelia when the configuration changes, enabled with the X_AUTHELIA_CONFIG_RELOAD environment variable. Paths outside the configuration such as secrets directories can be watched with X_AUTHELIA_CONFIG_RELOAD_PATHS.

The SIGHUP signal also performs a reload, regardless of whether the watcher is enabled, and reopening the log file has moved to SIGUSR1.

Closes #1275