### PR TITLE
ci: goreleaser additional hardening flags and fortify musl binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,8 +23,10 @@ builds:
     main: ./cmd/authelia
     env:
       - GOEXPERIMENT=nosynchashtriemap
-      - CGO_CPPFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong
-      - CGO_LDFLAGS=-Wl,-z,relro,-z,now
+      - CGO_CFLAGS=-O2 -pipe -fno-plt -fstack-protector-strong
+      - CGO_CPPFLAGS=-D_FORTIFY_SOURCE=3
+      - CGO_CXXFLAGS=-O2 -pipe -fno-plt
+      - CGO_LDFLAGS=-Wl,-O1,-sort-common,-as-needed,-z,relro,-z,now
       - CGO_ENABLED=1
     flags: -trimpath
     buildmode: pie
@@ -61,8 +63,10 @@ builds:
     main: ./cmd/authelia
     env:
       - GOEXPERIMENT=nosynchashtriemap
-      - CGO_CPPFLAGS=-D_FORTIFY_SOURCE=2 -fstack-protector-strong
-      - CGO_LDFLAGS=-Wl,-z,relro,-z,now
+      - CGO_CFLAGS=-O2 -pipe -fno-plt -fstack-protector-strong
+      - CGO_CPPFLAGS=-I/usr/local/include/fortify -D_FORTIFY_SOURCE=3
+      - CGO_CXXFLAGS=-O2 -pipe -fno-plt
+      - CGO_LDFLAGS=-Wl,-O1,-sort-common,-as-needed,-z,relro,-z,now
       - CGO_ENABLED=1
     flags: -trimpath
     buildmode: pie
@@ -174,8 +178,8 @@ signs:
   - id: gpg
     signature: '${artifact}.sig'
     args: [
+      "--batch", "--pinentry-mode", "loopback",
       "-u", "security@authelia.com",
-      "--pinentry-mode", "loopback",
       "--passphrase", "{{ .Env.GPG_PASSWORD }}",
       "--output", "${signature}",
       "--detach-sign", "${artifact}",

--- a/cmd/authelia-scripts/cmd/build.go
+++ b/cmd/authelia-scripts/cmd/build.go
@@ -80,7 +80,7 @@ func buildAutheliaBinaryCI(xflags []string) {
 	}
 
 	args := []string{
-		"run", "--rm", "-i",
+		"run", "--rm",
 		"--name", "authelia-crossbuild",
 		"--user", "1000:1000",
 		"-e", "GOPATH=/tmp/go",
@@ -91,6 +91,7 @@ func buildAutheliaBinaryCI(xflags []string) {
 		"-v", pwd + ":/workdir",
 		"-v", "/buildkite/.gnupg:/tmp/.gnupg",
 		"-v", "/buildkite/.go:/tmp/go",
+		"-v", "/usr/local/include:/usr/local/include",
 		"authelia/crossbuild",
 		"goreleaser", "release", "--skip=publish,validate",
 	}


### PR DESCRIPTION
Also removed `stdin_open: true` on `authelia/crossbuild` container in favour of gpg batch mode.