### PR TITLE
fix(oidc): consent claims not written to database

### DIFF
--- a/internal/handlers/handler_oauth2_consent.go
+++ b/internal/handlers/handler_oauth2_consent.go
@@ -772,7 +772,7 @@ func handleGetConsentForm(ctx *middlewares.AutheliaCtx, original url.Values) (fo
 		return requester.GetRequestForm(), nil
 	}
 
-	return form, err
+	return original, err
 }
 
 func handleGetConsentFormFromPushedAuthorizeRequestRedirectURI(ctx *middlewares.AutheliaCtx, form url.Values) (requester oauth2.AuthorizeRequester, err error) {


### PR DESCRIPTION
This fixes an issue where clients which requested claims caused authelia to continually prompt users for consent.

This fixes #10144.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth2 consent form behavior when not using Pushed Authorization Requests (PAR). Previously, the form could reset and lose entered values; it now retains the original input, preventing data loss and reducing friction.
  * Ensures consistent consent experience between PAR and non-PAR flows.
  * No other behavior or UI changes; error handling remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->