### PR TITLE
build: use build tags to determine dev mode

### DIFF
--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -37,7 +37,7 @@ ARG LDFLAGS_EXTRA
 RUN \
 	mv api internal/server/public_html/api && \
 	echo ">> Starting go build (coverage via -cover)..." && \
-	GOEXPERIMENT="nosynchashtriemap" CGO_ENABLED=1 CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong" CGO_LDFLAGS="-Wl,-z,relro,-z,now" go build -cover -covermode=atomic \
+	GOEXPERIMENT="nosynchashtriemap" CGO_ENABLED=1 CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-strong" CGO_LDFLAGS="-Wl,-z,relro,-z,now" go build -tags dev -cover -covermode=atomic \
 	-ldflags "${LDFLAGS_EXTRA}" -o authelia ./cmd/authelia
 
 # ===================================

--- a/internal/commands/build-info.go
+++ b/internal/commands/build-info.go
@@ -42,7 +42,7 @@ func (ctx *CmdCtx) BuildInfoRunE(cmd *cobra.Command, _ []string) (err error) {
 	b := &strings.Builder{}
 
 	b.WriteString(fmt.Sprintf(fmtAutheliaBuild, utils.BuildTag, utils.BuildState, utils.BuildBranch, utils.BuildCommit,
-		utils.BuildNumber, runtime.GOOS, runtime.GOARCH, runtime.Compiler, utils.BuildDate, utils.BuildExtra))
+		utils.BuildNumber, runtime.GOOS, runtime.GOARCH, runtime.Compiler, utils.BuildDate, utils.Dev, utils.BuildExtra))
 
 	var verbose bool
 

--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -30,6 +30,7 @@ Build OS: %s
 Build Arch: %s
 Build Compiler: %s
 Build Date: %s
+Development: %t
 Extra: %s`
 
 	fmtAutheliaBuildGo = `

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/authelia/authelia/v4/internal/logging"
@@ -64,7 +62,7 @@ func NewRootCmd() (cmd *cobra.Command) {
 func (ctx *CmdCtx) RootRunE(_ *cobra.Command, _ []string) (err error) {
 	ctx.log.Infof("Authelia %s is starting", utils.Version())
 
-	if os.Getenv("ENVIRONMENT") == "dev" {
+	if utils.Dev {
 		ctx.log.Info("===> Authelia is running in development mode. <===")
 	}
 

--- a/internal/server/const.go
+++ b/internal/server/const.go
@@ -47,8 +47,6 @@ var (
 )
 
 const (
-	environment = "ENVIRONMENT"
-	dev         = "dev"
 	strFalse    = "false"
 	strTrue     = "true"
 	localhost   = "localhost"

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -337,7 +337,7 @@ func handlerMain(config *schema.Configuration, providers middlewares.Providers) 
 	if !config.DuoAPI.Disable {
 		var duoAPI duo.API
 
-		if os.Getenv("ENVIRONMENT") == dev {
+		if utils.Dev {
 			duoAPI = duo.NewDuoAPI(duoapi.NewDuoApi(
 				config.DuoAPI.IntegrationKey,
 				config.DuoAPI.SecretKey,

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1" //nolint:gosec
 	"encoding/hex"
 	"fmt"
+	"github.com/authelia/authelia/v4/internal/utils"
 	"os"
 	"path"
 	"path/filepath"
@@ -25,7 +26,6 @@ import (
 // this is utilised to pass information between the backend and frontend
 // and generate a nonce to support a restrictive CSP while using material-ui.
 func ServeTemplatedFile(t templates.Template, opts *TemplatedFileOptions) middlewares.RequestHandler {
-	isDevEnvironment := os.Getenv(environment) == dev
 	ext := path.Ext(t.Name())
 
 	return func(ctx *middlewares.AutheliaCtx) {
@@ -55,7 +55,7 @@ func ServeTemplatedFile(t templates.Template, opts *TemplatedFileOptions) middle
 		switch {
 		case ctx.Configuration.Server.Headers.CSPTemplate != "":
 			ctx.Response.Header.Add(fasthttp.HeaderContentSecurityPolicy, strings.ReplaceAll(string(ctx.Configuration.Server.Headers.CSPTemplate), placeholderCSPNonce, nonce))
-		case isDevEnvironment:
+		case utils.Dev:
 			ctx.Response.Header.Add(fasthttp.HeaderContentSecurityPolicy, fmt.Sprintf(tmplCSPDevelopment, nonce))
 		default:
 			ctx.Response.Header.Add(fasthttp.HeaderContentSecurityPolicy, fmt.Sprintf(tmplCSPDefault, nonce))

--- a/internal/suites/example/compose/authelia/compose.backend.dev.yml
+++ b/internal/suites/example/compose/authelia/compose.backend.dev.yml
@@ -24,8 +24,6 @@ services:
       traefik.http.routers.authelia_backend.entrypoints: 'https'
       traefik.http.routers.authelia_backend.tls: 'true'
       traefik.http.services.authelia_backend.loadbalancer.server.scheme: 'https'
-    environment:
-      ENVIRONMENT: 'dev'
     networks:
       authelianet:
         ipv4_address: 192.168.240.50

--- a/internal/suites/example/compose/authelia/compose.backend.dist.yml
+++ b/internal/suites/example/compose/authelia/compose.backend.dist.yml
@@ -12,8 +12,6 @@ services:
       disable: true
     volumes:
       - '../..:/authelia'
-    environment:
-      ENVIRONMENT: 'dev'
     restart: 'always'
     networks:
       authelianet:

--- a/internal/suites/example/kube/authelia/authelia.yml
+++ b/internal/suites/example/kube/authelia/authelia.yml
@@ -56,8 +56,6 @@ spec:
               value: /config/secrets/sql_password
             - name: AUTHELIA_STORAGE_ENCRYPTION_KEY_FILE
               value: /config/secrets/encryption_key
-            - name: ENVIRONMENT
-              value: dev
       volumes:
         - name: authelia-config
           hostPath:

--- a/internal/utils/version.go
+++ b/internal/utils/version.go
@@ -80,6 +80,10 @@ func VersionAdv(tag, state, commit, branch, extra string) (version string) {
 		b.WriteString(extra)
 	}
 
+	if Dev {
+		b.WriteString("-dev")
+	}
+
 	b.WriteString(fmt.Sprintf(" (%s, %s)", branch, commitShort(commit)))
 
 	return b.String()

--- a/internal/utils/version_dev.go
+++ b/internal/utils/version_dev.go
@@ -1,0 +1,7 @@
+//go:build dev
+
+package utils
+
+const (
+	Dev = true
+)

--- a/internal/utils/version_prod.go
+++ b/internal/utils/version_prod.go
@@ -1,0 +1,7 @@
+//go:build !dev
+
+package utils
+
+const (
+	Dev = false
+)


### PR DESCRIPTION
This removes the use of the environment flag for detecting the dev mode.