### PR TITLE
fix: lower log level of totp not found error

### DIFF
--- a/internal/handlers/handler_sign_totp.go
+++ b/internal/handlers/handler_sign_totp.go
@@ -40,12 +40,13 @@ func TimeBasedOneTimePasswordGET(ctx *middlewares.AutheliaCtx) {
 	var config *model.TOTPConfiguration
 
 	if config, err = ctx.Providers.StorageProvider.LoadTOTPConfiguration(ctx, userSession.Username); err != nil {
-		ctx.Logger.WithError(err).Errorf("Error occurred retrieving TOTP configuration for user '%s': error occurred retrieving the configuration from the storage backend", userSession.Username)
 
 		if errors.Is(err, storage.ErrNoTOTPConfiguration) {
+			ctx.Logger.WithError(err).Debugf("Error occurred retrieving TOTP configuration for user '%s'", userSession.Username)
 			ctx.SetStatusCode(fasthttp.StatusNotFound)
 			ctx.SetJSONError("Could not find TOTP Configuration for user.")
 		} else {
+			ctx.Logger.WithError(err).Errorf("Error occurred retrieving TOTP configuration for user '%s': error occurred retrieving the configuration from the storage backend", userSession.Username)
 			ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 			ctx.SetJSONError("Could not find TOTP Configuration for user.")
 		}

--- a/internal/handlers/handler_sign_totp.go
+++ b/internal/handlers/handler_sign_totp.go
@@ -40,7 +40,6 @@ func TimeBasedOneTimePasswordGET(ctx *middlewares.AutheliaCtx) {
 	var config *model.TOTPConfiguration
 
 	if config, err = ctx.Providers.StorageProvider.LoadTOTPConfiguration(ctx, userSession.Username); err != nil {
-
 		if errors.Is(err, storage.ErrNoTOTPConfiguration) {
 			ctx.Logger.WithError(err).Debugf("Error occurred retrieving TOTP configuration for user '%s'", userSession.Username)
 			ctx.SetStatusCode(fasthttp.StatusNotFound)

--- a/internal/handlers/handler_sign_totp_test.go
+++ b/internal/handlers/handler_sign_totp_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"github.com/valyala/fasthttp"
@@ -560,6 +561,9 @@ func (s *HandlerSignTOTPSuite) TestShouldHandleGETErrorLoadConfiguration() {
 }
 
 func (s *HandlerSignTOTPSuite) TestShouldHandleGETErrorLoadConfigurationNotFound() {
+	level := s.mock.Ctx.Logger.Level
+	s.mock.SetLogLevel(logrus.DebugLevel)
+
 	gomock.InOrder(
 		s.mock.StorageMock.
 			EXPECT().
@@ -570,7 +574,8 @@ func (s *HandlerSignTOTPSuite) TestShouldHandleGETErrorLoadConfigurationNotFound
 	TimeBasedOneTimePasswordGET(s.mock.Ctx)
 	s.mock.Assert404KO(s.T(), "Could not find TOTP Configuration for user.")
 
-	s.AssertLastLogMessage("Error occurred retrieving TOTP configuration for user 'john': error occurred retrieving the configuration from the storage backend", "no TOTP configuration for user")
+	s.AssertLastLogMessage("Error occurred retrieving TOTP configuration for user 'john'", "no TOTP configuration for user")
+	s.mock.SetLogLevel(level)
 }
 
 func (s *HandlerSignTOTPSuite) TestShouldReturnErrorOnInvalidValue() {


### PR DESCRIPTION
This aims to reduce the *shock* factor of seeing errors for events that do not necessarily need review. (TOTP not found)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for TOTP retrieval: returns 404 when no configuration exists and 500 for unexpected errors.
  * Shortened and clarified log output for the not-found case while preserving response text and successful retrieval behavior.

* **Tests**
  * Updated tests to expect adjusted logging and to manage log level during assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->