### PR TITLE
Add docs for leantime

### DIFF
--- a/docs/content/integration/openid-connect/leantime/index.md
+++ b/docs/content/integration/openid-connect/leantime/index.md
@@ -25,7 +25,7 @@ seo:
 - [Leantime]
   - [v3.5.8](https://github.com/Leantime/leantime/releases/tag/v3.5.8)
 
-{{% oidc-common bugs="client-credentials-encoding,claims-hydration" %}}
+{{% oidc-common bugs="claims-hydration" %}}
 
 ### Assumptions
 
@@ -93,7 +93,7 @@ variables:
 ```shell {title=".env"}
 LEAN_OIDC_ENABLE=true
 LEAN_OIDC_CLIENT_ID=leantime
-LEAN_OIDC_CLIENT_SECRET=`insecure_secret`
+LEAN_OIDC_CLIENT_SECRET=insecure_secret
 LEAN_OIDC_PROVIDER_URL=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
 LEAN_OIDC_CREATE_USER=true
 LEAN_OIDC_DEFAULT_ROLE=20
@@ -108,7 +108,7 @@ services:
     environment:
       LEAN_OIDC_ENABLE: 'true'
       LEAN_OIDC_CLIENT_ID: leantime
-      LEAN_OIDC_CLIENT_SECRET: `insecure_secret`
+      LEAN_OIDC_CLIENT_SECRET: insecure_secret
       LEAN_OIDC_PROVIDER_URL: https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
       LEAN_OIDC_CREATE_USER: true
       LEAN_OIDC_DEFAULT_ROLE: 20

--- a/docs/content/integration/openid-connect/leantime/index.md
+++ b/docs/content/integration/openid-connect/leantime/index.md
@@ -1,0 +1,124 @@
+---
+title: "Leantime"
+description: "Integrating Leantime with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2025-06-29T17:51:47+10:00
+draft: false
+images: []
+weight: 620
+toc: true
+support:
+  level: community
+  versions: true
+  integration: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+- [Authelia]
+  - [v4.39.4](https://github.com/authelia/authelia/releases/tag/v4.39.4)
+- [Leantime]
+  - [v3.5.8](https://github.com/Leantime/leantime/releases/tag/v3.5.8)
+
+{{% oidc-common bugs="client-credentials-encoding,claims-hydration" %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+- __Application Root URL:__ `https://leantime.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Client ID:__ `leantime`
+- __Client Secret:__ `insecure_secret`
+
+Some of the values presented in this guide can automatically be replaced with documentation variables.
+
+{{< sitevar-preferences >}}
+
+## Configuration
+
+### Authelia
+
+{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
+At the time of this writing this third party client has a bug and does not support [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html). This
+configuration will likely require configuration of an escape hatch to work around the bug on their end. See
+[Configuration Escape Hatch](#configuration-escape-hatch) for details.
+{{< /callout >}}
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Leantime] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: leantime
+        client_name: leantime
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        consent_mode: implicit
+        scopes:
+          - openid
+          - groups
+          - email
+          - profile
+        redirect_uris:
+          - 'https://leantime.{{< sitevar name="domain" nojs="example.com" >}}/oidc/callback'
+        token_endpoint_auth_method: client_secret_post
+```
+
+#### Configuration Escape Hatch
+
+{{% oidc-escape-hatch-claims-hydration client_id="leantime" claims="email" %}}
+
+### Application
+
+To configure [leantime] there is one method, using the [Environment Variables](#environment-variables).
+
+#### Environment Variables
+
+To configure [leantime] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following environment
+variables:
+
+##### Standard
+
+```shell {title=".env"}
+LEAN_OIDC_ENABLE=true
+LEAN_OIDC_CLIENT_ID=leantime
+LEAN_OIDC_CLIENT_SECRET=`insecure_secret`
+LEAN_OIDC_PROVIDER_URL=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
+LEAN_OIDC_CREATE_USER=true
+LEAN_OIDC_DEFAULT_ROLE=20
+
+```
+
+##### Docker Compose
+
+```yaml {title="compose.yml"}
+services:
+  leantime:
+    environment:
+      LEAN_OIDC_ENABLE: 'true'
+      LEAN_OIDC_CLIENT_ID: leantime
+      LEAN_OIDC_CLIENT_SECRET: `insecure_secret`
+      LEAN_OIDC_PROVIDER_URL: https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
+      LEAN_OIDC_CREATE_USER: true
+      LEAN_OIDC_DEFAULT_ROLE: 20
+```
+
+## See Also
+
+- [Leantime OpenID Connect Documentation](https://docs.leantime.io/installation/configuration?id=openid-conenct-oidc-configuration)
+
+[Authelia]: https://www.authelia.com
+[Leantime]: https://leantime.io/
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md


### PR DESCRIPTION
After getting some help from James in Discord I thought I'd submit a PR to the docs to get [Leantime](https://leantime.io) working with OIDC.

I've followed the [Bookstack example docs](https://github.com/arcoast/authelia/blob/leantime-docs/docs/content/integration/openid-connect/bookstack/index.md) as best as I can.  Happy to make further changes if needs be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide detailing how to integrate Leantime with the Authelia OpenID Connect Provider, including configuration steps, example settings, troubleshooting notes, and relevant resource links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->