### PR TITLE
ci: sign all artifacts with goreleaser

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -57,6 +57,7 @@ steps:
       - "authelia-*.tar.gz.sha256"
       - "*.deb"
       - "*.deb.sha256"
+      - "*.sig"
     key: "unit-test"
     env:
       NODE_OPTIONS: "--no-deprecation"

--- a/.buildkite/steps/ghartifacts.sh
+++ b/.buildkite/steps/ghartifacts.sh
@@ -4,14 +4,14 @@ set -eu
 artifacts=()
 
 for FILE in \
-  authelia-linux-amd64.tar.gz authelia-linux-amd64.tar.gz.sha256 \
-  authelia-linux-arm.tar.gz authelia-linux-arm.tar.gz.sha256 \
-  authelia-linux-arm64.tar.gz authelia-linux-arm64.tar.gz.sha256 \
-  authelia-linux-amd64-musl.tar.gz authelia-linux-amd64-musl.tar.gz.sha256 \
-  authelia-linux-arm-musl.tar.gz authelia-linux-arm-musl.tar.gz.sha256 \
-  authelia-linux-arm64-musl.tar.gz authelia-linux-arm64-musl.tar.gz.sha256 \
-  authelia-freebsd-amd64.tar.gz authelia-freebsd-amd64.tar.gz.sha256 \
-  authelia-public_html.tar.gz authelia-public_html.tar.gz.sha256;
+  authelia-linux-amd64.tar.gz authelia-linux-amd64.tar.gz.sha256 authelia-linux-amd64.tar.gz.sha256.sig \
+  authelia-linux-arm.tar.gz authelia-linux-arm.tar.gz.sha256 authelia-linux-arm.tar.gz.sha256.sig \
+  authelia-linux-arm64.tar.gz authelia-linux-arm64.tar.gz.sha256 authelia-linux-arm64.tar.gz.sha256.sig \
+  authelia-linux-amd64-musl.tar.gz authelia-linux-amd64-musl.tar.gz.sha256 authelia-linux-amd64-musl.tar.gz.sha256.sig \
+  authelia-linux-arm-musl.tar.gz authelia-linux-arm-musl.tar.gz.sha256 authelia-linux-arm-musl.tar.gz.sha256.sig \
+  authelia-linux-arm64-musl.tar.gz authelia-linux-arm64-musl.tar.gz.sha256 authelia-linux-arm64-musl.tar.gz.sha256.sig \
+  authelia-freebsd-amd64.tar.gz authelia-freebsd-amd64.tar.gz.sha256 authelia-freebsd-amd64.tar.gz.sha256.sig \
+  authelia-public_html.tar.gz authelia-public_html.tar.gz.sha256 authelia-public_html.tar.gz.sha256.sig;
 do
   # Add the version to the artifact name
   mv ${FILE} ${FILE/authelia-/authelia-${BUILDKITE_TAG}-}
@@ -19,9 +19,9 @@ do
 done
 
 for FILE in \
-  authelia_amd64.deb authelia_amd64.deb.sha256 \
-  authelia_arm64.deb authelia_arm64.deb.sha256 \
-  authelia_armhf.deb authelia_armhf.deb.sha256;
+  authelia_amd64.deb authelia_amd64.deb.sha256 authelia_amd64.deb.sha256.sig \
+  authelia_arm64.deb authelia_arm64.deb.sha256 authelia_arm64.deb.sha256.sig \
+  authelia_armhf.deb authelia_armhf.deb.sha256 authelia_armhf.deb.sha256.sig;
 do
   # Add the version to the artifact name
   mv ${FILE} ${FILE/authelia_/authelia_${BUILDKITE_TAG}_}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -170,6 +170,18 @@ nfpms:
     scripts:
       postinstall: postinstall.sh
 
+signs:
+  - id: gpg
+    signature: '${artifact}.sig'
+    args: [
+      "-u", "security@authelia.com",
+      "--pinentry-mode", "loopback",
+      "--passphrase", "{{ .Env.GPG_PASSWORD }}",
+      "--output", "${signature}",
+      "--detach-sign", "${artifact}",
+    ]
+    artifacts: all
+
 checksum:
   name_template: '{{ .ArtifactName }}.{{ .Algorithm }}'
   algorithm: sha256

--- a/cmd/authelia-scripts/cmd/build.go
+++ b/cmd/authelia-scripts/cmd/build.go
@@ -80,12 +80,16 @@ func buildAutheliaBinaryCI(xflags []string) {
 	}
 
 	args := []string{
-		"run", "--rm",
+		"run", "--rm", "-i",
+		"--name", "authelia-crossbuild",
 		"--user", "1000:1000",
 		"-e", "GOPATH=/tmp/go",
 		"-e", "GOCACHE=/tmp/go-build",
+		"-e", "GPG_PASSWORD=" + os.Getenv("GPG_PASSWORD"),
+		"-e", "HOME=/tmp",
 		"-e", "XFLAGS=" + strings.Join(xflags, " "),
 		"-v", pwd + ":/workdir",
+		"-v", "/buildkite/.gnupg:/tmp/.gnupg",
 		"-v", "/buildkite/.go:/tmp/go",
 		"authelia/crossbuild",
 		"goreleaser", "release", "--skip=publish,validate",
@@ -114,7 +118,7 @@ func buildAutheliaBinaryGO(xflags []string) {
 }
 
 func buildFrontend(branch string) {
-	cmd := utils.CommandWithStdout("pnpm", "install")
+	cmd := utils.CommandWithStdout("pnpm", "install", "--ignore-scripts")
 	cmd.Dir = webDirectory
 
 	err := cmd.Run()


### PR DESCRIPTION
This change signs all artifacts with the same GPG key that's used to sign the Authelia Helm chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Release downloads now include cryptographic signature files (.sig) alongside existing checksums for archives and Debian packages, enabling easier verification.

- Chores
  - Improved build and release pipeline to better handle cross-compilation and signing workflows.
  - Adjusted frontend dependency installation to reduce side effects during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->