### PR TITLE
docs: update oidc

### DIFF
--- a/docs/content/configuration/identity-providers/openid-connect/clients.md
+++ b/docs/content/configuration/identity-providers/openid-connect/clients.md
@@ -325,6 +325,17 @@ type, but when it is supported it will include the `query` response mode.
 
 {{< confkey type="string" default="two_factor" required="no" >}}
 
+{{< callout context="note" title="Note" icon="outline/info-circle" >}}
+This option is aimed at providing authorization customization for this particular client. This option should not be
+confused with the [Access Control Rules](../../security/access-control.md#rules) section and this option is distinctly
+and intentionally different. The reasons for the differences are clearly explained in the
+[OpenID Connect 1.0 FAQ](../../../integration/openid-connect/frequently-asked-questions.md#why-doesnt-the-access-control-configuration-work-with-openid-connect-10)
+and [ADR1](../../../reference/architecture-decision-log/1.md). This policy specifically applies solely to Authorization Requests and
+should not be used as a crutch for applications which do not implement the most basic
+level of access control on their end.
+{{< /callout >}}
+
+
 The authorization policy for this client: either `one_factor`, `two_factor`, or one of the ones configured in the
 provider [authorization_policies](./provider.md#authorization_policies) section.
 

--- a/docs/content/configuration/identity-providers/openid-connect/provider.md
+++ b/docs/content/configuration/identity-providers/openid-connect/provider.md
@@ -393,7 +393,9 @@ available are distinctly and intentionally different to those of the
 [Access Control Rules](../../security/access-control.md#rules) unless explicitly specified in this section. The reasons
 for the differences are clearly explained in the
 [OpenID Connect 1.0 FAQ](../../../integration/openid-connect/frequently-asked-questions.md#why-doesnt-the-access-control-configuration-work-with-openid-connect-10)
-and [ADR1](../../../reference/architecture-decision-log/1.md).
+and [ADR1](../../../reference/architecture-decision-log/1.md). These policies specifically apply solely to Authorization Requests and
+should not be used as a crutch for applications which do not implement the most basic
+level of access control on their end.
 {{< /callout >}}
 
 The authorization policies section allows creating custom authorization policies which can be applied to clients. This

--- a/docs/content/reference/architecture-decision-log/1.md
+++ b/docs/content/reference/architecture-decision-log/1.md
@@ -118,6 +118,12 @@ sense. At the time of this decision being published the only element that is con
 is the possibility that the network criteria will be added in the future as a reasonable argument for why it may be
 practical has been made.
 
+These policies will only have an effect specifically during the **_Authorization Request_** itself, and not any subsequent
+flow as these policies should not be a replacement for applications implementing the bare minimum access controls
+(neither users without an account or with disabled accounts in the third-party application should not be able to
+authorize themselves) and as there is no room within the specification to perform these actions except through the
+various session management specifications.
+
 In addition, we will aim to instead of implementing provider side policies to implement the elements that are part of
 the specification such as the Authentication Method References claim (i.e. `amr`) which is already supported, and the
 Requested Authentication Context Class Reference parameter (i.e. `acr_values`).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the scope and intended use of OpenID Connect authorization policies, emphasizing they apply only to Authorization Requests and are not a substitute for basic application access controls.
  - Added explanatory notes and references to relevant FAQs and decision records for further guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->