### PR TITLE
test(suites): refactor password change suites

### DIFF
--- a/internal/suites/action_change_password.go
+++ b/internal/suites/action_change_password.go
@@ -7,9 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func (rs *RodSession) doChangePassword(t *testing.T, page *rod.Page, oldPassword, newPassword1, newPassword2 string) {
-	t.Helper()
-
+func (rs *RodSession) doChangePassword(t *testing.T, page *rod.Page, oldPassword, newPassword1, newPassword2, notification string) {
 	require.NoError(t, rs.WaitElementLocatedByID(t, page, "change-password-button").Click("left", 1))
 
 	rs.doMaybeVerifyIdentity(t, page)
@@ -23,60 +21,5 @@ func (rs *RodSession) doChangePassword(t *testing.T, page *rod.Page, oldPassword
 	require.NoError(t, repeatNewPasswordInput.Type(rs.toInputs(newPassword2)...))
 
 	require.NoError(t, rs.WaitElementLocatedByID(t, page, "password-change-dialog-submit").Click("left", 1))
-	rs.verifyNotificationDisplayed(t, page, "Password changed successfully")
-}
-
-func (rs *RodSession) doMustChangePasswordExistingPassword(t *testing.T, page *rod.Page, password string) {
-	require.NoError(t, rs.WaitElementLocatedByID(t, page, "change-password-button").Click("left", 1))
-
-	rs.doMaybeVerifyIdentity(t, page)
-	t.Helper()
-
-	oldPasswordInput := rs.WaitElementLocatedByID(t, page, "old-password")
-	newPasswordInput := rs.WaitElementLocatedByID(t, page, "new-password")
-	repeatNewPasswordInput := rs.WaitElementLocatedByID(t, page, "repeat-new-password")
-
-	require.NoError(t, oldPasswordInput.Type(rs.toInputs(password)...))
-	require.NoError(t, newPasswordInput.Type(rs.toInputs(password)...))
-	require.NoError(t, repeatNewPasswordInput.Type(rs.toInputs(password)...))
-
-	require.NoError(t, rs.WaitElementLocatedByID(t, page, "password-change-dialog-submit").Click("left", 1))
-	rs.verifyNotificationDisplayed(t, page, "Your supplied password does not meet the password policy requirements")
-}
-
-func (rs *RodSession) doMustChangePasswordWrongExistingPassword(t *testing.T, page *rod.Page, oldPassword, newPassword1 string) {
-	t.Helper()
-
-	require.NoError(t, rs.WaitElementLocatedByID(t, page, "change-password-button").Click("left", 1))
-
-	rs.doMaybeVerifyIdentity(t, page)
-
-	oldPasswordInput := rs.WaitElementLocatedByID(t, page, "old-password")
-	newPasswordInput := rs.WaitElementLocatedByID(t, page, "new-password")
-	repeatNewPasswordInput := rs.WaitElementLocatedByID(t, page, "repeat-new-password")
-
-	require.NoError(t, oldPasswordInput.Type(rs.toInputs(oldPassword)...))
-	require.NoError(t, newPasswordInput.Type(rs.toInputs(newPassword1)...))
-	require.NoError(t, repeatNewPasswordInput.Type(rs.toInputs(newPassword1)...))
-
-	require.NoError(t, rs.WaitElementLocatedByID(t, page, "password-change-dialog-submit").Click("left", 1))
-	rs.verifyNotificationDisplayed(t, page, "Incorrect password")
-}
-
-func (rs *RodSession) doMustChangePasswordMustMatch(t *testing.T, page *rod.Page, oldPassword, newPassword1, newPassword2 string) {
-	require.NoError(t, rs.WaitElementLocatedByID(t, page, "change-password-button").Click("left", 1))
-
-	rs.doMaybeVerifyIdentity(t, page)
-	t.Helper()
-
-	oldPasswordInput := rs.WaitElementLocatedByID(t, page, "old-password")
-	newPasswordInput := rs.WaitElementLocatedByID(t, page, "new-password")
-	repeatNewPasswordInput := rs.WaitElementLocatedByID(t, page, "repeat-new-password")
-
-	require.NoError(t, oldPasswordInput.Type(rs.toInputs(oldPassword)...))
-	require.NoError(t, newPasswordInput.Type(rs.toInputs(newPassword1)...))
-	require.NoError(t, repeatNewPasswordInput.Type(rs.toInputs(newPassword2)...))
-
-	require.NoError(t, rs.WaitElementLocatedByID(t, page, "password-change-dialog-submit").Click("left", 1))
-	rs.verifyNotificationDisplayed(t, page, "Passwords do not match")
+	rs.verifyNotificationDisplayed(t, page, notification)
 }

--- a/internal/suites/scenario_change_password_test.go
+++ b/internal/suites/scenario_change_password_test.go
@@ -43,13 +43,14 @@ func (s *ChangePasswordScenario) TearDownTest() {
 
 func (s *ChangePasswordScenario) TestShouldChangePassword() {
 	testCases := []struct {
-		name        string
-		username    string
-		oldPassword string
-		newPassword string
+		name         string
+		username     string
+		oldPassword  string
+		newPassword  string
+		notification string
 	}{
-		{"case1", "john", "password", "password1"},
-		{"case2", "john", "password1", "password"},
+		{"NewPassword", testUsername, testPassword, "password1", "Password changed successfully"},
+		{"OriginalPassword", testUsername, "password1", testPassword, "Password changed successfully"},
 	}
 
 	for _, tc := range testCases {
@@ -65,103 +66,63 @@ func (s *ChangePasswordScenario) TestShouldChangePassword() {
 			s.doOpenSettings(s.T(), s.Context(ctx))
 			s.doOpenSettingsMenuClickSecurity(s.T(), s.Context(ctx))
 
-			s.doChangePassword(s.T(), s.Context(ctx), tc.oldPassword, tc.newPassword, tc.newPassword)
+			s.doChangePassword(s.T(), s.Context(ctx), tc.oldPassword, tc.newPassword, tc.newPassword, tc.notification)
 			s.doLogout(s.T(), s.Context(ctx))
 		})
 	}
 }
 
-func (s *ChangePasswordScenario) TestCannotChangePasswordToExistingPassword() {
-	testCases := []struct {
-		testName    string
-		username    string
-		oldPassword string
-	}{
-		{"case1", "john", "password"},
-	}
+func (s *ChangePasswordScenario) TestShouldNotChangePasswordToExistingPassword() {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 
-	for _, tc := range testCases {
-		s.T().Run(tc.testName, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer func() {
+		cancel()
+		s.collectScreenshot(ctx.Err(), s.Page)
+	}()
 
-			defer func() {
-				cancel()
-				s.collectScreenshot(ctx.Err(), s.Page)
-			}()
+	s.doLoginOneFactor(s.T(), s.Context(ctx), testUsername, testPassword, false, BaseDomain, "")
+	s.doOpenSettings(s.T(), s.Context(ctx))
+	s.doOpenSettingsMenuClickSecurity(s.T(), s.Context(ctx))
 
-			s.doLoginOneFactor(s.T(), s.Context(ctx), tc.username, tc.oldPassword, false, BaseDomain, "")
-			s.doOpenSettings(s.T(), s.Context(ctx))
-			s.doOpenSettingsMenuClickSecurity(s.T(), s.Context(ctx))
+	s.doChangePassword(s.T(), s.Context(ctx), testPassword, testPassword, testPassword, "Your supplied password does not meet the password policy requirements")
 
-			s.doMustChangePasswordExistingPassword(s.T(), s.Context(ctx), tc.oldPassword)
-
-			s.doLogout(s.T(), s.Context(ctx))
-		})
-	}
+	s.doLogout(s.T(), s.Context(ctx))
 }
 
-func (s *ChangePasswordScenario) TestCannotChangePasswordWithIncorrectOldPassword() {
-	testCases := []struct {
-		testName         string
-		username         string
-		oldPassword      string
-		wrongOldPassword string
-		newPassword      string
-	}{
-		{"case1", "john", "password", "wrong_password", "new_password"},
-	}
+func (s *ChangePasswordScenario) TestShouldNotChangePasswordWithIncorrectOldPassword() {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 
-	for _, tc := range testCases {
-		s.T().Run(tc.testName, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer func() {
+		cancel()
+		s.collectScreenshot(ctx.Err(), s.Page)
+	}()
 
-			defer func() {
-				cancel()
-				s.collectScreenshot(ctx.Err(), s.Page)
-			}()
+	s.doLoginOneFactor(s.T(), s.Context(ctx), testUsername, testPassword, false, BaseDomain, "")
 
-			s.doLoginOneFactor(s.T(), s.Context(ctx), tc.username, tc.oldPassword, false, BaseDomain, "")
+	s.doOpenSettings(s.T(), s.Context(ctx))
 
-			s.doOpenSettings(s.T(), s.Context(ctx))
+	s.doOpenSettingsMenuClickSecurity(s.T(), s.Context(ctx))
 
-			s.doOpenSettingsMenuClickSecurity(s.T(), s.Context(ctx))
+	s.doChangePassword(s.T(), s.Context(ctx), "wrong_password", "new_password", "new_password", "Incorrect password")
 
-			s.doMustChangePasswordWrongExistingPassword(s.T(), s.Context(ctx), tc.wrongOldPassword, tc.newPassword)
-
-			s.doLogout(s.T(), s.Context(ctx))
-		})
-	}
+	s.doLogout(s.T(), s.Context(ctx))
 }
 
-func (s *ChangePasswordScenario) TestNewPasswordsMustMatch() {
-	testCases := []struct {
-		testName     string
-		username     string
-		oldPassword  string
-		newPassword1 string
-		newPassword2 string
-	}{
-		{"case1", "john", "password", "my_new_password", "new_password"},
-	}
+func (s *ChangePasswordScenario) TestShouldNotChangePasswordNewPasswordsMustMatch() {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 
-	for _, tc := range testCases {
-		s.T().Run(tc.testName, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer func() {
+		cancel()
+		s.collectScreenshot(ctx.Err(), s.Page)
+	}()
 
-			defer func() {
-				cancel()
-				s.collectScreenshot(ctx.Err(), s.Page)
-			}()
+	s.doLoginOneFactor(s.T(), s.Context(ctx), testUsername, testPassword, false, BaseDomain, "")
 
-			s.doLoginOneFactor(s.T(), s.Context(ctx), tc.username, tc.oldPassword, false, BaseDomain, "")
+	s.doOpenSettings(s.T(), s.Context(ctx))
 
-			s.doOpenSettings(s.T(), s.Context(ctx))
+	s.doOpenSettingsMenuClickSecurity(s.T(), s.Context(ctx))
 
-			s.doOpenSettingsMenuClickSecurity(s.T(), s.Context(ctx))
+	s.doChangePassword(s.T(), s.Context(ctx), testPassword, "my_new_password", "new_password", "Passwords do not match")
 
-			s.doMustChangePasswordMustMatch(s.T(), s.Context(ctx), tc.oldPassword, tc.newPassword1, tc.newPassword2)
-
-			s.doLogout(s.T(), s.Context(ctx))
-		})
-	}
+	s.doLogout(s.T(), s.Context(ctx))
 }

--- a/internal/suites/scenario_reset_password_test.go
+++ b/internal/suites/scenario_reset_password_test.go
@@ -107,7 +107,7 @@ func (s *ResetPasswordScenario) TestShouldNotifyUserOnBlankUsername() {
 	s.VerifyPageElementAttributeValueBoolean(s.T(), s.Context(ctx), "username-textfield", "aria-invalid", true, true)
 }
 
-func (s *ResetPasswordScenario) TestShouldLetUserNoticeThereIsAPasswordMismatch() {
+func (s *ResetPasswordScenario) TestShouldNotifyUserThereIsAPasswordMismatch() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	defer func() {


### PR DESCRIPTION
This change simplifies and reduces duplication with some of the password reset scenarios. I've also attempted to align test case naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and unified password change logic for improved consistency.
  * Consolidated multiple password change helper methods into a single, parameterized method.
  * Streamlined password change test scenarios to use explicit notification messages and shared test data.
  * Renamed test methods for clarity and consistency.
* **Tests**
  * Centralized context management and screenshot collection in password change tests.
  * Updated tests to verify notification messages directly during password change attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->