### PR TITLE
ci(golangci-lint): migrate to v2 configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,28 +1,5 @@
 ---
-run:
-  timeout: 3m
-
-linters-settings:
-  forbidigo:
-    forbid:
-      - p: ^print.*$
-        msg: Do not commit print statements.
-      - p: ^fmt\.Print.*$
-        pkg: ^fmt$
-        msg: Do not commit print statements.
-    analyze-types: true
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocyclo:
-    min-complexity: 15
-  godot:
-    scope: all
-  goimports:
-    local-prefixes: github.com/authelia/authelia
-  revive:
-    confidence: 0.8
-
+version: "2"
 linters:
   enable:
     - asciicheck
@@ -31,8 +8,6 @@ linters:
     - gocritic
     - gocyclo
     - godot
-    - gofmt
-    - goimports
     - gosec
     - misspell
     - nolintlint
@@ -41,27 +16,71 @@ linters:
     - unconvert
     - unparam
     - whitespace
-    - wsl
-
+    - wsl_v5
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: ^print.*$
+          msg: Do not commit print statements.
+        - pattern: ^fmt\.Print.*$
+          pkg: ^fmt$
+          msg: Do not commit print statements.
+      analyze-types: true
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocyclo:
+      min-complexity: 15
+    godot:
+      scope: all
+    revive:
+      confidence: 0.8
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - forbidigo
+        path: internal/commands/
+      - linters:
+          - forbidigo
+        path: cmd/
+      - path: (.+)\.go$
+        text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+      - path: (.+)\.go$
+        text: func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
+      - path: (.+)\.go$
+        text: (possible misuse of unsafe.Pointer|should have signature)
+      - path: (.+)\.go$
+        text: ineffective break statement. Did you mean to break out of the outer loop
+      - path: (.+)\.go$
+        text: Use of unsafe calls should be audited
+      - path: (.+)\.go$
+        text: Subprocess launch(ed with variable|ing should be audited)
+      - path: (.+)\.go$
+        text: (G104|G307)
+      - path: (.+)\.go$
+        text: (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
+      - path: (.+)\.go$
+        text: Potential file inclusion via variable
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude:
-    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked  # yamllint disable-line rule:line-length
-    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
-    - (possible misuse of unsafe.Pointer|should have signature)
-    - ineffective break statement. Did you mean to break out of the outer loop
-    - Use of unsafe calls should be audited
-    - Subprocess launch(ed with variable|ing should be audited)
-    - (G104|G307)
-    - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
-    - Potential file inclusion via variable
-  exclude-rules:
-    - path: internal/commands/
-      linters:
-        - forbidigo
-    - path: cmd/
-      linters:
-        - forbidigo
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/authelia/authelia
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 ...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,7 @@ linters:
           - forbidigo
         path: cmd/
       - path: (.+)\.go$
-        text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+        text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked  # yamllint disable-line rule:line-length
       - path: (.+)\.go$
         text: func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
       - path: (.+)\.go$

--- a/cmd/authelia-gen/cmd_docs_date.go
+++ b/cmd/authelia-gen/cmd_docs_date.go
@@ -134,7 +134,6 @@ func getTimeFromGitCmd(cmd *exec.Cmd) *time.Time {
 		err    error
 		t      time.Time
 	)
-
 	if output, err = cmd.Output(); err != nil {
 		return nil
 	}

--- a/cmd/authelia-gen/cmd_root.go
+++ b/cmd/authelia-gen/cmd_root.go
@@ -150,11 +150,7 @@ func resolveCmdName(cmd *cobra.Command) string {
 }
 
 func rootCmdGetArgs(cmd *cobra.Command, args []string) []string {
-	for {
-		if cmd == nil || cmd == rootCmd {
-			break
-		}
-
+	for cmd != nil && cmd != rootCmd {
 		args = append([]string{cmd.Use}, args...)
 
 		cmd = cmd.Parent()

--- a/cmd/authelia-gen/templates.go
+++ b/cmd/authelia-gen/templates.go
@@ -36,7 +36,6 @@ func mustLoadTmplFS(tmpl string) string {
 		content []byte
 		err     error
 	)
-
 	if content, err = templatesFS.ReadFile(fmt.Sprintf("templates/%s.tmpl", tmpl)); err != nil {
 		panic(err)
 	}

--- a/cmd/authelia-scripts/cmd/bootstrap.go
+++ b/cmd/authelia-scripts/cmd/bootstrap.go
@@ -143,8 +143,8 @@ var hostEntries = []HostEntry{
 
 func runCommand(cmd string, args ...string) {
 	command := utils.CommandWithStdout(cmd, args...)
-	err := command.Run()
 
+	err := command.Run()
 	if err != nil {
 		panic(err)
 	}
@@ -168,7 +168,6 @@ func checkCommandExist(cmd string, resolutionHint string) {
 
 func createTemporaryDirectory() {
 	err := os.MkdirAll("/tmp/authelia", 0755)
-
 	if err != nil {
 		panic(err)
 	}
@@ -220,7 +219,6 @@ func shell(cmd string) {
 
 func prepareHostsFile() {
 	contentBytes, err := readHostsFile()
-
 	if err != nil {
 		panic(err)
 	}
@@ -294,8 +292,8 @@ func readHostsFile() ([]byte, error) {
 
 func readVersion(cmd string, args ...string) {
 	command := exec.Command(cmd, args...)
-	b, err := command.Output()
 
+	b, err := command.Output()
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/authelia-scripts/cmd/clean.go
+++ b/cmd/authelia-scripts/cmd/clean.go
@@ -24,8 +24,8 @@ func newCleanCmd() (cmd *cobra.Command) {
 
 func cmdCleanRun(_ *cobra.Command, _ []string) {
 	log.Debug("Removing `" + OutputDir + txtDirectoryTidle)
-	err := os.RemoveAll(OutputDir)
 
+	err := os.RemoveAll(OutputDir)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/authelia-scripts/cmd/docker.go
+++ b/cmd/authelia-scripts/cmd/docker.go
@@ -102,15 +102,15 @@ func newDockerPushReadmeCmd() (cmd *cobra.Command) {
 func cmdDockerBuildRun(_ *cobra.Command, _ []string) {
 	log.Infof("Building Docker image %s...", DockerImageName)
 	checkContainerIsSupported(container)
-	err := dockerBuildOfficialImage(container)
 
+	err := dockerBuildOfficialImage(container)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	docker := &Docker{}
-	err = docker.Tag(IntermediateDockerImageName, DockerImageName)
 
+	err = docker.Tag(IntermediateDockerImageName, DockerImageName)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -199,8 +199,8 @@ func login(docker *Docker, registry string) {
 	}
 
 	log.Infof("Login to %s as %s", registry, username)
-	err := docker.Login(username, password, registry)
 
+	err := docker.Login(username, password, registry)
 	if err != nil {
 		log.Fatalf("Login to %s failed: %s", registry, err)
 	}

--- a/cmd/authelia-scripts/cmd/log.go
+++ b/cmd/authelia-scripts/cmd/log.go
@@ -7,9 +7,10 @@ import (
 var logLevel string
 
 func levelStringToLevel(level string) log.Level {
-	if level == "debug" {
+	switch level {
+	case "debug":
 		return log.DebugLevel
-	} else if level == "warning" {
+	case "warning":
 		return log.WarnLevel
 	}
 

--- a/cmd/authelia-scripts/cmd/suites.go
+++ b/cmd/authelia-scripts/cmd/suites.go
@@ -110,8 +110,8 @@ func cmdSuitesListRun(_ *cobra.Command, _ []string) {
 
 func cmdSuitesSetupRun(_ *cobra.Command, args []string) {
 	providedSuite := args[0]
-	runningSuite, err := getRunningSuite()
 
+	runningSuite, err := getRunningSuite()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -131,7 +131,6 @@ func cmdSuitesTeardownRun(_ *cobra.Command, args []string) {
 		suiteName = args[0]
 	} else {
 		runningSuite, err := getRunningSuite()
-
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -204,8 +203,8 @@ func checkSuiteAvailable(suite string) error {
 
 func runSuiteSetupTeardown(command string, suite string) error {
 	selectedSuite := suite
-	err := checkSuiteAvailable(selectedSuite)
 
+	err := checkSuiteAvailable(selectedSuite)
 	if err != nil {
 		if err == ErrNotAvailableSuite {
 			log.Fatal(errors.New("Suite named " + selectedSuite + " does not exist"))
@@ -297,7 +296,6 @@ func teardownSuite(suiteName string) error {
 
 func getRunningSuite() (string, error) {
 	exist, err := utils.FileExists(runningSuiteFile)
-
 	if err != nil {
 		return "", err
 	}

--- a/cmd/authelia-suites/main.go
+++ b/cmd/authelia-suites/main.go
@@ -85,7 +85,6 @@ func setupSuite(cmd *cobra.Command, args []string) {
 	s := suites.GlobalRegistry.Get(suiteName)
 
 	cwd, err := filepath.Abs("./")
-
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -93,7 +92,6 @@ func setupSuite(cmd *cobra.Command, args []string) {
 	suiteResourcePath := cwd + "/internal/suites/" + suiteName
 
 	exist, err := utils.PathExists(suiteResourcePath)
-
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -123,13 +121,11 @@ func setupSuite(cmd *cobra.Command, args []string) {
 
 	if exist {
 		err := copy.Copy(suiteResourcePath, suiteTmpDirectory)
-
 		if err != nil {
 			log.Fatal(err)
 		}
 	} else {
 		err := os.MkdirAll(suiteTmpDirectory, 0755)
-
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/authentication/file_user_provider.go
+++ b/internal/authentication/file_user_provider.go
@@ -180,7 +180,6 @@ func (p *FileUserProvider) ChangePassword(username string, oldPassword string, n
 	}
 
 	oldPasswordCorrect, err := p.CheckUserPassword(username, oldPassword)
-
 	if err != nil {
 		return ErrAuthenticationFailed
 	}

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -336,7 +336,6 @@ func (p *LDAPUserProvider) ChangePassword(username, oldPassword string, newPassw
 	}
 
 	userPasswordOk, err := p.CheckUserPassword(username, oldPassword)
-
 	if err != nil {
 		errorCode := getLDAPResultCode(err)
 		if errorCode == ldap.LDAPResultInvalidCredentials {
@@ -831,7 +830,6 @@ func (p *LDAPUserProvider) modify(client ldap.Client, modifyRequest *ldap.Modify
 			clientRef ldap.Client
 			errRef    error
 		)
-
 		if clientRef, errRef = p.factory.GetClient(WithAddress(referral)); errRef != nil {
 			return fmt.Errorf("error occurred connecting to referred LDAP server '%s': %+v. Original Error: %w", referral, errRef, err)
 		}
@@ -869,7 +867,6 @@ func (p *LDAPUserProvider) pwdModify(client ldap.Client, pwdModifyRequest *ldap.
 			clientRef ldap.Client
 			errRef    error
 		)
-
 		if clientRef, errRef = p.factory.GetClient(WithAddress(referral)); errRef != nil {
 			return fmt.Errorf("error occurred connecting to referred LDAP server '%s': %+v. Original Error: %w", referral, errRef, err)
 		}

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -6976,7 +6976,6 @@ func TestLDAPUserProviderChangePasswordErrors(t *testing.T) {
 			provider := NewLDAPUserProviderWithFactory(config, false, NewStandardLDAPClientFactory(config, nil, mockDialer))
 
 			err := provider.ChangePassword(tc.username, tc.oldPassword, tc.newPassword)
-
 			if tc.expectedError != nil {
 				assert.Error(t, err)
 				assert.Equal(t, tc.expectedError.Error(), err.Error())

--- a/internal/authentication/ldap_util.go
+++ b/internal/authentication/ldap_util.go
@@ -113,7 +113,6 @@ func ldapGetReferral(err error) (referral string, ok bool) {
 
 func getLDAPResultCode(err error) int {
 	var e *ldap.Error
-
 	if errors.As(err, &e) {
 		return int(e.ResultCode)
 	}

--- a/internal/commands/build-info.go
+++ b/internal/commands/build-info.go
@@ -41,19 +41,19 @@ func (ctx *CmdCtx) BuildInfoRunE(cmd *cobra.Command, _ []string) (err error) {
 
 	b := &strings.Builder{}
 
-	b.WriteString(fmt.Sprintf(fmtAutheliaBuild, utils.BuildTag, utils.BuildState, utils.BuildBranch, utils.BuildCommit,
-		utils.BuildNumber, runtime.GOOS, runtime.GOARCH, runtime.Compiler, utils.BuildDate, utils.BuildExtra))
+	fmt.Fprintf(b, fmtAutheliaBuild, utils.BuildTag, utils.BuildState, utils.BuildBranch, utils.BuildCommit,
+		utils.BuildNumber, runtime.GOOS, runtime.GOARCH, runtime.Compiler, utils.BuildDate, utils.BuildExtra)
 
 	var verbose bool
 
-	b.WriteString(fmt.Sprintf("\n"+fmtAutheliaBuildGo, info.GoVersion, info.Main.Path, info.Path))
+	fmt.Fprintf(b, "\n"+fmtAutheliaBuildGo, info.GoVersion, info.Main.Path, info.Path)
 
 	if verbose, err = cmd.Flags().GetBool("verbose"); err == nil && verbose {
 		if len(info.Settings) != 0 {
 			b.WriteString("    Settings:\n")
 
 			for _, setting := range info.Settings {
-				b.WriteString(fmt.Sprintf("        %s: %s\n", setting.Key, setting.Value))
+				fmt.Fprintf(b, "        %s: %s\n", setting.Key, setting.Value)
 			}
 		}
 
@@ -61,7 +61,7 @@ func (ctx *CmdCtx) BuildInfoRunE(cmd *cobra.Command, _ []string) (err error) {
 			b.WriteString("    Dependencies:\n")
 
 			for _, dep := range info.Deps {
-				b.WriteString(fmt.Sprintf("        %s@%s (%s)\n", dep.Path, dep.Version, dep.Sum))
+				fmt.Fprintf(b, "        %s@%s (%s)\n", dep.Path, dep.Version, dep.Sum)
 			}
 		}
 	}

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -141,13 +141,13 @@ func (ctx *CmdCtx) ConfigTemplateRunE(_ *cobra.Command, _ []string) (err error) 
 			return err
 		}
 
-		buf.WriteString(fmt.Sprintf(fmtYAMLConfigTemplateHeader, strings.Join(source.GetBytesFilterNames(), ", ")))
+		fmt.Fprintf(buf, fmtYAMLConfigTemplateHeader, strings.Join(source.GetBytesFilterNames(), ", "))
 
 		for _, file := range files {
 			if reYAMLComment.Match(file.Data) {
 				buf.Write(reYAMLComment.ReplaceAll(file.Data, []byte(fmt.Sprintf(fmtYAMLConfigTemplateFileHeader+"$1", file.Path))))
 			} else {
-				buf.WriteString(fmt.Sprintf(fmtYAMLConfigTemplateFileHeader, file.Path))
+				fmt.Fprintf(buf, fmtYAMLConfigTemplateFileHeader, file.Path)
 				buf.Write(file.Data)
 			}
 		}

--- a/internal/commands/context.go
+++ b/internal/commands/context.go
@@ -263,7 +263,7 @@ func (ctx *CmdCtx) LogConfigure(_ *cobra.Command, _ []string) (err error) {
 	config.KeepStdout = true
 
 	if err = logging.InitializeLogger(schema.Log{Level: ctx.config.Log.Level}, false); err != nil {
-		return fmt.Errorf("Cannot initialize logger: %w", err)
+		return fmt.Errorf("cannot initialize logger: %w", err)
 	}
 
 	ctx.log.WithFields(map[string]any{"filters": ctx.cconfig.filters, "files": ctx.cconfig.files}).Debug("Loaded Configuration Sources")

--- a/internal/commands/crypto.go
+++ b/internal/commands/crypto.go
@@ -513,7 +513,7 @@ func (ctx *CmdCtx) CryptoCertificateGenerateRunE(cmd *cobra.Command, _ []string,
 
 	b.WriteString("Generating Certificate\n\n")
 
-	b.WriteString(fmt.Sprintf("\tSerial: %x\n\n", template.SerialNumber))
+	fmt.Fprintf(b, "\tSerial: %x\n\n", template.SerialNumber)
 
 	switch caCertificate {
 	case nil:
@@ -523,30 +523,30 @@ func (ctx *CmdCtx) CryptoCertificateGenerateRunE(cmd *cobra.Command, _ []string,
 	default:
 		parent = caCertificate
 
-		b.WriteString(fmt.Sprintf("Signed By:\n\t%s\n", caCertificate.Subject.CommonName))
-		b.WriteString(fmt.Sprintf("\tSerial: %x, Expires: %s\n", caCertificate.SerialNumber, caCertificate.NotAfter.Format(time.RFC3339)))
+		fmt.Fprintf(b, "Signed By:\n\t%s\n", caCertificate.Subject.CommonName)
+		fmt.Fprintf(b, "\tSerial: %x, Expires: %s\n", caCertificate.SerialNumber, caCertificate.NotAfter.Format(time.RFC3339))
 	}
 
 	b.WriteString("\nSubject:\n")
-	b.WriteString(fmt.Sprintf("\tCommon Name: %s, Organization: %s, Organizational Unit: %s\n", template.Subject.CommonName, template.Subject.Organization, template.Subject.OrganizationalUnit))
-	b.WriteString(fmt.Sprintf("\tCountry: %v, Province: %v, Street Address: %v, Postal Code: %v, Locality: %v\n\n", template.Subject.Country, template.Subject.Province, template.Subject.StreetAddress, template.Subject.PostalCode, template.Subject.Locality))
+	fmt.Fprintf(b, "\tCommon Name: %s, Organization: %s, Organizational Unit: %s\n", template.Subject.CommonName, template.Subject.Organization, template.Subject.OrganizationalUnit)
+	fmt.Fprintf(b, "\tCountry: %v, Province: %v, Street Address: %v, Postal Code: %v, Locality: %v\n\n", template.Subject.Country, template.Subject.Province, template.Subject.StreetAddress, template.Subject.PostalCode, template.Subject.Locality)
 
 	b.WriteString("Properties:\n")
-	b.WriteString(fmt.Sprintf("\tNot Before: %s, Not After: %s\n", template.NotBefore.Format(time.RFC3339), template.NotAfter.Format(time.RFC3339)))
+	fmt.Fprintf(b, "\tNot Before: %s, Not After: %s\n", template.NotBefore.Format(time.RFC3339), template.NotAfter.Format(time.RFC3339))
 
-	b.WriteString(fmt.Sprintf("\tCA: %v, CSR: %v, Signature Algorithm: %s, Public Key Algorithm: %s", template.IsCA, false, template.SignatureAlgorithm, template.PublicKeyAlgorithm))
+	fmt.Fprintf(b, "\tCA: %v, CSR: %v, Signature Algorithm: %s, Public Key Algorithm: %s", template.IsCA, false, template.SignatureAlgorithm, template.PublicKeyAlgorithm)
 
 	switch k := privateKey.(type) {
 	case *rsa.PrivateKey:
-		b.WriteString(fmt.Sprintf(", Bits: %d", k.N.BitLen()))
+		fmt.Fprintf(b, ", Bits: %d", k.N.BitLen())
 	case *ecdsa.PrivateKey:
-		b.WriteString(fmt.Sprintf(", Elliptic Curve: %s", k.Curve.Params().Name))
+		fmt.Fprintf(b, ", Elliptic Curve: %s", k.Curve.Params().Name)
 	case ed25519.PrivateKey:
 		// Legacy format is not available for Ed25519.
 		legacy = false
 	}
 
-	b.WriteString(fmt.Sprintf("\n\tSubject Alternative Names: %s\n\n", strings.Join(cryptoSANsToString(template.DNSNames, template.IPAddresses), ", ")))
+	fmt.Fprintf(b, "\n\tSubject Alternative Names: %s\n\n", strings.Join(cryptoSANsToString(template.DNSNames, template.IPAddresses), ", "))
 
 	var (
 		dir, privateKeyPath, privateKeyLegacyPath, certificatePath string
@@ -573,11 +573,11 @@ func (ctx *CmdCtx) CryptoCertificateGenerateRunE(cmd *cobra.Command, _ []string,
 	b.WriteString("Output Paths:\n")
 
 	if cdir := filepath.Clean(dir); len(cdir) != 0 {
-		b.WriteString(fmt.Sprintf("\tDirectory: %s\n", cdir))
+		fmt.Fprintf(b, "\tDirectory: %s\n", cdir)
 	}
 
-	b.WriteString(fmt.Sprintf("\tPrivate Key: %s\n", strings.Join(privateKeyPaths, ", ")))
-	b.WriteString(fmt.Sprintf("\tCertificate: %s\n", filepath.Base(certificatePath)))
+	fmt.Fprintf(b, "\tPrivate Key: %s\n", strings.Join(privateKeyPaths, ", "))
+	fmt.Fprintf(b, "\tCertificate: %s\n", filepath.Base(certificatePath))
 
 	if certificate, err = x509.CreateCertificate(ctx.providers.Random, template, parent, publicKey, signatureKey); err != nil {
 		return fmt.Errorf("failed to create certificate: %w", err)

--- a/internal/commands/crypto_helper.go
+++ b/internal/commands/crypto_helper.go
@@ -197,7 +197,7 @@ func cryptoGenerateCertificateBundlesFromCmd(cmd *cobra.Command, b *strings.Buil
 
 		pathPEM := filepath.Join(dir, name)
 
-		b.WriteString(fmt.Sprintf("\tCertificate (chain): %s\n", pathPEM))
+		fmt.Fprintf(b, "\tCertificate (chain): %s\n", pathPEM)
 
 		if err = utils.WritePEMBlocksToPath(pathPEM, blocks...); err != nil {
 			return err
@@ -219,7 +219,7 @@ func cryptoGenerateCertificateBundlesFromCmd(cmd *cobra.Command, b *strings.Buil
 
 		pathPEM := filepath.Join(dir, name)
 
-		b.WriteString(fmt.Sprintf("\tCertificate (priv-chain): %s\n", pathPEM))
+		fmt.Fprintf(b, "\tCertificate (priv-chain): %s\n", pathPEM)
 
 		if err = utils.WritePEMBlocksToPath(pathPEM, blocks...); err != nil {
 			return err

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -90,7 +90,6 @@ func (ctx *CmdCtx) RootRunE(_ *cobra.Command, _ []string) (err error) {
 
 	if err = ctx.providers.StartupChecks(ctx, true); err != nil {
 		var scerr *middlewares.ErrProviderStartupCheck
-
 		if errors.As(err, &scerr) {
 			ctx.GetLogger().WithField("providers", scerr.Failed()).Fatalf("One or more providers had fatal failures performing startup checks, for more details check the error level logs")
 		} else {

--- a/internal/commands/storage_run.go
+++ b/internal/commands/storage_run.go
@@ -1442,7 +1442,7 @@ func (ctx *CmdCtx) StorageUserTOTPExportURIRunE(_ *cobra.Command, _ []string) (e
 		}
 
 		for _, c := range configs {
-			buf.WriteString(fmt.Sprintf("%s\n", c.URI()))
+			fmt.Fprintf(buf, "%s\n", c.URI())
 		}
 
 		l := len(configs)
@@ -1493,7 +1493,7 @@ func (ctx *CmdCtx) StorageUserTOTPExportCSVRunE(cmd *cobra.Command, _ []string) 
 		}
 
 		for _, c := range configs {
-			buf.WriteString(fmt.Sprintf("%s,%s,%s,%d,%d,%s\n", c.Issuer, c.Username, c.Algorithm, c.Digits, c.Period, string(c.Secret)))
+			fmt.Fprintf(buf, "%s,%s,%s,%d,%d,%s\n", c.Issuer, c.Username, c.Algorithm, c.Digits, c.Period, string(c.Secret))
 		}
 
 		l := len(configs)

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -378,7 +378,7 @@ func exportYAMLWithJSONSchema(name, filename string, v any) (err error) {
 		version = fmt.Sprintf("v%d.%d", semver.Major, semver.Minor+1)
 	}
 
-	if _, err = f.WriteString(fmt.Sprintf(model.FormatJSONSchemaYAMLLanguageServer, version, name)); err != nil {
+	if _, err = fmt.Fprintf(f, model.FormatJSONSchemaYAMLLanguageServer, version, name); err != nil {
 		return err
 	}
 

--- a/internal/configuration/decode_hooks_test.go
+++ b/internal/configuration/decode_hooks_test.go
@@ -2354,7 +2354,6 @@ func MustLoadCryptoRaw(ca bool, alg, ext string, extra ...string) string {
 		data []byte
 		err  error
 	)
-
 	if data, err = os.ReadFile(fmt.Sprintf(pathCrypto, strings.Join(fparts, "."), ext)); err != nil {
 		panic(err)
 	}

--- a/internal/configuration/provider_test.go
+++ b/internal/configuration/provider_test.go
@@ -803,7 +803,7 @@ func TestShouldHandleOIDCClaims(t *testing.T) {
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).D)
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).N)
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).E)
-	assert.Equal(t, 256, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).PublicKey.Size())
+	assert.Equal(t, 256, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).Size())
 	require.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[0].CertificateChain)
 	assert.True(t, config.IdentityProviders.OIDC.JSONWebKeys[0].CertificateChain.HasCertificates())
 
@@ -825,7 +825,7 @@ func TestShouldHandleOIDCClaims(t *testing.T) {
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).D)
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).N)
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).E)
-	assert.Equal(t, 512, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).PublicKey.Size())
+	assert.Equal(t, 512, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).Size())
 }
 
 func TestShouldDisableOIDCModern(t *testing.T) {
@@ -857,7 +857,7 @@ func TestShouldDisableOIDCModern(t *testing.T) {
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).D)
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).N)
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).E)
-	assert.Equal(t, 256, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).PublicKey.Size())
+	assert.Equal(t, 256, config.IdentityProviders.OIDC.JSONWebKeys[0].Key.(*rsa.PrivateKey).Size())
 	require.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[0].CertificateChain)
 	assert.True(t, config.IdentityProviders.OIDC.JSONWebKeys[0].CertificateChain.HasCertificates())
 
@@ -879,7 +879,7 @@ func TestShouldDisableOIDCModern(t *testing.T) {
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).D)
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).N)
 	assert.NotNil(t, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).E)
-	assert.Equal(t, 512, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).PublicKey.Size())
+	assert.Equal(t, 512, config.IdentityProviders.OIDC.JSONWebKeys[2].Key.(*rsa.PrivateKey).Size())
 }
 
 func TestShouldConfigureConsent(t *testing.T) {
@@ -1437,7 +1437,6 @@ func MustLoadCryptoRaw(ca bool, alg, ext string, extra ...string) string {
 		data []byte
 		err  error
 	)
-
 	if data, err = os.ReadFile(fmt.Sprintf(pathCrypto, strings.Join(fparts, "."), ext)); err != nil {
 		panic(err)
 	}

--- a/internal/configuration/schema/types_test.go
+++ b/internal/configuration/schema/types_test.go
@@ -867,7 +867,6 @@ func MustLoadCryptoRaw(ca bool, alg, ext string, extra ...string) string {
 		data []byte
 		err  error
 	)
-
 	if data, err = os.ReadFile(fmt.Sprintf(pathCrypto, strings.Join(fparts, "."), ext)); err != nil {
 		panic(err)
 	}

--- a/internal/configuration/validator/access_control.go
+++ b/internal/configuration/validator/access_control.go
@@ -162,7 +162,6 @@ func validateQuery(i int, rule schema.AccessControlRule, config *schema.Configur
 						pattern *regexp.Regexp
 						err     error
 					)
-
 					if pattern, err = regexp.Compile(v); err != nil {
 						validator.Push(fmt.Errorf(errFmtAccessControlRuleQueryInvalidValueParse, ruleDescriptor(i+1, rule), "value", err))
 					} else {

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -488,7 +488,6 @@ func validateLDAPAuthenticationAddress(config *schema.AuthenticationBackendLDAP,
 	var (
 		err error
 	)
-
 	if err = config.Address.ValidateLDAP(); err != nil {
 		validator.Push(fmt.Errorf(errFmtLDAPAuthBackendAddress, config.Address.String(), err))
 	}

--- a/internal/configuration/validator/identity_providers.go
+++ b/internal/configuration/validator/identity_providers.go
@@ -380,7 +380,7 @@ func validateOIDCIssuerJSONWebKeys(config *schema.IdentityProvidersOpenIDConnect
 			continue
 		}
 
-		if key, ok := config.JSONWebKeys[i].Key.(*rsa.PrivateKey); ok && key.PublicKey.N == nil {
+		if key, ok := config.JSONWebKeys[i].Key.(*rsa.PrivateKey); ok && key.N == nil {
 			validator.Push(fmt.Errorf(errFmtOIDCProviderPrivateKeysInvalid, i+1))
 
 			continue

--- a/internal/configuration/validator/identity_providers_test.go
+++ b/internal/configuration/validator/identity_providers_test.go
@@ -3395,7 +3395,7 @@ func TestValidateOIDCClientJWKS(t *testing.T) {
 
 	*frankenkey = *keyRSA2048
 
-	frankenkey.PublicKey.N = nil
+	frankenkey.N = nil
 
 	testCases := []struct {
 		name     string
@@ -3719,7 +3719,7 @@ func TestValidateOIDCIssuer(t *testing.T) {
 
 	*frankenkey = *keyRSA2048
 
-	frankenkey.PublicKey.N = nil
+	frankenkey.N = nil
 
 	testCases := []struct {
 		name     string
@@ -5125,7 +5125,6 @@ func MustLoadCrypto(alg, mod, ext string, extra ...string) any {
 		decoded any
 		err     error
 	)
-
 	if data, err = os.ReadFile(fmt.Sprintf(pathCrypto, strings.Join(fparts, "."), ext)); err != nil {
 		panic(err)
 	}

--- a/internal/configuration/validator/keys.go
+++ b/internal/configuration/validator/keys.go
@@ -19,8 +19,8 @@ func ValidateKeys(keys, remapped []string, prefix string, validator *schema.Stru
 	for _, key := range schema.Keys {
 		pattern, _ := NewKeyPattern(key)
 
-		switch {
-		case pattern == nil:
+		switch pattern {
+		case nil:
 			continue
 		default:
 			patterns = append(patterns, pattern)

--- a/internal/configuration/validator/notifier.go
+++ b/internal/configuration/validator/notifier.go
@@ -113,7 +113,6 @@ func validateSMTPNotifierAddress(config *schema.NotifierSMTP, validator *schema.
 		}
 
 		var err error
-
 		if err = config.Address.ValidateSMTP(); err != nil {
 			validator.Push(fmt.Errorf(errFmtNotifierSMTPAddress, config.Address.String(), err))
 		}

--- a/internal/configuration/validator/server.go
+++ b/internal/configuration/validator/server.go
@@ -93,7 +93,6 @@ func ValidateServerAddress(config *schema.Configuration, validator *schema.Struc
 		config.Server.Address = schema.DefaultServerConfiguration.Address
 	} else {
 		var err error
-
 		if err = config.Server.Address.ValidateHTTP(); err != nil {
 			validator.Push(fmt.Errorf(errFmtServerAddress, config.Server.Address.String(), err))
 		}
@@ -185,7 +184,6 @@ func validateServerAssets(config *schema.Configuration, validator *schema.Struct
 		entries []fs.DirEntry
 		err     error
 	)
-
 	if entries, err = os.ReadDir(filepath.Join(config.Server.AssetPath, "locales")); err != nil {
 		if !os.IsNotExist(err) {
 			validator.Push(fmt.Errorf("server: asset_path: error occurred reading the '%s' directory: %w", filepath.Join(config.Server.AssetPath, "locales"), err))

--- a/internal/configuration/validator/session_test.go
+++ b/internal/configuration/validator/session_test.go
@@ -1028,7 +1028,6 @@ func TestShouldNotAllowLegacyAndModernCookiesConfig(t *testing.T) {
 
 func MustParseURL(uri string) *url.URL {
 	u, err := url.Parse(uri)
-
 	if err != nil {
 		panic(err)
 	}

--- a/internal/configuration/validator/storage.go
+++ b/internal/configuration/validator/storage.go
@@ -60,7 +60,6 @@ func validateSQLConfiguration(config, defaults *schema.StorageSQL, validator *sc
 		validator.Push(fmt.Errorf(errFmtStorageOptionMustBeProvided, provider, "address"))
 	} else {
 		var err error
-
 		if err = config.Address.ValidateSQL(); err != nil {
 			validator.Push(fmt.Errorf(errFmtStorageAddressValidate, provider, config.Address.String(), err))
 		}
@@ -144,7 +143,6 @@ func validatePostgreSQLConfigurationServers(config *schema.StoragePostgreSQL, va
 			validator.Push(fmt.Errorf(errFmtStorageOptionMustBeProvided, description, "address"))
 		} else {
 			var err error
-
 			if err = server.Address.ValidateSQL(); err != nil {
 				validator.Push(fmt.Errorf(errFmtStorageAddressValidate, description, server.Address.String(), err))
 			}

--- a/internal/configuration/validator/util.go
+++ b/internal/configuration/validator/util.go
@@ -131,7 +131,7 @@ func schemaJWKGetProperties(jwk schema.JWK) (properties *JWKProperties, err erro
 	case ed25519.PrivateKey, ed25519.PublicKey:
 		return &JWKProperties{}, nil
 	case *rsa.PrivateKey:
-		if key.PublicKey.N == nil {
+		if key.N == nil {
 			return &JWKProperties{oidc.KeyUseSignature, oidc.SigningAlgRSAUsingSHA256, 0, nil}, nil
 		}
 
@@ -191,7 +191,7 @@ func schemaJWKGetPropertiesEnc(jwk schema.JWK) (properties *JWKProperties, err e
 	case ed25519.PrivateKey, ed25519.PublicKey:
 		return &JWKProperties{}, nil
 	case *rsa.PrivateKey:
-		if key.PublicKey.N == nil {
+		if key.N == nil {
 			return &JWKProperties{oidc.KeyUseEncryption, oidc.EncryptionAlgRSAOAEP256, 0, nil}, nil
 		}
 

--- a/internal/configuration/validator/util_test.go
+++ b/internal/configuration/validator/util_test.go
@@ -71,7 +71,7 @@ func TestSchemaJWKGetPropertiesMissingTests(t *testing.T) {
 	rsa := &rsa.PrivateKey{}
 
 	*rsa = *keyRSA2048
-	rsa.PublicKey.N = nil
+	rsa.N = nil
 
 	props, err = schemaJWKGetProperties(schema.JWK{Key: rsa})
 

--- a/internal/duo/duo.go
+++ b/internal/duo/duo.go
@@ -22,7 +22,7 @@ func NewDuoAPI(duoAPI *duoapi.DuoApi) *APIImpl {
 func (d *APIImpl) Call(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, values url.Values, method string, path string) (*Response, error) {
 	var response Response
 
-	_, responseBytes, err := d.DuoApi.SignedCall(method, path, values)
+	_, responseBytes, err := d.SignedCall(method, path, values)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/expression/user_attributes.go
+++ b/internal/expression/user_attributes.go
@@ -232,7 +232,6 @@ func (e *UserAttributesExpressions) Resolve(name string, detailer UserDetailer, 
 			val ref.Val
 			err error
 		)
-
 		if val, _, err = program.Eval(activation); err != nil {
 			return nil, false
 		}

--- a/internal/handlers/handler_authz.go
+++ b/internal/handlers/handler_authz.go
@@ -19,7 +19,6 @@ func (authz *Authz) Handler(ctx *middlewares.AutheliaCtx) {
 		provider    *session.Session
 		err         error
 	)
-
 	if object, err = authz.handleGetObject(ctx); err != nil {
 		ctx.Logger.WithError(err).Error("Error getting Target URL and Request Method")
 

--- a/internal/handlers/handler_authz_authn.go
+++ b/internal/handlers/handler_authz_authn.go
@@ -520,7 +520,6 @@ func handleSessionValidateRefresh(ctx *middlewares.AutheliaCtx, userSession *ses
 		details *authentication.UserDetails
 		err     error
 	)
-
 	if details, err = ctx.Providers.UserProvider.GetDetails(userSession.Username); err != nil {
 		if errors.Is(err, authentication.ErrUserNotFound) {
 			ctx.Logger.WithField("username", userSession.Username).Error("Error occurred while attempting to update user details for user: the user was not found indicating they were deleted, disabled, or otherwise no longer authorized to login")
@@ -589,7 +588,6 @@ func handleVerifyGETAuthorizationBearerIntrospection(ctx context.Context, provid
 		ErrorField:       "invalid_token",
 		DescriptionField: "The access token is expired, revoked, malformed, or invalid for other reasons. The client can obtain a new access token and try again.",
 	}
-
 	if use, requester, err = provider.IntrospectToken(ctx, authn.Header.Authorization.Value(), oauthelia2.AccessToken, oidc.NewSession(), oidc.ScopeAutheliaBearerAuthz); err != nil {
 		return "", "", false, authentication.NotAuthenticated, fmt.Errorf("error performing token introspection: %w", oauthelia2.ErrorToDebugRFC6749Error(err))
 	}
@@ -631,7 +629,7 @@ func handleVerifyGETAuthorizationBearerIntrospection(ctx context.Context, provid
 		return "", "", false, authentication.NotAuthenticated, fmt.Errorf("client id '%s' is registered but does not permit an audience for the url '%s' with the error: %w", osession.ClientID, audience[0], err)
 	}
 
-	if osession.DefaultSession == nil || osession.DefaultSession.Claims == nil {
+	if osession.DefaultSession == nil || osession.Claims == nil {
 		return "", "", false, authentication.NotAuthenticated, fmt.Errorf("introspection returned a session missing required values")
 	}
 

--- a/internal/handlers/handler_authz_impl_extauthz.go
+++ b/internal/handlers/handler_authz_impl_extauthz.go
@@ -11,7 +11,7 @@ import (
 )
 
 func handleAuthzGetObjectExtAuthz(ctx *middlewares.AutheliaCtx) (object authorization.Object, err error) {
-	protocol, host, uri := ctx.XForwardedProto(), ctx.RequestCtx.Host(), ctx.AuthzPath()
+	protocol, host, uri := ctx.XForwardedProto(), ctx.Host(), ctx.AuthzPath()
 
 	var (
 		targetURL *url.URL

--- a/internal/handlers/handler_change_password.go
+++ b/internal/handlers/handler_change_password.go
@@ -16,7 +16,6 @@ func ChangePasswordPOST(ctx *middlewares.AutheliaCtx) {
 		provider    *session.Session
 		err         error
 	)
-
 	if provider, err = ctx.GetSessionProvider(); err != nil {
 		ctx.Logger.WithError(err).
 			Error("Unable to change password for user: error occurred retrieving session provider")

--- a/internal/handlers/handler_checks_safe_redirection.go
+++ b/internal/handlers/handler_checks_safe_redirection.go
@@ -14,7 +14,6 @@ func CheckSafeRedirectionPOST(ctx *middlewares.AutheliaCtx) {
 		s   session.UserSession
 		err error
 	)
-
 	if s, err = ctx.GetSession(); err != nil {
 		ctx.ReplyUnauthorized()
 		return

--- a/internal/handlers/handler_configuration_password_policy.go
+++ b/internal/handlers/handler_configuration_password_policy.go
@@ -23,7 +23,6 @@ func PasswordPolicyConfigurationGET(ctx *middlewares.AutheliaCtx) {
 	}
 
 	var err error
-
 	if err = ctx.SetJSONBody(policyResponse); err != nil {
 		ctx.Logger.Errorf("Unable to send password Policy: %s", err)
 	}

--- a/internal/handlers/handler_firstfactor_passkey.go
+++ b/internal/handlers/handler_firstfactor_passkey.go
@@ -24,7 +24,6 @@ func FirstFactorPasskeyGET(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf(logFmtErrPasskeyAuthenticationChallengeGenerate, errStrUserSessionData)
 
@@ -107,7 +106,6 @@ func FirstFactorPasskeyPOST(ctx *middlewares.AutheliaCtx) {
 
 		response *protocol.ParsedCredentialAssertionData
 	)
-
 	if provider, err = ctx.GetSessionProvider(); err != nil {
 		ctx.Logger.WithError(err).Errorf(logFmtErrPasskeyAuthenticationChallengeValidate, errStrUserSessionData)
 
@@ -337,7 +335,7 @@ func FirstFactorPasskeyPOST(ctx *middlewares.AutheliaCtx) {
 	userSession.SetOneFactorPasskey(
 		ctx.Clock.Now(), details,
 		keepMeLoggedIn,
-		response.ParsedPublicKeyCredential.AuthenticatorAttachment == protocol.CrossPlatform,
+		response.AuthenticatorAttachment == protocol.CrossPlatform,
 		response.Response.AuthenticatorData.Flags.HasUserPresent(),
 		response.Response.AuthenticatorData.Flags.HasUserVerified(),
 	)

--- a/internal/handlers/handler_firstfactor_password.go
+++ b/internal/handlers/handler_firstfactor_password.go
@@ -29,7 +29,6 @@ func FirstFactorPasswordPOST(delayFunc middlewares.TimingAttackDelayFunc) middle
 			details *authentication.UserDetails
 			err     error
 		)
-
 		if err = ctx.ParseBody(&bodyJSON); err != nil {
 			ctx.Logger.WithError(err).Errorf(logFmtErrParseRequestBody, regulation.AuthType1FA)
 
@@ -171,7 +170,6 @@ func FirstFactorReauthenticatePOST(delayFunc middlewares.TimingAttackDelayFunc) 
 		bodyJSON := bodyFirstFactorReauthenticateRequest{}
 
 		var err error
-
 		if err = ctx.ParseBody(&bodyJSON); err != nil {
 			ctx.Logger.WithError(err).Errorf(logFmtErrParseRequestBody, regulation.AuthType1FA)
 

--- a/internal/handlers/handler_oauth2_authorization.go
+++ b/internal/handlers/handler_oauth2_authorization.go
@@ -27,7 +27,6 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 		policy    oidc.ClientAuthorizationPolicy
 		err       error
 	)
-
 	if requester, err = ctx.Providers.OpenIDConnect.NewAuthorizeRequest(ctx, r); requester == nil {
 		err = oauthelia2.ErrServerError.WithDebug("The requester was nil.")
 
@@ -141,7 +140,7 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 	session := oidc.NewSessionWithRequester(ctx, issuer, ctx.Providers.OpenIDConnect.Issuer.GetKeyID(ctx, client.GetIDTokenSignedResponseKeyID(), client.GetIDTokenSignedResponseAlg()), details.Username, userSession.AuthenticationMethodRefs.MarshalRFC8176(), extra, userSession.LastAuthenticatedTime(), consent, requester, requests)
 
 	if client.GetClaimsStrategy().MergeAccessTokenAudienceWithIDTokenAudience() {
-		session.DefaultSession.Claims.Audience = append([]string{clientID}, requester.GetGrantedAudience()...)
+		session.Claims.Audience = append([]string{clientID}, requester.GetGrantedAudience()...)
 	}
 
 	ctx.Logger.Tracef("Authorization Request with id '%s' on client with id '%s' using policy '%s' creating session for Authorization Response for subject '%s' with username '%s' with groups: %+v and claims: %+v",
@@ -172,7 +171,6 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 // included if available.
 func OAuth2AuthorizationPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, r *http.Request) {
 	var err error
-
 	if err = r.ParseMultipartForm(1 << 20); err != nil && !errors.Is(err, http.ErrNotMultipart) {
 		requester := oauthelia2.NewAuthorizeRequest()
 
@@ -203,7 +201,6 @@ func OAuth2PushedAuthorizationRequest(ctx *middlewares.AutheliaCtx, rw http.Resp
 		responder oauthelia2.PushedAuthorizeResponder
 		err       error
 	)
-
 	if requester, err = ctx.Providers.OpenIDConnect.NewPushedAuthorizeRequest(ctx, r); err != nil {
 		ctx.Logger.Errorf("Pushed Authorization Request failed with error: %s", oauthelia2.ErrorToDebugRFC6749Error(err))
 

--- a/internal/handlers/handler_oauth2_authorization_consent_core.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_core.go
@@ -122,7 +122,6 @@ func handleOAuth2AuthorizationConsentNotAuthenticated(ctx *middlewares.AutheliaC
 	_ session.UserSession, _ uuid.UUID,
 	rw http.ResponseWriter, r *http.Request, requester oauthelia2.Requester) (consent *model.OAuth2ConsentSession, handled bool) {
 	var err error
-
 	if consent, err = handleOAuth2NewConsentSession(ctx, uuid.UUID{}, requester, ctx.Providers.OpenIDConnect.GetPushedAuthorizeRequestURIPrefix(ctx)); err != nil {
 		ctx.Logger.Errorf(logFmtErrConsentGenerateError, requester.GetID(), client.GetID(), client.GetConsentPolicy(), "generating", err)
 

--- a/internal/handlers/handler_oauth2_authorization_consent_implicit.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_implicit.go
@@ -109,7 +109,6 @@ func handleOAuth2AuthorizationConsentModeImplicitWithoutID(ctx *middlewares.Auth
 	var (
 		err error
 	)
-
 	if consent, err = handleOAuth2NewConsentSession(ctx, subject, requester, ctx.Providers.OpenIDConnect.GetPushedAuthorizeRequestURIPrefix(ctx)); err != nil {
 		ctx.Logger.Errorf(logFmtErrConsentGenerateError, requester.GetID(), client.GetID(), client.GetConsentPolicy(), "generating", err)
 

--- a/internal/handlers/handler_oauth2_authorization_consent_preconfigured.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_preconfigured.go
@@ -150,7 +150,6 @@ func handleOAuth2AuthorizationConsentModePreConfiguredWithoutID(ctx *middlewares
 		config *model.OAuth2ConsentPreConfig
 		err    error
 	)
-
 	if config, err = handleOAuth2AuthorizationConsentModePreConfiguredGetPreConfig(ctx, client, subject, requester); err != nil {
 		ctx.Logger.Errorf(logFmtErrConsentPreConfLookup, requester.GetID(), client.GetID(), client.GetConsentPolicy(), err)
 

--- a/internal/handlers/handler_oauth2_consent.go
+++ b/internal/handlers/handler_oauth2_consent.go
@@ -38,7 +38,6 @@ func handleOAuth2ConsentFlowIDGET(ctx *middlewares.AutheliaCtx, raw []byte) {
 		flowID uuid.UUID
 		err    error
 	)
-
 	if flowID, err = uuid.ParseBytes(raw); err != nil {
 		ctx.Logger.
 			WithError(err).
@@ -154,7 +153,6 @@ func OAuth2ConsentPOST(ctx *middlewares.AutheliaCtx) {
 		bodyJSON oidc.ConsentPostRequestBody
 		err      error
 	)
-
 	if err = json.Unmarshal(ctx.Request.Body(), &bodyJSON); err != nil {
 		ctx.Logger.
 			WithError(err).
@@ -432,7 +430,7 @@ func handleOAuth2ConsentDeviceAuthorizationPOST(ctx *middlewares.AutheliaCtx, bo
 
 	code := *bodyJSON.UserCode
 
-	if signature, err = ctx.Providers.OpenIDConnect.Config.Strategy.Core.RFC8628UserCodeSignature(ctx, code); err != nil {
+	if signature, err = ctx.Providers.OpenIDConnect.Strategy.Core.RFC8628UserCodeSignature(ctx, code); err != nil {
 		ctx.Logger.
 			WithError(err).
 			WithFields(map[string]any{logging.FieldUsername: userSession.Username, logging.FieldClientID: bodyJSON.ClientID}).
@@ -617,7 +615,6 @@ func handleOAuth2ConsentGetSessionsAndClient(ctx *middlewares.AutheliaCtx, flowI
 	var (
 		err error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.
 			WithError(err).
@@ -690,7 +687,6 @@ func handleOAuth2ConsentDeviceAuthorizationGetSessionsAndClient(ctx *middlewares
 		signature string
 		err       error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.
 			WithError(err).

--- a/internal/handlers/handler_oauth2_device_authorization.go
+++ b/internal/handlers/handler_oauth2_device_authorization.go
@@ -26,7 +26,6 @@ func OAuth2DeviceAuthorizationPOST(ctx *middlewares.AutheliaCtx, rw http.Respons
 
 		err error
 	)
-
 	if requester, err = ctx.Providers.OpenIDConnect.NewRFC862DeviceAuthorizeRequest(ctx, r); err != nil {
 		ctx.Logger.
 			WithError(oauthelia2.ErrorToDebugRFC6749Error(err)).
@@ -65,7 +64,6 @@ func OAuth2DeviceAuthorizationPUT(ctx *middlewares.AutheliaCtx, rw http.Response
 
 		err error
 	)
-
 	if requester, err = ctx.Providers.OpenIDConnect.NewRFC8628UserAuthorizeRequest(ctx, r); err != nil {
 		ctx.Logger.
 			WithError(oauthelia2.ErrorToDebugRFC6749Error(err)).
@@ -194,7 +192,7 @@ func OAuth2DeviceAuthorizationPUT(ctx *middlewares.AutheliaCtx, rw http.Response
 	session := oidc.NewSessionWithRequester(ctx, issuer, ctx.Providers.OpenIDConnect.Issuer.GetKeyID(ctx, client.GetIDTokenSignedResponseKeyID(), client.GetIDTokenSignedResponseAlg()), details.Username, userSession.AuthenticationMethodRefs.MarshalRFC8176(), extra, userSession.LastAuthenticatedTime(), consent, requester, requests)
 
 	if client.GetClaimsStrategy().MergeAccessTokenAudienceWithIDTokenAudience() {
-		session.DefaultSession.Claims.Audience = append([]string{client.GetID()}, requester.GetGrantedAudience()...)
+		session.Claims.Audience = append([]string{client.GetID()}, requester.GetGrantedAudience()...)
 	}
 
 	requester.SetStatus(oauthelia2.DeviceAuthorizeStatusApproved)

--- a/internal/handlers/handler_oauth2_introspection.go
+++ b/internal/handlers/handler_oauth2_introspection.go
@@ -19,7 +19,6 @@ func OAuth2IntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWrite
 		responder oauthelia2.IntrospectionResponder
 		err       error
 	)
-
 	if requestID, err = uuid.NewRandom(); err != nil {
 		ctx.Providers.OpenIDConnect.WriteIntrospectionError(ctx, rw, oauthelia2.ErrServerError)
 

--- a/internal/handlers/handler_oauth2_oidc_userinfo.go
+++ b/internal/handlers/handler_oauth2_oidc_userinfo.go
@@ -28,7 +28,6 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 		client    oidc.Client
 		err       error
 	)
-
 	if requestID, err = uuid.NewRandom(); err != nil {
 		errorsx.WriteJSONError(rw, r, oauthelia2.ErrServerError)
 

--- a/internal/handlers/handler_oauth2_oidc_wellknown.go
+++ b/internal/handlers/handler_oauth2_oidc_wellknown.go
@@ -23,7 +23,6 @@ func WellKnownOpenIDConfigurationGET(ctx *middlewares.AutheliaCtx) {
 		issuer *url.URL
 		err    error
 	)
-
 	if issuer, err = ctx.IssuerURL(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred determining issuer")
 

--- a/internal/handlers/handler_oauth2_revocation.go
+++ b/internal/handlers/handler_oauth2_revocation.go
@@ -17,7 +17,6 @@ func OAuth2RevocationPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, 
 		requestID uuid.UUID
 		err       error
 	)
-
 	if requestID, err = uuid.NewRandom(); err != nil {
 		ctx.Providers.OpenIDConnect.WriteRevocationResponse(ctx, rw, oauthelia2.ErrServerError)
 

--- a/internal/handlers/handler_oauth2_wellknown.go
+++ b/internal/handlers/handler_oauth2_wellknown.go
@@ -23,7 +23,6 @@ func WellKnownOAuthAuthorizationServerGET(ctx *middlewares.AutheliaCtx) {
 		issuer *url.URL
 		err    error
 	)
-
 	if issuer, err = ctx.IssuerURL(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred determining issuer")
 

--- a/internal/handlers/handler_register_duo_device.go
+++ b/internal/handlers/handler_register_duo_device.go
@@ -19,7 +19,6 @@ func DuoDevicesGET(duoAPI duo.API) middlewares.RequestHandler {
 			userSession session.UserSession
 			err         error
 		)
-
 		if userSession, err = ctx.GetSession(); err != nil {
 			ctx.Error(fmt.Errorf("failed to get session data: %w", err), messageMFAValidationFailed)
 			return
@@ -96,7 +95,6 @@ func DuoDevicePOST(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if err = ctx.ParseBody(&bodyJSON); err != nil {
 		ctx.Error(err, messageMFAValidationFailed)
 		return
@@ -113,8 +111,8 @@ func DuoDevicePOST(ctx *middlewares.AutheliaCtx) {
 	}
 
 	ctx.Logger.Debugf("Save new preferred Duo device and method of user %s to %s using %s", userSession.Username, bodyJSON.Device, bodyJSON.Method)
-	err = ctx.Providers.StorageProvider.SavePreferredDuoDevice(ctx, model.DuoDevice{Username: userSession.Username, Device: bodyJSON.Device, Method: bodyJSON.Method})
 
+	err = ctx.Providers.StorageProvider.SavePreferredDuoDevice(ctx, model.DuoDevice{Username: userSession.Username, Device: bodyJSON.Device, Method: bodyJSON.Method})
 	if err != nil {
 		ctx.Error(fmt.Errorf("unable to save new preferred Duo device and method: %w", err), messageMFAValidationFailed)
 		return
@@ -129,7 +127,6 @@ func DuoDeviceDELETE(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Error(fmt.Errorf("unable to get session to delete preferred Duo device and method: %w", err), messageMFAValidationFailed)
 		return

--- a/internal/handlers/handler_register_totp.go
+++ b/internal/handlers/handler_register_totp.go
@@ -20,7 +20,6 @@ func TOTPRegisterGET(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred retrieving TOTP registration options: %s", errStrUserSessionData)
 
@@ -54,7 +53,6 @@ func TOTPRegisterPUT(ctx *middlewares.AutheliaCtx) {
 		bodyJSON    bodyRegisterTOTP
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred generating a TOTP registration session: %s", errStrUserSessionData)
 
@@ -146,7 +144,6 @@ func TOTPRegisterPOST(ctx *middlewares.AutheliaCtx) {
 		step        uint64
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred validating a TOTP registration session: %s", errStrUserSessionData)
 
@@ -268,7 +265,6 @@ func TOTPRegisterDELETE(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred deleting a TOTP registration session: %s", errStrUserSessionData)
 
@@ -313,7 +309,6 @@ func TOTPConfigurationDELETE(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred deleting a TOTP configuration: %s", errStrUserSessionData)
 

--- a/internal/handlers/handler_register_webauthn.go
+++ b/internal/handlers/handler_register_webauthn.go
@@ -25,7 +25,6 @@ func WebAuthnRegistrationPUT(ctx *middlewares.AutheliaCtx) {
 		bodyJSON    bodyRegisterWebAuthnPUTRequest
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred generating a WebAuthn registration challenge: %s", errStrUserSessionData)
 
@@ -147,7 +146,6 @@ func WebAuthnRegistrationPOST(ctx *middlewares.AutheliaCtx) {
 
 		c *webauthn.Credential
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred validating a WebAuthn registration challenge: %s", errStrUserSessionData)
 
@@ -259,7 +257,6 @@ func WebAuthnRegistrationDELETE(ctx *middlewares.AutheliaCtx) {
 		err         error
 		userSession session.UserSession
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred deleting a WebAuthn registration challenge: %s", errStrUserSessionData)
 

--- a/internal/handlers/handler_reset_password.go
+++ b/internal/handlers/handler_reset_password.go
@@ -125,7 +125,6 @@ func ResetPasswordPOST(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Error(fmt.Errorf("error occurred retrieving session for user: %w", err), messageUnableToResetPassword)
 		return
@@ -218,14 +217,13 @@ func ResetPasswordPOST(ctx *middlewares.AutheliaCtx) {
 
 func identityRetrieverFromStorage(ctx *middlewares.AutheliaCtx) (*session.Identity, error) {
 	var requestBody resetPasswordStep1RequestBody
-	err := json.Unmarshal(ctx.PostBody(), &requestBody)
 
+	err := json.Unmarshal(ctx.PostBody(), &requestBody)
 	if err != nil {
 		return nil, err
 	}
 
 	details, err := ctx.Providers.UserProvider.GetDetails(requestBody.Username)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/handlers/handler_session_elevation.go
+++ b/internal/handlers/handler_session_elevation.go
@@ -123,7 +123,6 @@ func UserSessionElevationPOST(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred creating user session elevation One-Time Code challenge: %s", errStrUserSessionData)
 
@@ -224,7 +223,6 @@ func UserSessionElevationPUT(ctx *middlewares.AutheliaCtx) {
 		code        *model.OneTimeCode
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred validating user session elevation One-Time Code challenge: %s", errStrUserSessionData)
 
@@ -366,7 +364,6 @@ func UserSessionElevateDELETE(ctx *middlewares.AutheliaCtx) {
 		code *model.OneTimeCode
 		err  error
 	)
-
 	if _, err = base64.RawURLEncoding.Decode(decoded, []byte(value)); err != nil {
 		ctx.Logger.WithError(err).
 			Error("Error occurred revoking user session elevation One-Time Code challenge: error occurred decoding the identifier")

--- a/internal/handlers/handler_sign_duo.go
+++ b/internal/handlers/handler_sign_duo.go
@@ -22,7 +22,6 @@ func DuoPOST(duoAPI duo.API) middlewares.RequestHandler {
 			userSession session.UserSession
 			err         error
 		)
-
 		if err = ctx.ParseBody(bodyJSON); err != nil {
 			ctx.Logger.WithError(err).Errorf(logFmtErrParseRequestBody, regulation.AuthTypeDuo)
 
@@ -251,7 +250,6 @@ func HandleAllow(ctx *middlewares.AutheliaCtx, userSession *session.UserSession,
 	var (
 		err error
 	)
-
 	if err = ctx.RegenerateSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf(logFmtErrSessionRegenerate, regulation.AuthTypeDuo, userSession.Username)
 

--- a/internal/handlers/handler_sign_password.go
+++ b/internal/handlers/handler_sign_password.go
@@ -23,7 +23,6 @@ func SecondFactorPasswordPOST(delayFunc middlewares.TimingAttackDelayFunc) middl
 		bodyJSON := bodySecondFactorPasswordRequest{}
 
 		var err error
-
 		if err = ctx.ParseBody(&bodyJSON); err != nil {
 			ctx.Logger.WithError(err).Errorf(logFmtErrParseRequestBody, regulation.AuthType1FA)
 

--- a/internal/handlers/handler_sign_totp.go
+++ b/internal/handlers/handler_sign_totp.go
@@ -19,7 +19,6 @@ func TimeBasedOneTimePasswordGET(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred retrieving TOTP configuration: %s", errStrUserSessionData)
 
@@ -77,7 +76,6 @@ func TimeBasedOneTimePasswordPOST(ctx *middlewares.AutheliaCtx) {
 		step          uint64
 		err           error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred validating a TOTP authentication: %s", errStrUserSessionData)
 

--- a/internal/handlers/handler_sign_webauthn.go
+++ b/internal/handlers/handler_sign_webauthn.go
@@ -24,7 +24,6 @@ func WebAuthnAssertionGET(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.SetStatusCode(fasthttp.StatusForbidden)
 		ctx.SetJSONError(messageMFAValidationFailed)
@@ -141,7 +140,6 @@ func WebAuthnAssertionPOST(ctx *middlewares.AutheliaCtx) {
 
 		response *protocol.ParsedCredentialAssertionData
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred validating a WebAuthn authentication challenge: %s", errStrUserSessionData)
 
@@ -273,7 +271,7 @@ func WebAuthnAssertionPOST(ctx *middlewares.AutheliaCtx) {
 	doMarkAuthenticationAttempt(ctx, true, regulation.NewBan(regulation.BanTypeNone, userSession.Username, nil), regulation.AuthTypeWebAuthn, nil)
 
 	userSession.SetTwoFactorWebAuthn(ctx.Clock.Now(),
-		response.ParsedPublicKeyCredential.AuthenticatorAttachment == protocol.CrossPlatform,
+		response.AuthenticatorAttachment == protocol.CrossPlatform,
 		response.Response.AuthenticatorData.Flags.HasUserPresent(),
 		response.Response.AuthenticatorData.Flags.HasUserVerified())
 

--- a/internal/handlers/handler_state.go
+++ b/internal/handlers/handler_state.go
@@ -11,7 +11,6 @@ func StateGET(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Error("Error occurred retrieving user session")
 

--- a/internal/handlers/handler_user_info.go
+++ b/internal/handlers/handler_user_info.go
@@ -21,7 +21,6 @@ func UserInfoPOST(ctx *middlewares.AutheliaCtx) {
 		userInfo    model.UserInfo
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Error("Error occurred retrieving user session")
 
@@ -83,7 +82,6 @@ func UserInfoGET(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Error("Error occurred retrieving user session")
 
@@ -120,7 +118,6 @@ func MethodPreferencePOST(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Error("Error occurred retrieving user session")
 

--- a/internal/handlers/handler_webauthn_credentials.go
+++ b/internal/handlers/handler_webauthn_credentials.go
@@ -39,7 +39,6 @@ func WebAuthnCredentialsGET(ctx *middlewares.AutheliaCtx) {
 		origin      *url.URL
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred loading WebAuthn credentials: %s", errStrUserSessionData)
 
@@ -94,7 +93,6 @@ func WebAuthnCredentialPUT(ctx *middlewares.AutheliaCtx) {
 
 		err error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred modifying WebAuthn credential: %s", errStrUserSessionData)
 
@@ -211,7 +209,6 @@ func WebAuthnCredentialDELETE(ctx *middlewares.AutheliaCtx) {
 		userSession session.UserSession
 		err         error
 	)
-
 	if userSession, err = ctx.GetSession(); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred deleting WebAuthn credential: %s", errStrUserSessionData)
 

--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -175,7 +175,6 @@ func handleFlowResponseOpenIDConnectNoSubflow(ctx *middlewares.AutheliaCtx, user
 		consent *model.OAuth2ConsentSession
 		err     error
 	)
-
 	if flowID, err = uuid.Parse(id); err != nil {
 		ctx.SetJSONError(messageAuthenticationFailed)
 
@@ -328,7 +327,7 @@ func handleFlowResponseOpenIDConnectDeviceAuthSubflow(ctx *middlewares.AutheliaC
 		return
 	}
 
-	if signature, err = ctx.Providers.OpenIDConnect.Config.Strategy.Core.RFC8628UserCodeSignature(ctx, userCode); err != nil {
+	if signature, err = ctx.Providers.OpenIDConnect.Strategy.Core.RFC8628UserCodeSignature(ctx, userCode); err != nil {
 		ctx.Logger.
 			WithError(err).
 			WithFields(map[string]any{logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldUsername: userSession.Username}).

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -99,7 +99,6 @@ func (ctx *AutheliaCtx) SetAuthenticationErrorJSON(status int, message string, a
 // ReplyError reply with an error but does not display any stack trace in the logs.
 func (ctx *AutheliaCtx) ReplyError(err error, message string) {
 	b, marshalErr := json.Marshal(ErrorResponse{Status: "KO", Message: message})
-
 	if marshalErr != nil {
 		ctx.Logger.Error(marshalErr)
 	}
@@ -182,7 +181,7 @@ func (ctx *AutheliaCtx) GetXForwardedHost() (host []byte) {
 	host = ctx.XForwardedHost()
 
 	if host == nil {
-		return ctx.RequestCtx.Host()
+		return ctx.Host()
 	}
 
 	return host
@@ -436,19 +435,17 @@ func (ctx *AutheliaCtx) ReplyOK() {
 // ParseBody parse the request body into the type of value.
 func (ctx *AutheliaCtx) ParseBody(value any) error {
 	err := json.Unmarshal(ctx.PostBody(), &value)
-
 	if err != nil {
 		return fmt.Errorf("unable to parse body: %w", err)
 	}
 
 	valid, err := govalidator.ValidateStruct(value)
-
 	if err != nil {
 		return fmt.Errorf("unable to validate body: %w", err)
 	}
 
 	if !valid {
-		return fmt.Errorf("Body is not valid")
+		return fmt.Errorf("body is not valid")
 	}
 
 	return nil

--- a/internal/middlewares/authelia_context_test.go
+++ b/internal/middlewares/authelia_context_test.go
@@ -41,7 +41,7 @@ func TestAutheliaCtx_RemoteIP(t *testing.T) {
 			mock.Ctx.SetRemoteAddr(&net.TCPAddr{Port: 80, IP: net.ParseIP("127.0.0.127")})
 
 			if tc.have != nil {
-				mock.Ctx.RequestCtx.Request.Header.SetBytesV(fasthttp.HeaderXForwardedFor, tc.have)
+				mock.Ctx.Request.Header.SetBytesV(fasthttp.HeaderXForwardedFor, tc.have)
 			}
 
 			assert.Equal(t, tc.expected, mock.Ctx.RemoteIP())
@@ -355,6 +355,7 @@ func TestShouldGetOriginalURLFromOriginalURLHeader(t *testing.T) {
 func TestShouldGetOriginalURLFromForwardedHeadersWithoutURI(t *testing.T) {
 	mock := mocks.NewMockAutheliaCtx(t)
 	defer mock.Close()
+
 	mock.Ctx.Request.Header.Set(fasthttp.HeaderXForwardedProto, "https")
 	mock.Ctx.Request.Header.Set(fasthttp.HeaderXForwardedHost, "home.example.com")
 	originalURL, err := mock.Ctx.GetXOriginalURLOrXForwardedURL()
@@ -368,6 +369,7 @@ func TestShouldGetOriginalURLFromForwardedHeadersWithoutURI(t *testing.T) {
 func TestShouldGetOriginalURLFromForwardedHeadersWithURI(t *testing.T) {
 	mock := mocks.NewMockAutheliaCtx(t)
 	defer mock.Close()
+
 	mock.Ctx.Request.Header.Set("X-Original-URL", "htt-ps//home?-.example.com")
 	_, err := mock.Ctx.GetXOriginalURLOrXForwardedURL()
 	assert.Error(t, err)
@@ -380,8 +382,8 @@ func TestShouldFallbackToNonXForwardedHeaders(t *testing.T) {
 
 	defer mock.Close()
 
-	mock.Ctx.RequestCtx.Request.SetRequestURI("/2fa/one-time-password")
-	mock.Ctx.RequestCtx.Request.SetHost("auth.example.com:1234")
+	mock.Ctx.Request.SetRequestURI("/2fa/one-time-password")
+	mock.Ctx.Request.SetHost("auth.example.com:1234")
 
 	assert.Equal(t, []byte("http"), mock.Ctx.XForwardedProto())
 	assert.Equal(t, []byte("auth.example.com:1234"), mock.Ctx.GetXForwardedHost())
@@ -394,12 +396,12 @@ func TestShouldOnlyFallbackToNonXForwardedHeadersWhenNil(t *testing.T) {
 
 	mock.Ctx.Request.Header.Del(fasthttp.HeaderXForwardedHost)
 
-	mock.Ctx.RequestCtx.Request.SetRequestURI("/2fa/one-time-password")
-	mock.Ctx.RequestCtx.Request.SetHost("localhost")
-	mock.Ctx.RequestCtx.Request.Header.Set(fasthttp.HeaderXForwardedHost, "auth.example.com:1234")
-	mock.Ctx.RequestCtx.Request.Header.Set("X-Forwarded-URI", "/base/2fa/one-time-password")
-	mock.Ctx.RequestCtx.Request.Header.Set(fasthttp.HeaderXForwardedProto, "https")
-	mock.Ctx.RequestCtx.Request.Header.Set("X-Forwarded-Method", fasthttp.MethodGet)
+	mock.Ctx.Request.SetRequestURI("/2fa/one-time-password")
+	mock.Ctx.Request.SetHost("localhost")
+	mock.Ctx.Request.Header.Set(fasthttp.HeaderXForwardedHost, "auth.example.com:1234")
+	mock.Ctx.Request.Header.Set("X-Forwarded-URI", "/base/2fa/one-time-password")
+	mock.Ctx.Request.Header.Set(fasthttp.HeaderXForwardedProto, "https")
+	mock.Ctx.Request.Header.Set("X-Forwarded-Method", fasthttp.MethodGet)
 
 	assert.Equal(t, []byte("https"), mock.Ctx.XForwardedProto())
 	assert.Equal(t, []byte("auth.example.com:1234"), mock.Ctx.GetXForwardedHost())
@@ -411,7 +413,7 @@ func TestShouldDetectXHR(t *testing.T) {
 	mock := mocks.NewMockAutheliaCtx(t)
 	defer mock.Close()
 
-	mock.Ctx.RequestCtx.Request.Header.Set(fasthttp.HeaderXRequestedWith, "XMLHttpRequest")
+	mock.Ctx.Request.Header.Set(fasthttp.HeaderXRequestedWith, "XMLHttpRequest")
 
 	assert.True(t, mock.Ctx.IsXHR())
 }

--- a/internal/middlewares/http_to_authelia_handler_adaptor.go
+++ b/internal/middlewares/http_to_authelia_handler_adaptor.go
@@ -99,8 +99,8 @@ func NewHTTPToAutheliaHandlerAdaptor(h AutheliaHandlerFunc) RequestHandler {
 
 		r.Header = hdr
 		r.Body = &netHTTPBody{body}
-		rURL, err := url.ParseRequestURI(r.RequestURI)
 
+		rURL, err := url.ParseRequestURI(r.RequestURI)
 		if err != nil {
 			ctx.Logger.Errorf("Cannot parse requestURI %q: %s", r.RequestURI, err)
 			ctx.RequestCtx.Error("Internal Server Error", fasthttp.StatusInternalServerError)

--- a/internal/middlewares/identity_verification.go
+++ b/internal/middlewares/identity_verification.go
@@ -17,7 +17,7 @@ import (
 // IdentityVerificationStart the handler for initiating the identity validation process.
 func IdentityVerificationStart(args IdentityVerificationStartArgs, delayFunc TimingAttackDelayFunc) RequestHandler {
 	if args.IdentityRetrieverFunc == nil {
-		panic(fmt.Errorf("Identity verification requires an identity retriever"))
+		panic(fmt.Errorf("identity verification requires an identity retriever"))
 	}
 
 	return func(ctx *AutheliaCtx) {
@@ -130,14 +130,13 @@ func IdentityVerificationFinish(args IdentityVerificationFinishArgs, next func(c
 		b := ctx.PostBody()
 
 		err := json.Unmarshal(b, &finishBody)
-
 		if err != nil {
 			ctx.Error(err, messageOperationFailed)
 			return
 		}
 
 		if finishBody.Token == "" {
-			ctx.Error(fmt.Errorf("No token provided"), messageOperationFailed)
+			ctx.Error(fmt.Errorf("no token provided"), messageOperationFailed)
 			return
 		}
 

--- a/internal/middlewares/identity_verification_test.go
+++ b/internal/middlewares/identity_verification_test.go
@@ -166,7 +166,7 @@ func (s *IdentityVerificationFinishProcess) TestShouldFailIfTokenIsNotProvided()
 	middlewares.IdentityVerificationFinish(newFinishArgs(), next)(s.mock.Ctx)
 
 	s.mock.Assert200KO(s.T(), "Operation failed")
-	assert.Equal(s.T(), "No token provided", s.mock.Hook.LastEntry().Message)
+	assert.Equal(s.T(), "no token provided", s.mock.Hook.LastEntry().Message)
 }
 
 func (s *IdentityVerificationFinishProcess) TestShouldFailIfTokenIsNotFoundInDB() {

--- a/internal/middlewares/require_auth.go
+++ b/internal/middlewares/require_auth.go
@@ -27,7 +27,6 @@ func RequireElevated(next RequestHandler) RequestHandler {
 			userSession session.UserSession
 			err         error
 		)
-
 		if userSession, err = ctx.GetSession(); err != nil {
 			ctx.Logger.WithError(err).Error("Error occurred attempting to lookup user session during an elevation check.")
 

--- a/internal/middlewares/startup.go
+++ b/internal/middlewares/startup.go
@@ -81,7 +81,6 @@ func doStartupCheck(ctx Context, name string, provider model.StartupCheck, requi
 	}
 
 	var err error
-
 	if err = provider.StartupCheck(); err != nil {
 		if log {
 			ctx.GetLogger().WithError(err).WithField(logging.FieldProvider, name).Error(LogMessageStartupCheckError)

--- a/internal/middlewares/util.go
+++ b/internal/middlewares/util.go
@@ -47,7 +47,6 @@ func NewProviders(config *schema.Configuration, caCertPool *x509.CertPool) (prov
 	providers.UserProvider = NewAuthenticationProvider(config, caCertPool)
 
 	var err error
-
 	if providers.Templates, err = templates.New(templates.Config{EmailTemplatesPath: config.Notifier.TemplatePath}); err != nil {
 		errs = append(errs, err)
 	}

--- a/internal/mocks/authelia_ctx.go
+++ b/internal/mocks/authelia_ctx.go
@@ -214,7 +214,6 @@ func NewMockAutheliaCtx(t *testing.T) *MockAutheliaCtx {
 	providers.Random = random.NewMathematical()
 
 	var err error
-
 	if providers.Templates, err = templates.New(templates.Config{}); err != nil {
 		panic(err)
 	}

--- a/internal/model/oidc_test.go
+++ b/internal/model/oidc_test.go
@@ -608,7 +608,6 @@ func TestMisc(t *testing.T) {
 
 func MustParseRequestURI(uri string) (parsed *url.URL) {
 	var err error
-
 	if parsed, err = url.ParseRequestURI(uri); err != nil {
 		panic(err)
 	}

--- a/internal/notification/file_notifier.go
+++ b/internal/notification/file_notifier.go
@@ -67,7 +67,7 @@ func (n *FileNotifier) Send(_ context.Context, recipient mail.Address, subject s
 
 	w := bufio.NewWriter(f)
 
-	if _, err = w.WriteString(fmt.Sprintf(fileNotifierHeader, time.Now(), recipient, subject)); err != nil {
+	if _, err = fmt.Fprintf(w, fileNotifierHeader, time.Now(), recipient, subject); err != nil {
 		return fmt.Errorf("failed to write to the buffer: %w", err)
 	}
 

--- a/internal/oidc/client_credentials.go
+++ b/internal/oidc/client_credentials.go
@@ -15,7 +15,7 @@ type ClientSecretDigest struct {
 
 // Compare decorates the *schema.PasswordDigest's implementation to satisfy oauth2.ClientSecret's Compare function.
 func (d *ClientSecretDigest) Compare(ctx context.Context, rawSecret []byte) (err error) {
-	if d.PasswordDigest == nil || d.PasswordDigest.Digest == nil {
+	if d.PasswordDigest == nil || d.Digest == nil {
 		return oauthelia2.ErrClientSecretNotRegistered
 	}
 

--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -849,7 +849,6 @@ func (c *Config) GetAllowedJWTAssertionAudiences(ctx context.Context) (audiences
 		issuer *url.URL
 		err    error
 	)
-
 	if issuer, err = octx.IssuerURL(); err != nil {
 		logging.Logger().WithError(err).Error("Error retrieving issuer")
 		return nil

--- a/internal/oidc/const_test.go
+++ b/internal/oidc/const_test.go
@@ -57,7 +57,6 @@ func MustLoadCrypto(alg, mod, ext string, extra ...string) any {
 		decoded any
 		err     error
 	)
-
 	if data, err = os.ReadFile(fmt.Sprintf(pathCrypto, strings.Join(fparts, "_"), ext)); err != nil {
 		panic(err)
 	}
@@ -83,7 +82,6 @@ func MustLoadRSACryptoSet(legacy bool, extra ...string) (chain schema.X509Certif
 		err     error
 		ok      bool
 	)
-
 	if decoded, err = utils.ParseX509FromPEMRecursive(k); err != nil {
 		panic(err)
 	}
@@ -109,7 +107,6 @@ func MustLoadECDSACryptoSet(legacy bool, extra ...string) (chain schema.X509Cert
 		err     error
 		ok      bool
 	)
-
 	if decoded, err = utils.ParseX509FromPEMRecursive(k); err != nil {
 		panic(err)
 	}
@@ -154,7 +151,6 @@ func MustLoadCryptoRaw(ca bool, alg, ext string, extra ...string) []byte {
 		data []byte
 		err  error
 	)
-
 	if data, err = os.ReadFile(fmt.Sprintf(pathCrypto, strings.Join(fparts, "."), ext)); err != nil {
 		panic(err)
 	}
@@ -173,7 +169,6 @@ func MustParseCertificateChain(blocks ...[]byte) schema.X509CertificateChain {
 		decoded any
 		err     error
 	)
-
 	if decoded, err = utils.ParseX509FromPEMRecursive(buf.Bytes()); err != nil {
 		panic(err)
 	}

--- a/internal/oidc/errors.go
+++ b/internal/oidc/errors.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	errClientSecretMismatch = errors.New("The provided client secret did not match the registered client secret.")
+	errClientSecretMismatch = errors.New("The provided client secret did not match the registered client secret.") //nolint:staticcheck // Log error message.
 )
 
 var (

--- a/internal/oidc/provider.go
+++ b/internal/oidc/provider.go
@@ -27,7 +27,7 @@ func NewOpenIDConnectProvider(config *schema.Configuration, store storage.Provid
 
 	provider.Provider = oauthelia2.New(provider.Store, provider.Config)
 
-	provider.Config.LoadHandlers(provider.Store)
+	provider.LoadHandlers(provider.Store)
 
 	provider.discovery = NewOpenIDConnectWellKnownConfiguration(config.IdentityProviders.OIDC)
 

--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -66,8 +66,8 @@ type Session struct {
 
 func (s *Session) SetValuesFromRequester(requester oauthelia2.Requester) {
 	s.ClientID = requester.GetClient().GetID()
-	s.DefaultSession.Claims.AuthorizedParty = requester.GetClient().GetID()
-	s.DefaultSession.Claims.Nonce = requester.GetRequestForm().Get(FormParameterNonce)
+	s.Claims.AuthorizedParty = requester.GetClient().GetID()
+	s.Claims.Nonce = requester.GetRequestForm().Get(FormParameterNonce)
 }
 
 func (s *Session) SetValuesFromConsentSession(consent *model.OAuth2ConsentSession) {
@@ -75,31 +75,31 @@ func (s *Session) SetValuesFromConsentSession(consent *model.OAuth2ConsentSessio
 
 	s.ChallengeID = model.NullUUID(consent.ChallengeID)
 	s.GrantedClaims = consent.GrantedClaims
-	s.DefaultSession.Subject = consent.Subject.UUID.String()
-	s.DefaultSession.Claims.Subject = consent.Subject.UUID.String()
+	s.Subject = consent.Subject.UUID.String()
+	s.Claims.Subject = consent.Subject.UUID.String()
 }
 
 func (s *Session) SetValuesGeneral(ctx Context, issuer *url.URL, kid string, username string, amr []string, authTime time.Time, claims *ClaimsRequests, extra map[string]any) {
 	if issuer != nil {
-		s.DefaultSession.Claims.Issuer = issuer.String()
+		s.Claims.Issuer = issuer.String()
 	}
 
-	s.DefaultSession.Claims.IssuedAt = jwt.NewNumericDate(ctx.GetClock().Now())
+	s.Claims.IssuedAt = jwt.NewNumericDate(ctx.GetClock().Now())
 
 	if !authTime.IsZero() {
-		s.DefaultSession.Claims.AuthTime = jwt.NewNumericDate(authTime)
+		s.Claims.AuthTime = jwt.NewNumericDate(authTime)
 	}
 
 	if len(kid) != 0 {
-		s.DefaultSession.Headers.Extra[JWTHeaderKeyIdentifier] = kid
+		s.Headers.Extra[JWTHeaderKeyIdentifier] = kid
 	}
 
 	if len(username) != 0 {
-		s.DefaultSession.Username = username
+		s.Username = username
 	}
 
 	if len(amr) != 0 {
-		s.DefaultSession.Claims.AuthenticationMethodsReferences = amr
+		s.Claims.AuthenticationMethodsReferences = amr
 	}
 
 	if claims != nil {
@@ -107,7 +107,7 @@ func (s *Session) SetValuesGeneral(ctx Context, issuer *url.URL, kid string, use
 	}
 
 	if len(extra) != 0 {
-		s.DefaultSession.Claims.Extra = extra
+		s.Claims.Extra = extra
 	}
 }
 
@@ -163,17 +163,17 @@ func (s *Session) GetJWTClaims() jwt.JWTClaimsContainer {
 		claims.Extra[ClaimExtra] = s.Extra
 	}
 
-	if s.DefaultSession != nil && s.DefaultSession.Claims != nil {
+	if s.DefaultSession != nil && s.Claims != nil {
 		for _, allowedClaim := range allowed {
-			if cl, ok := s.DefaultSession.Claims.Extra[allowedClaim]; ok {
+			if cl, ok := s.Claims.Extra[allowedClaim]; ok {
 				claims.Extra[allowedClaim] = cl
 			}
 		}
 
-		claims.Issuer = s.DefaultSession.Claims.Issuer
+		claims.Issuer = s.Claims.Issuer
 
-		if amr && len(s.DefaultSession.Claims.AuthenticationMethodsReferences) != 0 {
-			claims.Extra[ClaimAuthenticationMethodsReference] = s.DefaultSession.Claims.AuthenticationMethodsReferences
+		if amr && len(s.Claims.AuthenticationMethodsReferences) != 0 {
+			claims.Extra[ClaimAuthenticationMethodsReference] = s.Claims.AuthenticationMethodsReferences
 		}
 	}
 
@@ -190,7 +190,7 @@ func (s *Session) GetIDTokenClaims() (claims *jwt.IDTokenClaims) {
 		return nil
 	}
 
-	return s.DefaultSession.Claims
+	return s.Claims
 }
 
 // GetExtraClaims returns the Extra/Unregistered claims for this session.

--- a/internal/oidc/util.go
+++ b/internal/oidc/util.go
@@ -287,8 +287,8 @@ func PopulateClientCredentialsFlowSessionWithAccessRequest(ctx Context, client o
 	session.Subject = ""
 	session.Claims.Subject = client.GetID()
 	session.ClientID = client.GetID()
-	session.DefaultSession.Claims.Issuer = issuer.String()
-	session.DefaultSession.Claims.IssuedAt = fjwt.NewNumericDate(ctx.GetClock().Now().UTC())
+	session.Claims.Issuer = issuer.String()
+	session.Claims.IssuedAt = fjwt.NewNumericDate(ctx.GetClock().Now().UTC())
 	session.SetRequestedAt(ctx.GetClock().Now().UTC())
 	session.ClientCredentials = true
 
@@ -398,7 +398,6 @@ func RequestFormRequiresLogin(form url.Values, requested, authenticated time.Tim
 			age int64
 			err error
 		)
-
 		if age, err = strconv.ParseInt(value, 10, 64); err != nil {
 			age = 0
 		}

--- a/internal/random/cryptographical.go
+++ b/internal/random/cryptographical.go
@@ -125,7 +125,6 @@ func (r *Cryptographical) IntErr(max *big.Int) (value *big.Int, err error) {
 // Int returns a random *big.Int with a maximum of max.
 func (r *Cryptographical) Int(max *big.Int) (value *big.Int) {
 	var err error
-
 	if value, err = r.IntErr(max); err != nil {
 		return big.NewInt(-1)
 	}

--- a/internal/random/mathematical.go
+++ b/internal/random/mathematical.go
@@ -122,7 +122,6 @@ func (r *Mathematical) IntnErr(n int) (output int, err error) {
 // Int returns a random *big.Int with a maximum of max.
 func (r *Mathematical) Int(max *big.Int) (value *big.Int) {
 	var err error
-
 	if value, err = r.IntErr(max); err != nil {
 		return big.NewInt(-1)
 	}

--- a/internal/regulation/regulator.go
+++ b/internal/regulation/regulator.go
@@ -38,7 +38,6 @@ func (r *Regulator) HandleAttempt(ctx Context, successful, banned bool, username
 	}
 
 	var err error
-
 	if err = r.store.AppendAuthenticationLog(ctx, attempt); err != nil {
 		ctx.GetLogger().WithFields(map[string]any{fieldUsername: username, "successful": successful}).WithError(err).Errorf("Failed to record %s authentication attempt", authType)
 	}

--- a/internal/server/asset.go
+++ b/internal/server/asset.go
@@ -54,7 +54,6 @@ func newPublicHTMLEmbeddedHandler() fasthttp.RequestHandler {
 			data []byte
 			err  error
 		)
-
 		if data, err = assets.ReadFile(p); err != nil {
 			hfsHandleErr(ctx, err)
 
@@ -252,7 +251,6 @@ func getEmbedETags(embedFS embed.FS, root string, etags map[string][]byte) {
 		err     error
 		entries []fs.DirEntry
 	)
-
 	if entries, err = embedFS.ReadDir(root); err != nil {
 		return
 	}
@@ -301,7 +299,6 @@ func newLocalesListHandler() (handler func(ctx *middlewares.AutheliaCtx), err er
 
 	// parse embedded locales.
 	data, err = json.Marshal(middlewares.OKResponse{Status: "OK", Data: localeInfo})
-
 	if err != nil {
 		return nil, fmt.Errorf("error occurred initializing the locale list handler: error occurred marshalling the locale list: %w", err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -91,8 +91,8 @@ func (cc *CertificateContext) GenerateCertificate() (*TemporaryCertificate, erro
 	tmpCertificate.CertificatePEM = certBytes
 
 	block, _ := pem.Decode(certBytes)
-	c, err := x509.ParseCertificate(block.Bytes)
 
+	c, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse certificate: %v", err)
 	}
@@ -149,7 +149,6 @@ func NewTLSServerContext(configuration schema.Configuration) (serverContext *TLS
 	}
 
 	s, listener, _, _, err := New(&configuration, providers)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -243,7 +243,7 @@ func writeHealthCheckEnv(disabled bool, scheme, host, path string, port uint16) 
 		path = ""
 	}
 
-	_, err = file.WriteString(fmt.Sprintf(healthCheckEnv, scheme, host, port, path))
+	_, err = fmt.Fprintf(file, healthCheckEnv, scheme, host, port, path)
 
 	return err
 }
@@ -262,13 +262,13 @@ func NewTemplatedFileOptions(config *schema.Configuration) (opts *TemplatedFileO
 		PrivacyPolicyAccept:     strFalse,
 		Session:                 "",
 		Theme:                   config.Theme,
-		EndpointsPasswordReset:  !(config.AuthenticationBackend.PasswordReset.Disable || config.AuthenticationBackend.PasswordReset.CustomURL.String() != ""),
+		EndpointsPasswordReset:  !config.AuthenticationBackend.PasswordReset.Disable && config.AuthenticationBackend.PasswordReset.CustomURL.String() == "",
 		EndpointsPasswordChange: !config.AuthenticationBackend.PasswordChange.Disable,
 		EndpointsWebAuthn:       !config.WebAuthn.Disable,
 		EndpointsPasskeys:       !config.WebAuthn.Disable && config.WebAuthn.EnablePasskeyLogin,
 		EndpointsTOTP:           !config.TOTP.Disable,
 		EndpointsDuo:            !config.DuoAPI.Disable,
-		EndpointsOpenIDConnect:  !(config.IdentityProviders.OIDC == nil),
+		EndpointsOpenIDConnect:  config.IdentityProviders.OIDC != nil,
 		EndpointsAuthz:          config.Server.Endpoints.Authz,
 	}
 

--- a/internal/service/signal_test.go
+++ b/internal/service/signal_test.go
@@ -251,6 +251,7 @@ func TestSignalService_Shutdown(t *testing.T) {
 	}
 
 	done := make(chan struct{})
+
 	go func() {
 		err := service.Run()
 		assert.NoError(t, err)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -96,7 +96,6 @@ func (p *Session) UpdateExpiration(ctx *fasthttp.RequestCtx, expiration time.Dur
 	}
 
 	err = store.SetExpiration(expiration)
-
 	if err != nil {
 		return err
 	}
@@ -107,7 +106,6 @@ func (p *Session) UpdateExpiration(ctx *fasthttp.RequestCtx, expiration time.Dur
 // GetExpiration get the expiration of the current session.
 func (p *Session) GetExpiration(ctx *fasthttp.RequestCtx) (time.Duration, error) {
 	store, err := p.sessionHolder.Get(ctx)
-
 	if err != nil {
 		return time.Duration(0), err
 	}

--- a/internal/storage/sql_provider.go
+++ b/internal/storage/sql_provider.go
@@ -1231,7 +1231,6 @@ func (p *SQLProvider) SaveOAuth2Session(ctx context.Context, sessionType OAuth2S
 		session.Subject, session.RequestedAt, session.RequestedScopes, session.GrantedScopes,
 		session.RequestedAudience, session.GrantedAudience,
 		session.Active, session.Revoked, session.Form, session.Session)
-
 	if err != nil {
 		return fmt.Errorf("error inserting oauth2 %s session with signature '%s' for subject '%s' and request id '%s' and challenge id '%s': %w", sessionType, session.Signature, session.Subject.String, session.RequestID, session.ChallengeID.UUID, err)
 	}
@@ -1386,7 +1385,6 @@ func (p *SQLProvider) SaveOAuth2DeviceCodeSession(ctx context.Context, session *
 		session.RequestedScopes, session.GrantedScopes,
 		session.RequestedAudience, session.GrantedAudience,
 		session.Active, session.Revoked, session.Form, session.Session)
-
 	if err != nil {
 		return fmt.Errorf("error inserting oauth2 device code session with device code signature '%s' and user code signature '%s' for subject '%s' and request id '%s': %w", session.Signature, session.UserCodeSignature, session.Subject.String, session.RequestID, err)
 	}
@@ -1403,7 +1401,6 @@ func (p *SQLProvider) UpdateOAuth2DeviceCodeSession(ctx context.Context, session
 		session.ChallengeID, session.RequestID, session.ClientID, session.Status, session.Subject, session.RequestedAt,
 		session.CheckedAt, session.RequestedScopes, session.RequestedAudience, session.GrantedScopes, session.GrantedAudience,
 		session.Active, session.Revoked, session.Form, session.Session, session.Signature)
-
 	if err != nil {
 		return fmt.Errorf("error updating oauth2 device code session with device code signature '%s': %w", session.Signature, err)
 	}
@@ -1420,7 +1417,6 @@ func (p *SQLProvider) UpdateOAuth2DeviceCodeSessionData(ctx context.Context, ses
 		session.ChallengeID, session.ClientID, session.Status, session.Subject,
 		session.RequestedScopes, session.RequestedAudience, session.GrantedScopes, session.GrantedAudience,
 		session.Form, session.Session, session.Signature)
-
 	if err != nil {
 		return fmt.Errorf("error updating oauth2 device code session data with device code signature '%s': %w", session.Signature, err)
 	}
@@ -1430,7 +1426,6 @@ func (p *SQLProvider) UpdateOAuth2DeviceCodeSessionData(ctx context.Context, ses
 
 func (p *SQLProvider) DeactivateOAuth2DeviceCodeSession(ctx context.Context, signature string) (err error) {
 	_, err = p.db.ExecContext(ctx, p.sqlDeactivateOAuth2DeviceCodeSession, signature)
-
 	if err != nil {
 		return fmt.Errorf("error deactivating oauth2 device code session with device code signature '%s': %w", signature, err)
 	}

--- a/internal/storage/sql_provider_encryption.go
+++ b/internal/storage/sql_provider_encryption.go
@@ -363,7 +363,6 @@ func schemaEncryptionCheckKeyOneTimeCode(ctx context.Context, provider *SQLProvi
 		rows *sqlx.Rows
 		err  error
 	)
-
 	if rows, err = provider.db.QueryxContext(ctx, fmt.Sprintf(queryFmtSelectOTCEncryptedData, tableOneTimeCode)); err != nil {
 		return tableOneTimeCode, EncryptionValidationTableResult{Error: fmt.Errorf("error selecting one time-codes: %w", err)}
 	}
@@ -394,7 +393,6 @@ func schemaEncryptionCheckKeyTOTP(ctx context.Context, provider *SQLProvider) (t
 		rows *sqlx.Rows
 		err  error
 	)
-
 	if rows, err = provider.db.QueryxContext(ctx, fmt.Sprintf(queryFmtSelectTOTPConfigurationsEncryptedData, tableTOTPConfigurations)); err != nil {
 		return tableTOTPConfigurations, EncryptionValidationTableResult{Error: fmt.Errorf("error selecting TOTP configurations: %w", err)}
 	}
@@ -425,7 +423,6 @@ func schemaEncryptionCheckKeyWebAuthn(ctx context.Context, provider *SQLProvider
 		rows *sqlx.Rows
 		err  error
 	)
-
 	if rows, err = provider.db.QueryxContext(ctx, fmt.Sprintf(queryFmtSelectWebAuthnCredentialsEncryptedData, tableWebAuthnCredentials)); err != nil {
 		return tableWebAuthnCredentials, EncryptionValidationTableResult{Error: fmt.Errorf("error selecting WebAuthn credentials: %w", err)}
 	}
@@ -460,7 +457,6 @@ func schemaEncryptionCheckKeyCachedData(ctx context.Context, provider *SQLProvid
 		rows *sqlx.Rows
 		err  error
 	)
-
 	if rows, err = provider.db.QueryxContext(ctx, provider.db.Rebind(fmt.Sprintf(queryFmtSelectCachedDataValueEncrypted, tableCachedData)), true); err != nil {
 		return tableCachedData, EncryptionValidationTableResult{Error: fmt.Errorf("error selecting cached data: %w", err)}
 	}
@@ -492,7 +488,6 @@ func schemaEncryptionCheckKeyOpenIDConnect(typeOAuth2Session OAuth2SessionType) 
 			rows *sqlx.Rows
 			err  error
 		)
-
 		if rows, err = provider.db.QueryxContext(ctx, fmt.Sprintf(queryFmtSelectOAuth2SessionEncryptedData, typeOAuth2Session.Table())); err != nil {
 			return typeOAuth2Session.Table(), EncryptionValidationTableResult{Error: fmt.Errorf("error selecting oauth2 %s sessions: %w", typeOAuth2Session.String(), err)}
 		}
@@ -524,7 +519,6 @@ func schemaEncryptionCheckKeyEncryption(ctx context.Context, provider *SQLProvid
 		rows *sqlx.Rows
 		err  error
 	)
-
 	if rows, err = provider.db.QueryxContext(ctx, fmt.Sprintf(queryFmtSelectEncryptionEncryptedData, tableEncryption)); err != nil {
 		return tableEncryption, EncryptionValidationTableResult{Error: fmt.Errorf("error selecting encryption values: %w", err)}
 	}
@@ -592,7 +586,6 @@ func (p *SQLProvider) getHMACKey(ctx context.Context, name string, size int) (ke
 			key = make([]byte, size)
 
 			_, err = rand.Read(key)
-
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate hmac key: %w", err)
 			}

--- a/internal/suites/action_http.go
+++ b/internal/suites/action_http.go
@@ -19,6 +19,7 @@ func doHTTPGetQuery(t *testing.T, url string) []byte {
 	assert.NoError(t, err)
 
 	defer resp.Body.Close()
+
 	body, _ := io.ReadAll(resp.Body)
 
 	return body

--- a/internal/suites/action_login.go
+++ b/internal/suites/action_login.go
@@ -15,6 +15,7 @@ func (rs *RodSession) doFillLoginPageAndClick(t *testing.T, page *rod.Page, user
 
 username:
 	err := usernameElement.MustSelectAllText().Input(username)
+
 	require.NoError(t, err)
 
 	if usernameElement.MustText() != username {
@@ -23,6 +24,7 @@ username:
 
 password:
 	err = passwordElement.MustSelectAllText().Input(password)
+
 	require.NoError(t, err)
 
 	if passwordElement.MustText() != password {
@@ -37,6 +39,7 @@ password:
 
 click:
 	err = buttonElement.Click("left", 1)
+
 	require.NoError(t, err)
 
 	if buttonElement.MustInteractable() {
@@ -52,6 +55,7 @@ func (rs *RodSession) doFillPasswordAndClick(t *testing.T, page *rod.Page, passw
 
 password:
 	err = element.MustSelectAllText().Input(password)
+
 	require.NoError(t, err)
 
 	if element.MustText() != password {
@@ -60,6 +64,7 @@ password:
 
 click:
 	err = button.Click("left", 1)
+
 	require.NoError(t, err)
 
 	if button.MustInteractable() {

--- a/internal/suites/action_reset_password.go
+++ b/internal/suites/action_reset_password.go
@@ -31,6 +31,7 @@ func (rs *RodSession) doCompletePasswordReset(t *testing.T, page *rod.Page, newP
 
 password1:
 	err := password1.MustSelectAllText().Input(newPassword1)
+
 	require.NoError(t, err)
 
 	if password1.MustText() != newPassword1 {
@@ -39,6 +40,7 @@ password1:
 
 password2:
 	err = password2.MustSelectAllText().Input(newPassword2)
+
 	require.NoError(t, err)
 
 	if password2.MustText() != newPassword2 {

--- a/internal/suites/environment.go
+++ b/internal/suites/environment.go
@@ -20,7 +20,6 @@ func waitUntilServiceLogDetected(
 
 	err := utils.CheckUntil(interval, timeout, func() (bool, error) {
 		logs, err := dockerEnvironment.Logs(service, []string{"--tail", "40"})
-
 		if err != nil {
 			return false, err
 		}

--- a/internal/suites/kubernetes.go
+++ b/internal/suites/kubernetes.go
@@ -42,8 +42,8 @@ func (k K3D) ClusterExists() (bool, error) {
 	cmd := k3dCommand("k3d cluster list")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	output, err := cmd.Output()
 
+	output, err := cmd.Output()
 	if err != nil {
 		return false, err
 	}

--- a/internal/suites/scenario_available_methods_test.go
+++ b/internal/suites/scenario_available_methods_test.go
@@ -31,8 +31,7 @@ func (s *AvailableMethodsScenario) SetupSuite() {
 }
 
 func (s *AvailableMethodsScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -50,6 +49,7 @@ func (s *AvailableMethodsScenario) TearDownTest() {
 
 func (s *AvailableMethodsScenario) TestShouldCheckAvailableMethods() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_bypass_policy_test.go
+++ b/internal/suites/scenario_bypass_policy_test.go
@@ -30,8 +30,7 @@ func (s *BypassPolicyScenario) SetupSuite() {
 }
 
 func (s *BypassPolicyScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,6 +48,7 @@ func (s *BypassPolicyScenario) TearDownTest() {
 
 func (s *BypassPolicyScenario) TestShouldAccessPublicResource() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_change_password_test.go
+++ b/internal/suites/scenario_change_password_test.go
@@ -25,8 +25,7 @@ func (s *ChangePasswordScenario) SetupSuite() {
 }
 
 func (s *ChangePasswordScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -56,10 +55,12 @@ func (s *ChangePasswordScenario) TestShouldChangePassword() {
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+
 			defer func() {
 				cancel()
 				s.collectScreenshot(ctx.Err(), s.Page)
 			}()
+
 			s.doLoginOneFactor(s.T(), s.Context(ctx), tc.username, tc.oldPassword, false, BaseDomain, "")
 			s.doOpenSettings(s.T(), s.Context(ctx))
 			s.doOpenSettingsMenuClickSecurity(s.T(), s.Context(ctx))
@@ -82,10 +83,12 @@ func (s *ChangePasswordScenario) TestCannotChangePasswordToExistingPassword() {
 	for _, tc := range testCases {
 		s.T().Run(tc.testName, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+
 			defer func() {
 				cancel()
 				s.collectScreenshot(ctx.Err(), s.Page)
 			}()
+
 			s.doLoginOneFactor(s.T(), s.Context(ctx), tc.username, tc.oldPassword, false, BaseDomain, "")
 			s.doOpenSettings(s.T(), s.Context(ctx))
 			s.doOpenSettingsMenuClickSecurity(s.T(), s.Context(ctx))
@@ -111,10 +114,12 @@ func (s *ChangePasswordScenario) TestCannotChangePasswordWithIncorrectOldPasswor
 	for _, tc := range testCases {
 		s.T().Run(tc.testName, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+
 			defer func() {
 				cancel()
 				s.collectScreenshot(ctx.Err(), s.Page)
 			}()
+
 			s.doLoginOneFactor(s.T(), s.Context(ctx), tc.username, tc.oldPassword, false, BaseDomain, "")
 
 			s.doOpenSettings(s.T(), s.Context(ctx))
@@ -142,10 +147,12 @@ func (s *ChangePasswordScenario) TestNewPasswordsMustMatch() {
 	for _, tc := range testCases {
 		s.T().Run(tc.testName, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+
 			defer func() {
 				cancel()
 				s.collectScreenshot(ctx.Err(), s.Page)
 			}()
+
 			s.doLoginOneFactor(s.T(), s.Context(ctx), tc.username, tc.oldPassword, false, BaseDomain, "")
 
 			s.doOpenSettings(s.T(), s.Context(ctx))

--- a/internal/suites/scenario_custom_headers_test.go
+++ b/internal/suites/scenario_custom_headers_test.go
@@ -32,8 +32,7 @@ func (s *CustomHeadersScenario) SetupSuite() {
 }
 
 func (s *CustomHeadersScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -51,6 +50,7 @@ func (s *CustomHeadersScenario) TearDownTest() {
 
 func (s *CustomHeadersScenario) TestShouldNotForwardCustomHeaderForUnauthenticatedUser() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -82,6 +82,7 @@ type HeadersPayload struct {
 
 func (s *CustomHeadersScenario) TestShouldForwardCustomHeaderForAuthenticatedUser() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_default_redirection_url_test.go
+++ b/internal/suites/scenario_default_redirection_url_test.go
@@ -29,6 +29,7 @@ func (s *DefaultRedirectionURLScenario) SetupSuite() {
 	s.RodSession = browser
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -42,8 +43,7 @@ func (s *DefaultRedirectionURLScenario) SetupSuite() {
 }
 
 func (s *DefaultRedirectionURLScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -61,6 +61,7 @@ func (s *DefaultRedirectionURLScenario) TearDownTest() {
 
 func (s *DefaultRedirectionURLScenario) TestUserIsRedirectedToDefaultURL() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_inactivity_test.go
+++ b/internal/suites/scenario_inactivity_test.go
@@ -30,6 +30,7 @@ func (s *InactivityScenario) SetupSuite() {
 	s.RodSession = browser
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -45,8 +46,7 @@ func (s *InactivityScenario) SetupSuite() {
 }
 
 func (s *InactivityScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -64,6 +64,7 @@ func (s *InactivityScenario) TearDownTest() {
 
 func (s *InactivityScenario) TestShouldRequireReauthenticationAfterInactivityPeriod() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -83,6 +84,7 @@ func (s *InactivityScenario) TestShouldRequireReauthenticationAfterInactivityPer
 
 func (s *InactivityScenario) TestShouldRequireReauthenticationAfterCookieExpiration() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -110,6 +112,7 @@ func (s *InactivityScenario) TestShouldRequireReauthenticationAfterCookieExpirat
 
 func (s *InactivityScenario) TestShouldDisableCookieExpirationAndInactivity() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_language_menu_test.go
+++ b/internal/suites/scenario_language_menu_test.go
@@ -26,8 +26,7 @@ func (s *LanguageMenuScenario) SetupSuite() {
 }
 
 func (s *LanguageMenuScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,6 +44,7 @@ func (s *LanguageMenuScenario) TearDownTest() {
 
 func (s *LanguageMenuScenario) TestShouldChangePreferredLanguage() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_multiple_cookie_domain_test.go
+++ b/internal/suites/scenario_multiple_cookie_domain_test.go
@@ -41,8 +41,7 @@ func (s *MultiCookieDomainScenario) SetupSuite() {
 }
 
 func (s *MultiCookieDomainScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -60,6 +59,7 @@ func (s *MultiCookieDomainScenario) TearDownTest() {
 
 func (s *MultiCookieDomainScenario) TestCookieName() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -76,6 +76,7 @@ func (s *MultiCookieDomainScenario) TestCookieName() {
 
 func (s *MultiCookieDomainScenario) TestRememberMe() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -92,6 +93,7 @@ func (s *MultiCookieDomainScenario) TestRememberMe() {
 
 func (s *MultiCookieDomainScenario) TestShouldAuthorizeSecret() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -104,6 +106,7 @@ func (s *MultiCookieDomainScenario) TestShouldAuthorizeSecret() {
 
 func (s *MultiCookieDomainScenario) TestShouldRequestLoginOnNextDomainAfterLoginOnFirstDomain() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -121,6 +124,7 @@ func (s *MultiCookieDomainScenario) TestShouldRequestLoginOnNextDomainAfterLogin
 
 func (s *MultiCookieDomainScenario) TestShouldStayLoggedInOnNextDomainWhenLoggedOffOnFirstDomain() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_oidc_test.go
+++ b/internal/suites/scenario_oidc_test.go
@@ -33,6 +33,7 @@ func (s *OIDCScenario) SetupSuite() {
 	s.RodSession = browser
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -46,8 +47,7 @@ func (s *OIDCScenario) SetupSuite() {
 }
 
 func (s *OIDCScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -55,6 +55,7 @@ func (s *OIDCScenario) TearDownSuite() {
 
 func (s *OIDCScenario) SetupTest() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -72,6 +73,7 @@ func (s *OIDCScenario) TearDownTest() {
 
 func (s *OIDCScenario) TestShouldAuthorizeAccessToOIDCApp() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -149,6 +151,7 @@ func (s *OIDCScenario) TestShouldAuthorizeAccessToOIDCApp() {
 
 func (s *OIDCScenario) TestShouldDenyConsent() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_one_factor_test.go
+++ b/internal/suites/scenario_one_factor_test.go
@@ -32,8 +32,7 @@ func (s *OneFactorScenario) SetupSuite() {
 }
 
 func (s *OneFactorScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -51,6 +50,7 @@ func (s *OneFactorScenario) TearDownTest() {
 
 func (s *OneFactorScenario) TestShouldNotAuthorizeSecretBeforeOneFactor() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -81,6 +81,7 @@ func (s *OneFactorScenario) TestShouldNotAuthorizeSecretBeforeOneFactor() {
 
 func (s *OneFactorScenario) TestShouldAuthorizeSecretAfterOneFactor() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -93,6 +94,7 @@ func (s *OneFactorScenario) TestShouldAuthorizeSecretAfterOneFactor() {
 
 func (s *OneFactorScenario) TestShouldRedirectToSecondFactor() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -105,6 +107,7 @@ func (s *OneFactorScenario) TestShouldRedirectToSecondFactor() {
 
 func (s *OneFactorScenario) TestShouldDenyAccessOnBadPassword() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -118,6 +121,7 @@ func (s *OneFactorScenario) TestShouldDenyAccessOnBadPassword() {
 
 func (s *OneFactorScenario) TestShouldDenyAccessOnForbidden() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_passkey_test.go
+++ b/internal/suites/scenario_passkey_test.go
@@ -29,6 +29,7 @@ func (s *PasskeyScenario) SetupSuite() {
 	s.RodSession = browser
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -46,8 +47,7 @@ func (s *PasskeyScenario) SetupSuite() {
 }
 
 func (s *PasskeyScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -68,6 +68,7 @@ func (s *PasskeyScenario) TearDownTest() {
 
 func (s *PasskeyScenario) TestShouldAuthorizeAfterPasskeyLogin() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_password_complexity_test.go
+++ b/internal/suites/scenario_password_complexity_test.go
@@ -27,8 +27,7 @@ func (s *PasswordComplexityScenario) SetupSuite() {
 }
 
 func (s *PasswordComplexityScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -46,6 +45,7 @@ func (s *PasswordComplexityScenario) TearDownTest() {
 
 func (s *PasswordComplexityScenario) TestShouldRejectPasswordReset() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_redirection_check_test.go
+++ b/internal/suites/scenario_redirection_check_test.go
@@ -29,8 +29,7 @@ func (s *RedirectionCheckScenario) SetupSuite() {
 }
 
 func (s *RedirectionCheckScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -59,6 +58,7 @@ var redirectionAuthorizations = map[string]bool{
 
 func (s *RedirectionCheckScenario) TestShouldRedirectOnLoginOnlyWhenDomainIsSafe() {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -94,6 +94,7 @@ var logoutRedirectionURLs = map[string]bool{
 
 func (s *RedirectionCheckScenario) TestShouldRedirectOnLogoutOnlyWhenDomainIsSafe() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_redirection_url_test.go
+++ b/internal/suites/scenario_redirection_url_test.go
@@ -30,8 +30,7 @@ func (s *RedirectionURLScenario) SetupSuite() {
 }
 
 func (s *RedirectionURLScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,6 +48,7 @@ func (s *RedirectionURLScenario) TearDownTest() {
 
 func (s *RedirectionURLScenario) TestShouldVerifyCustomURLParametersArePropagatedAfterRedirection() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_regulation_test.go
+++ b/internal/suites/scenario_regulation_test.go
@@ -30,8 +30,7 @@ func (s *RegulationScenario) SetupSuite() {
 }
 
 func (s *RegulationScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,6 +48,7 @@ func (s *RegulationScenario) TearDownTest() {
 
 func (s *RegulationScenario) TestShouldBanUserAfterTooManyAttempt() {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_reset_password_test.go
+++ b/internal/suites/scenario_reset_password_test.go
@@ -27,8 +27,7 @@ func (s *ResetPasswordScenario) SetupSuite() {
 }
 
 func (s *ResetPasswordScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -46,6 +45,7 @@ func (s *ResetPasswordScenario) TearDownTest() {
 
 func (s *ResetPasswordScenario) TestShouldResetPassword() {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -73,6 +73,7 @@ func (s *ResetPasswordScenario) TestShouldResetPassword() {
 
 func (s *ResetPasswordScenario) TestShouldMakeAttackerThinkPasswordResetIsInitiated() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -90,6 +91,7 @@ func (s *ResetPasswordScenario) TestShouldMakeAttackerThinkPasswordResetIsInitia
 
 func (s *ResetPasswordScenario) TestShouldNotifyUserOnBlankUsername() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -107,6 +109,7 @@ func (s *ResetPasswordScenario) TestShouldNotifyUserOnBlankUsername() {
 
 func (s *ResetPasswordScenario) TestShouldLetUserNoticeThereIsAPasswordMismatch() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_signin_email_test.go
+++ b/internal/suites/scenario_signin_email_test.go
@@ -32,8 +32,7 @@ func (s *SigninEmailScenario) SetupSuite() {
 }
 
 func (s *SigninEmailScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -51,6 +50,7 @@ func (s *SigninEmailScenario) TearDownTest() {
 
 func (s *SigninEmailScenario) TestShouldSignInWithUserEmail() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_two_factor_one_time_password_test.go
+++ b/internal/suites/scenario_two_factor_one_time_password_test.go
@@ -30,8 +30,7 @@ func (s *TwoFactorOneTimePasswordScenario) SetupSuite() {
 }
 
 func (s *TwoFactorOneTimePasswordScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -44,6 +43,7 @@ func (s *TwoFactorOneTimePasswordScenario) TearDownTest() {
 
 func (s *TwoFactorOneTimePasswordScenario) TestShouldRegisterAllAdvancedOptions() {
 	ctx, cancel := context.WithTimeout(context.Background(), 240*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_two_factor_totp_test.go
+++ b/internal/suites/scenario_two_factor_totp_test.go
@@ -31,6 +31,7 @@ func (s *TwoFactorTOTPScenario) SetupSuite() {
 	s.RodSession = browser
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -44,8 +45,7 @@ func (s *TwoFactorTOTPScenario) SetupSuite() {
 }
 
 func (s *TwoFactorTOTPScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -63,6 +63,7 @@ func (s *TwoFactorTOTPScenario) TearDownTest() {
 
 func (s *TwoFactorTOTPScenario) TestShouldNotAuthorizeSecretBeforeTwoFactor() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -93,6 +94,7 @@ func (s *TwoFactorTOTPScenario) TestShouldNotAuthorizeSecretBeforeTwoFactor() {
 
 func (s *TwoFactorTOTPScenario) TestShouldAuthorizeSecretAfterTwoFactor() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -119,6 +121,7 @@ func (s *TwoFactorTOTPScenario) TestShouldAuthorizeSecretAfterTwoFactor() {
 
 func (s *TwoFactorTOTPScenario) TestShouldFailTwoFactor() {
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_two_factor_webauthn_test.go
+++ b/internal/suites/scenario_two_factor_webauthn_test.go
@@ -29,6 +29,7 @@ func (s *TwoFactorWebAuthnScenario) SetupSuite() {
 	s.RodSession = browser
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -46,8 +47,7 @@ func (s *TwoFactorWebAuthnScenario) SetupSuite() {
 }
 
 func (s *TwoFactorWebAuthnScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -68,6 +68,7 @@ func (s *TwoFactorWebAuthnScenario) TearDownTest() {
 
 func (s *TwoFactorWebAuthnScenario) TestShouldAuthorizeSecretAfterTwoFactor() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -95,6 +96,7 @@ func (s *TwoFactorWebAuthnScenario) TestShouldAuthorizeSecretAfterTwoFactor() {
 
 func (s *TwoFactorWebAuthnScenario) TestShouldRenameCredential() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -120,6 +122,7 @@ func (s *TwoFactorWebAuthnScenario) TestShouldRenameCredential() {
 
 func (s *TwoFactorWebAuthnScenario) TestShouldShowCredentialInformation() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -138,6 +141,7 @@ func (s *TwoFactorWebAuthnScenario) TestShouldShowCredentialInformation() {
 
 func (s *TwoFactorWebAuthnScenario) TestShouldDeleteAndRegisterCredential() {
 	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/scenario_user_preferences_test.go
+++ b/internal/suites/scenario_user_preferences_test.go
@@ -29,8 +29,7 @@ func (s *UserPreferencesScenario) SetupSuite() {
 }
 
 func (s *UserPreferencesScenario) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -48,6 +47,7 @@ func (s *UserPreferencesScenario) TearDownTest() {
 
 func (s *UserPreferencesScenario) TestShouldRememberLastUsed2FAMethod() {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/suite_bypass_all_test.go
+++ b/internal/suites/suite_bypass_all_test.go
@@ -32,8 +32,7 @@ func (s *BypassAllWebDriverSuite) SetupSuite() {
 }
 
 func (s *BypassAllWebDriverSuite) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -51,6 +50,7 @@ func (s *BypassAllWebDriverSuite) TearDownTest() {
 
 func (s *BypassAllWebDriverSuite) TestShouldAccessPublicResource() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/suite_duo_push_test.go
+++ b/internal/suites/suite_duo_push_test.go
@@ -35,8 +35,7 @@ func (s *DuoPushWebDriverSuite) SetupSuite() {
 }
 
 func (s *DuoPushWebDriverSuite) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,6 +48,7 @@ func (s *DuoPushWebDriverSuite) SetupTest() {
 
 func (s *DuoPushWebDriverSuite) TearDownTest() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -110,7 +110,7 @@ func (s *DuoPushWebDriverSuite) TestShouldAskUserToRegister() {
 	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")
 	s.WaitElementLocatedByClassName(s.T(), s.Context(ctx), "state-not-registered")
 	s.verifyNotificationDisplayed(s.T(), s.Context(ctx), "No compatible device found")
-	enrollPage := s.Page.MustWaitOpen()
+	enrollPage := s.MustWaitOpen()
 	s.WaitElementLocatedByID(s.T(), s.Context(ctx), "register-link").MustClick()
 	s.Page = enrollPage()
 
@@ -330,6 +330,7 @@ func (s *DuoPushWebDriverSuite) TestShouldFailAuthenticationBecausePreauthDenied
 
 func (s *DuoPushWebDriverSuite) TestShouldSucceedAuthentication() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -357,6 +358,7 @@ func (s *DuoPushWebDriverSuite) TestShouldSucceedAuthentication() {
 
 func (s *DuoPushWebDriverSuite) TestShouldFailAuthentication() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -402,8 +404,7 @@ func (s *DuoPushDefaultRedirectionSuite) SetupSuite() {
 }
 
 func (s *DuoPushDefaultRedirectionSuite) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -421,6 +422,7 @@ func (s *DuoPushDefaultRedirectionSuite) TearDownTest() {
 
 func (s *DuoPushDefaultRedirectionSuite) TestUserIsRedirectedToDefaultURL() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/suite_high_availability_test.go
+++ b/internal/suites/suite_high_availability_test.go
@@ -35,8 +35,7 @@ func (s *HighAvailabilityWebDriverSuite) SetupSuite() {
 }
 
 func (s *HighAvailabilityWebDriverSuite) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -54,6 +53,7 @@ func (s *HighAvailabilityWebDriverSuite) TearDownTest() {
 
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActive() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -70,6 +70,7 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActive() {
 
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrimaryRedisNodeFailure() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -107,6 +108,7 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrim
 
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrimaryRedisSentinelFailureAndSecondaryRedisNodeFailure() {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -146,6 +148,7 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrim
 
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserDataInDB() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -165,6 +168,7 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserDataInDB() {
 
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepSessionAfterAutheliaRestart() {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -254,6 +258,7 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldVerifyAccessControl() {
 	verifyAuthorization := func(username string) func(t *testing.T) {
 		return func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 			defer func() {
 				s.collectScreenshot(ctx.Err(), s.Page)
 				cancel()

--- a/internal/suites/suite_kubernetes.go
+++ b/internal/suites/suite_kubernetes.go
@@ -116,7 +116,6 @@ func loadDockerImages() error {
 
 	for _, image := range images {
 		err := k3d.LoadImage(image)
-
 		if err != nil {
 			return err
 		}

--- a/internal/suites/suite_one_factor_only_test.go
+++ b/internal/suites/suite_one_factor_only_test.go
@@ -32,8 +32,7 @@ func (s *OneFactorOnlySuite) SetupSuite() {
 }
 
 func (s *OneFactorOnlySuite) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -52,6 +51,7 @@ func (s *OneFactorOnlySuite) TearDownTest() {
 // No target url is provided, then the user should be redirect to the default url.
 func (s *OneFactorOnlySuite) TestShouldRedirectUserToDefaultURL() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -64,6 +64,7 @@ func (s *OneFactorOnlySuite) TestShouldRedirectUserToDefaultURL() {
 // Unsafe URL is provided, then the user should be redirect to the default url.
 func (s *OneFactorOnlySuite) TestShouldRedirectUserToDefaultURLWhenURLIsUnsafe() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -76,6 +77,7 @@ func (s *OneFactorOnlySuite) TestShouldRedirectUserToDefaultURLWhenURLIsUnsafe()
 // When use logged in and visit the portal again, she gets redirect to the authenticated view.
 func (s *OneFactorOnlySuite) TestShouldDisplayAuthenticatedView() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -89,6 +91,7 @@ func (s *OneFactorOnlySuite) TestShouldDisplayAuthenticatedView() {
 
 func (s *OneFactorOnlySuite) TestShouldRedirectAlreadyAuthenticatedUser() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -104,6 +107,7 @@ func (s *OneFactorOnlySuite) TestShouldRedirectAlreadyAuthenticatedUser() {
 
 func (s *OneFactorOnlySuite) TestShouldNotRedirectAlreadyAuthenticatedUserToUnsafeURL() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/suite_pathprefix_test.go
+++ b/internal/suites/suite_pathprefix_test.go
@@ -43,12 +43,13 @@ func (s *PathPrefixSuite) TestChangePasswordScenario() {
 
 func (s *PathPrefixSuite) TestShouldRenderFrontendWithTrailingSlash() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectCoverage(s.Page)
 		s.collectScreenshot(ctx.Err(), s.Page)
 		s.MustClose()
-		err := s.RodSession.Stop()
+		err := s.Stop()
 		s.Require().NoError(err)
 	}()
 
@@ -65,12 +66,13 @@ func (s *PathPrefixSuite) TestShouldRenderFrontendWithTrailingSlash() {
 
 func (s *PathPrefixSuite) TestShouldRenderFrontendWithoutTrailingSlash() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectCoverage(s.Page)
 		s.collectScreenshot(ctx.Err(), s.Page)
 		s.MustClose()
-		err := s.RodSession.Stop()
+		err := s.Stop()
 		s.Require().NoError(err)
 	}()
 

--- a/internal/suites/suite_standalone_test.go
+++ b/internal/suites/suite_standalone_test.go
@@ -40,8 +40,7 @@ func (s *StandaloneWebDriverSuite) SetupSuite() {
 }
 
 func (s *StandaloneWebDriverSuite) TearDownSuite() {
-	err := s.RodSession.Stop()
-
+	err := s.Stop()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -59,6 +58,7 @@ func (s *StandaloneWebDriverSuite) TearDownTest() {
 
 func (s *StandaloneWebDriverSuite) TestShouldLetUserKnowHeIsAlreadyAuthenticated() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -91,7 +91,7 @@ func (s *StandaloneWebDriverSuite) TestShouldRedirectAfterOneFactorOnAnotherTab(
 	page2.MustWaitLoad()
 
 	// Switch to first, visit the login page and wait for redirection to secret page with secret displayed.
-	s.Page.MustActivate()
+	s.MustActivate()
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, targetURL)
 	s.verifySecretAuthorized(s.T(), s.Page)
 
@@ -102,6 +102,7 @@ func (s *StandaloneWebDriverSuite) TestShouldRedirectAfterOneFactorOnAnotherTab(
 
 func (s *StandaloneWebDriverSuite) TestShouldRedirectAlreadyAuthenticatedUser() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -116,13 +117,14 @@ func (s *StandaloneWebDriverSuite) TestShouldRedirectAlreadyAuthenticatedUser() 
 	// Visit the login page and wait for redirection to 2FA page with success icon displayed.
 	s.doVisit(s.T(), s.Context(ctx), fmt.Sprintf("%s?rd=https://secure.example.com:8080", GetLoginBaseURL(BaseDomain)))
 
-	_, err := s.Page.ElementR("h1", "Public resource")
+	_, err := s.ElementR("h1", "Public resource")
 	require.NoError(s.T(), err)
 	s.verifyURLIs(s.T(), s.Context(ctx), "https://secure.example.com:8080/")
 }
 
 func (s *StandaloneWebDriverSuite) TestShouldNotRedirectAlreadyAuthenticatedUserToUnsafeURL() {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)
@@ -141,6 +143,7 @@ func (s *StandaloneWebDriverSuite) TestShouldNotRedirectAlreadyAuthenticatedUser
 
 func (s *StandaloneWebDriverSuite) TestShouldCheckUserIsAskedToRegisterDevice() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectScreenshot(ctx.Err(), s.Page)

--- a/internal/suites/suite_standalone_test.go
+++ b/internal/suites/suite_standalone_test.go
@@ -88,10 +88,11 @@ func (s *StandaloneWebDriverSuite) TestShouldRedirectAfterOneFactorOnAnotherTab(
 	}()
 
 	// Open second tab with secret page.
-	page2.MustWaitLoad()
+	page2.MustWaitStable()
 
 	// Switch to first, visit the login page and wait for redirection to secret page with secret displayed.
 	s.MustActivate()
+	s.verifyIsHome(s.T(), s.Context(ctx))
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, targetURL)
 	s.verifySecretAuthorized(s.T(), s.Page)
 

--- a/internal/suites/suite_traefik_test.go
+++ b/internal/suites/suite_traefik_test.go
@@ -36,12 +36,13 @@ func (s *TraefikSuite) TestResetPasswordScenario() {
 
 func (s *TraefikSuite) TestShouldKeepSessionAfterRedisRestart() {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+
 	defer func() {
 		cancel()
 		s.collectCoverage(s.Page)
 		s.collectScreenshot(ctx.Err(), s.Page)
 		s.MustClose()
-		err := s.RodSession.Stop()
+		err := s.Stop()
 		s.Require().NoError(err)
 	}()
 

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -213,7 +213,7 @@ func (rs *RodSession) collectScreenshot(err error, page *rod.Page) {
 }
 
 func (s *RodSuite) GetCookieNames() (names []string) {
-	cookies, err := s.Page.Cookies(nil)
+	cookies, err := s.Cookies(nil)
 	s.Require().NoError(err)
 
 	for _, cookie := range cookies {
@@ -252,7 +252,6 @@ func fixCoveragePath(path string, file os.FileInfo, err error) error {
 	}
 
 	coverage, err := filepath.Match("*.json", file.Name())
-
 	if err != nil {
 		return err
 	}

--- a/internal/templates/funcs.go
+++ b/internal/templates/funcs.go
@@ -616,7 +616,6 @@ func FuncDateInZone(format string, date any, zone string) string {
 		location *time.Location
 		err      error
 	)
-
 	if location, err = time.LoadLocation(zone); err != nil {
 		location = time.UTC
 	}

--- a/internal/utils/crypto.go
+++ b/internal/utils/crypto.go
@@ -343,7 +343,6 @@ func NewTLSConfig(config *schema.TLS, rootCAs *x509.CertPool) (tlsConfig *tls.Co
 // NewX509CertPool generates a x509.CertPool from the system PKI and the directory specified.
 func NewX509CertPool(directory string) (certPool *x509.CertPool, warnings []error, errors []error) {
 	var err error
-
 	if certPool, err = x509.SystemCertPool(); err != nil {
 		warnings = append(warnings, fmt.Errorf("could not load system certificate pool which may result in untrusted certificate issues: %v", err))
 		certPool = x509.NewCertPool()

--- a/internal/utils/exec.go
+++ b/internal/utils/exec.go
@@ -80,7 +80,6 @@ func RunCommandUntilCtrlC(cmd *exec.Cmd) {
 		fmt.Println("Hit Ctrl+C to shutdown...") //nolint:forbidigo
 
 		err := cmd.Run()
-
 		if err != nil {
 			fmt.Println(err) //nolint:forbidigo
 			cond.Broadcast()
@@ -116,9 +115,9 @@ func RunFuncUntilCtrlC(fn func() error) error {
 		fmt.Println("Hit Ctrl+C to shutdown...") //nolint:forbidigo
 
 		err := fn()
-
 		if err != nil {
 			errorChannel <- err
+
 			fmt.Println(err) //nolint:forbidigo
 			cond.Broadcast()
 			mutex.Unlock()

--- a/internal/webauthn/credential.go
+++ b/internal/webauthn/credential.go
@@ -12,7 +12,6 @@ func VerifyCredential(config *schema.WebAuthn, credential *model.WebAuthnCredent
 		c   *webauthn.Credential
 		err error
 	)
-
 	if c, err = credential.ToCredential(); err != nil {
 		result.Malformed = true
 	}

--- a/internal/webauthn/util.go
+++ b/internal/webauthn/util.go
@@ -70,7 +70,6 @@ func ValidateCredentialAllowed(config *schema.WebAuthn, credential *model.WebAut
 
 func FormatError(err error) error {
 	out := &protocol.Error{}
-
 	if errors.As(err, &out) {
 		if len(out.DevInfo) == 0 {
 			if len(out.Type) == 0 {


### PR DESCRIPTION
Migrate golangci-lint configuration to v2 and refactor codebase for updated linter configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved code readability and maintainability by removing unnecessary blank lines and updating formatting across multiple files.
  * Updated logic to directly reference fields (e.g., session claims, RSA key modulus) for clarity and efficiency.
  * Corrected method calls and field accesses to use more appropriate or direct references.
  * Enhanced error message consistency and minor string formatting.

* **Tests**
  * Improved test reliability by adding explicit error checks after UI interactions.
  * Adjusted test cleanup routines to use higher-level stop methods.
  * Refined test field access to match updated logic in core code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->