### PR TITLE
Fix existing user linking in example Jellyfin openid configuration

### DIFF
--- a/docs/content/integration/openid-connect/jellyfin/index.md
+++ b/docs/content/integration/openid-connect/jellyfin/index.md
@@ -77,6 +77,7 @@ identity_providers:
         pkce_challenge_method: 'S256'
         redirect_uris:
           - 'https://jellyfin.{{< sitevar name="domain" nojs="example.com" >}}/sso/OID/redirect/authelia'
+          - 'https://jellyfin.{{< sitevar name="domain" nojs="example.com" >}}/sso/OID/r/authelia'
         scopes:
           - 'openid'
           - 'profile'


### PR DESCRIPTION
Per jellyfin-plugin-sso documentation:

"Note that you should add both "/r/" and "/redirect/" paths to your SSO provider's configuration!"

It seems that without the /r/ path in redirect_uris, linking existing user with authelia fails.