### PR TITLE
Mailcow documentation error on token_endpoint_auth_method setting

### DIFF
--- a/docs/content/integration/openid-connect/clients/mailcow/index.md
+++ b/docs/content/integration/openid-connect/clients/mailcow/index.md
@@ -74,7 +74,7 @@ identity_providers:
           - 'authorization_code'
         access_token_signed_response_alg: 'none'
         userinfo_signed_response_alg: 'none'
-        token_endpoint_auth_method: 'client_secret_basic'
+        token_endpoint_auth_method: 'client_secret_post'
 ```
 
 ### Application


### PR DESCRIPTION
Mailcow OAuth flow uses for `token_endpoint_auth_method` the `client_secret_post` mechanism not `client_secret_basic`.

If `client_secret_basic` is being used, authelia will throw the following error:
```
Access Request failed with error: Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'token_endpoint_auth_method' method 'client_secret_post', however the OAuth 2.0 client registration does not allow this method. The registered client with id 'mailcow' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'client_secret_post' or the Relying Party will need to be configured to use 'client_secret_basic'.
```