### PR TITLE
fix(configuration): default pbkdf2 iterations

### DIFF
--- a/cmd/authelia-gen/cmd_docs_data.go
+++ b/cmd/authelia-gen/cmd_docs_data.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -77,6 +78,14 @@ func docsDataMiscRunE(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	data.Support.Traefik = append(data.Support.Traefik, tag)
+
+	data.HashingAlgorithms.PBKDF2.Variants = map[string]DocsDataMiscHashingAlgorithmsVariant{
+		schema.SHA512Lower: {DefaultIterations: strconv.Itoa(schema.PBKDF2VariantDefaultIterations(schema.SHA512Lower)), FIPS: "Approved"},
+		schema.SHA384Lower: {DefaultIterations: strconv.Itoa(schema.PBKDF2VariantDefaultIterations(schema.SHA384Lower)), FIPS: "Approved (Recommended)"},
+		schema.SHA256Lower: {DefaultIterations: strconv.Itoa(schema.PBKDF2VariantDefaultIterations(schema.SHA256Lower)), FIPS: "Approved"},
+		schema.SHA224Lower: {DefaultIterations: strconv.Itoa(schema.PBKDF2VariantDefaultIterations(schema.SHA224Lower)), FIPS: "Approved"},
+		schema.SHA1Lower:   {DefaultIterations: strconv.Itoa(schema.PBKDF2VariantDefaultIterations(schema.SHA1Lower)), FIPS: "Approved only for Legacy Systems"},
+	}
 
 	var (
 		outputPath string

--- a/cmd/authelia-gen/types.go
+++ b/cmd/authelia-gen/types.go
@@ -74,9 +74,23 @@ type GitHubAuthorJSON struct {
 
 // DocsDataMisc represents the docs misc data schema.
 type DocsDataMisc struct {
-	CSP     TemplateCSP         `json:"csp"`
-	Latest  string              `json:"latest"`
-	Support DocsDataMiscSupport `json:"support"`
+	CSP               TemplateCSP                   `json:"csp"`
+	Latest            string                        `json:"latest"`
+	Support           DocsDataMiscSupport           `json:"support"`
+	HashingAlgorithms DocsDataMiscHashingAlgorithms `json:"hashing_algorithms"`
+}
+
+type DocsDataMiscHashingAlgorithms struct {
+	PBKDF2 DocsDataMiscHashingAlgorithmsPBKDF2 `json:"pbkdf2"`
+}
+
+type DocsDataMiscHashingAlgorithmsPBKDF2 struct {
+	Variants map[string]DocsDataMiscHashingAlgorithmsVariant `json:"variants"`
+}
+
+type DocsDataMiscHashingAlgorithmsVariant struct {
+	FIPS              string `json:"fips"`
+	DefaultIterations string `json:"default_iterations"`
 }
 
 type DocsDataMiscSupport struct {

--- a/cmd/authelia-scripts/cmd/gen.go
+++ b/cmd/authelia-scripts/cmd/gen.go
@@ -7,5 +7,5 @@
 package cmd
 
 const (
-	versionSwaggerUI = "5.24.1"
+	versionSwaggerUI = "5.25.2"
 )

--- a/docs/content/configuration/first-factor/file.md
+++ b/docs/content/configuration/first-factor/file.md
@@ -260,14 +260,24 @@ The [PBKDF2] algorithm implementation.
 
 {{< confkey type="string" default="sha512" required="no" >}}
 
-Controls the variant when hashing passwords using [PBKDF2]. Recommended `sha512`.
-Permitted values `sha1`, `sha224`, `sha256`, `sha384`, `sha512`.
+Controls the variant when hashing passwords using [PBKDF2].
+
+The below table has the supported variants, information on NIST FIPS 140 compliance status. Compliant means it's been
+formally tested by a NIST accredited laboratory, Approved means it should theoretically become Compliant when formally
+tested by a NIST accredited laboratory.
+
+{{% hashing-pbkdf2-variants %}}
 
 #### iterations
 
-{{< confkey type="integer" default="310000" required="no" >}}
+{{< confkey type="integer" required="no" >}}
 
 Controls the number of iterations when hashing passwords using [PBKDF2].
+
+The default value is based on the variant as described in the below table. These values are slightly higher than the
+FIPS 140 recommendations for future proofing.
+
+{{% hashing-pbkdf2-iterations %}}
 
 #### salt_length
 

--- a/docs/content/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
+++ b/docs/content/reference/cli/authelia/authelia_crypto_hash_generate_pbkdf2.md
@@ -38,7 +38,7 @@ authelia crypto hash generate pbkdf2 --help
 
 ```
   -h, --help             help for pbkdf2
-  -i, --iterations int   number of iterations (default 310000)
+  -i, --iterations int   number of iterations (default is determined by the variant)
   -s, --salt-size int    salt size in bytes (default 16)
   -v, --variant string   variant, options are 'sha1', 'sha224', 'sha256', 'sha384', and 'sha512' (default "sha512")
 ```

--- a/docs/data/misc.json
+++ b/docs/data/misc.json
@@ -10,5 +10,31 @@
             "v3.4.1",
             "v2.11.25"
         ]
+    },
+    "hashing_algorithms": {
+        "pbkdf2": {
+            "variants": {
+                "sha1": {
+                    "fips": "Approved only for Legacy Systems",
+                    "default_iterations": "1600000"
+                },
+                "sha224": {
+                    "fips": "Approved",
+                    "default_iterations": "900000"
+                },
+                "sha256": {
+                    "fips": "Approved",
+                    "default_iterations": "700000"
+                },
+                "sha384": {
+                    "fips": "Approved (Recommended)",
+                    "default_iterations": "280000"
+                },
+                "sha512": {
+                    "fips": "Approved",
+                    "default_iterations": "310000"
+                }
+            }
+        }
     }
 }

--- a/docs/layouts/shortcodes/hashing-pbkdf2-iterations.html
+++ b/docs/layouts/shortcodes/hashing-pbkdf2-iterations.html
@@ -1,0 +1,5 @@
+|      Variant     |        Default Iterations        |
+|:----------------:|:--------------------------------:|
+{{- range $variant, $values := .Site.Data.misc.hashing_algorithms.pbkdf2.variants }}
+| `{{ $variant }}` | {{ $values.default_iterations }} |
+{{- end }}

--- a/docs/layouts/shortcodes/hashing-pbkdf2-variants.html
+++ b/docs/layouts/shortcodes/hashing-pbkdf2-variants.html
@@ -1,0 +1,5 @@
+|     Variant      |      FIPS 140      |          Iterations              |
+|:----------------:|:------------------:|:--------------------------------:|
+{{- range $variant, $values := .Site.Data.misc.hashing_algorithms.pbkdf2.variants }}
+| `{{ $variant }}` | {{ $values.fips }} | {{ $values.default_iterations }} |
+{{- end }}

--- a/internal/commands/crypto_hash.go
+++ b/internal/commands/crypto_hash.go
@@ -124,7 +124,7 @@ func newCryptoHashGenerateSubCmd(ctx *CmdCtx, use string) (cmd *cobra.Command) {
 		cmd.Flags().StringP(cmdFlagNameVariant, "v", schema.DefaultPasswordConfig.SHA2Crypt.Variant, "variant, options are sha256 and sha512")
 		cmd.PreRunE = ctx.ChainRunE()
 	case cmdUseHashPBKDF2:
-		cmdFlagIterations(cmd, schema.DefaultPasswordConfig.PBKDF2.Iterations)
+		cmdFlagIterationsWithUsage(cmd, 0, "number of iterations (default is determined by the variant)")
 		cmdFlagSaltSize(cmd, schema.DefaultPasswordConfig.PBKDF2.SaltLength)
 
 		cmd.Flags().StringP(cmdFlagNameVariant, "v", schema.DefaultPasswordConfig.PBKDF2.Variant, "variant, options are 'sha1', 'sha224', 'sha256', 'sha384', and 'sha512'")
@@ -361,7 +361,11 @@ func cmdFlagRandomPassword(cmd *cobra.Command) {
 }
 
 func cmdFlagIterations(cmd *cobra.Command, value int) {
-	cmd.Flags().IntP(cmdFlagNameIterations, "i", value, "number of iterations")
+	cmdFlagIterationsWithUsage(cmd, value, "number of iterations")
+}
+
+func cmdFlagIterationsWithUsage(cmd *cobra.Command, value int, usage string) {
+	cmd.Flags().IntP(cmdFlagNameIterations, "i", value, usage)
 }
 
 func cmdFlagKeySize(cmd *cobra.Command, value int) {

--- a/internal/configuration/schema/authentication.go
+++ b/internal/configuration/schema/authentication.go
@@ -210,13 +210,13 @@ var DefaultPasswordConfig = AuthenticationBackendFilePassword{
 		SaltLength:  16,
 	},
 	SHA2Crypt: AuthenticationBackendFilePasswordSHA2Crypt{
-		Variant:    sha512,
+		Variant:    SHA512Lower,
 		Iterations: 50000,
 		SaltLength: 16,
 	},
 	PBKDF2: AuthenticationBackendFilePasswordPBKDF2{
-		Variant:    sha512,
-		Iterations: 310000,
+		Variant:    SHA512Lower,
+		Iterations: defaultIterationsPBKDF2SHA512,
 		SaltLength: 16,
 	},
 	Bcrypt: AuthenticationBackendFilePasswordBcrypt{
@@ -233,6 +233,14 @@ var DefaultPasswordConfig = AuthenticationBackendFilePassword{
 	},
 }
 
+const (
+	defaultIterationsPBKDF2SHA512 = 310000
+	defaultIterationsPBKDF2SHA384 = 280000
+	defaultIterationsPBKDF2SHA256 = 700000
+	defaultIterationsPBKDF2SHA224 = 900000
+	defaultIterationsPBKDF2SHA1   = 1600000
+)
+
 // DefaultCIPasswordConfig represents the default configuration related to Argon2id hashing for CI.
 var DefaultCIPasswordConfig = AuthenticationBackendFilePassword{
 	Algorithm: argon2,
@@ -244,7 +252,7 @@ var DefaultCIPasswordConfig = AuthenticationBackendFilePassword{
 		SaltLength:  16,
 	},
 	SHA2Crypt: AuthenticationBackendFilePasswordSHA2Crypt{
-		Variant:    sha512,
+		Variant:    SHA512Lower,
 		Iterations: 50000,
 		SaltLength: 16,
 	},

--- a/internal/configuration/schema/const.go
+++ b/internal/configuration/schema/const.go
@@ -9,7 +9,14 @@ import (
 const (
 	argon2   = "argon2"
 	argon2id = "argon2id"
-	sha512   = "sha512"
+)
+
+const (
+	SHA1Lower   = "sha1"
+	SHA224Lower = "sha224"
+	SHA256Lower = "sha256"
+	SHA384Lower = "sha384"
+	SHA512Lower = "sha512"
 )
 
 const (

--- a/internal/configuration/schema/util.go
+++ b/internal/configuration/schema/util.go
@@ -1,0 +1,16 @@
+package schema
+
+func PBKDF2VariantDefaultIterations(variant string) int {
+	switch variant {
+	case SHA512Lower, "":
+		return defaultIterationsPBKDF2SHA512
+	case SHA384Lower:
+		return defaultIterationsPBKDF2SHA384
+	case SHA256Lower:
+		return defaultIterationsPBKDF2SHA256
+	case SHA224Lower:
+		return defaultIterationsPBKDF2SHA224
+	default:
+		return defaultIterationsPBKDF2SHA1
+	}
+}

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -197,7 +197,7 @@ func validateFileAuthenticationBackendPasswordConfigPBKDF2(config *schema.Authen
 
 	switch {
 	case config.PBKDF2.Iterations == 0:
-		config.PBKDF2.Iterations = schema.DefaultPasswordConfig.PBKDF2.Iterations
+		config.PBKDF2.Iterations = schema.PBKDF2VariantDefaultIterations(config.PBKDF2.Variant)
 	case config.PBKDF2.Iterations < pbkdf2.IterationsMin:
 		validator.Push(fmt.Errorf(errFmtFileAuthBackendPasswordOptionTooSmall, hashPBKDF2, "iterations", config.PBKDF2.Iterations, pbkdf2.IterationsMin))
 	case config.PBKDF2.Iterations > pbkdf2.IterationsMax:

--- a/internal/configuration/validator/authentication_test.go
+++ b/internal/configuration/validator/authentication_test.go
@@ -116,7 +116,7 @@ func (suite *FileBasedAuthenticationBackend) TestShouldMigrateLegacyConfiguratio
 	suite.Equal("", suite.config.File.Password.Algorithm)
 
 	suite.config.File.Password = schema.AuthenticationBackendFilePassword{
-		Algorithm:  digestSHA512,
+		Algorithm:  schema.SHA512Lower,
 		Iterations: 1000000,
 		SaltLength: 8,
 	}
@@ -127,7 +127,7 @@ func (suite *FileBasedAuthenticationBackend) TestShouldMigrateLegacyConfiguratio
 	suite.Len(suite.validator.Errors(), 0)
 
 	suite.Equal(hashSHA2Crypt, suite.config.File.Password.Algorithm)
-	suite.Equal(digestSHA512, suite.config.File.Password.SHA2Crypt.Variant)
+	suite.Equal(schema.SHA512Lower, suite.config.File.Password.SHA2Crypt.Variant)
 	suite.Equal(1000000, suite.config.File.Password.SHA2Crypt.Iterations)
 	suite.Equal(8, suite.config.File.Password.SHA2Crypt.SaltLength)
 }
@@ -137,11 +137,11 @@ func (suite *FileBasedAuthenticationBackend) TestShouldMigrateLegacyConfiguratio
 	suite.Equal("", suite.config.File.Password.Algorithm)
 
 	suite.config.File.Password = schema.AuthenticationBackendFilePassword{
-		Algorithm:  digestSHA512,
+		Algorithm:  schema.SHA512Lower,
 		Iterations: 1000000,
 		SaltLength: 8,
 		SHA2Crypt: schema.AuthenticationBackendFilePasswordSHA2Crypt{
-			Variant:    digestSHA256,
+			Variant:    schema.SHA256Lower,
 			Iterations: 50000,
 			SaltLength: 12,
 		},
@@ -153,7 +153,7 @@ func (suite *FileBasedAuthenticationBackend) TestShouldMigrateLegacyConfiguratio
 	suite.Len(suite.validator.Errors(), 0)
 
 	suite.Equal(hashSHA2Crypt, suite.config.File.Password.Algorithm)
-	suite.Equal(digestSHA256, suite.config.File.Password.SHA2Crypt.Variant)
+	suite.Equal(schema.SHA256Lower, suite.config.File.Password.SHA2Crypt.Variant)
 	suite.Equal(50000, suite.config.File.Password.SHA2Crypt.Iterations)
 	suite.Equal(12, suite.config.File.Password.SHA2Crypt.SaltLength)
 }
@@ -163,7 +163,7 @@ func (suite *FileBasedAuthenticationBackend) TestShouldMigrateLegacyConfiguratio
 	suite.Equal("", suite.config.File.Password.Algorithm)
 
 	suite.config.File.Password = schema.AuthenticationBackendFilePassword{
-		Algorithm:  digestSHA512,
+		Algorithm:  schema.SHA512Lower,
 		Iterations: 1000000,
 		SaltLength: 64,
 	}
@@ -174,7 +174,7 @@ func (suite *FileBasedAuthenticationBackend) TestShouldMigrateLegacyConfiguratio
 	suite.Len(suite.validator.Errors(), 0)
 
 	suite.Equal(hashSHA2Crypt, suite.config.File.Password.Algorithm)
-	suite.Equal(digestSHA512, suite.config.File.Password.SHA2Crypt.Variant)
+	suite.Equal(schema.SHA512Lower, suite.config.File.Password.SHA2Crypt.Variant)
 	suite.Equal(1000000, suite.config.File.Password.SHA2Crypt.Iterations)
 	suite.Equal(16, suite.config.File.Password.SHA2Crypt.SaltLength)
 }
@@ -244,7 +244,7 @@ func (suite *FileBasedAuthenticationBackend) TestShouldMigrateLegacyConfiguratio
 func (suite *FileBasedAuthenticationBackend) TestShouldMigrateLegacyConfigurationWhenOnlySHA512Set() {
 	suite.config.File.Password = schema.AuthenticationBackendFilePassword{}
 	suite.Equal("", suite.config.File.Password.Algorithm)
-	suite.config.File.Password.Algorithm = digestSHA512
+	suite.config.File.Password.Algorithm = schema.SHA512Lower
 
 	ValidateAuthenticationBackend(&suite.config, suite.validator)
 
@@ -252,7 +252,7 @@ func (suite *FileBasedAuthenticationBackend) TestShouldMigrateLegacyConfiguratio
 	suite.Len(suite.validator.Errors(), 0)
 
 	suite.Equal(hashSHA2Crypt, suite.config.File.Password.Algorithm)
-	suite.Equal(digestSHA512, suite.config.File.Password.SHA2Crypt.Variant)
+	suite.Equal(schema.SHA512Lower, suite.config.File.Password.SHA2Crypt.Variant)
 	suite.Equal(schema.DefaultPasswordConfig.SHA2Crypt.Iterations, suite.config.File.Password.SHA2Crypt.Iterations)
 	suite.Equal(schema.DefaultPasswordConfig.SHA2Crypt.SaltLength, suite.config.File.Password.SHA2Crypt.SaltLength)
 }

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -32,18 +32,10 @@ const (
 	durationZero = time.Duration(0)
 )
 
-const (
-	digestSHA1   = "sha1"
-	digestSHA224 = "sha224"
-	digestSHA256 = "sha256"
-	digestSHA384 = "sha384"
-	digestSHA512 = "sha512"
-)
-
 // Hashing constants.
 const (
 	hashLegacyArgon2id = "argon2id"
-	hashLegacySHA512   = digestSHA512
+	hashLegacySHA512   = schema.SHA512Lower
 
 	hashArgon2    = "argon2"
 	hashSHA2Crypt = "sha2crypt"
@@ -522,9 +514,9 @@ var (
 
 var (
 	validArgon2Variants    = []string{"argon2id", "id", "argon2i", "i", "argon2d", "d"}
-	validSHA2CryptVariants = []string{digestSHA256, digestSHA512}
-	validPBKDF2Variants    = []string{digestSHA1, digestSHA224, digestSHA256, digestSHA384, digestSHA512}
-	validBcryptVariants    = []string{"standard", digestSHA256}
+	validSHA2CryptVariants = []string{schema.SHA256Lower, schema.SHA512Lower}
+	validPBKDF2Variants    = []string{schema.SHA1Lower, schema.SHA224Lower, schema.SHA256Lower, schema.SHA384Lower, schema.SHA512Lower}
+	validBcryptVariants    = []string{"standard", schema.SHA256Lower}
 	validScryptVariants    = []string{"scrypt", "yescrypt"}
 	validHashAlgorithms    = []string{hashSHA2Crypt, hashPBKDF2, hashScrypt, hashBcrypt, hashArgon2}
 )

--- a/internal/configuration/validator/totp_test.go
+++ b/internal/configuration/validator/totp_test.go
@@ -30,7 +30,7 @@ func TestValidateTOTP(t *testing.T) {
 		{
 			desc: "ShouldNormalizeTOTPAlgorithm",
 			have: schema.TOTP{
-				DefaultAlgorithm: digestSHA1,
+				DefaultAlgorithm: schema.SHA1Lower,
 				DefaultDigits:    6,
 				DefaultPeriod:    30,
 				SecretSize:       32,


### PR DESCRIPTION
This fixes an issue where realistically the default iterations for PBKDF2 were always 310,000. But reasonably we should increase the iterations for weaker algorithms. As such the new default values are based on the NIST FIPS 140 recommendations and have been tuned to be slightly higher than those. Effectively this is a minor issue, but it deserves to be adjusted to the benefit of all users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documentation now includes detailed tables listing PBKDF2 hashing algorithm variants, their FIPS 140 compliance status, and default iteration counts.
  - The CLI now dynamically determines the default PBKDF2 iteration count based on the selected variant.

- **Bug Fixes**
  - Improved consistency in the use of hashing algorithm variant names across configuration, validation, and tests.

- **Documentation**
  - Expanded and clarified PBKDF2 configuration documentation, including compliance explanations and dynamic default values.
  - Added new shortcodes for rendering PBKDF2 variant and iteration tables.

- **Chores**
  - Updated Swagger UI version in scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->