### PR TITLE
Update oauth docs for latest immich

### DIFF
--- a/docs/content/integration/openid-connect/immich/index.md
+++ b/docs/content/integration/openid-connect/immich/index.md
@@ -91,7 +91,6 @@ To configure [Immich] to utilize Authelia as an [OpenID Connect 1.0] Provider, u
     - ISSUER_URL: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/.well-known/openid-configuration`.
     - CLIENT_ID: `immich`.
     - CLIENT_SECRET: `insecure_secret`.
-    - TOKEN_ENDPOINT_AUTH_METHOD: `client_secret_basic`
     - SCOPE: `openid profile email`.
     - BUTTON TEXT: `Login with Authelia`.
     - AUTO REGISTER: `Enable` (if desired).


### PR DESCRIPTION
A new option `TOKEN_ENDPOINT_AUTH_METHOD` is now available which is set to `client_secret_post` by default which leads to errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated integration guide with newer tested versions of Authelia and Immich.
  * Revised OAuth client configuration instructions to use uppercase parameter names.
  * Changed `AUTO REGISTER` parameter guidance to specify using the string "Enable".
  * Adjusted formatting of OAuth client parameters for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->