### PR TITLE
test(suites): update webauthn mds3 test to use a local file

### DIFF
--- a/internal/suites/CLI/compose.yml
+++ b/internal/suites/CLI/compose.yml
@@ -11,5 +11,6 @@ services:
       - './common/pki/public.crt:/certs/public.crt'
       - './common/pki/ca/ca.public.crt:/certs/ca.public.crt'
       - '/tmp:/tmp'
+      - '/buildkite/.cache/fido/mds.jwt:/tmp/mds.jwt'
     user: '${USER_ID}:${GROUP_ID}'
 ...

--- a/internal/suites/CLI/configuration.yml
+++ b/internal/suites/CLI/configuration.yml
@@ -56,6 +56,7 @@ webauthn:
     user_verification: 'preferred'
   metadata:
     enabled: false
+    cache_policy: relaxed
     validate_trust_anchor: true
     validate_entry: false
     validate_entry_permit_zero_aaguid: true


### PR DESCRIPTION
This change allows our local CI to override our test with a local copy of the MDS3 blob.