### PR TITLE
Added documentation about needing pretty urls.

### DIFF
--- a/docs/content/integration/openid-connect/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/nextcloud/index.md
@@ -61,8 +61,7 @@ The following two tested options exist for Nextcloud:
 
 ## OpenID Connect Login App
 
-The following example uses the [Nextcloud OpenID Connect Login app] which is assumed to be installed when following this
-section of the guide.
+The following example uses the [Nextcloud OpenID Connect Login app] which is assumed to be installed, as well as have [pretty urls](https://docs.nextcloud.com/server/latest/admin_manual/installation/source_installation.html#pretty-urls) enabled when following this section of the guide.
 
 ### Configuration
 
@@ -178,8 +177,7 @@ $CONFIG = array (
 
 ## OpenID Connect user backend App
 
-The following example uses the [Nextcloud OpenID Connect user backend app] which is assumed to be installed when
-following this section of the guide.
+The following example uses the [Nextcloud OpenID Connect user backend app] which is assumed to be installed, as well as have [pretty urls](https://docs.nextcloud.com/server/latest/admin_manual/installation/source_installation.html#pretty-urls) enabled when following this section of the guide.
 
 ### Configuration
 


### PR DESCRIPTION
I basically went and went to re-setup my nextcloud instance and found my authelia configuration wasn't working.

It was due to needing to enable the pretty urls so no "index.php" is in the url as this would mess up the redirect uri.

The documentation doesn't actually acknowledge this, so why not add it.