### PR TITLE
feat(commands): command to prune authentication logs

### DIFF
--- a/docs/content/reference/cli/authelia/authelia_storage.md
+++ b/docs/content/reference/cli/authelia/authelia_storage.md
@@ -62,6 +62,7 @@ authelia storage --help
 * [authelia storage bans](authelia_storage_bans.md)	 - Manages user and ip bans
 * [authelia storage cache](authelia_storage_cache.md)	 - Manage storage cache
 * [authelia storage encryption](authelia_storage_encryption.md)	 - Manage storage encryption
+* [authelia storage logs](authelia_storage_logs.md)	 - Manage various types of logs
 * [authelia storage migrate](authelia_storage_migrate.md)	 - Perform or list migrations
 * [authelia storage schema-info](authelia_storage_schema-info.md)	 - Show the storage information
 * [authelia storage user](authelia_storage_user.md)	 - Manages user settings

--- a/docs/content/reference/cli/authelia/authelia_storage_logs.md
+++ b/docs/content/reference/cli/authelia/authelia_storage_logs.md
@@ -1,0 +1,53 @@
+---
+title: "authelia storage logs"
+description: "Reference for the authelia storage logs command."
+lead: ""
+date: 2025-07-15T16:04:46-07:00
+draft: false
+images: []
+weight: 905
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia storage logs
+
+Manage various types of logs
+
+### Synopsis
+
+Commands for managing different types of logs stored in the database
+
+### Options
+
+```
+  -h, --help   help for logs
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config strings                        configuration files or directories to load, for more information run 'authelia -h authelia config' (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information run 'authelia -h authelia filters'
+      --encryption-key string                 the storage encryption key to use
+      --mysql.address string                  the MySQL server address (default "tcp://127.0.0.1:3306")
+      --mysql.database string                 the MySQL database name (default "authelia")
+      --mysql.password string                 the MySQL password
+      --mysql.username string                 the MySQL username (default "authelia")
+      --postgres.address string               the PostgreSQL server address (default "tcp://127.0.0.1:5432")
+      --postgres.database string              the PostgreSQL database name (default "authelia")
+      --postgres.password string              the PostgreSQL password
+      --postgres.schema string                the PostgreSQL schema name (default "public")
+      --postgres.username string              the PostgreSQL username (default "authelia")
+      --sqlite.path string                    the SQLite database path
+```
+
+### SEE ALSO
+
+* [authelia storage](authelia_storage.md)	 - Manage the Authelia storage
+* [authelia storage logs auth](authelia_storage_logs_auth.md)	 - Manage authentication logs
+

--- a/docs/content/reference/cli/authelia/authelia_storage_logs.md
+++ b/docs/content/reference/cli/authelia/authelia_storage_logs.md
@@ -2,7 +2,7 @@
 title: "authelia storage logs"
 description: "Reference for the authelia storage logs command."
 lead: ""
-date: 2025-07-15T16:04:46-07:00
+date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 905

--- a/docs/content/reference/cli/authelia/authelia_storage_logs_auth.md
+++ b/docs/content/reference/cli/authelia/authelia_storage_logs_auth.md
@@ -1,0 +1,54 @@
+---
+title: "authelia storage logs auth"
+description: "Reference for the authelia storage logs auth command."
+lead: ""
+date: 2025-07-15T16:04:46-07:00
+draft: false
+images: []
+weight: 905
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia storage logs auth
+
+Manage authentication logs
+
+### Synopsis
+
+Commands for managing authentication logs including pruning old entries and viewing statistics
+
+### Options
+
+```
+  -h, --help   help for auth
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config strings                        configuration files or directories to load, for more information run 'authelia -h authelia config' (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information run 'authelia -h authelia filters'
+      --encryption-key string                 the storage encryption key to use
+      --mysql.address string                  the MySQL server address (default "tcp://127.0.0.1:3306")
+      --mysql.database string                 the MySQL database name (default "authelia")
+      --mysql.password string                 the MySQL password
+      --mysql.username string                 the MySQL username (default "authelia")
+      --postgres.address string               the PostgreSQL server address (default "tcp://127.0.0.1:5432")
+      --postgres.database string              the PostgreSQL database name (default "authelia")
+      --postgres.password string              the PostgreSQL password
+      --postgres.schema string                the PostgreSQL schema name (default "public")
+      --postgres.username string              the PostgreSQL username (default "authelia")
+      --sqlite.path string                    the SQLite database path
+```
+
+### SEE ALSO
+
+* [authelia storage logs](authelia_storage_logs.md)	 - Manage various types of logs
+* [authelia storage logs auth prune](authelia_storage_logs_auth_prune.md)	 - Prune old authentication logs
+* [authelia storage logs auth stats](authelia_storage_logs_auth_stats.md)	 - Show authentication logs statistics
+

--- a/docs/content/reference/cli/authelia/authelia_storage_logs_auth.md
+++ b/docs/content/reference/cli/authelia/authelia_storage_logs_auth.md
@@ -2,7 +2,7 @@
 title: "authelia storage logs auth"
 description: "Reference for the authelia storage logs auth command."
 lead: ""
-date: 2025-07-15T16:04:46-07:00
+date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 905

--- a/docs/content/reference/cli/authelia/authelia_storage_logs_auth_prune.md
+++ b/docs/content/reference/cli/authelia/authelia_storage_logs_auth_prune.md
@@ -2,7 +2,7 @@
 title: "authelia storage logs auth prune"
 description: "Reference for the authelia storage logs auth prune command."
 lead: ""
-date: 2025-07-15T16:04:46-07:00
+date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 905
@@ -23,7 +23,7 @@ Prune old authentication logs
 Prune authentication logs based on age criteria.
 
 This command helps manage the authentication_logs table which grows indefinitely.
-Use this to remove old authentication records older than a specified period to
+Use this to remove authentication records older than a specified period to
 prevent excessive database growth and improve performance.
 
 ```

--- a/docs/content/reference/cli/authelia/authelia_storage_logs_auth_prune.md
+++ b/docs/content/reference/cli/authelia/authelia_storage_logs_auth_prune.md
@@ -1,0 +1,71 @@
+---
+title: "authelia storage logs auth prune"
+description: "Reference for the authelia storage logs auth prune command."
+lead: ""
+date: 2025-07-15T16:04:46-07:00
+draft: false
+images: []
+weight: 905
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia storage logs auth prune
+
+Prune old authentication logs
+
+### Synopsis
+
+Prune authentication logs based on age criteria.
+
+This command helps manage the authentication_logs table which grows indefinitely.
+Use this to remove old authentication records older than a specified period to
+prevent excessive database growth and improve performance.
+
+```
+authelia storage logs auth prune [flags]
+```
+
+### Examples
+
+```
+authelia storage logs auth prune --older-than 90d
+authelia storage logs auth prune --older-than 6m --batch-size 50000
+authelia storage logs auth prune --older-than 1y --dry-run
+```
+
+### Options
+
+```
+      --batch-size int      Number of records to delete per batch (prevents long-running commands) (default 20000)
+      --dry-run             Show what would be deleted without actually deleting
+  -h, --help                help for prune
+      --older-than string   Delete logs older than this duration (e.g., 90d, 6m, 1y)
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config strings                        configuration files or directories to load, for more information run 'authelia -h authelia config' (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information run 'authelia -h authelia filters'
+      --encryption-key string                 the storage encryption key to use
+      --mysql.address string                  the MySQL server address (default "tcp://127.0.0.1:3306")
+      --mysql.database string                 the MySQL database name (default "authelia")
+      --mysql.password string                 the MySQL password
+      --mysql.username string                 the MySQL username (default "authelia")
+      --postgres.address string               the PostgreSQL server address (default "tcp://127.0.0.1:5432")
+      --postgres.database string              the PostgreSQL database name (default "authelia")
+      --postgres.password string              the PostgreSQL password
+      --postgres.schema string                the PostgreSQL schema name (default "public")
+      --postgres.username string              the PostgreSQL username (default "authelia")
+      --sqlite.path string                    the SQLite database path
+```
+
+### SEE ALSO
+
+* [authelia storage logs auth](authelia_storage_logs_auth.md)	 - Manage authentication logs
+

--- a/docs/content/reference/cli/authelia/authelia_storage_logs_auth_stats.md
+++ b/docs/content/reference/cli/authelia/authelia_storage_logs_auth_stats.md
@@ -2,7 +2,7 @@
 title: "authelia storage logs auth stats"
 description: "Reference for the authelia storage logs auth stats command."
 lead: ""
-date: 2025-07-15T16:04:46-07:00
+date: 2022-06-15T17:51:47+10:00
 draft: false
 images: []
 weight: 905

--- a/docs/content/reference/cli/authelia/authelia_storage_logs_auth_stats.md
+++ b/docs/content/reference/cli/authelia/authelia_storage_logs_auth_stats.md
@@ -1,0 +1,62 @@
+---
+title: "authelia storage logs auth stats"
+description: "Reference for the authelia storage logs auth stats command."
+lead: ""
+date: 2025-07-15T16:04:46-07:00
+draft: false
+images: []
+weight: 905
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia storage logs auth stats
+
+Show authentication logs statistics
+
+### Synopsis
+
+Display statistics about the authentication logs table including success/failure rates and record counts.
+
+```
+authelia storage logs auth stats [flags]
+```
+
+### Examples
+
+```
+authelia storage logs auth stats
+```
+
+### Options
+
+```
+  -h, --help   help for stats
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config strings                        configuration files or directories to load, for more information run 'authelia -h authelia config' (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information run 'authelia -h authelia filters'
+      --encryption-key string                 the storage encryption key to use
+      --mysql.address string                  the MySQL server address (default "tcp://127.0.0.1:3306")
+      --mysql.database string                 the MySQL database name (default "authelia")
+      --mysql.password string                 the MySQL password
+      --mysql.username string                 the MySQL username (default "authelia")
+      --postgres.address string               the PostgreSQL server address (default "tcp://127.0.0.1:5432")
+      --postgres.database string              the PostgreSQL database name (default "authelia")
+      --postgres.password string              the PostgreSQL password
+      --postgres.schema string                the PostgreSQL schema name (default "public")
+      --postgres.username string              the PostgreSQL username (default "authelia")
+      --sqlite.path string                    the SQLite database path
+```
+
+### SEE ALSO
+
+* [authelia storage logs auth](authelia_storage_logs_auth.md)	 - Manage authentication logs
+

--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -505,6 +505,32 @@ schema version of the database.`
 authelia storage migrate down --target 20 --config config.yml
 authelia storage migrate down --target 20 --encryption-key b3453fde-ecc2-4a1f-9422-2707ddbed495 --postgres.address tcp://postgres:5432 --postgres.password autheliapw`
 
+	cmdAutheliaStorageLogsShort = "Manage various types of logs"
+
+	cmdAutheliaStorageLogsLong = "Commands for managing different types of logs stored in the database"
+
+	cmdAutheliaStorageLogsAuthShort = "Manage authentication logs"
+
+	cmdAutheliaStorageLogsAuthLong = "Commands for managing authentication logs including pruning old entries and viewing statistics"
+
+	cmdAutheliaStorageLogsAuthStatsShort = "Show authentication logs statistics"
+
+	cmdAutheliaStorageLogsAuthStatsLong = "Display statistics about the authentication logs table including success/failure rates and record counts."
+
+	cmdAutheliaStorageLogsAuthStatsExample = `authelia storage logs auth stats`
+
+	cmdAutheliaStorageLogsAuthPruneShort = "Prune old authentication logs"
+
+	cmdAutheliaStorageLogsAuthPruneLong = `Prune authentication logs based on age criteria.
+
+This command helps manage the authentication_logs table which grows indefinitely.
+Use this to remove authentication records older than a specified period to
+prevent excessive database growth and improve performance.`
+
+	cmdAutheliaStorageLogsAuthPruneExample = `authelia storage logs auth prune --older-than 90d
+authelia storage logs auth prune --older-than 6m --batch-size 50000
+authelia storage logs auth prune --older-than 1y --dry-run`
+
 	cmdAutheliaConfigShort = "Perform config related actions"
 
 	cmdAutheliaConfigLong = `Perform config related actions.
@@ -707,6 +733,17 @@ This subcommand allows checking an OpenID Connect 1.0 claims hydration scenario 
 const (
 	storageMigrateDirectionUp   = "up"
 	storageMigrateDirectionDown = "down"
+)
+
+const (
+	storageLogs          = "logs"
+	storageLogsAuth      = "auth"
+	storageLogsAuthPrune = "prune"
+	storageLogsAuthStats = "stats"
+
+	cmdFlagLogsOlderThan = "older-than"
+	cmdFlagLogsBatchSize = "batch-size"
+	cmdFlagLogsDryRun    = "dry-run"
 )
 
 const (

--- a/internal/commands/storage.go
+++ b/internal/commands/storage.go
@@ -849,6 +849,12 @@ func newStorageLogsAuthPruneCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 	cmd.Flags().Int(cmdFlagLogsBatchSize, 20000, "Number of records to delete per batch (prevents long-running commands)")
 	cmd.Flags().Bool(cmdFlagLogsDryRun, false, "Show what would be deleted without actually deleting")
 
+	err := cmd.MarkFlagRequired(cmdFlagLogsOlderThan)
+	if err != nil {
+		fmt.Printf("Error marking flag as required: %v\n", err)
+		return nil
+	}
+
 	return cmd
 }
 

--- a/internal/commands/storage.go
+++ b/internal/commands/storage.go
@@ -48,6 +48,7 @@ func newStorageCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 		newStorageEncryptionCmd(ctx),
 		newStorageUserCmd(ctx),
 		newStorageBansCmd(ctx),
+		newStorageLogsCmd(ctx),
 	)
 
 	return cmd
@@ -796,6 +797,71 @@ func newStorageMigrateDownCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 
 	cmd.Flags().IntP(cmdFlagNameTarget, "t", 0, "sets the version to migrate to")
 	cmd.Flags().Bool(cmdFlagNameDestroyData, false, "confirms you want to destroy data with this migration")
+
+	return cmd
+}
+
+func newStorageLogsCmd(ctx *CmdCtx) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:               storageLogs,
+		Short:             cmdAutheliaStorageLogsShort,
+		Long:              cmdAutheliaStorageLogsLong,
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+	}
+
+	cmd.AddCommand(
+		newStorageLogsAuthCmd(ctx),
+	)
+
+	return cmd
+}
+
+func newStorageLogsAuthCmd(ctx *CmdCtx) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:               storageLogsAuth,
+		Short:             cmdAutheliaStorageLogsAuthShort,
+		Long:              cmdAutheliaStorageLogsAuthLong,
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+	}
+
+	cmd.AddCommand(
+		newStorageLogsAuthPruneCmd(ctx),
+		newStorageLogsAuthStatsCmd(ctx),
+	)
+
+	return cmd
+}
+
+func newStorageLogsAuthPruneCmd(ctx *CmdCtx) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:               storageLogsAuthPrune,
+		Short:             cmdAutheliaStorageLogsAuthPruneShort,
+		Long:              cmdAutheliaStorageLogsAuthPruneLong,
+		Example:           cmdAutheliaStorageLogsAuthPruneExample,
+		RunE:              ctx.StorageLogsAuthPruneRunE,
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+	}
+
+	cmd.Flags().String(cmdFlagLogsOlderThan, "", "Delete logs older than this duration (e.g., 90d, 6m, 1y)")
+	cmd.Flags().Int(cmdFlagLogsBatchSize, 20000, "Number of records to delete per batch (prevents long-running commands)")
+	cmd.Flags().Bool(cmdFlagLogsDryRun, false, "Show what would be deleted without actually deleting")
+
+	return cmd
+}
+
+func newStorageLogsAuthStatsCmd(ctx *CmdCtx) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:               storageLogsAuthStats,
+		Short:             cmdAutheliaStorageLogsAuthStatsShort,
+		Long:              cmdAutheliaStorageLogsAuthStatsLong,
+		Example:           cmdAutheliaStorageLogsAuthStatsExample,
+		RunE:              ctx.StorageLogsAuthStatsRunE,
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+	}
 
 	return cmd
 }

--- a/internal/commands/storage_run.go
+++ b/internal/commands/storage_run.go
@@ -1830,3 +1830,119 @@ func (ctx *CmdCtx) StorageUserIdentifiersAddRunE(cmd *cobra.Command, args []stri
 
 	return nil
 }
+
+func (ctx *CmdCtx) StorageLogsAuthPruneRunE(cmd *cobra.Command, args []string) error {
+	flags := []string{cmdFlagLogsOlderThan, cmdFlagLogsBatchSize, cmdFlagLogsDryRun}
+	setFlags := make([]string, 0)
+
+	for _, flag := range flags {
+		if cmd.Flags().Changed(flag) {
+			setFlags = append(setFlags, flag)
+		}
+	}
+
+	if len(setFlags) == 0 {
+		return fmt.Errorf("must specify --%s", cmdFlagLogsOlderThan)
+	}
+
+	defer func() {
+		_ = ctx.providers.StorageProvider.Close()
+	}()
+
+	olderThanStr, _ := cmd.Flags().GetString(cmdFlagLogsOlderThan)
+	olderThan, err := utils.ParseDurationString(olderThanStr)
+	batchSize, _ := cmd.Flags().GetInt(cmdFlagLogsBatchSize)
+	dryRun, _ := cmd.Flags().GetBool(cmdFlagLogsDryRun)
+
+	if err != nil {
+		return fmt.Errorf("invalid duration: %w", err)
+	}
+
+	if olderThan <= 0 {
+		return fmt.Errorf("duration must be positive, got: %v", olderThan)
+	}
+
+	if batchSize <= 0 {
+		return fmt.Errorf("batch size must be positive, got: %d", batchSize)
+	}
+
+	if dryRun {
+		fmt.Printf("DRY RUN: Would delete logs older than %v...\n", olderThan)
+
+		// Get stats for what would be deleted.
+		stats, err := ctx.providers.StorageProvider.GetAuthenticationLogsPrunePreview(cmd.Context(), olderThan)
+		if err != nil {
+			return fmt.Errorf("failed to get preview: %w", err)
+		}
+
+		if stats.TotalCount == 0 || !stats.MinID.Valid || !stats.MaxID.Valid {
+			fmt.Println("No records found to delete.")
+			return nil
+		}
+
+		estimatedBatches := int((stats.TotalCount + int64(batchSize) - 1) / int64(batchSize))
+
+		fmt.Printf("Would delete %d records in approximately %d batches\n", stats.TotalCount, estimatedBatches)
+		fmt.Printf("Record ID range: %d to %d\n", stats.MinID.Int64, stats.MaxID.Int64)
+		fmt.Printf("Batch size: %d\n", batchSize)
+
+		return nil
+	}
+
+	fmt.Printf("Deleting logs older than %v...\n", olderThan)
+
+	results, err := ctx.providers.StorageProvider.PruneAuthenticationLogs(cmd.Context(), olderThan, batchSize)
+	if err != nil {
+		if results != nil {
+			fmt.Printf("Partially completed: deleted %d records in %d batches before error\n",
+				results.TotalDeleted, results.TotalBatches)
+		}
+
+		return fmt.Errorf("pruning failed: %w", err)
+	}
+
+	if results.TotalDeleted == 0 {
+		fmt.Println("No records found to delete.")
+		return nil
+	}
+
+	fmt.Printf("Successfully deleted %d records in %d batches.\n", results.TotalDeleted, results.TotalBatches)
+	fmt.Printf("Total duration: %.2fs\n", results.TotalTime.Seconds())
+	fmt.Printf("Average time per batch: %.2fs\n", results.AverageTime.Seconds())
+	fmt.Printf("Records per second: %d\n", results.RecordsPerSecond)
+
+	return nil
+}
+
+func (ctx *CmdCtx) StorageLogsAuthStatsRunE(cmd *cobra.Command, args []string) error {
+	defer func() {
+		_ = ctx.providers.StorageProvider.Close()
+	}()
+
+	stats, err := ctx.providers.StorageProvider.GetAuthenticationLogsStats(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to get authentication log statistics: %w", err)
+	}
+
+	fmt.Printf("Authentication Log Statistics:\n")
+	fmt.Printf("Total records: %d\n", stats.Total)
+
+	if stats.Total > 0 {
+		successPct := float64(stats.SuccessCount) / float64(stats.Total) * 100
+		failurePct := float64(stats.FailureCount) / float64(stats.Total) * 100
+		bannedPct := float64(stats.BannedCount) / float64(stats.Total) * 100
+
+		fmt.Printf("Successful logins: %d (%.1f%%)\n", stats.SuccessCount, successPct)
+		fmt.Printf("Failed logins: %d (%.1f%%)\n", stats.FailureCount, failurePct)
+		fmt.Printf("Banned attempts: %d (%.1f%%)\n", stats.BannedCount, bannedPct)
+	} else {
+		fmt.Printf("Successful logins: %d\n", stats.SuccessCount)
+		fmt.Printf("Failed logins: %d\n", stats.FailureCount)
+		fmt.Printf("Banned attempts: %d\n", stats.BannedCount)
+	}
+
+	fmt.Printf("Oldest record: %v\n", stats.Oldest)
+	fmt.Printf("Newest record: %v\n", stats.Newest)
+
+	return nil
+}

--- a/internal/commands/storage_run.go
+++ b/internal/commands/storage_run.go
@@ -1832,31 +1832,18 @@ func (ctx *CmdCtx) StorageUserIdentifiersAddRunE(cmd *cobra.Command, args []stri
 }
 
 func (ctx *CmdCtx) StorageLogsAuthPruneRunE(cmd *cobra.Command, args []string) error {
-	flags := []string{cmdFlagLogsOlderThan, cmdFlagLogsBatchSize, cmdFlagLogsDryRun}
-	setFlags := make([]string, 0)
-
-	for _, flag := range flags {
-		if cmd.Flags().Changed(flag) {
-			setFlags = append(setFlags, flag)
-		}
-	}
-
-	if len(setFlags) == 0 {
-		return fmt.Errorf("must specify --%s", cmdFlagLogsOlderThan)
-	}
-
 	defer func() {
 		_ = ctx.providers.StorageProvider.Close()
 	}()
 
 	olderThanStr, _ := cmd.Flags().GetString(cmdFlagLogsOlderThan)
 	olderThan, err := utils.ParseDurationString(olderThanStr)
-	batchSize, _ := cmd.Flags().GetInt(cmdFlagLogsBatchSize)
-	dryRun, _ := cmd.Flags().GetBool(cmdFlagLogsDryRun)
-
 	if err != nil {
 		return fmt.Errorf("invalid duration: %w", err)
 	}
+
+	batchSize, _ := cmd.Flags().GetInt(cmdFlagLogsBatchSize)
+	dryRun, _ := cmd.Flags().GetBool(cmdFlagLogsDryRun)
 
 	if olderThan <= 0 {
 		return fmt.Errorf("duration must be positive, got: %v", olderThan)

--- a/internal/commands/storage_run.go
+++ b/internal/commands/storage_run.go
@@ -1837,6 +1837,7 @@ func (ctx *CmdCtx) StorageLogsAuthPruneRunE(cmd *cobra.Command, args []string) e
 	}()
 
 	olderThanStr, _ := cmd.Flags().GetString(cmdFlagLogsOlderThan)
+
 	olderThan, err := utils.ParseDurationString(olderThanStr)
 	if err != nil {
 		return fmt.Errorf("invalid duration: %w", err)

--- a/internal/mocks/storage.go
+++ b/internal/mocks/storage.go
@@ -272,6 +272,36 @@ func (mr *MockStorageMockRecorder) FindIdentityVerification(ctx, jti any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindIdentityVerification", reflect.TypeOf((*MockStorage)(nil).FindIdentityVerification), ctx, jti)
 }
 
+// GetAuthenticationLogsPrunePreview mocks base method.
+func (m *MockStorage) GetAuthenticationLogsPrunePreview(ctx context.Context, cutoffDuration time.Duration) (*storage.DeleteAuthLogStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuthenticationLogsPrunePreview", ctx, cutoffDuration)
+	ret0, _ := ret[0].(*storage.DeleteAuthLogStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAuthenticationLogsPrunePreview indicates an expected call of GetAuthenticationLogsPrunePreview.
+func (mr *MockStorageMockRecorder) GetAuthenticationLogsPrunePreview(ctx, cutoffDuration any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthenticationLogsPrunePreview", reflect.TypeOf((*MockStorage)(nil).GetAuthenticationLogsPrunePreview), ctx, cutoffDuration)
+}
+
+// GetAuthenticationLogsStats mocks base method.
+func (m *MockStorage) GetAuthenticationLogsStats(ctx context.Context) (*storage.AuthLogStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuthenticationLogsStats", ctx)
+	ret0, _ := ret[0].(*storage.AuthLogStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAuthenticationLogsStats indicates an expected call of GetAuthenticationLogsStats.
+func (mr *MockStorageMockRecorder) GetAuthenticationLogsStats(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthenticationLogsStats", reflect.TypeOf((*MockStorage)(nil).GetAuthenticationLogsStats), ctx)
+}
+
 // LoadBannedIP mocks base method.
 func (m *MockStorage) LoadBannedIP(ctx context.Context, remoteIP model.IP) ([]model.BannedIP, error) {
 	m.ctrl.T.Helper()
@@ -795,6 +825,21 @@ func (m *MockStorage) LoadWebAuthnUserByUserID(ctx context.Context, rpid, userID
 func (mr *MockStorageMockRecorder) LoadWebAuthnUserByUserID(ctx, rpid, userID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadWebAuthnUserByUserID", reflect.TypeOf((*MockStorage)(nil).LoadWebAuthnUserByUserID), ctx, rpid, userID)
+}
+
+// PruneAuthenticationLogs mocks base method.
+func (m *MockStorage) PruneAuthenticationLogs(ctx context.Context, cutoffDuration time.Duration, batchSize int) (*storage.DeleteAuthLogResults, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PruneAuthenticationLogs", ctx, cutoffDuration, batchSize)
+	ret0, _ := ret[0].(*storage.DeleteAuthLogResults)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PruneAuthenticationLogs indicates an expected call of PruneAuthenticationLogs.
+func (mr *MockStorageMockRecorder) PruneAuthenticationLogs(ctx, cutoffDuration, batchSize any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneAuthenticationLogs", reflect.TypeOf((*MockStorage)(nil).PruneAuthenticationLogs), ctx, cutoffDuration, batchSize)
 }
 
 // RevokeBannedIP mocks base method.

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -290,6 +290,19 @@ type Provider interface {
 	LoadOAuth2BlacklistedJTI(ctx context.Context, signature string) (blacklistedJTI *model.OAuth2BlacklistedJTI, err error)
 
 	/*
+		Implementation for authentication logs cleanup.
+	*/
+
+	// GetAuthenticationLogsStats retrieves overall statistics for the authentication logs table.
+	GetAuthenticationLogsStats(ctx context.Context) (stats *AuthLogStats, err error)
+
+	// GetAuthenticationLogsPrunePreview shows what records would be deleted without actually deleting them.
+	GetAuthenticationLogsPrunePreview(ctx context.Context, cutoffDuration time.Duration) (stats *DeleteAuthLogStats, err error)
+
+	// PruneAuthenticationLogs deletes authentication log records older than the specified duration in batches.
+	PruneAuthenticationLogs(ctx context.Context, cutoffDuration time.Duration, batchSize int) (results *DeleteAuthLogResults, err error)
+
+	/*
 		Implementation for Schema controls.
 	*/
 

--- a/internal/storage/sql_provider_backend_postgres.go
+++ b/internal/storage/sql_provider_backend_postgres.go
@@ -95,6 +95,9 @@ func NewPostgreSQLProvider(config *schema.Configuration, caCertPool *x509.CertPo
 	provider.sqlInsertAuthenticationAttempt = provider.db.Rebind(provider.sqlInsertAuthenticationAttempt)
 	provider.sqlSelectAuthenticationLogsRegulationRecordsByUsername = provider.db.Rebind(provider.sqlSelectAuthenticationLogsRegulationRecordsByUsername)
 	provider.sqlSelectAuthenticationLogsRegulationRecordsByRemoteIP = provider.db.Rebind(provider.sqlSelectAuthenticationLogsRegulationRecordsByRemoteIP)
+	provider.sqlSelectAuthenticationLogsStats = provider.db.Rebind(provider.sqlSelectAuthenticationLogsStats)
+	provider.sqlSelectTotalMinMaxAuthenticationLogs = provider.db.Rebind(provider.sqlSelectTotalMinMaxAuthenticationLogs)
+	provider.sqlDeleteAuthenticationLogsWithTime = provider.db.Rebind(provider.sqlDeleteAuthenticationLogsWithTime)
 
 	provider.sqlInsertBannedUser = provider.db.Rebind(provider.sqlInsertBannedUser)
 	provider.sqlSelectBannedUser = provider.db.Rebind(provider.sqlSelectBannedUser)

--- a/internal/storage/sql_provider_queries.go
+++ b/internal/storage/sql_provider_queries.go
@@ -620,3 +620,29 @@ const (
 		SELECT id, service, sector_id, username, identifier
 		FROM %s;`
 )
+
+const (
+	queryFmtSelectAuthenticationLogsStats = `
+		SELECT
+		COUNT(*) as total,
+		SUM(CASE WHEN successful = true THEN 1 ELSE 0 END) as success_count,
+		SUM(CASE WHEN successful = false THEN 1 ELSE 0 END) as failure_count,
+		SUM(CASE WHEN banned = true THEN 1 ELSE 0 END) as banned_count,
+		MIN(time) as oldest,
+		MAX(time) as newest
+		FROM %s;`
+
+	queryFmtSelectTotalMinMaxAuthenticationLogs = `
+		SELECT
+		COUNT(*) as total,
+		MIN(id) as min,
+		MAX(id) as max
+		FROM %s
+		WHERE time < ?;`
+
+	queryFmtDeleteAuthenticationLogsWithTime = `
+		DELETE FROM %s
+		WHERE time < ?
+		    AND id >= ?
+		    AND id < ?;`
+)

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -130,6 +130,30 @@ func (r EncryptionValidationTableResult) ResultDescriptor() string {
 	return "SUCCESS"
 }
 
+// AuthLogStats contains information about the authentication_logs table.
+type AuthLogStats struct {
+	Total        int64  `db:"total"`
+	SuccessCount int64  `db:"success_count"`
+	FailureCount int64  `db:"failure_count"`
+	BannedCount  int64  `db:"banned_count"`
+	Oldest       string `db:"oldest"`
+	Newest       string `db:"newest"`
+}
+
+type DeleteAuthLogStats struct {
+	TotalCount int64         `db:"total"`
+	MinID      sql.NullInt64 `db:"min"`
+	MaxID      sql.NullInt64 `db:"max"`
+}
+
+type DeleteAuthLogResults struct {
+	TotalBatches     int
+	TotalDeleted     int64
+	TotalTime        time.Duration
+	AverageTime      time.Duration
+	RecordsPerSecond int
+}
+
 // OAuth2SessionType represents the potential OAuth 2.0 session types.
 type OAuth2SessionType int
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new CLI commands to manage authentication logs, including viewing statistics and pruning old entries with configurable options.
  * Added preview and dry-run capabilities for authentication log pruning to estimate deletions before execution.

* **Documentation**
  * Added comprehensive documentation for new log management CLI commands, including usage examples and option references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->