### PR TITLE
build(cmd): utilise original publish readme method with token

### DIFF
--- a/cmd/authelia-scripts/cmd/docker.go
+++ b/cmd/authelia-scripts/cmd/docker.go
@@ -37,7 +37,7 @@ func newDockerCmd() (cmd *cobra.Command) {
 		DisableAutoGenTag: true,
 	}
 
-	cmd.AddCommand(newDockerBuildCmd(), newDockerPushManifestCmd(), newDockerPushReadmeCmd())
+	cmd.AddCommand(newDockerBuildCmd(), newDockerPushManifestCmd())
 
 	return cmd
 }
@@ -70,31 +70,6 @@ func newDockerPushManifestCmd() (cmd *cobra.Command) {
 
 		DisableAutoGenTag: true,
 	}
-
-	return cmd
-}
-
-func newDockerPushReadmeCmd() (cmd *cobra.Command) {
-	cmd = &cobra.Command{
-		Use: "push-readme",
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			var token string
-
-			if cmd.Flags().Changed("token") {
-				if token, err = cmd.Flags().GetString("token"); err != nil {
-					return err
-				}
-			} else {
-				token = os.Getenv("DOCKER_TOKEN")
-			}
-
-			docker := &Docker{}
-
-			return docker.PublishReadmeWithToken(token)
-		},
-	}
-
-	cmd.Flags().String("token", "", "docker auth token")
 
 	return cmd
 }


### PR DESCRIPTION
This change reverts the method to publish README's to DockerHub with the original method, albeit using a token when specified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined the process for publishing the Docker Hub README by consolidating logic and simplifying credential handling.
  * Removed the command-line option for pushing the Docker README directly, reducing command options.

* **Chores**
  * Improved maintainability by removing redundant helper functions and unused command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->