### PR TITLE
fix(oidc): authorize request relies on session update

### DIFF
--- a/internal/handlers/handler_oauth2_authorization.go
+++ b/internal/handlers/handler_oauth2_authorization.go
@@ -112,7 +112,7 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 
 	issuer = ctx.RootURL()
 
-	if consent, handled = handleOAuth2AuthorizationConsent(ctx, issuer, client, provider, userSession, rw, r, requester); handled {
+	if consent, handled = handleOAuth2AuthorizationConsent(ctx, issuer, client, policy, provider, userSession, rw, r, requester); handled {
 		return
 	}
 

--- a/internal/handlers/handler_oauth2_authorization.go
+++ b/internal/handlers/handler_oauth2_authorization.go
@@ -82,10 +82,19 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 		issuer      *url.URL
 		userSession session.UserSession
 		consent     *model.OAuth2ConsentSession
+		provider    *session.Session
 		handled     bool
 	)
 
-	if userSession, err = ctx.GetSession(); err != nil {
+	if provider, err = ctx.GetSessionProvider(); err != nil {
+		ctx.Logger.Errorf("Authorization Request with id '%s' on client with id '%s' using policy '%s' could not be processed: error occurred obtaining session information: %+v", requester.GetID(), client.GetID(), policy.Name, err)
+
+		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oauthelia2.ErrServerError.WithHint("Could not obtain the user session."))
+
+		return
+	}
+
+	if userSession, err = provider.GetSession(ctx.RequestCtx); err != nil {
 		ctx.Logger.Errorf("Authorization Request with id '%s' on client with id '%s' using policy '%s' could not be processed: error occurred obtaining session information: %+v", requester.GetID(), client.GetID(), policy.Name, err)
 
 		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oauthelia2.ErrServerError.WithHint("Could not obtain the user session."))
@@ -103,7 +112,7 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 
 	issuer = ctx.RootURL()
 
-	if consent, handled = handleOAuth2AuthorizationConsent(ctx, issuer, client, userSession, rw, r, requester); handled {
+	if consent, handled = handleOAuth2AuthorizationConsent(ctx, issuer, client, provider, userSession, rw, r, requester); handled {
 		return
 	}
 

--- a/internal/handlers/handler_oauth2_authorization_consent_core.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_core.go
@@ -18,7 +18,7 @@ import (
 	"github.com/authelia/authelia/v4/internal/session"
 )
 
-func handleOAuth2AuthorizationConsent(ctx *middlewares.AutheliaCtx, issuer *url.URL, client oidc.Client,
+func handleOAuth2AuthorizationConsent(ctx *middlewares.AutheliaCtx, issuer *url.URL, client oidc.Client, policy oidc.ClientAuthorizationPolicy,
 	provider *session.Session, userSession session.UserSession,
 	rw http.ResponseWriter, r *http.Request, requester oauthelia2.Requester) (consent *model.OAuth2ConsentSession, handled bool) {
 	var (
@@ -28,24 +28,10 @@ func handleOAuth2AuthorizationConsent(ctx *middlewares.AutheliaCtx, issuer *url.
 
 	var handler handlerAuthorizationConsent
 
-	if modified, invalid := handleSessionValidateRefresh(ctx, &userSession, ctx.Configuration.AuthenticationBackend.RefreshInterval); invalid {
-		if err = ctx.DestroySession(); err != nil {
-			ctx.Logger.WithError(err).Errorf("Unable to destroy user session")
-		}
-
-		userSession = provider.NewDefaultUserSession()
-		userSession.LastActivity = ctx.Clock.Now().Unix()
-
-		if err = provider.SaveSession(ctx.RequestCtx, userSession); err != nil {
-			ctx.Logger.WithError(err).Error("Unable to save updated user session")
-		}
-	} else if modified {
-		if err = provider.SaveSession(ctx.RequestCtx, userSession); err != nil {
-			ctx.Logger.WithError(err).Error("Unable to save updated user session")
-		}
+	if handled = handleOAuth2AuthorizationConsentSessionUpdates(ctx, provider, &userSession, client, policy, rw, requester); handled {
+		return nil, handled
 	}
 
-	policy := client.GetAuthorizationPolicy()
 	level := policy.GetRequiredLevel(authorization.Subject{Username: userSession.Username, Groups: userSession.Groups, IP: ctx.RemoteIP()})
 
 	switch {
@@ -99,6 +85,37 @@ func handleOAuth2AuthorizationConsent(ctx *middlewares.AutheliaCtx, issuer *url.
 	}
 
 	return handler(ctx, issuer, client, userSession, subject, rw, r, requester)
+}
+
+func handleOAuth2AuthorizationConsentSessionUpdates(ctx *middlewares.AutheliaCtx, provider *session.Session, userSession *session.UserSession, client oidc.Client, policy oidc.ClientAuthorizationPolicy, rw http.ResponseWriter, requester oauthelia2.Requester) (handled bool) {
+	var err error
+
+	if modified, invalid := handleSessionValidateRefresh(ctx, userSession, ctx.Configuration.AuthenticationBackend.RefreshInterval); invalid {
+		if err = ctx.DestroySession(); err != nil {
+			ctx.Logger.WithError(err).Errorf("Authorization Request with id '%s' on client with id '%s' using policy '%s' for user '%s' had an error while destroying session", requester.GetID(), client.GetID(), policy.Name, userSession.Username)
+		}
+
+		*userSession = provider.NewDefaultUserSession()
+		userSession.LastActivity = ctx.Clock.Now().Unix()
+
+		if err = provider.SaveSession(ctx.RequestCtx, *userSession); err != nil {
+			ctx.Logger.WithError(err).Errorf("Authorization Request with id '%s' on client with id '%s' using policy '%s' for user '%s' had an error while saving updated session", requester.GetID(), client.GetID(), policy.Name, userSession.Username)
+
+			ctx.Providers.OpenIDConnect.WriteDynamicAuthorizeError(ctx, rw, requester, oidc.ErrClientAuthorizationUserAccessDenied)
+
+			return true
+		}
+	} else if modified {
+		if err = provider.SaveSession(ctx.RequestCtx, *userSession); err != nil {
+			ctx.Logger.WithError(err).Errorf("Authorization Request with id '%s' on client with id '%s' using policy '%s' for user '%s' had an error while saving updated session", requester.GetID(), client.GetID(), policy.Name, userSession.Username)
+
+			ctx.Providers.OpenIDConnect.WriteDynamicAuthorizeError(ctx, rw, requester, oidc.ErrClientAuthorizationUserAccessDenied)
+
+			return true
+		}
+	}
+
+	return false
 }
 
 func handleOAuth2AuthorizationConsentNotAuthenticated(ctx *middlewares.AutheliaCtx, issuer *url.URL, client oidc.Client,


### PR DESCRIPTION
This fixes an issue where the Authorization Request relies on background updates to user sessions which under niche conditions may result in sessions not being updated promptly.

Fixes #9677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved session validation to track and save changes only when necessary, reducing unnecessary session saves.
	- Enhanced session refresh logic during OAuth2 authorization consent, ensuring user sessions are updated or reset as appropriate.
	- Streamlined session retrieval and error handling in OAuth2 authorization flows for better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->