### PR TITLE
docs(oidc): update linkding

### DIFF
--- a/docs/content/integration/openid-connect/clients/linkding/index.md
+++ b/docs/content/integration/openid-connect/clients/linkding/index.md
@@ -86,8 +86,6 @@ variables:
 
 ```shell {title=".env"}
 LD_ENABLE_OIDC=True
-LD_ENABLE_AUTH_PROXY=True
-LD_AUTH_PROXY_LOGOUT_URL=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/logout
 LD_CSRF_TRUSTED_ORIGINS=https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}
 OIDC_RP_CLIENT_ID=linkding
 OIDC_RP_CLIENT_SECRET=insecure_secret
@@ -104,8 +102,6 @@ services:
   linkding:
     environment:
       LD_ENABLE_OIDC: 'True'
-      LD_ENABLE_AUTH_PROXY: 'True'
-      LD_AUTH_PROXY_LOGOUT_URL: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}/logout'
       LD_CSRF_TRUSTED_ORIGINS: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}'
       OIDC_RP_CLIENT_ID: 'linkding'
       OIDC_RP_CLIENT_SECRET: 'insecure_secret'


### PR DESCRIPTION
We do not require this for OIDC, login won't work if we enable both - should move this to Trusted Header SSO section instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linkding OpenID Connect integration guide to remove deprecated authentication proxy variables.
  * Simplified configuration by removing LD_ENABLE_AUTH_PROXY and LD_AUTH_PROXY_LOGOUT_URL from .env and Docker Compose examples.
  * Clarifies OIDC-focused setup while keeping existing settings (e.g., LD_ENABLE_OIDC, LD_CSRF_TRUSTED_ORIGINS) unchanged.
  * Reduces confusion and aligns examples with current recommended configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->