### PR TITLE
docs(oidc): add dashy

### DIFF
--- a/docs/content/integration/openid-connect/clients/dashy/index.md
+++ b/docs/content/integration/openid-connect/clients/dashy/index.md
@@ -1,0 +1,106 @@
+---
+title: "Dashy"
+description: "Integrating Dashy with the Authelia OpenID Connect 1.0 Provider."
+summary: ""
+date: 2025-06-13T14:12:09+00:00
+draft: false
+images: []
+weight: 620
+toc: true
+aliases: []
+support:
+  level: community
+  versions: true
+  integration: true
+seo:
+  title: "Dashy | OpenID Connect 1.0 | Integration"
+  description: "Step-by-step guide to configuring Dashy with OpenID Connect 1.0 for secure SSO. Enhance your login flow using Authelia’s modern identity management."
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Tested Versions
+
+- [Authelia]
+  - [v4.39.5](https://github.com/authelia/authelia/releases/tag/v4.39.5)
+- [Dashy]
+  - [v3.1.1](https://github.com/Lissy93/dashy/releases/tag/3.1.1)
+
+{{% oidc-common bugs="claims-hydration" %}}
+
+### Assumptions
+
+This example makes the following assumptions:
+
+- __Application Root URL:__ `https://dashy.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Client ID:__ `dashy`
+
+Some of the values presented in this guide can automatically be replaced with documentation variables.
+
+{{< sitevar-preferences >}}
+
+## Configuration
+
+### Authelia
+
+The following YAML configuration is an example __Authelia__ [client configuration] for use with [Dashy] which will operate with the application example:
+
+```yaml {title="configuration.yml"}
+identity_providers:
+  oidc:
+    ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
+    ## See: https://www.authelia.com/c/oidc
+    clients:
+      - client_id: 'dashy'
+        client_name: 'Dashy'
+        public: true
+        authorization_policy: 'two_factor'
+        require_pkce: true
+        pkce_challenge_method: 'S256'
+        redirect_uris:
+          - 'https://dashy.{{< sitevar name="domain" nojs="example.com" >}}'
+        scopes:
+          - 'openid'
+          - 'profile'
+          - 'email'
+          - 'groups'
+          - 'roles'
+        grant_types:
+          - 'authorization_code'
+        response_types:
+          - 'code'
+        access_token_signed_response_alg: 'none'
+        userinfo_signed_response_alg: 'none'
+        token_endpoint_auth_method: 'none'
+```
+
+#### Configuration Escape Hatch
+
+{{% oidc-escape-hatch-claims-hydration client_id="dashy" claims="email,email_verified,alt_emails,preferred_username,name" %}}
+
+### Application
+
+To configure [Dashy] there is one method, using the [Configuration File](#configuration-file).
+
+#### Configuration File
+
+To configure [Dashy] to utilize Authelia as an [OpenID Connect 1.0] Provider, use the following configuration:
+
+```yaml
+appConfig:
+  auth:
+    enableOidc: true
+    oidc:
+      clientId: 'dashy'
+      endpoint: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}'
+```
+
+## See Also
+
+- [Dashy OIDC Authentication Documentation](https://dashy.to/docs/authentication#oidc)
+
+[Authelia]: https://www.authelia.com
+[Dashy]: https://dashy.to/
+[OpenID Connect 1.0]: ../../../openid-connect/introduction.md
+[client configuration]: ../../../../configuration/identity-providers/openid-connect/clients.md

--- a/docs/content/integration/openid-connect/clients/envoy-gateway/index.md
+++ b/docs/content/integration/openid-connect/clients/envoy-gateway/index.md
@@ -33,9 +33,9 @@ seo:
 
 This example makes the following assumptions:
 
-- __Application Root URL:__ `https://envoy-app.{{< sitevar name="domain" nojs="example.com" >}}/`
+- __Application Root URL:__ `https://envoy.{{< sitevar name="domain" nojs="example.com" >}}/`
 - __Authelia Root URL:__ `https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/`
-- __Client ID:__ `envoy-app`
+- __Client ID:__ `envoy`
 - __Client Secret:__ `insecure_secret`
 
 Some of the values presented in this guide can automatically be replaced with documentation variables.
@@ -54,7 +54,7 @@ identity_providers:
     ## The other portions of the mandatory OpenID Connect 1.0 configuration go here.
     ## See: https://www.authelia.com/c/oidc
     clients:
-      - client_id: 'envoy-app'
+      - client_id: 'envoy'
         client_name: 'Envoy Gateway'
         client_secret: '$pbkdf2-sha512$310000$c8p78n7pUMln0jzvd4aK4Q$JNRBzwAo0ek5qKn50cFzzvE9RXV88h1wJn5KGiHrD0YKtZaR/nCb2CJPOsKaPK0hjf.9yHxzQGZziziccp6Yng'  # The digest of 'insecure_secret'.
         public: false
@@ -62,7 +62,7 @@ identity_providers:
         require_pkce: false
         pkce_challenge_method: ''
         redirect_uris:
-          - 'https://envoy-app.{{< sitevar name="domain" nojs="example.com" >}}/authelia/openid_connect/callback'
+          - 'https://envoy.{{< sitevar name="domain" nojs="example.com" >}}/authelia/openid_connect/callback'
         scopes:
           - 'openid'
           - 'offline_access'
@@ -95,35 +95,35 @@ To configure [Envoy Gateway] to utilize Authelia as an [OpenID Connect 1.0] Prov
 following instructions:
 
 1. Use `kubectl` to create the secret:
-   - `kubectl create secret generic envoy-app-oidc-client-secret --from-literal=client-secret=insecure_secret`
+   - `kubectl create secret generic envoy-oidc-client-secret --from-literal=client-secret=insecure_secret`
 2. Apply the below manifests for the example application.
 
 The following example [HTTPRoute] is a example real application just for the purposes of showcasing this. The important
-factors are the `name` value being `envoy-app`.
+factors are the `name` value being `envoy`.
 
 ```yaml {title="httproute.yaml
 ---
 apiVersion: 'gateway.networking.k8s.io/v1'
 kind: 'HTTPRoute'
 metadata:
-  name: 'envoy-app'
+  name: 'envoy'
 spec:
   parentRefs:
     - name: 'eg'
   hostnames:
-    - 'envoy-app.{{< sitevar name="domain" nojs="example.com" >}}'
+    - 'envoy.{{< sitevar name="domain" nojs="example.com" >}}'
   rules:
     - matches:
         - path:
             type: 'PathPrefix'
             value: '/'
       backendRefs:
-        - name: 'envoy-app-service-backend'
+        - name: 'envoy-service-backend'
           port: 80
 ...
 ```
 
-The following [SecurityPolicy] requires [OpenID Connect 1.0] authorization for just the `envoy-app` [HTTPRoute] as
+The following [SecurityPolicy] requires [OpenID Connect 1.0] authorization for just the `envoy` [HTTPRoute] as
 described above, the important factors are the `targetRefs` which indicates what resource to apply this to.
 
 ```yaml
@@ -131,28 +131,28 @@ described above, the important factors are the `targetRefs` which indicates what
 apiVersion: 'gateway.envoyproxy.io/v1alpha1'
 kind: 'SecurityPolicy'
 metadata:
-  name: 'envoy-app-oidc'
+  name: 'envoy-oidc'
 spec:
   targetRefs:
     - group: 'gateway.networking.k8s.io'
       kind: 'HTTPRoute'
-      name: 'envoy-app'
+      name: 'envoy'
   oidc:
     provider:
       issuer: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}'
       authorizationEndpoint: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/authorization'
       tokenEndpoint: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/token'
-    clientID: 'app'
+    clientID: 'envoy'
     clientSecret:
-      name: 'envoy-app-oidc-client-secret'
-    cookieDomain: 'envoy-app.{{< sitevar name="domain" nojs="example.com" >}}'
+      name: 'envoy-oidc-client-secret'
+    cookieDomain: 'envoy.{{< sitevar name="domain" nojs="example.com" >}}'
     cookieNames:
       idToken: ''
       accessToken: ''
     scopes:
       - 'openid'
       - 'offline_access'
-    redirectURL: 'https://envoy-app.{{< sitevar name="domain" nojs="example.com" >}}/authelia/openid_connect/callback'
+    redirectURL: 'https://envoy.{{< sitevar name="domain" nojs="example.com" >}}/authelia/openid_connect/callback'
     forwardAccessToken: false
     refreshToken: true
     passThroughAuthHeader: false
@@ -164,7 +164,7 @@ To configure [Envoy Gateway] to utilize Authelia as an [OpenID Connect 1.0] Prov
 following instructions:
 
 1. Use `kubectl` to create the secret:
-  - `kubectl create secret generic envoy-app-oidc-client-secret --from-literal=client-secret=insecure_secret`
+  - `kubectl create secret generic envoy-oidc-client-secret --from-literal=client-secret=insecure_secret`
 2. Apply the below manifests for the `eg` [Gateway].
 
 The following example [HTTPRoute] is a fake application just for the redirection behaviour.
@@ -196,7 +196,7 @@ the important factors are the `targetRefs` which indicates what resource to appl
 apiVersion: 'gateway.envoyproxy.io/v1alpha1'
 kind: 'SecurityPolicy'
 metadata:
-  name: 'envoy-app-oidc'
+  name: 'envoy-oidc'
 spec:
   targetRefs:
     - group: 'gateway.networking.k8s.io'
@@ -207,10 +207,10 @@ spec:
       issuer: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}'
       authorizationEndpoint: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/authorization'
       tokenEndpoint: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/api/oidc/token'
-    clientID: 'app'
+    clientID: 'envoy'
     clientSecret:
-      name: 'envoy-app-oidc-client-secret'
-    cookieDomain: 'envoy-app.{{< sitevar name="domain" nojs="example.com" >}}'
+      name: 'envoy-oidc-client-secret'
+    cookieDomain: 'envoy-oidc.{{< sitevar name="domain" nojs="example.com" >}}'
     cookieNames:
       idToken: ''
       accessToken: ''

--- a/docs/content/integration/openid-connect/clients/grafana/index.md
+++ b/docs/content/integration/openid-connect/clients/grafana/index.md
@@ -46,12 +46,6 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-At the time of this writing this third party client has a bug and does not support [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html). This
-configuration will likely require configuration of an escape hatch to work around the bug on their end. See
-[Configuration Escape Hatch](#configuration-escape-hatch) for details.
-{{< /callout >}}
-
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [Grafana] which will
 operate with the application example:
 

--- a/docs/content/integration/openid-connect/clients/headscale/index.md
+++ b/docs/content/integration/openid-connect/clients/headscale/index.md
@@ -46,12 +46,6 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-At the time of this writing this third party client has a bug and does not support [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html). This
-configuration will likely require configuration of an escape hatch to work around the bug on their end. See
-[Configuration Escape Hatch](#configuration-escape-hatch) for details.
-{{< /callout >}}
-
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [Headscale] which will
 operate with the application example:
 

--- a/docs/content/integration/openid-connect/clients/leantime/index.md
+++ b/docs/content/integration/openid-connect/clients/leantime/index.md
@@ -46,12 +46,6 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-At the time of this writing this third party client has a bug and does not support [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html). This
-configuration will likely require configuration of an escape hatch to work around the bug on their end. See
-[Configuration Escape Hatch](#configuration-escape-hatch) for details.
-{{< /callout >}}
-
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [Leantime] which will
 operate with the application example:
 

--- a/docs/content/integration/openid-connect/clients/minio/index.md
+++ b/docs/content/integration/openid-connect/clients/minio/index.md
@@ -46,12 +46,6 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-At the time of this writing this third party client has a bug and does not support [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html). This
-configuration will likely require configuration of an escape hatch to work around the bug on their end. See
-[Configuration Escape Hatch](#configuration-escape-hatch) for details.
-{{< /callout >}}
-
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [MinIO] which will
 operate with the application example:
 

--- a/docs/content/integration/openid-connect/clients/pangolin/index.md
+++ b/docs/content/integration/openid-connect/clients/pangolin/index.md
@@ -45,12 +45,6 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-At the time of this writing this third party client has a bug and does not support [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html). This
-configuration will likely require configuration of an escape hatch to work around the bug on their end. See
-[Configuration Escape Hatch](#configuration-escape-hatch) for details.
-{{< /callout >}}
-
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [Pangolin] which will
 operate with the application example:
 

--- a/docs/content/integration/openid-connect/clients/passbolt/index.md
+++ b/docs/content/integration/openid-connect/clients/passbolt/index.md
@@ -46,12 +46,6 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-At the time of this writing this third party client has a bug and does not support [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html). This
-configuration will likely require configuration of an escape hatch to work around the bug on their end. See
-[Configuration Escape Hatch](#configuration-escape-hatch) for details.
-{{< /callout >}}
-
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [Passbolt] which will
 operate with the application example:
 

--- a/docs/content/integration/openid-connect/clients/romm/index.md
+++ b/docs/content/integration/openid-connect/clients/romm/index.md
@@ -46,12 +46,6 @@ Some of the values presented in this guide can automatically be replaced with do
 
 ### Authelia
 
-{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
-At the time of this writing this third party client has a bug and does not support [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0.html). This
-configuration will likely require configuration of an escape hatch to work around the bug on their end. See
-[Configuration Escape Hatch](#configuration-escape-hatch) for details.
-{{< /callout >}}
-
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [ROM Manager] which will
 operate with the application example:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new integration guide for Dashy with Authelia OpenID Connect.
  * Standardized naming conventions in the Envoy integration guide for consistency.
  * Removed outdated cautionary notes about OpenID Connect 1.0 support from several client integration guides, including Grafana, Headscale, Leantime, MinIO, Pangolin, Passbolt, and ROM Manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->