### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -308,11 +308,7 @@ func validateFileAuthenticationBackendPasswordConfigLegacy(config *schema.Authen
 		}
 
 		if config.SaltLength > 0 && config.SHA2Crypt.SaltLength == 0 {
-			if config.SaltLength > 16 {
-				config.SHA2Crypt.SaltLength = 16
-			} else {
-				config.SHA2Crypt.SaltLength = config.SaltLength
-			}
+			config.SHA2Crypt.SaltLength = min(config.SaltLength, 16)
 		}
 	case hashLegacyArgon2id:
 		config.Algorithm = hashArgon2


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal handling of legacy SHA-512 password hashing configuration by clearly clamping the salt length to the existing limit. Behavior and compatibility remain unchanged, ensuring consistent authentication results. No changes to user settings, workflows, or migration steps are required. This is an internal improvement aimed at clarity and maintainability with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->