### PR TITLE
fix(webauthn): allow relaxed cache policy

### DIFF
--- a/docs/data/configkeys.json
+++ b/docs/data/configkeys.json
@@ -1275,6 +1275,11 @@
         "env": "AUTHELIA_WEBAUTHN_FILTERING_PROHIBIT_BACKUP_ELIGIBILITY"
     },
     {
+        "path": "webauthn.metadata.cache_policy",
+        "secret": false,
+        "env": "AUTHELIA_WEBAUTHN_METADATA_CACHE_POLICY"
+    },
+    {
         "path": "webauthn.metadata.enabled",
         "secret": false,
         "env": "AUTHELIA_WEBAUTHN_METADATA_ENABLED"

--- a/docs/static/schemas/latest/json-schema/configuration.json
+++ b/docs/static/schemas/latest/json-schema/configuration.json
@@ -4399,6 +4399,16 @@
           "description": "Enables the use of the WebAuthn Metadata Service.",
           "default": false
         },
+        "cache_policy": {
+          "type": "string",
+          "enum": [
+            "compliant",
+            "relaxed"
+          ],
+          "title": "Cache Policy",
+          "description": "WebAuthn Authenticator metadata cache policy.",
+          "default": "compliant"
+        },
         "validate_trust_anchor": {
           "type": "boolean",
           "title": "Validate Trust Anchor",

--- a/docs/static/schemas/v4.39/json-schema/configuration.json
+++ b/docs/static/schemas/v4.39/json-schema/configuration.json
@@ -4399,6 +4399,16 @@
           "description": "Enables the use of the WebAuthn Metadata Service.",
           "default": false
         },
+        "cache_policy": {
+          "type": "string",
+          "enum": [
+            "compliant",
+            "relaxed"
+          ],
+          "title": "Cache Policy",
+          "description": "WebAuthn Authenticator metadata cache policy.",
+          "default": "compliant"
+        },
         "validate_trust_anchor": {
           "type": "boolean",
           "title": "Validate Trust Anchor",

--- a/internal/configuration/schema/keys.go
+++ b/internal/configuration/schema/keys.go
@@ -479,6 +479,7 @@ var Keys = []string{
 	"webauthn.filtering.permitted_aaguids",
 	"webauthn.filtering.prohibit_backup_eligibility",
 	"webauthn.filtering.prohibited_aaguids",
+	"webauthn.metadata.cache_policy",
 	"webauthn.metadata.enabled",
 	"webauthn.metadata.validate_entry",
 	"webauthn.metadata.validate_entry_permit_zero_aaguid",

--- a/internal/configuration/schema/webauthn.go
+++ b/internal/configuration/schema/webauthn.go
@@ -28,6 +28,8 @@ type WebAuthn struct {
 type WebAuthnMetadata struct {
 	Enabled bool `koanf:"enabled" yaml:"enabled" toml:"enabled" json:"enabled" jsonschema:"default=false,title=Enabled" jsonschema_description:"Enables the use of the WebAuthn Metadata Service."`
 
+	CachePolicy string `koanf:"cache_policy" yaml:"cache_policy" toml:"cache_policy" json:"cache_policy" jsonschema:"default=compliant,enum=compliant,enum=relaxed,title=Cache Policy" jsonschema_description:"WebAuthn Authenticator metadata cache policy."`
+
 	ValidateTrustAnchor           bool `koanf:"validate_trust_anchor" yaml:"validate_trust_anchor" toml:"validate_trust_anchor" json:"validate_trust_anchor" jsonschema:"default=true,title=Validate Trust Anchor" jsonschema_description:"WebAuthn Authenticator metadata entry trust anchor validation."`
 	ValidateEntry                 bool `koanf:"validate_entry" yaml:"validate_entry" toml:"validate_entry" json:"validate_entry" jsonschema:"default=true,title=Filtering" jsonschema_description:"WebAuthn Authenticator metadata entry validation requires the AAGUID exists as a MDS3 registered entry."`
 	ValidateEntryPermitZeroAAGUID bool `koanf:"validate_entry_permit_zero_aaguid" yaml:"validate_entry_permit_zero_aaguid" toml:"validate_entry_permit_zero_aaguid" json:"validate_entry_permit_zero_aaguid" jsonschema:"default=true,title=Filtering" jsonschema_description:"WebAuthn Authenticator metadata entry validation zero AAGUID's can be skipped'."`

--- a/internal/logging/const.go
+++ b/internal/logging/const.go
@@ -65,6 +65,7 @@ const (
 	FieldResponded           = "responded"
 	FieldGranted             = "granted"
 	FieldStatus              = "status"
+	FieldProvider            = "provider"
 )
 
 var (

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -101,7 +101,6 @@ const (
 )
 
 const (
-	LogFieldProvider                 = "provider"
 	LogMessageStartupCheckError      = "Error occurred running a startup check"
 	LogMessageStartupCheckPerforming = "Performing Startup Check"
 

--- a/internal/middlewares/startup.go
+++ b/internal/middlewares/startup.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/authelia/authelia/v4/internal/logging"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/utils"
 )
@@ -17,23 +18,23 @@ func (p *Providers) StartupChecks(ctx Context, log bool) (err error) {
 	)
 
 	provider, disable = ctx.GetProviders().StorageProvider, false
-	doStartupCheck(ctx, ProviderNameStorage, provider, disable, log, e.errors)
+	doStartupCheck(ctx, ProviderNameStorage, provider, nil, disable, log, e.errors)
 
 	provider, disable = ctx.GetProviders().UserProvider, false
-	doStartupCheck(ctx, ProviderNameUser, provider, disable, log, e.errors)
+	doStartupCheck(ctx, ProviderNameUser, provider, nil, disable, log, e.errors)
 
 	provider, disable = ctx.GetProviders().Notifier, ctx.GetConfiguration().Notifier.DisableStartupCheck
-	doStartupCheck(ctx, ProviderNameNotification, provider, disable, log, e.errors)
+	doStartupCheck(ctx, ProviderNameNotification, provider, nil, disable, log, e.errors)
 
 	provider, disable = ctx.GetProviders().NTP, ctx.GetConfiguration().NTP.DisableStartupCheck
-	doStartupCheck(ctx, ProviderNameNTP, provider, disable, log, e.errors)
+	doStartupCheck(ctx, ProviderNameNTP, provider, nil, disable, log, e.errors)
 
 	provider, disable = ctx.GetProviders().UserAttributeResolver, false
-	doStartupCheck(ctx, ProviderNameExpressions, provider, disable, log, e.errors)
+	doStartupCheck(ctx, ProviderNameExpressions, provider, nil, disable, log, e.errors)
 
 	provider = ctx.GetProviders().MetaDataService
 	disable = !ctx.GetConfiguration().WebAuthn.Metadata.Enabled || ctx.GetProviders().MetaDataService == nil
-	doStartupCheck(ctx, ProviderNameWebAuthnMetaData, provider, disable, log, e.errors)
+	doStartupCheck(ctx, ProviderNameWebAuthnMetaData, provider, []string{ProviderNameStorage}, disable, log, e.errors)
 
 	var filters []string
 
@@ -44,9 +45,9 @@ func (p *Providers) StartupChecks(ctx Context, log bool) (err error) {
 	return e.FilterError(filters...)
 }
 
-func doStartupCheck(ctx Context, name string, provider model.StartupCheck, disabled, log bool, errors map[string]error) {
+func doStartupCheck(ctx Context, name string, provider model.StartupCheck, required []string, disabled, log bool, errors map[string]error) {
 	if log {
-		ctx.GetLogger().WithFields(map[string]any{LogFieldProvider: name}).Trace(LogMessageStartupCheckPerforming)
+		ctx.GetLogger().WithFields(map[string]any{logging.FieldProvider: name}).Trace(LogMessageStartupCheckPerforming)
 	}
 
 	if disabled {
@@ -63,11 +64,26 @@ func doStartupCheck(ctx Context, name string, provider model.StartupCheck, disab
 		return
 	}
 
+	if len(required) > 0 {
+		for _, rname := range required {
+			if _, ok := errors[rname]; ok {
+				err := fmt.Errorf("provider requires that the '%s' provider was sccessful but it wasn't", rname)
+
+				errors[name] = err
+
+				if log {
+					ctx.GetLogger().WithError(err).WithField(logging.FieldProvider, name).Error(LogMessageStartupCheckError)
+				}
+
+				return
+			}
+		}
+	}
 	var err error
 
 	if err = provider.StartupCheck(); err != nil {
 		if log {
-			ctx.GetLogger().WithError(err).WithField(LogFieldProvider, name).Error(LogMessageStartupCheckError)
+			ctx.GetLogger().WithError(err).WithField(logging.FieldProvider, name).Error(LogMessageStartupCheckError)
 		}
 
 		errors[name] = err
@@ -76,7 +92,7 @@ func doStartupCheck(ctx Context, name string, provider model.StartupCheck, disab
 	}
 
 	if log {
-		ctx.GetLogger().WithFields(map[string]any{LogFieldProvider: name}).Trace("Startup Check Completed Successfully")
+		ctx.GetLogger().WithFields(map[string]any{logging.FieldProvider: name}).Trace("Startup Check Completed Successfully")
 	}
 }
 

--- a/internal/webauthn/metadata.go
+++ b/internal/webauthn/metadata.go
@@ -14,9 +14,11 @@ import (
 	"github.com/go-webauthn/webauthn/metadata/providers/cached"
 	"github.com/go-webauthn/webauthn/metadata/providers/memory"
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/logging"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/storage"
 )
@@ -25,10 +27,12 @@ import (
 func NewMetaDataProvider(config *schema.Configuration, store storage.CachedDataProvider) (provider MetaDataProvider, err error) {
 	if config.WebAuthn.Metadata.Enabled {
 		p := &StoreCachedMetadataProvider{
-			new:     newMetadataProviderMemory(config),
-			clock:   &metadata.RealClock{},
-			store:   store,
-			handler: &productionMDS3Provider{},
+			new:         newMetadataProviderMemory(config),
+			clock:       &metadata.RealClock{},
+			store:       store,
+			log:         logging.Logger().WithFields(map[string]any{logging.FieldProvider: "webauthn-metadata"}),
+			cachePolicy: config.WebAuthn.Metadata.CachePolicy,
+			handler:     &productionMDS3Provider{},
 		}
 
 		if p.decoder, err = metadata.NewDecoder(metadata.WithIgnoreEntryParsingErrors()); err != nil {
@@ -77,6 +81,10 @@ type StoreCachedMetadataProvider struct {
 	decoder *metadata.Decoder
 	clock   metadata.Clock
 	handler MDS3Provider
+
+	log *logrus.Entry
+
+	cachePolicy string
 
 	update time.Time
 	number int
@@ -131,11 +139,19 @@ func (p *StoreCachedMetadataProvider) init() (err error) {
 	_, _, _ = p.loadCache(ctx)
 
 	if _, data, err = p.loadCurrent(ctx, p.number); err != nil {
-		return fmt.Errorf("error initializing provider: %w", err)
+		if p.cachePolicy != "relaxed" {
+			return fmt.Errorf("error initializing provider: %w", err)
+		}
+
+		p.log.WithError(err).Debug("Error occurred fetching current metadata but the cache policy is relaxed")
 	}
 
 	if p.number <= 0 {
 		return fmt.Errorf("error initializing provider: no metadata was loaded")
+	}
+
+	if p.update.Before(p.clock.Now()) {
+		return fmt.Errorf("error initializing provider: outdated metadata was loaded")
 	}
 
 	if data == nil {


### PR DESCRIPTION
This allows a relaxed cache policy for the MDS3. The compliant mode is recommended but this allows for a more relaxed update profile.