### PR TITLE
ci: add slsa provenance attestations for artifacts

### DIFF
--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -1,0 +1,63 @@
+---
+name: SLSA Provenance
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  buildkite:
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch artifact metadata and prepare hashes
+        id: hash
+        shell: bash
+        env:
+          ORG: authelia
+          PIPELINE: authelia
+          COMMIT: ${{ github.sha }}
+          BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
+        # yamllint disable rule:indentation
+        run: |
+          # Fetch artifact metadata and prepare hashes
+          echo "Looking up Buildkite build for commit: ${COMMIT}"
+          build_url=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" \
+            "https://api.buildkite.com/v2/organizations/${ORG}/pipelines/${PIPELINE}/builds?commit=${COMMIT}" \
+            | jq -r '.[0].url')
+          echo "Found Buildkite Build URL: ${build_url}"
+
+          echo "Polling for artifact metadata..."
+          sleep 600
+          while true; do
+            state=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" "${build_url}" | jq -r '.state')
+            if [ "${state}" = "passed" ]; then
+              break
+            fi
+            sleep 300
+          done
+          echo "Artifact metadata retrieved"
+
+          hashes=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" \
+            "${build_url}/artifacts" | jq -r '
+              .[]
+              | select(.filename | test("\\.(deb|tar\\.gz)$"))
+              | "\(.sha256sum) \(.filename)"
+            ' | base64 -w0)
+
+          echo "hashes=${hashes}" >> "${GITHUB_OUTPUT}"
+        # yamllint enable rule:indentation
+
+  provenance:
+    needs: [buildkite]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      provenance-name: authelia.intoto.jsonl
+      upload-assets: true
+...


### PR DESCRIPTION
This change adds SLSA3 provenance attestations for all Authelia `.deb` and `.tar.gz` artifacts from tagged releases. 