### PR TITLE
docs: fix opkssh integration

### DIFF
--- a/docs/content/integration/openid-connect/opkssh/index.md
+++ b/docs/content/integration/openid-connect/opkssh/index.md
@@ -23,7 +23,7 @@ seo:
 - [Authelia]
   - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
 - [opkssh]
-  - [v0.4.0](https://github.com/openpubkey/opkssh/releases/tag/v0.4.0)
+  - [v0.7.0](https://github.com/openpubkey/opkssh/releases/tag/v0.7.0)
 
 {{% oidc-common %}}
 
@@ -67,13 +67,15 @@ identity_providers:
           - 'openid'
           - 'profile'
           - 'email'
+          - 'offline_access'
         response_types:
           - 'code'
         grant_types:
           - 'authorization_code'
+          - 'refresh_token'
         access_token_signed_response_alg: 'none'
         userinfo_signed_response_alg: 'none'
-        token_endpoint_auth_method: 'client_secret_basic'
+        token_endpoint_auth_method: 'none'
 ```
 
 ### Application
@@ -110,6 +112,26 @@ To log in using Authelia run:
 
 ```shell
 opkssh login --provider=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/,opkssh
+```
+
+##### Configuration File
+
+{{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
+Generally the configuration file is named `~/.opk/config.yml` on Linux and `C:\Users\{USER}\.opk\config.yml` on Windows.
+{{< /callout >}}
+
+```yaml{title="~/.opk/config.yml"}
+providers:
+  - alias: authelia
+    issuer: https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
+    client_id: opkssh
+    scopes: openid offline_access profile email
+    access_type: offline
+    prompt: consent
+    redirect_uris:
+      - http://localhost:3000/login-callback
+      - http://localhost:10001/login-callback
+      - http://localhost:11110/login-callback
 ```
 
 ## See Also

--- a/docs/content/integration/openid-connect/opkssh/index.md
+++ b/docs/content/integration/openid-connect/opkssh/index.md
@@ -116,15 +116,17 @@ opkssh login --provider=https://{{< sitevar name="subdomain-authelia" nojs="auth
 
 ##### Configuration File
 
+{{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
+Generally the configuration file is named `~/.opk/config.yml` on Linux and `C:\Users\{USER}\.opk\config.yml` on Windows.
+{{< /callout >}}
+
 To create a persistent configuration, generate a new configuration file by running the following command:
 
 ```shell
 opkssh login --create-config
 ```
 
-{{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
-Generally the configuration file is named `~/.opk/config.yml` on Linux and `C:\Users\{USER}\.opk\config.yml` on Windows.
-{{< /callout >}}
+Then add Authelia to the existing providers:
 
 ```yaml{title="~/.opk/config.yml"}
 providers:
@@ -139,6 +141,8 @@ providers:
       - http://localhost:10001/login-callback
       - http://localhost:11110/login-callback
 ```
+
+You can now run `opkssh login` to login.
 
 ## See Also
 

--- a/docs/content/integration/openid-connect/opkssh/index.md
+++ b/docs/content/integration/openid-connect/opkssh/index.md
@@ -116,6 +116,12 @@ opkssh login --provider=https://{{< sitevar name="subdomain-authelia" nojs="auth
 
 ##### Configuration File
 
+To create a persistent configuration, generate a new configuration file by running the following command:
+
+```shell
+opkssh login --create-config
+```
+
 {{< callout context="tip" title="Did you know?" icon="outline/rocket" >}}
 Generally the configuration file is named `~/.opk/config.yml` on Linux and `C:\Users\{USER}\.opk\config.yml` on Windows.
 {{< /callout >}}


### PR DESCRIPTION
Set the `token_endpoint_auth_method` to `none` for a public client and add a configuration file option.

It is btw possible to configure opkssh oidc spec conform by using the `sub`, however it is not really feasible as the admin doesn't know the `sub` of the users. Let me know what you think.