### PR TITLE
ci(buildkite): prevent dockerhub pull limitations for integration tests

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -43,7 +43,7 @@ if [[ ${BUILDKITE_LABEL} == ":debian: Package Builds" ]]; then
   buildkite-agent annotate --style "success" --context "ctx-success" < .buildkite/annotations/artifacts
 fi
 
-if [[ ${BUILDKITE_LABEL} =~ ":docker: Deploy" ]]; then
+if [[ ${BUILDKITE_LABEL} =~ ":docker: Deploy" ]] || [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
   docker logout
   docker logout ghcr.io
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -57,7 +57,7 @@ if [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
   fi
 fi
 
-if [[ "${BUILDKITE_LABEL}" == ":docker: Build and Deploy" ]]; then
+if [[ "${BUILDKITE_LABEL}" == ":docker: Build and Deploy" ]] || [[ "${BUILDKITE_LABEL}" =~ ":selenium:" ]]; then
   echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded the conditions for Docker login and logout during builds to include cases where the label contains ":selenium:" in addition to the previous Docker-related labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->