### PR TITLE
docs(oidc): adjust headscale escape hatch

### DIFF
--- a/docs/content/integration/openid-connect/headscale/index.md
+++ b/docs/content/integration/openid-connect/headscale/index.md
@@ -84,7 +84,7 @@ identity_providers:
 
 #### Configuration Escape Hatch
 
-{{% oidc-conformance-claims client_id="opkssh" claims="email" %}}
+{{% oidc-conformance-claims client_id="headscale" claims="email,groups" %}}
 
 Note this additional configuration of a `claims_policy` is only necessary if you are authorizing users based on domain,
 groups or email (`oidc.allowed_domains`, `oidc.allowed_groups` and `oidc.allowed_users` in the [Headscale] configuration


### PR DESCRIPTION
This patch fixes a copy-paste error introduced in
ebfda9214dff6a915a92127815d43a0a64f680ec. I have verified that, as of
Headscale v0.26.1, only email and groups are needed from the id token.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Headscale integration guide to correct the client ID and expand the claims parameter, ensuring the documentation accurately reflects the required configuration for email and group claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->