### PR TITLE
fix(middlewares): remove deprecated method

### DIFF
--- a/internal/middlewares/http_to_authelia_handler_adaptor.go
+++ b/internal/middlewares/http_to_authelia_handler_adaptor.go
@@ -84,7 +84,8 @@ func NewHTTPToAutheliaHandlerAdaptor(h AutheliaHandlerFunc) RequestHandler {
 		r.RemoteAddr = ctx.RemoteAddr().String()
 
 		hdr := make(http.Header)
-		ctx.Request.Header.VisitAll(func(k, v []byte) {
+
+		for k, v := range ctx.Request.Header.All() {
 			sk := string(k)
 			sv := string(v)
 
@@ -94,7 +95,7 @@ func NewHTTPToAutheliaHandlerAdaptor(h AutheliaHandlerFunc) RequestHandler {
 			default:
 				hdr.Set(sk, sv)
 			}
-		})
+		}
 
 		r.Header = hdr
 		r.Body = &netHTTPBody{body}


### PR DESCRIPTION
removes depreciated `VisitAll` method and replaces it with `All()`.
Fixes golang-ci warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the method used for processing HTTP headers to enhance code clarity and maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->