### PR TITLE
docs(zipline): Update token_endpoint_auth_method 

### DIFF
--- a/docs/content/integration/openid-connect/clients/zipline/index.md
+++ b/docs/content/integration/openid-connect/clients/zipline/index.md
@@ -23,9 +23,9 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.38.0](https://github.com/authelia/authelia/releases/tag/v4.38.0)
+  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
 - [Zipline]
-  - [v4.0.0](https://github.com/diced/zipline/releases/tag/v4.0.0)
+  - [v4.2.3](https://github.com/diced/zipline/releases/tag/v4.2.3)
 
 {{% oidc-common %}}
 


### PR DESCRIPTION
Updated the Zipline docs to use `token_endpoint_auth_method: 'client_secret_post'` 

Zipline didn't want to work for me until i changed this to client_secret_post

```
time="2025-08-23T22:42:13Z" level=error msg="Access Request failed with error: Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using 'token_endpoint_auth_method' method 'client_secret_post', however the OAuth 2.0 client registration does not allow this method. The registered client with id 'KFm2VYfMoYdKHT7uVIclnBpFvPntGMjz8Scl6NBa' is configured to only support 'token_endpoint_auth_method' method 'client_secret_basic'. Either the Authorization Server client registration will need to have the 'token_endpoint_auth_method' updated to 'client_secret_post' or the Relying Party will need to be configured to use 'client_secret_basic'." method=POST path=/api/oidc/token remote_ip=10.244.0.88
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Zipline OpenID Connect guide: tested Authelia version bumped (v4.38.0 → v4.39.6) and Zipline version bumped (v4.0.0 → v4.2.3).
  * Changed token endpoint authentication to use client_secret_post instead of client_secret_basic.
  * Users should verify and update their client configuration to ensure successful token exchanges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->