### PR TITLE
fix(configuration): allow claim name override

### DIFF
--- a/docs/content/configuration/identity-providers/openid-connect/provider.md
+++ b/docs/content/configuration/identity-providers/openid-connect/provider.md
@@ -100,6 +100,7 @@ identity_providers:
         id_token_audience_mode: 'specification'
         custom_claims:
           claim_name:
+            name: 'claim_name'
             attribute: 'attribute_name'
     scopes:
       scope_name:
@@ -647,13 +648,19 @@ The list of claims available in this policy in addition to the standard claims. 
 which can either be concrete attributes from the [first factor](../../first-factor/introduction.md) backend or can be
 those defined via [definitions](../../definitions/user-attributes.md).
 
-The keys under `custom_claims` are arbitrary values which are the names of the claims.
+The keys under `custom_claims` are arbitrary values, and by default are the claim name and attribute values.
+
+##### name
+
+{{< confkey type="string" required="no" >}}
+
+The claim name for this claim. By default it's the same as the dictionary key.
 
 ##### attribute
 
 {{< confkey type="string" required="no" >}}
 
-The attribute name that this claim returns. By default it's the same as the claim name.
+The attribute name that this claim returns. By default it's the same as the dictionary key.
 
 ### scopes
 

--- a/docs/static/schemas/latest/json-schema/configuration.json
+++ b/docs/static/schemas/latest/json-schema/configuration.json
@@ -1484,12 +1484,7 @@
           "default": "specification"
         },
         "custom_claims": {
-          "patternProperties": {
-            ".*": {
-              "$ref": "#/$defs/IdentityProvidersOpenIDConnectCustomClaim"
-            }
-          },
-          "type": "object",
+          "$ref": "#/$defs/IdentityProvidersOpenIDConnectCustomClaims",
           "title": "Custom Claims",
           "description": "The custom claims available in this policy in addition to the Standard Claims."
         }
@@ -2299,6 +2294,11 @@
     },
     "IdentityProvidersOpenIDConnectCustomClaim": {
       "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of claim."
+        },
         "attribute": {
           "type": "string",
           "title": "Attribute",
@@ -2306,6 +2306,14 @@
         }
       },
       "additionalProperties": false,
+      "type": "object"
+    },
+    "IdentityProvidersOpenIDConnectCustomClaims": {
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/$defs/IdentityProvidersOpenIDConnectCustomClaim"
+        }
+      },
       "type": "object"
     },
     "IdentityProvidersOpenIDConnectLifespan": {

--- a/docs/static/schemas/v4.39/json-schema/configuration.json
+++ b/docs/static/schemas/v4.39/json-schema/configuration.json
@@ -1484,12 +1484,7 @@
           "default": "specification"
         },
         "custom_claims": {
-          "patternProperties": {
-            ".*": {
-              "$ref": "#/$defs/IdentityProvidersOpenIDConnectCustomClaim"
-            }
-          },
-          "type": "object",
+          "$ref": "#/$defs/IdentityProvidersOpenIDConnectCustomClaims",
           "title": "Custom Claims",
           "description": "The custom claims available in this policy in addition to the Standard Claims."
         }
@@ -2299,6 +2294,11 @@
     },
     "IdentityProvidersOpenIDConnectCustomClaim": {
       "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of claim."
+        },
         "attribute": {
           "type": "string",
           "title": "Attribute",
@@ -2306,6 +2306,14 @@
         }
       },
       "additionalProperties": false,
+      "type": "object"
+    },
+    "IdentityProvidersOpenIDConnectCustomClaims": {
+      "patternProperties": {
+        ".*": {
+          "$ref": "#/$defs/IdentityProvidersOpenIDConnectCustomClaim"
+        }
+      },
       "type": "object"
     },
     "IdentityProvidersOpenIDConnectLifespan": {

--- a/internal/configuration/schema/identity_providers.go
+++ b/internal/configuration/schema/identity_providers.go
@@ -51,10 +51,23 @@ type IdentityProvidersOpenIDConnectClaimsPolicy struct {
 
 	IDTokenAudienceMode string `koanf:"id_token_audience_mode" yaml:"id_token_audience_mode,omitempty" toml:"id_token_audience_mode,omitempty" json:"id_token_audience_mode,omitempty" jsonschema:"default=specification,title=ID Token Audience Mode,enum=specification,enum=experimental-merged" jsonschema_description:"Sets the mode for ID Token audience derivation for clients that use this policy."`
 
-	CustomClaims map[string]IdentityProvidersOpenIDConnectCustomClaim `koanf:"custom_claims" yaml:"custom_claims,omitempty" toml:"custom_claims,omitempty" json:"custom_claims,omitempty" jsonschema:"title=Custom Claims" jsonschema_description:"The custom claims available in this policy in addition to the Standard Claims."`
+	CustomClaims IdentityProvidersOpenIDConnectCustomClaims `koanf:"custom_claims" yaml:"custom_claims,omitempty" toml:"custom_claims,omitempty" json:"custom_claims,omitempty" jsonschema:"title=Custom Claims" jsonschema_description:"The custom claims available in this policy in addition to the Standard Claims."`
+}
+
+type IdentityProvidersOpenIDConnectCustomClaims map[string]IdentityProvidersOpenIDConnectCustomClaim
+
+func (c IdentityProvidersOpenIDConnectCustomClaims) GetCustomClaimByName(name string) IdentityProvidersOpenIDConnectCustomClaim {
+	for _, properties := range c {
+		if properties.Name == name {
+			return properties
+		}
+	}
+
+	return IdentityProvidersOpenIDConnectCustomClaim{}
 }
 
 type IdentityProvidersOpenIDConnectCustomClaim struct {
+	Name      string `koanf:"name" yaml:"name" toml:"name,omitempty" json:"name,omitempty" jsonschema:"title=Name" jsonschema_description:"The name of claim."`
 	Attribute string `koanf:"attribute" yaml:"attribute,omitempty" toml:"attribute,omitempty" json:"attribute,omitempty" jsonschema:"title=Attribute" jsonschema_description:"The attribute that populates this claim."`
 }
 

--- a/internal/configuration/schema/keys.go
+++ b/internal/configuration/schema/keys.go
@@ -143,6 +143,7 @@ var Keys = []string{
 	"identity_providers.oidc.claims_policies.*.custom_claims",
 	"identity_providers.oidc.claims_policies.*.custom_claims.*",
 	"identity_providers.oidc.claims_policies.*.custom_claims.*.attribute",
+	"identity_providers.oidc.claims_policies.*.custom_claims.*.name",
 	"identity_providers.oidc.claims_policies.*.id_token",
 	"identity_providers.oidc.claims_policies.*.id_token_audience_mode",
 	"identity_providers.oidc.clients",

--- a/internal/configuration/test_resources/config_oidc_claims.yml
+++ b/internal/configuration/test_resources/config_oidc_claims.yml
@@ -131,6 +131,8 @@ definitions:
   user_attributes:
     authelia_admin:
       expression: '"admin" in groups'
+    ioadmin:
+      expression: '"ioadmin" in groups'
 
 identity_providers:
   oidc:
@@ -265,12 +267,36 @@ identity_providers:
       allowed_origins:
         - 'https://google.com'
         - 'https://example.com'
+    scopes:
+      example_scope:
+        claims:
+          - 'http://example.com/myclaim'
     claims_policies:
       default:
         custom_claims:
           authelia_admin: {}
+      example_policy:
+        custom_claims:
+          example:
+            name: 'http://example.com/myclaim'
+            attribute: 'ioadmin'
     clients:
       - client_id: 'abc'
         client_secret: '123'
         consent_mode: 'explicit'
+      - client_id: 'example_client'
+        client_secret: ''
+        public: true
+        authorization_policy: 'one_factor'
+        consent_mode: 'implicit'
+        redirect_uris:
+          - 'http://localhost:42420/3rdparty.UIL.Shell'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'groups'
+          - 'email'
+          - 'example_scope'
+        token_endpoint_auth_method: 'none'
+        claims_policy: 'example_policy'
 ...

--- a/internal/oidc/claims.go
+++ b/internal/oidc/claims.go
@@ -439,6 +439,8 @@ func NewDefaultCustomClaimsStrategy() (strategy *CustomClaimsStrategy) {
 
 // NewCustomClaimsStrategy creates a *CustomClaimsStrategy given a policy name, list of allowed scopes, the scope map,
 // and the policy map.
+//
+//nolint:gocyclo
 func NewCustomClaimsStrategy(policyName string, scopes []string, scopeMap map[string]schema.IdentityProvidersOpenIDConnectScope, policyMap map[string]schema.IdentityProvidersOpenIDConnectClaimsPolicy) (strategy *CustomClaimsStrategy) {
 	strategy = NewDefaultCustomClaimsStrategy()
 
@@ -448,8 +450,8 @@ func NewCustomClaimsStrategy(policyName string, scopes []string, scopeMap map[st
 
 	var (
 		policy  schema.IdentityProvidersOpenIDConnectClaimsPolicy
-		mapping schema.IdentityProvidersOpenIDConnectScope
 		claim   schema.IdentityProvidersOpenIDConnectCustomClaim
+		mapping schema.IdentityProvidersOpenIDConnectScope
 
 		ok   bool
 		name string
@@ -491,12 +493,10 @@ func NewCustomClaimsStrategy(policyName string, scopes []string, scopeMap map[st
 			case ClaimPhoneNumber:
 				strategy.scopes[scope][name] = expression.AttributeUserPhoneNumberRFC3966
 			default:
-				claim = policy.CustomClaims[name]
-
-				if claim.Attribute == "" {
-					strategy.scopes[scope][name] = name
-				} else {
+				if claim = policy.CustomClaims.GetCustomClaimByName(name); claim.Name != "" || claim.Attribute != "" {
 					strategy.scopes[scope][name] = claim.Attribute
+				} else {
+					strategy.scopes[scope][name] = name
 				}
 			}
 		}

--- a/internal/oidc/claims_test.go
+++ b/internal/oidc/claims_test.go
@@ -236,6 +236,7 @@ func TestNewClaimRequestsMatcher(t *testing.T) {
 			policy: {
 				CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 					claim: {
+						Name:      claim,
 						Attribute: attribute,
 					},
 				},
@@ -813,6 +814,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -863,6 +865,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -916,6 +919,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -969,6 +973,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -1022,6 +1027,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -1075,6 +1081,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -1125,6 +1132,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -1175,6 +1183,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -1228,9 +1237,11 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 							"example-claim-alt": {
+								Name:      "example-claim-alt",
 								Attribute: "example-claim",
 							},
 						},
@@ -1281,6 +1292,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -1331,6 +1343,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -1378,6 +1391,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},
@@ -1428,6 +1442,7 @@ func TestNewCustomClaimsStrategy(t *testing.T) {
 						AccessToken: []string{},
 						CustomClaims: map[string]schema.IdentityProvidersOpenIDConnectCustomClaim{
 							"example-claim": {
+								Name:      "example-claim",
 								Attribute: "example-claim",
 							},
 						},


### PR DESCRIPTION
This fixes an issue where certain custom claim names can't be specified by introducing an explicit configuration key that defines it.

Fixes #9687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom name for each OpenID Connect custom claim, allowing explicit control over claim naming in configuration.

* **Documentation**
  * Updated documentation to clarify how custom claim names and attributes are determined, including the new optional claim name field.

* **Bug Fixes**
  * Improved validation to ensure claim names are unique within a policy and that reserved claim names are properly checked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->