### PR TITLE
docs(oidc): fixes links to openid scope definitions in clients doc

### DIFF
--- a/docs/content/configuration/identity-providers/openid-connect/clients.md
+++ b/docs/content/configuration/identity-providers/openid-connect/clients.md
@@ -262,12 +262,12 @@ audience unless the [claims policy](#claims_policy) changes this behaviour.
 {{< confkey type="list(string)" default="openid,groups,profile,email" required="no" >}}
 
 A list of scopes to allow this client to consume. See
-[scope definitions](../../../integration/openid-connect/introduction.md#scope-definitions) for more information. The
+[scope definitions](../../../integration/openid-connect/openid-connect-1.0-claims.md#scope-definitions) for more information. The
 documentation for the application you are trying to configure [OpenID Connect 1.0] for will likely have a list of scopes
 or claims required which can be matched with the above guide.
 
 The scope values should generally be one of those documented in the
-[scope definitions](../../../integration/openid-connect/introduction.md#scope-definitions) with the exception of when a client requires a specific scope we do not define. Users should
+[scope definitions](../../../integration/openid-connect/openid-connect-1.0-claims.md#scope-definitions) with the exception of when a client requires a specific scope we do not define. Users should
 expect to see a warning in the logs if they configure a scope not in our definitions with the exception of a client
 where the configured [grant_types](#grant_types) includes the `client_credentials` grant in which case arbitrary scopes are
 expected,


### PR DESCRIPTION
Hello Authelia,

while reading your wonderful documentation, I noticed two dead links and thought, hey, time for a first contribution!
I've read all the contribution guides and hope I didn't miss anything :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hyperlinks for "scope definitions" in the OpenID Connect 1.0 Clients configuration section to point to the correct reference page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->