### PR TITLE
docs: add did you know callout to explain role mapping examples

### DIFF
--- a/docs/content/integration/openid-connect/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/nextcloud/index.md
@@ -68,6 +68,12 @@ section of the guide.
 
 #### Authelia
 
+{{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
+The `is_nextcloud_admin` user attribute renders the value `true` if the user is in the `nextcloud-admins` group within
+Authelia, otherwise it renders `false`. You can adjust this to your preference to assign a role to the appropriate user
+groups.
+{{< /callout >}}
+
 The following YAML configuration is an example __Authelia__
 [client configuration] for use with [Nextcloud]
 which will operate with the application example:
@@ -202,6 +208,11 @@ identity_providers:
           - 'profile'
           - 'email'
           - 'groups'
+        response_types:
+          - 'code'
+        grant_types:
+          - 'authorization_code'
+        access_token_signed_response_alg: 'none'
         userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'client_secret_post'
 ```

--- a/docs/content/integration/openid-connect/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/nextcloud/index.md
@@ -70,8 +70,8 @@ section of the guide.
 
 {{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
 The `is_nextcloud_admin` user attribute renders the value `true` if the user is in the `nextcloud-admins` group within
-Authelia, otherwise it renders `false`. You can adjust this to your preference to assign a role to the appropriate user
-groups.
+Authelia, otherwise it renders `false`. You can adjust this to your preference to assign the admin role to the
+appropriate user groups.
 {{< /callout >}}
 
 The following YAML configuration is an example __Authelia__

--- a/docs/content/integration/openid-connect/sftpgo/index.md
+++ b/docs/content/integration/openid-connect/sftpgo/index.md
@@ -46,7 +46,7 @@ Some of the values presented in this guide can automatically be replaced with do
 
 {{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
 The `sftpgo_role` user attribute renders the value `admin` if the user is in the `sftpgo_admins` group within Authelia,
-renders the value `manager` if they are in the "sftpgo_managers" group, otherwise it renders `user`. You can adjust this
+renders the value `manager` if they are in the `sftpgo_managers` group, otherwise it renders `user`. You can adjust this
 to your preference to assign a role to the appropriate user groups.
 {{< /callout >}}
 

--- a/docs/content/integration/openid-connect/vaultwarden/index.md
+++ b/docs/content/integration/openid-connect/vaultwarden/index.md
@@ -38,7 +38,6 @@ This example makes the following assumptions:
 - __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
 - __Client ID:__ `vaultwarden`
 - __Client Secret:__ `insecure_secret`
-- __Groups:__ `vaultwarden_users` for users and `vaultwarden_admins` for admins
 
 Some of the values presented in this guide can automatically be replaced with documentation variables.
 
@@ -47,6 +46,12 @@ Some of the values presented in this guide can automatically be replaced with do
 ## Configuration
 
 ### Authelia
+
+{{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
+The `vaultwarden_roles` user attribute renders the value `["admin"]` if the user is in the `vaultwarden_admins` group
+within Authelia, renders the value `["user"]` if they are in the `vaultwarden_users` group, otherwise it renders `""`.
+You can adjust this to your preference to assign a role to the appropriate user groups.
+{{< /callout >}}
 
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [Vaultwarden] which
 will operate with the application example:


### PR DESCRIPTION
This should streamline the three examples using custom claims and make them more understandable by explaining what the CEL mapping does

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added informational callouts explaining user attribute behavior and customization for admin roles in the Nextcloud and Vaultwarden OpenID Connect integration guides.
	- Updated configuration examples for the Nextcloud integration to clarify OAuth2 response types and token signing algorithm.
	- Improved formatting consistency for group names in the SFTPGo integration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->