### PR TITLE
[Documentation] Add required claims for OIDC client Jenkins.

### DIFF
--- a/docs/content/integration/openid-connect/clients/jenkins/index.md
+++ b/docs/content/integration/openid-connect/clients/jenkins/index.md
@@ -64,6 +64,10 @@ jenkins-plugin-cli --plugins oic-auth
 
 ### Authelia
 
+{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
+NOTE: As of time of this commit, Jenkins' `oic-auth` plugin requires the `offline_access`, `address` and `phone` claims.
+{{< /callout >}}
+
 The following YAML configuration is an example __Authelia__ [client configuration] for use with [Jenkins] which will
 operate with the application example:
 
@@ -87,6 +91,9 @@ identity_providers:
           - 'profile'
           - 'email'
           - 'groups'
+          - 'offline_access'
+          - 'address'
+          - 'phone'
         response_types:
           - 'code'
         grant_types:


### PR DESCRIPTION
Jenkins now requests the `offline_access`, `address` and `phone`claims.