### PR TITLE
docs(oidc): add passbolt and seo changes

### DIFF
--- a/cmd/authelia-gen/cmd_docs.go
+++ b/cmd/authelia-gen/cmd_docs.go
@@ -13,7 +13,7 @@ func newDocsCmd() *cobra.Command {
 		DisableAutoGenTag: true,
 	}
 
-	cmd.AddCommand(newDocsCLICmd(), newDocsDataCmd(), newDocsDateCmd(), newDocsJSONSchemaCmd(), newDocsManageCmd())
+	cmd.AddCommand(newDocsCLICmd(), newDocsDataCmd(), newDocsDateCmd(), newDocsSEOCmd(), newDocsJSONSchemaCmd(), newDocsManageCmd())
 
 	return cmd
 }

--- a/cmd/authelia-gen/cmd_docs_date.go
+++ b/cmd/authelia-gen/cmd_docs_date.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"io/fs"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -123,7 +120,7 @@ func getDateFromGit(cwd, path, commitFilter string) *time.Time {
 		args = append(args, commitFilter)
 	}
 
-	args = append(args, "-1", "--follow", "--diff-filter=A", "--pretty=format:%cD", "--", path)
+	args = append(args, "-1", "--diff-filter=A", "--pretty=format:%cD", "--", path)
 
 	return getTimeFromGitCmd(exec.Command("git", args...))
 }
@@ -146,15 +143,6 @@ func getTimeFromGitCmd(cmd *exec.Cmd) *time.Time {
 }
 
 func replaceDates(path string, date time.Time, dateGit *time.Time) {
-	f, err := os.Open(path)
-	if err != nil {
-		return
-	}
-
-	buf := bytes.Buffer{}
-
-	scanner := bufio.NewScanner(f)
-
 	var dateGitLine string
 
 	dateLine := fmt.Sprintf("date: %s", date.Format(dateFmtYAML))
@@ -165,69 +153,5 @@ func replaceDates(path string, date time.Time, dateGit *time.Time) {
 		dateGitLine = dateLine
 	}
 
-	found := 0
-
-	frontmatter := 0
-
-	for scanner.Scan() {
-		if found < 2 && frontmatter < 2 {
-			switch {
-			case scanner.Text() == delimiterLineFrontMatter:
-				buf.Write(scanner.Bytes())
-
-				frontmatter++
-			case frontmatter != 0 && strings.HasPrefix(scanner.Text(), "date: "):
-				buf.WriteString(dateGitLine)
-
-				found++
-			default:
-				buf.Write(scanner.Bytes())
-			}
-		} else {
-			buf.Write(scanner.Bytes())
-		}
-
-		buf.Write(newline)
-	}
-
-	f.Close()
-
-	newF, err := os.Create(path)
-	if err != nil {
-		return
-	}
-
-	_, _ = buf.WriteTo(newF)
-
-	newF.Close()
-}
-
-func getFrontmatter(path string) []byte {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil
-	}
-
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-
-	var start bool
-
-	buf := bytes.Buffer{}
-
-	for scanner.Scan() {
-		if start {
-			if scanner.Text() == delimiterLineFrontMatter {
-				break
-			}
-
-			buf.Write(scanner.Bytes())
-			buf.Write(newline)
-		} else if scanner.Text() == delimiterLineFrontMatter {
-			start = true
-		}
-	}
-
-	return buf.Bytes()
+	replaceFrontMatter(path, dateLine, dateGitLine, "date: ")
 }

--- a/cmd/authelia-gen/cmd_docs_seo.go
+++ b/cmd/authelia-gen/cmd_docs_seo.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func newDocsSEOCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "seo",
+		Short: "Generate doc seo tags",
+		RunE:  rootSubCommandsRunE,
+
+		DisableAutoGenTag: true,
+	}
+
+	cmd.AddCommand(newDocsSEOOpenIDConnectCmd())
+
+	return cmd
+}
+
+func newDocsSEOOpenIDConnectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "openid-connect",
+		Short: "Generate doc openid connect integration guide seo tags",
+		RunE:  docsSEOOpenIDConnectRunE,
+
+		DisableAutoGenTag: true,
+	}
+
+	return cmd
+}
+
+//nolint:gocyclo
+func docsSEOOpenIDConnectRunE(cmd *cobra.Command, args []string) (err error) {
+	var (
+		pathDocsContent string
+	)
+
+	if pathDocsContent, err = getPFlagPath(cmd.Flags(), cmdFlagRoot, cmdFlagDocs, cmdFlagDocsContent); err != nil {
+		return err
+	}
+
+	root := filepath.Join(pathDocsContent, "integration", "openid-connect")
+
+	return filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() || info.Name() != "index.md" || filepath.Dir(path) == root {
+			return nil
+		}
+
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return nil
+		}
+
+		frontmatterBytes := getFrontmatter(abs)
+
+		if frontmatterBytes == nil {
+			return nil
+		}
+
+		frontmatter := map[string]any{}
+
+		if err = yaml.Unmarshal(frontmatterBytes, frontmatter); err != nil {
+			return err
+		}
+
+		var (
+			ok          bool
+			raw         any
+			seo         map[string]any
+			title, desc string
+		)
+
+		if raw, ok = frontmatter["seo"]; !ok {
+			return fmt.Errorf("error parsing frontmatter for %s: seo is missing", path)
+		}
+
+		if seo, ok = raw.(map[string]any); !ok {
+			return fmt.Errorf("error parsing frontmatter for %s: seo is not a map", path)
+		}
+
+		if raw, ok = seo["description"]; !ok {
+			return fmt.Errorf("error parsing frontmatter for %s: seo description is missing", path)
+		}
+
+		if desc, ok = raw.(string); !ok {
+			return fmt.Errorf("error parsing frontmatter for %s: seo description is not a string", path)
+		}
+
+		if raw, ok = frontmatter["title"]; !ok {
+			return fmt.Errorf("error parsing frontmatter for %s: title is missing", path)
+		}
+
+		if title, ok = raw.(string); !ok {
+			return fmt.Errorf("error parsing frontmatter for %s: title is not a string", path)
+		}
+
+		expected := fmt.Sprintf("Step-by-step guide to configuring %s with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management.", title)
+
+		if desc == expected {
+			return nil
+		}
+
+		replaceFrontMatter(abs, "", fmt.Sprintf(`  description: "%s"`, expected), "  description:")
+
+		return nil
+	})
+}

--- a/cmd/authelia-gen/cmd_root_test.go
+++ b/cmd/authelia-gen/cmd_root_test.go
@@ -90,7 +90,12 @@ func TestSortCmds(t *testing.T) {
 		{
 			"ShouldSortDocsCmd",
 			newDocsCmd(),
-			[]string{"cli", "data", pathJSONSchema, cmdUseManage, "date"},
+			[]string{"cli", "data", pathJSONSchema, cmdUseManage, "seo", "date"},
+		},
+		{
+			"ShouldSortDocsSEOCmd",
+			newDocsSEOCmd(),
+			[]string{"openid-connect"},
 		},
 		{
 			"ShouldSortGitHubCmd",

--- a/cmd/authelia-gen/helpers.go
+++ b/cmd/authelia-gen/helpers.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"encoding/json"
@@ -345,4 +347,83 @@ func removeDuplicate[T comparable](sliceList []T) []T {
 	}
 
 	return list
+}
+
+func replaceFrontMatter(path, current, replacement, prefix string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+
+	buf := bytes.Buffer{}
+
+	scanner := bufio.NewScanner(f)
+
+	found := 0
+
+	frontmatter := 0
+
+	for scanner.Scan() {
+		if found < 2 && frontmatter < 2 {
+			switch {
+			case scanner.Text() == delimiterLineFrontMatter:
+				buf.Write(scanner.Bytes())
+
+				frontmatter++
+			case frontmatter != 0 && len(prefix) == 0 && scanner.Text() == current:
+				fallthrough
+			case frontmatter != 0 && len(prefix) != 0 && strings.HasPrefix(scanner.Text(), prefix):
+				buf.WriteString(replacement)
+
+				found++
+			default:
+				buf.Write(scanner.Bytes())
+			}
+		} else {
+			buf.Write(scanner.Bytes())
+		}
+
+		buf.Write(newline)
+	}
+
+	f.Close()
+
+	newF, err := os.Create(path)
+	if err != nil {
+		return
+	}
+
+	_, _ = buf.WriteTo(newF)
+
+	newF.Close()
+}
+
+func getFrontmatter(path string) []byte {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+
+	var start bool
+
+	buf := bytes.Buffer{}
+
+	for scanner.Scan() {
+		if start {
+			if scanner.Text() == delimiterLineFrontMatter {
+				break
+			}
+
+			buf.Write(scanner.Bytes())
+			buf.Write(newline)
+		} else if scanner.Text() == delimiterLineFrontMatter {
+			start = true
+		}
+	}
+
+	return buf.Bytes()
 }

--- a/docs/content/integration/openid-connect/_index.md
+++ b/docs/content/integration/openid-connect/_index.md
@@ -2,7 +2,7 @@
 title: "OpenID Connect 1.0"
 description: "OpenID Connect 1.0 Integration"
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 600

--- a/docs/content/integration/openid-connect/actual-budget/index.md
+++ b/docs/content/integration/openid-connect/actual-budget/index.md
@@ -2,7 +2,7 @@
 title: "Actual Budget"
 description: "Integrating Actual Budget with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-01-25T12:36:00+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Actual Budget with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/adventure-log/index.md
+++ b/docs/content/integration/openid-connect/adventure-log/index.md
@@ -2,7 +2,7 @@
 title: "AdventureLog"
 description: "Integrating AdventureLog with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T18:35:57+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring AdventureLog with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/apache-guacamole/index.md
+++ b/docs/content/integration/openid-connect/apache-guacamole/index.md
@@ -2,7 +2,7 @@
 title: "Apache Guacamole"
 description: "Integrating Apache Guacamole with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-07-31T13:09:05+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Apache Guacamole with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/argocd/index.md
+++ b/docs/content/integration/openid-connect/argocd/index.md
@@ -2,7 +2,7 @@
 title: "Argo CD"
 description: "Integrating Argo CD with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-07-13T04:27:30+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Argo CD with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/audiobookshelf/index.md
+++ b/docs/content/integration/openid-connect/audiobookshelf/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring audiobookshelf with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/beszel/index.md
+++ b/docs/content/integration/openid-connect/beszel/index.md
@@ -2,7 +2,7 @@
 title: "Beszel"
 description: "Integrating Beszel with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T11:03:16+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Beszel with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/bookstack/index.md
+++ b/docs/content/integration/openid-connect/bookstack/index.md
@@ -2,7 +2,7 @@
 title: "BookStack"
 description: "Integrating BookStack with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring BookStack with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/budibase/index.md
+++ b/docs/content/integration/openid-connect/budibase/index.md
@@ -2,7 +2,7 @@
 title: "Budibase"
 description: "Integrating Budibase with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-11-16T06:16:54+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Budibase with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/chronograf/index.md
+++ b/docs/content/integration/openid-connect/chronograf/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Chronograf with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/cloudflare-zerotrust/index.md
+++ b/docs/content/integration/openid-connect/cloudflare-zerotrust/index.md
@@ -2,7 +2,7 @@
 title: "Cloudflare Zero Trust"
 description: "Integrating Cloudflare Zero Trust with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Cloudflare Zero Trust with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/dokuwiki/index.md
+++ b/docs/content/integration/openid-connect/dokuwiki/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring DokuWiki with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/drupal/index.md
+++ b/docs/content/integration/openid-connect/drupal/index.md
@@ -2,7 +2,7 @@
 title: "Drupal"
 description: "Integrating Drupal with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-11-12T21:18:09+11:00
+date: 2025-04-26T11:03:16+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Drupal with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/envoy-gateway/index.md
+++ b/docs/content/integration/openid-connect/envoy-gateway/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Envoy Gateway with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/espocrm/index.md
+++ b/docs/content/integration/openid-connect/espocrm/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring EspoCRM with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/expressjs/index.md
+++ b/docs/content/integration/openid-connect/expressjs/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Express.js with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/firezone/index.md
+++ b/docs/content/integration/openid-connect/firezone/index.md
@@ -2,7 +2,7 @@
 title: "Firezone"
 description: "Integrating Firezone with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-03-28T20:29:13+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Firezone with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/flower/index.md
+++ b/docs/content/integration/openid-connect/flower/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Flower with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/forgejo/index.md
+++ b/docs/content/integration/openid-connect/forgejo/index.md
@@ -2,7 +2,7 @@
 title: "Forgejo"
 description: "Integrating Forgejo with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-07-01T13:07:02+10:00
+date: 2025-07-10T08:55:15+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Forgejo with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/frequently-asked-questions.md
+++ b/docs/content/integration/openid-connect/frequently-asked-questions.md
@@ -2,7 +2,7 @@
 title: "Frequently Asked Questions"
 description: "Frequently Asked Questions regarding integrating the Authelia OpenID Connect 1.0 Provider with an OpenID Connect 1.0 Relying Party"
 summary: "Frequently Asked Questions regarding integrating the Authelia OpenID Connect 1.0 Provider with an OpenID Connect 1.0 Relying Party."
-date: 2022-10-20T15:27:09+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 615

--- a/docs/content/integration/openid-connect/freshrss/index.md
+++ b/docs/content/integration/openid-connect/freshrss/index.md
@@ -2,7 +2,7 @@
 title: "FreshRSS"
 description: "Integrating FreshRSS with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2024-03-05T21:58:32+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring FreshRSS with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/gatus/index.md
+++ b/docs/content/integration/openid-connect/gatus/index.md
@@ -2,7 +2,7 @@
 title: "Gatus"
 description: "Integrating Gatus with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T11:03:16+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Gatus with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/gitea/index.md
+++ b/docs/content/integration/openid-connect/gitea/index.md
@@ -2,7 +2,7 @@
 title: "Gitea"
 description: "Integrating Gitea with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-07-01T13:07:02+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Gitea with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/gitlab/index.md
+++ b/docs/content/integration/openid-connect/gitlab/index.md
@@ -2,7 +2,7 @@
 title: "GitLab"
 description: "Integrating GitLab with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring GitLab with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/glitchtip/index.md
+++ b/docs/content/integration/openid-connect/glitchtip/index.md
@@ -2,7 +2,7 @@
 title: "Glitchtip"
 description: "Integrating Glitchtip with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T11:03:16+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Glitchtip with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/go-to-social/index.md
+++ b/docs/content/integration/openid-connect/go-to-social/index.md
@@ -2,7 +2,7 @@
 title: "GoToSocial"
 description: "Integrating GoToSocial with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-07-14T23:37:32+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring GoToSocial with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/grafana/index.md
+++ b/docs/content/integration/openid-connect/grafana/index.md
@@ -2,7 +2,7 @@
 title: "Grafana"
 description: "Integrating Grafana with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Grafana with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/gravitee/index.md
+++ b/docs/content/integration/openid-connect/gravitee/index.md
@@ -2,7 +2,7 @@
 title: "Gravitee"
 description: "Integrating Gravitee with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2025-01-25T10:04:53+11:00
+date: 2025-04-26T11:03:16+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Gravitee with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/harbor/index.md
+++ b/docs/content/integration/openid-connect/harbor/index.md
@@ -2,7 +2,7 @@
 title: "Harbor"
 description: "Integrating Harbor with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Harbor with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/hashicorp-vault/index.md
+++ b/docs/content/integration/openid-connect/hashicorp-vault/index.md
@@ -2,7 +2,7 @@
 title: "HashiCorp Vault"
 description: "Integrating HashiCorp Vault with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring HashiCorp Vault with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/headscale/index.md
+++ b/docs/content/integration/openid-connect/headscale/index.md
@@ -2,7 +2,7 @@
 title: "Headscale"
 description: "Integrating Headscale with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-06-26T09:01:31+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Headscale with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/hedge-doc/index.md
+++ b/docs/content/integration/openid-connect/hedge-doc/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring HedgeDoc with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/homarr/index.md
+++ b/docs/content/integration/openid-connect/homarr/index.md
@@ -2,7 +2,7 @@
 title: "Homarr"
 description: "Integrating Homarr with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-04-09T15:00:29+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Homarr with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/home-assistant/index.md
+++ b/docs/content/integration/openid-connect/home-assistant/index.md
@@ -2,7 +2,7 @@
 title: "Home Assistant"
 description: "Integrating Home Assistant with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-18T23:36:08+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Home Assistant with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/humhub/index.md
+++ b/docs/content/integration/openid-connect/humhub/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring HumHub with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/immich/index.md
+++ b/docs/content/integration/openid-connect/immich/index.md
@@ -2,7 +2,7 @@
 title: "Immich"
 description: "Integrating Immich with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-04-16T06:05:17+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Immich with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/incus/index.md
+++ b/docs/content/integration/openid-connect/incus/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Incus with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/introduction.md
+++ b/docs/content/integration/openid-connect/introduction.md
@@ -2,7 +2,7 @@
 title: "OpenID Connect 1.0"
 description: "An introduction into integrating the Authelia OpenID Connect 1.0 Provider with an OpenID Connect 1.0 Relying Party"
 summary: "An introduction into integrating the Authelia OpenID Connect 1.0 Provider with an OpenID Connect 1.0 Relying Party."
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 610

--- a/docs/content/integration/openid-connect/jellyfin/index.md
+++ b/docs/content/integration/openid-connect/jellyfin/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Jellyfin with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/jellyseerr/index.md
+++ b/docs/content/integration/openid-connect/jellyseerr/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Jellyseerr with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/jenkins/index.md
+++ b/docs/content/integration/openid-connect/jenkins/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Jenkins with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/karakeep/index.md
+++ b/docs/content/integration/openid-connect/karakeep/index.md
@@ -2,7 +2,7 @@
 title: "Karakeep"
 description: "Integrating Karakeep with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2025-01-26T23:14:15+11:00
+date: 2025-04-19T01:05:09+00:00
 draft: false
 images: []
 weight: 620
@@ -15,7 +15,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Karakeep with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/kasm-workspaces/index.md
+++ b/docs/content/integration/openid-connect/kasm-workspaces/index.md
@@ -2,7 +2,7 @@
 title: "Kasm Workspaces"
 description: "Integrating Kasm Workspaces with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-04-27T18:40:06+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Kasm Workspaces with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/komga/index.md
+++ b/docs/content/integration/openid-connect/komga/index.md
@@ -2,7 +2,7 @@
 title: "Komga"
 description: "Integrating Komga with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-08-26T11:39:00+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Komga with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/komodo/index.md
+++ b/docs/content/integration/openid-connect/komodo/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Komodo with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/kubelogin/index.md
+++ b/docs/content/integration/openid-connect/kubelogin/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Kube Login with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/leantime/index.md
+++ b/docs/content/integration/openid-connect/leantime/index.md
@@ -2,7 +2,7 @@
 title: "Leantime"
 description: "Integrating Leantime with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-06-29T00:59:33+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Leantime with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/librechat/index.md
+++ b/docs/content/integration/openid-connect/librechat/index.md
@@ -2,7 +2,7 @@
 title: "LibreChat"
 description: "Integrating LibreChat with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-09-18T18:02:11+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring LibreChat with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/linkwarden/index.md
+++ b/docs/content/integration/openid-connect/linkwarden/index.md
@@ -2,7 +2,7 @@
 title: "Linkwarden"
 description: "Integrating Linkwarden with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-01-13T08:35:59+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Linkwarden with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/mailcow/index.md
+++ b/docs/content/integration/openid-connect/mailcow/index.md
@@ -2,7 +2,7 @@
 title: "Mailcow"
 description: "Integrating Mailcow with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-11-12T21:18:09+11:00
+date: 2025-04-26T18:35:57+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Mailcow with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/mastodon/index.md
+++ b/docs/content/integration/openid-connect/mastodon/index.md
@@ -2,7 +2,7 @@
 title: "Mastodon"
 description: "Integrating Mastodon with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-04-13T13:46:05+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Mastodon with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/matomo/index.md
+++ b/docs/content/integration/openid-connect/matomo/index.md
@@ -2,7 +2,7 @@
 title: "Matomo"
 description: "Integrating Matomo with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-10-05T22:31:30+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Matomo with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/mealie/index.md
+++ b/docs/content/integration/openid-connect/mealie/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Mealie with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/memos/index.md
+++ b/docs/content/integration/openid-connect/memos/index.md
@@ -2,7 +2,7 @@
 title: "Memos"
 description: "Integrating Memos with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-11-12T21:18:09+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Memos with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/meshcentral/index.md
+++ b/docs/content/integration/openid-connect/meshcentral/index.md
@@ -2,7 +2,7 @@
 title: "MeshCentral"
 description: "Integrating MeshCentral with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T18:35:57+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring MeshCentral with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/miniflux/index.md
+++ b/docs/content/integration/openid-connect/miniflux/index.md
@@ -2,7 +2,7 @@
 title: "Miniflux"
 description: "Integrating Miniflux with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T11:03:16+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Miniflux with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/minio/index.md
+++ b/docs/content/integration/openid-connect/minio/index.md
@@ -2,7 +2,7 @@
 title: "MinIO"
 description: "Integrating MinIO with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-03-21T11:21:23+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring MinIO with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/misago/index.md
+++ b/docs/content/integration/openid-connect/misago/index.md
@@ -2,7 +2,7 @@
 title: "Misago"
 description: "Integrating Misago with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-03-14T08:51:13+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Misago with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/mobilizon/index.md
+++ b/docs/content/integration/openid-connect/mobilizon/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Mobilizon with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/netbird/index.md
+++ b/docs/content/integration/openid-connect/netbird/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring NetBird with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/nextcloud/index.md
@@ -2,7 +2,7 @@
 title: "Nextcloud"
 description: "Integrating Nextcloud with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Nextcloud with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/node-red/index.md
+++ b/docs/content/integration/openid-connect/node-red/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Node-RED with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/oauth-2.0-bearer-token-usage.md
+++ b/docs/content/integration/openid-connect/oauth-2.0-bearer-token-usage.md
@@ -2,7 +2,7 @@
 title: "OAuth 2.0 Bearer Token Usage"
 description: "An introduction into utilizing the Authelia OAuth 2.0 Provider as an authorization method"
 summary: "An introduction into utilizing the Authelia OAuth 2.0 Provider as an authorization method."
-date: 2024-03-05T19:11:16+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 611

--- a/docs/content/integration/openid-connect/ocis/index.md
+++ b/docs/content/integration/openid-connect/ocis/index.md
@@ -2,7 +2,7 @@
 title: "ownCloud Infinite Scale"
 description: "Integrating ownCloud Infinite Scale with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2024-03-05T21:58:32+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring ownCloud Infinite Scale with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/odoo/index.md
+++ b/docs/content/integration/openid-connect/odoo/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Odoo with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/open-webui/index.md
+++ b/docs/content/integration/openid-connect/open-webui/index.md
@@ -15,7 +15,7 @@ aliases:
   - /docs/community/oidc-integrations/open-webui.html
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Open WebUI with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/openid-connect-playground/index.md
+++ b/docs/content/integration/openid-connect/openid-connect-playground/index.md
@@ -2,7 +2,7 @@
 title: "OpenID Connect Playground"
 description: "Integrating OpenID Connect Playground with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-11-12T21:18:09+11:00
+date: 2025-05-07T09:48:38+10:00
 draft: false
 images: []
 weight: 620
@@ -14,7 +14,7 @@ support:
 aliases: []
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring OpenID Connect Playground with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/openproject/index.md
+++ b/docs/content/integration/openid-connect/openproject/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring OpenProject with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/opkssh/index.md
+++ b/docs/content/integration/openid-connect/opkssh/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring opkssh with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---
@@ -25,7 +25,7 @@ seo:
 - [opkssh]
   - [v0.7.0](https://github.com/openpubkey/opkssh/releases/tag/v0.7.0)
 
-{{% oidc-common bugs="claims-hydration" %}}
+{{% oidc-common %}}
 
 ### Assumptions
 

--- a/docs/content/integration/openid-connect/outline/index.md
+++ b/docs/content/integration/openid-connect/outline/index.md
@@ -2,7 +2,7 @@
 title: "Outline"
 description: "Integrating Outline with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-08-12T09:11:42+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Outline with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/pangolin/index.md
+++ b/docs/content/integration/openid-connect/pangolin/index.md
@@ -2,7 +2,7 @@
 title: "Pangolin"
 description: "Integrating Pangolin with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-05-07T10:26:55+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Pangolin with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/paperless/index.md
+++ b/docs/content/integration/openid-connect/paperless/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Paperless with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/passbolt/index.md
+++ b/docs/content/integration/openid-connect/passbolt/index.md
@@ -1,0 +1,115 @@
+---
+title: "Passbolt"
+description: "Integrating Passbolt with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2022-06-15T17:51:47+10:00
+draft: false
+images: []
+weight: 620
+toc: true
+support:
+  level: community
+  versions: true
+  integration: true
+seo:
+  title: "" # custom title (optional)
+  description: "Step-by-step guide to configuring Passbolt with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+- [Authelia]
+  - [v4.39.5](https://github.com/authelia/authelia/releases/tag/v4.39.5)
+- [Passbolt]
+  - [v5.3.2](https://www.passbolt.com/changelog/api-bext/somebody-to-love-browser-extension-api)
+
+{{% oidc-common bugs="claims-hydration" %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+- __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Client ID:__ `passbolt`
+- __Client Secret:__ `insecure_secret`
+
+Some of the values presented in this guide can automatically be replaced with documentation variables.
+
+{{< sitevar-preferences >}}
+
+## Configuration
+
+### Authelia
+
+{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
+At the time of this writing this third party client has a bug and does not support [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html). This
+configuration will likely require configuration of an escape hatch to work around the bug on their end. See
+[Configuration Escape Hatch](#configuration-escape-hatch) for details.
+{{< /callout >}}
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Passbolt] which will
+operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'passbolt'
+        client_name: 'Passbolt'
+        client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
+        public: false
+        authorization_policy: 'two_factor'
+        require_pkce: false
+        pkce_challenge_method: ''
+        redirect_uris:
+          - '<copy from the passbolt setup>'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+        response_types:
+          - 'code'
+        grant_types:
+          - 'authorization_code'
+        access_token_signed_response_alg: 'none'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'client_secret_post'
+```
+
+#### Configuration Escape Hatch
+
+{{% oidc-escape-hatch-claims-hydration client_id="passbolt" claims="email,email_verified,alt_emails,preferred_username,name" %}}
+
+### Application
+
+To configure [Passbolt] there is one method, using the [Web GUI](#web-gui).
+
+#### Web GUI
+
+To configure [Passbolt] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following
+instructions:
+
+1. Visit the [Passbolt] admin panel
+2. Visit `Org Settings`
+3. Visit `Auth`
+4. Visit `SSO`
+5. Configure the following values:
+   1. Login URL: `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
+   2. OpenID configuration URI: `/.well-known/openid-configuration`
+   3. Scope: `openid email profile`
+   4. Client Login: `passbolt`
+   5. Client Secret: `insecure_secret`
+6. Copy the callback URL into the `redirect_uris` of the Authelia configuration
+
+## See Also
+
+- [Passbolt OpenID Blog Post](https://www.passbolt.com/blog/openid-for-sso)
+
+[Authelia]: https://www.authelia.com
+[Passbolt]: https://www.passbolt.com/
+[OpenID Connect 1.0]: ../../openid-connect/introduction.md
+[client configuration]: ../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/passbolt/index.md
+++ b/docs/content/integration/openid-connect/passbolt/index.md
@@ -2,7 +2,7 @@
 title: "Passbolt"
 description: "Integrating Passbolt with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-07-19T10:42:35+10:00
 draft: false
 images: []
 weight: 620

--- a/docs/content/integration/openid-connect/peertube/index.md
+++ b/docs/content/integration/openid-connect/peertube/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring PeerTube with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/pgadmin/index.md
+++ b/docs/content/integration/openid-connect/pgadmin/index.md
@@ -2,7 +2,7 @@
 title: "pgAdmin"
 description: "Integrating pgAdmin with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-04-13T13:46:05+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring pgAdmin with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/photoprism/index.md
+++ b/docs/content/integration/openid-connect/photoprism/index.md
@@ -2,7 +2,7 @@
 title: "PhotoPrism"
 description: "Integrating PhotoPrism with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-10-09T07:24:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring PhotoPrism with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/plesk/index.md
+++ b/docs/content/integration/openid-connect/plesk/index.md
@@ -2,7 +2,7 @@
 title: "Plesk"
 description: "Integrating Plesk with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T18:35:57+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Plesk with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/pocketbase/index.md
+++ b/docs/content/integration/openid-connect/pocketbase/index.md
@@ -2,7 +2,7 @@
 title: "PocketBase"
 description: "Integrating PocketBase with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring PocketBase with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/portainer/index.md
+++ b/docs/content/integration/openid-connect/portainer/index.md
@@ -2,7 +2,7 @@
 title: "Portainer"
 description: "Integrating Portainer with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -15,7 +15,7 @@ aliases:
   - /docs/community/oidc-integrations/portainer.html
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Portainer with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/powerdns/index.md
+++ b/docs/content/integration/openid-connect/powerdns/index.md
@@ -2,7 +2,7 @@
 title: "PowerDNS Admin"
 description: "Integrating PowerDNS Admin with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2024-01-16T08:47:18+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring PowerDNS Admin with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/proxmox/index.md
+++ b/docs/content/integration/openid-connect/proxmox/index.md
@@ -2,7 +2,7 @@
 title: "Proxmox"
 description: "Integrating Proxmox with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -15,7 +15,7 @@ aliases:
   - /docs/community/oidc-integrations/proxmox.html
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Proxmox with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/rocket-chat/index.md
+++ b/docs/content/integration/openid-connect/rocket-chat/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Rocket.Chat with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/romm/index.md
+++ b/docs/content/integration/openid-connect/romm/index.md
@@ -2,7 +2,7 @@
 title: "ROM Manager (RomM)"
 description: "Integrating ROM Manager (RomM) with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-06-01T12:55:40+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring ROM Manager (RomM) with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/roundcube/index.md
+++ b/docs/content/integration/openid-connect/roundcube/index.md
@@ -2,7 +2,7 @@
 title: "Roundcube"
 description: "Integrating Roundcube and Dovecot with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-11-15T08:58:00+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Roundcube with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/rustdesk-server-pro/index.md
+++ b/docs/content/integration/openid-connect/rustdesk-server-pro/index.md
@@ -2,7 +2,7 @@
 title: "RustDesk Server Pro"
 description: "Integrating RustDesk Server Pro with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2025-01-25T10:04:53+11:00
+date: 2025-04-26T18:35:57+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring RustDesk Server Pro with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/seafile/index.md
+++ b/docs/content/integration/openid-connect/seafile/index.md
@@ -2,7 +2,7 @@
 title: "Seafile"
 description: "Integrating Seafile with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Seafile with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/semaphore/index.md
+++ b/docs/content/integration/openid-connect/semaphore/index.md
@@ -2,7 +2,7 @@
 title: "Semaphore"
 description: "Integrating Semaphore with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T11:03:16+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Semaphore with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/sftpgo/index.md
+++ b/docs/content/integration/openid-connect/sftpgo/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring SFTPGo with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/stalwart/index.md
+++ b/docs/content/integration/openid-connect/stalwart/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Stalwart with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/stirling-pdf/index.md
+++ b/docs/content/integration/openid-connect/stirling-pdf/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Stirling-PDF with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management." # custom description (recommended)
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---
@@ -129,7 +129,6 @@ services:
       SECURITY_OAUTH2_USEASUSERNAME: 'preferred_username'
       SECURITY_OAUTH2_PROVIDER: 'Authelia'
 ```
-
 
 ## See Also
 

--- a/docs/content/integration/openid-connect/synapse/index.md
+++ b/docs/content/integration/openid-connect/synapse/index.md
@@ -2,7 +2,7 @@
 title: "Synapse"
 description: "Integrating Synapse with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Synapse with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/synology-dsm/index.md
+++ b/docs/content/integration/openid-connect/synology-dsm/index.md
@@ -2,7 +2,7 @@
 title: "Synology DSM"
 description: "Integrating Synology DSM with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-10-18T21:22:13+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Synology DSM with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/tailscale/index.md
+++ b/docs/content/integration/openid-connect/tailscale/index.md
@@ -2,7 +2,7 @@
 title: "Tailscale"
 description: "Integrating Tailscale with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-04-23T10:06:28+10:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Tailscale with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/tandoor/index.md
+++ b/docs/content/integration/openid-connect/tandoor/index.md
@@ -2,7 +2,7 @@
 title: "Tandoor"
 description: "Integrating Tandoor with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2024-04-13T13:46:05+10:00
+date: 2025-04-26T11:03:16+00:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Tandoor with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/terrakube/index.md
+++ b/docs/content/integration/openid-connect/terrakube/index.md
@@ -2,7 +2,7 @@
 title: "Terrakube"
 description: "Integrating Terrakube with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-01-25T10:04:53+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Terrakube with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/unreal-engine/index.md
+++ b/docs/content/integration/openid-connect/unreal-engine/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Unreal Engine with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/uptime-kuma/index.md
+++ b/docs/content/integration/openid-connect/uptime-kuma/index.md
@@ -2,7 +2,7 @@
 title: "Uptime Kuma"
 description: "Integrating Uptime Kuma status monitors with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2024-03-12T10:09:59+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Uptime Kuma with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/vaultwarden/index.md
+++ b/docs/content/integration/openid-connect/vaultwarden/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Vaultwarden with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/vikunja/index.md
+++ b/docs/content/integration/openid-connect/vikunja/index.md
@@ -2,7 +2,7 @@
 title: "Vikunja"
 description: "Integrating Vikunja with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-04-13T13:46:05+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Vikunja with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/warpgate/index.md
+++ b/docs/content/integration/openid-connect/warpgate/index.md
@@ -2,7 +2,7 @@
 title: "Warpgate"
 description: "Integrating Warpgate with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-12-10T10:52:22+11:00
+date: 2024-03-23T23:08:06+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Warpgate with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/wekan/index.md
+++ b/docs/content/integration/openid-connect/wekan/index.md
@@ -2,7 +2,7 @@
 title: "WeKan"
 description: "Integrating WeKan with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-04-13T13:46:05+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring WeKan with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/wikijs/index.md
+++ b/docs/content/integration/openid-connect/wikijs/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Wiki.js with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/windmill/index.md
+++ b/docs/content/integration/openid-connect/windmill/index.md
@@ -2,7 +2,7 @@
 title: "Windmill"
 description: "Integrating Windmill with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-12-10T10:52:22+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Windmill with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/wordpress/index.md
+++ b/docs/content/integration/openid-connect/wordpress/index.md
@@ -2,7 +2,7 @@
 title: "WordPress"
 description: "Integrating WordPress with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2024-04-13T13:46:05+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring WordPress with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/writefreely/index.md
+++ b/docs/content/integration/openid-connect/writefreely/index.md
@@ -2,7 +2,7 @@
 title: "Writefreely"
 description: "Integrating Writefreely with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2024-08-20T21:53:14+10:00
+date: 2025-01-25T10:04:53+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Writefreely with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/wud/index.md
+++ b/docs/content/integration/openid-connect/wud/index.md
@@ -2,7 +2,7 @@
 title: "WUD (What's Up Docker)"
 description: "Integrating WUD (What's Up Docker) with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-01-13T08:35:59+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring WUD (What's Up Docker) with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/xen-orchestra/index.md
+++ b/docs/content/integration/openid-connect/xen-orchestra/index.md
@@ -2,7 +2,7 @@
 title: "Xen Orchestra"
 description: "Integrating Xen Orchestra with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2022-06-15T17:51:47+10:00
+date: 2025-04-26T18:35:57+10:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Xen Orchestra with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/youtrack/index.md
+++ b/docs/content/integration/openid-connect/youtrack/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring YouTrack with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/zammad/index.md
+++ b/docs/content/integration/openid-connect/zammad/index.md
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Zammad with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---

--- a/docs/content/integration/openid-connect/zipline/index.md
+++ b/docs/content/integration/openid-connect/zipline/index.md
@@ -2,7 +2,7 @@
 title: "Zipline"
 description: "Integrating Zipline with the Authelia OpenID Connect 1.0 Provider."
 summary: ""
-date: 2023-11-12T21:18:09+11:00
+date: 2025-03-04T23:12:34+11:00
 draft: false
 images: []
 weight: 620
@@ -13,7 +13,7 @@ support:
   integration: true
 seo:
   title: "" # custom title (optional)
-  description: "" # custom description (recommended)
+  description: "Step-by-step guide to configuring Zipline with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---


### PR DESCRIPTION
This adds Passbolt to the integration guides and improves various SEO elements for the OpenID Connect 1.0 guides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new documentation page with a step-by-step guide for integrating Passbolt with Authelia OpenID Connect 1.0 Provider.
  * Introduced a command-line tool to automate SEO metadata updates for OpenID Connect integration guides.

* **Documentation**
  * Updated OpenID Connect integration guides with enhanced SEO descriptions for improved discoverability.
  * Refreshed publication dates across multiple integration guides for accuracy and recency.

* **Bug Fixes**
  * Improved handling and updating of front matter metadata in documentation files for consistency.

* **Tests**
  * Expanded test coverage to include new documentation and SEO command features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->