### PR TITLE
build: allow use of token for readme updates

### DIFF
--- a/cmd/authelia-scripts/cmd/docker.go
+++ b/cmd/authelia-scripts/cmd/docker.go
@@ -37,7 +37,7 @@ func newDockerCmd() (cmd *cobra.Command) {
 		DisableAutoGenTag: true,
 	}
 
-	cmd.AddCommand(newDockerBuildCmd(), newDockerPushManifestCmd())
+	cmd.AddCommand(newDockerBuildCmd(), newDockerPushManifestCmd(), newDockerPushReadmeCmd())
 
 	return cmd
 }
@@ -70,6 +70,31 @@ func newDockerPushManifestCmd() (cmd *cobra.Command) {
 
 		DisableAutoGenTag: true,
 	}
+
+	return cmd
+}
+
+func newDockerPushReadmeCmd() (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use: "push-readme",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			var token string
+
+			if cmd.Flags().Changed("token") {
+				if token, err = cmd.Flags().GetString("token"); err != nil {
+					return err
+				}
+			} else {
+				token = os.Getenv("DOCKER_TOKEN")
+			}
+
+			docker := &Docker{}
+
+			return docker.PublishReadmeWithToken(token)
+		},
+	}
+
+	cmd.Flags().String("token", "", "docker auth token")
 
 	return cmd
 }

--- a/cmd/authelia-scripts/cmd/helpers_docker.go
+++ b/cmd/authelia-scripts/cmd/helpers_docker.go
@@ -104,7 +104,21 @@ func (d *Docker) Manifest(tags []string) error {
 
 // PublishReadme push README.md to dockerhub.
 func (d *Docker) PublishReadme() error {
+	token, hasToken := os.LookupEnv("DOCKER_TOKEN")
+
+	if hasToken {
+		return d.PublishReadmeWithToken(token)
+	}
+
 	return utils.CommandWithStdout("bash", "-c", `token=$(curl -fs --retry 3 -H "Content-Type: application/json" -X "POST" -d '{"username": "'$DOCKER_USERNAME'", "password": "'$DOCKER_PASSWORD'"}' https://hub.docker.com/v2/users/login/ | jq -r .token) && jq -n --arg msg "$(cat README.md | sed -r 's/(\<img\ src\=\")(\.\/)/\1https:\/\/github.com\/authelia\/authelia\/raw\/master\//' | sed 's/\.\//https:\/\/github.com\/authelia\/authelia\/blob\/master\//g' | sed '/start \[contributing\]/ a <a href="https://github.com/authelia/authelia/graphs/contributors"><img src="https://opencollective.com/authelia-sponsors/contributors.svg?width=890" /></a>' | sed '/Thanks goes to/,/### Backers/{/### Backers/!d}')" '{"registry":"registry-1.docker.io","full_description": $msg }' | curl -fs --retry 3 -o /dev/null -L -X "PATCH" -H "Content-Type: application/json" -H "Authorization: JWT $token" -d @- https://hub.docker.com/v2/repositories/authelia/authelia/`).Run()
+}
+
+func (d *Docker) PublishReadmeWithToken(token string) error {
+	if len(token) == 0 {
+		return fmt.Errorf("no token supplied")
+	}
+
+	return utils.CommandWithStdout("bash", "-c", fmt.Sprintf(`jq -n --arg msg "$(cat README.md | sed -r 's/(\<img\ src\=\")(\.\/)/\1https:\/\/github.com\/authelia\/authelia\/raw\/master\//' | sed 's/\.\//https:\/\/github.com\/authelia\/authelia\/blob\/master\//g' | sed '/start \[contributing\]/ a <a href="https://github.com/authelia/authelia/graphs/contributors"><img src="https://opencollective.com/authelia-sponsors/contributors.svg?width=890" /></a>' | sed '/Thanks goes to/,/### Backers/{/### Backers/!d}')" '{"registry":"registry-1.docker.io","full_description": $msg }' | curl -fs --retry 3 -o /dev/null -L -X "PATCH" -H "Content-Type: application/json" -H "Authorization: Bearer %s" -d @- https://hub.docker.com/v2/repositories/authelia/authelia/`, token)).Run()
 }
 
 func getBaseImageDigests(tag string) (amd64, arm, arm64 string, err error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new command to publish Docker README files with support for authentication via a token flag or environment variable.

* **Enhancements**
  * Improved Docker README publishing to allow direct use of authentication tokens, streamlining the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->