### PR TITLE
fix: skip pnpm scripts in suite frontend entrypoint

### DIFF
--- a/internal/suites/example/compose/authelia/resources/entrypoint-frontend.sh
+++ b/internal/suites/example/compose/authelia/resources/entrypoint-frontend.sh
@@ -6,4 +6,4 @@ if [[ -f "${PNPM_MODULE}" ]]; then
   rm "${PNPM_MODULE}"
 fi
 
-pnpm install --frozen-lockfile && pnpm start
+pnpm install --ignore-scripts --frozen-lockfile && pnpm start


### PR DESCRIPTION
This fixes suites failing to start due to `"git": not being found in $PATH`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the frontend installation process to skip package lifecycle scripts, improving reliability and reducing side effects during setup.
  - Preserves lockfile integrity to ensure consistent dependency resolution across environments.
  - Slightly improves installation performance by avoiding unnecessary script execution.
  - No changes to runtime behavior or user-facing features; application startup remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->