### PR TITLE
release: v4.39.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -34,6 +34,7 @@ body:
         What version(s) of Authelia can you reproduce this bug on?
       multiple: true
       options:
+        - 'v4.39.7'
         - 'v4.39.6'
         - 'v4.39.5'
         - 'v4.39.4'

--- a/docs/content/integration/openid-connect/clients/1password/index.md
+++ b/docs/content/integration/openid-connect/clients/1password/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [1Password]
 
 {{% oidc-common %}}

--- a/docs/content/integration/openid-connect/clients/adventure-log/index.md
+++ b/docs/content/integration/openid-connect/clients/adventure-log/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [AdventureLog]
   - [v0.9.0](https://github.com/seanmorley15/AdventureLog/releases/tag/v0.9.0)
 

--- a/docs/content/integration/openid-connect/clients/ansible-awx/index.md
+++ b/docs/content/integration/openid-connect/clients/ansible-awx/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Ansible AWX]
   - [v24.6.1](https://github.com/ansible/awx/releases/tag/24.6.1)
 

--- a/docs/content/integration/openid-connect/clients/apache-guacamole/index.md
+++ b/docs/content/integration/openid-connect/clients/apache-guacamole/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Apache Guacamole]
   - [v1.5.5](https://guacamole.apache.org/releases/1.5.5/)
 

--- a/docs/content/integration/openid-connect/clients/beszel/index.md
+++ b/docs/content/integration/openid-connect/clients/beszel/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Beszel]
   - [v0.10.2](https://github.com/henrygd/beszel/releases/tag/v0.10.2)
 

--- a/docs/content/integration/openid-connect/clients/bitwarden/index.md
+++ b/docs/content/integration/openid-connect/clients/bitwarden/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Bitwarden]
   - [v2025.7.3](https://github.com/bitwarden/server/releases/tag/v2025.7.3)
 

--- a/docs/content/integration/openid-connect/clients/bookstack/index.md
+++ b/docs/content/integration/openid-connect/clients/bookstack/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [BookStack]
   - [v25.07](https://github.com/BookStackApp/BookStack/releases/tag/v25.07)
 

--- a/docs/content/integration/openid-connect/clients/chronograf/index.md
+++ b/docs/content/integration/openid-connect/clients/chronograf/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Chronograf]
   - [v1.10.7](https://docs.influxdata.com/chronograf/v1/about_the_project/release-notes/#v1107)
 

--- a/docs/content/integration/openid-connect/clients/claper/index.md
+++ b/docs/content/integration/openid-connect/clients/claper/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Claper]
   - [v2.3.3](https://github.com/ClaperCo/Claper/releases/tag/v2.3.3)
 

--- a/docs/content/integration/openid-connect/clients/cloud-identity-engine/index.md
+++ b/docs/content/integration/openid-connect/clients/cloud-identity-engine/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Cloud Identity Engine]
 
 {{% oidc-common %}}

--- a/docs/content/integration/openid-connect/clients/cloudflare-zerotrust/index.md
+++ b/docs/content/integration/openid-connect/clients/cloudflare-zerotrust/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 
 {{% oidc-common bugs="client-credentials-encoding,claims-hydration" %}}
 

--- a/docs/content/integration/openid-connect/clients/coder/index.md
+++ b/docs/content/integration/openid-connect/clients/coder/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Coder]
   - [v2.24.2](https://github.com/coder/coder/releases/tag/v2.24.2)
 

--- a/docs/content/integration/openid-connect/clients/dashy/index.md
+++ b/docs/content/integration/openid-connect/clients/dashy/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Dashy]
   - [v3.1.1](https://github.com/Lissy93/dashy/releases/tag/3.1.1)
 

--- a/docs/content/integration/openid-connect/clients/docmost/index.md
+++ b/docs/content/integration/openid-connect/clients/docmost/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Docmost]
   - [v0.22.2](https://github.com/docmost/docmost/releases/tag/v0.22.2)
 

--- a/docs/content/integration/openid-connect/clients/donetick/index.md
+++ b/docs/content/integration/openid-connect/clients/donetick/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Donetick]
   - [v0.1.53](https://github.com/donetick/donetick/releases/tag/v0.1.53)
 

--- a/docs/content/integration/openid-connect/clients/drupal/index.md
+++ b/docs/content/integration/openid-connect/clients/drupal/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Drupal]
   - [v10.4.0](https://www.drupal.org/project/drupal/releases/10.4.0)
 

--- a/docs/content/integration/openid-connect/clients/engomo/index.md
+++ b/docs/content/integration/openid-connect/clients/engomo/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [engomo]
 
 {{% oidc-common %}}

--- a/docs/content/integration/openid-connect/clients/envoy-gateway/index.md
+++ b/docs/content/integration/openid-connect/clients/envoy-gateway/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Envoy Gateway]
   - [v1.4.1](https://github.com/envoyproxy/gateway/releases/tag/v1.4.1)
 

--- a/docs/content/integration/openid-connect/clients/file-rise/index.md
+++ b/docs/content/integration/openid-connect/clients/file-rise/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [FileRise]
   - [v1.3.9](https://github.com/error311/FileRise/releases/tag/v1.3.9)
 

--- a/docs/content/integration/openid-connect/clients/filebrowser-quantum/index.md
+++ b/docs/content/integration/openid-connect/clients/filebrowser-quantum/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [FileBrowser Quantum]
   - [v0.7.18-beta](https://github.com/gtsteffaniak/filebrowser/releases/tag/v0.7.18-beta)
 

--- a/docs/content/integration/openid-connect/clients/forgejo/index.md
+++ b/docs/content/integration/openid-connect/clients/forgejo/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Forgejo]
   - [v11.0.2](https://codeberg.org/forgejo/forgejo/releases/tag/v11.0.2)
 

--- a/docs/content/integration/openid-connect/clients/gatus/index.md
+++ b/docs/content/integration/openid-connect/clients/gatus/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Gatus]
   - [v5.17.0](https://github.com/TwiN/gatus/releases/tag/v5.17.0)
 

--- a/docs/content/integration/openid-connect/clients/glitchtip/index.md
+++ b/docs/content/integration/openid-connect/clients/glitchtip/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Glitchtip]
   - [v4.2](https://glitchtip.com/blog/2024-11-01-glitchtip-4-2-release)
 

--- a/docs/content/integration/openid-connect/clients/grafana/index.md
+++ b/docs/content/integration/openid-connect/clients/grafana/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Grafana]
   - [v12.0.2](https://github.com/grafana/grafana/releases/tag/v12.0.2)
 

--- a/docs/content/integration/openid-connect/clients/gravitee/index.md
+++ b/docs/content/integration/openid-connect/clients/gravitee/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Gravitee]
   - [v4.7](https://documentation.gravitee.io/apim/release-information/release-notes/apim-4.7)
 

--- a/docs/content/integration/openid-connect/clients/headscale/index.md
+++ b/docs/content/integration/openid-connect/clients/headscale/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Headscale]
   - [v0.26.1](https://github.com/juanfont/headscale/releases/tag/v0.26.1)
 

--- a/docs/content/integration/openid-connect/clients/home-assistant/index.md
+++ b/docs/content/integration/openid-connect/clients/home-assistant/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Home Assistant]
   - Application:
     - [v2025.4.2](https://github.com/home-assistant/core/releases/tag/2025.4.2)

--- a/docs/content/integration/openid-connect/clients/jellyseerr/index.md
+++ b/docs/content/integration/openid-connect/clients/jellyseerr/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Jellyseerr]
   - [development version tag:preview-OIDC](https://github.com/fallenbagel/jellyseerr/releases/tag/preview-OIDC)
 

--- a/docs/content/integration/openid-connect/clients/kanboard/index.md
+++ b/docs/content/integration/openid-connect/clients/kanboard/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Kanboard]
   - [v1.2.46](https://github.com/kanboard/kanboard/releases/tag/v1.2.46)
 

--- a/docs/content/integration/openid-connect/clients/karakeep/index.md
+++ b/docs/content/integration/openid-connect/clients/karakeep/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Karakeep] (previously named Hoarder)
   - [v0.26.0](https://github.com/karakeep-app/karakeep/releases/tag/v0.26.0)
 

--- a/docs/content/integration/openid-connect/clients/komodo/index.md
+++ b/docs/content/integration/openid-connect/clients/komodo/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Komodo]
   - [v1.17.5](https://github.com/moghtech/komodo/releases/tag/v1.17.5)
 

--- a/docs/content/integration/openid-connect/clients/kubelogin/index.md
+++ b/docs/content/integration/openid-connect/clients/kubelogin/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Kube Login]
   - [v1.33.0](https://github.com/int128/kubelogin/releases/tag/v1.33.0)
 

--- a/docs/content/integration/openid-connect/clients/landscape/index.md
+++ b/docs/content/integration/openid-connect/clients/landscape/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Landscape]
   - [24.04 LTS](https://documentation.ubuntu.com/landscape/reference/release-notes/24-04-lts-release-notes/)
 

--- a/docs/content/integration/openid-connect/clients/leantime/index.md
+++ b/docs/content/integration/openid-connect/clients/leantime/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Leantime]
   - [v3.5.8](https://github.com/Leantime/leantime/releases/tag/v3.5.8)
 

--- a/docs/content/integration/openid-connect/clients/mailcow/index.md
+++ b/docs/content/integration/openid-connect/clients/mailcow/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Mailcow]
   - [v2025-03](https://github.com/mailcow/mailcow-dockerized/releases/tag/2025-03)
 

--- a/docs/content/integration/openid-connect/clients/mattermost/index.md
+++ b/docs/content/integration/openid-connect/clients/mattermost/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Mattermost]
 
 {{% oidc-common %}}

--- a/docs/content/integration/openid-connect/clients/meshcentral/index.md
+++ b/docs/content/integration/openid-connect/clients/meshcentral/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [MeshCentral]
   - [v1.1.44](https://github.com/Ylianst/MeshCentral/releases/tag/1.1.44)
 

--- a/docs/content/integration/openid-connect/clients/miniflux/index.md
+++ b/docs/content/integration/openid-connect/clients/miniflux/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Miniflux]
   - [v2.2.8](https://github.com/miniflux/v2/releases/tag/2.2.8)
 

--- a/docs/content/integration/openid-connect/clients/minio/index.md
+++ b/docs/content/integration/openid-connect/clients/minio/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [MinIO]
   - [2025-04-22T22-12-26Z](https://github.com/minio/minio/releases/tag/RELEASE.2025-04-22T22-12-26Z)
 

--- a/docs/content/integration/openid-connect/clients/open-webui/index.md
+++ b/docs/content/integration/openid-connect/clients/open-webui/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Open WebUI]
   - [v0.6.13](https://github.com/open-webui/open-webui/releases/tag/v0.6.13)
 

--- a/docs/content/integration/openid-connect/clients/openid-connect-playground/index.md
+++ b/docs/content/integration/openid-connect/clients/openid-connect-playground/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [OpenID Connect Playground]
   - Not Applicable
 

--- a/docs/content/integration/openid-connect/clients/openproject/index.md
+++ b/docs/content/integration/openid-connect/clients/openproject/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [OpenProject]
   - [v15.4.2](https://www.openproject.org/docs/release-notes/#1550)
 

--- a/docs/content/integration/openid-connect/clients/opkssh/index.md
+++ b/docs/content/integration/openid-connect/clients/opkssh/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [opkssh]
   - [v0.7.0](https://github.com/openpubkey/opkssh/releases/tag/v0.7.0)
 

--- a/docs/content/integration/openid-connect/clients/pangolin/index.md
+++ b/docs/content/integration/openid-connect/clients/pangolin/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Pangolin]
   - [v1.3.1](https://github.com/fosrl/pangolin/releases/tag/1.3.1)
 

--- a/docs/content/integration/openid-connect/clients/papra/index.md
+++ b/docs/content/integration/openid-connect/clients/papra/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Papra]
   - [v0.7.0](https://github.com/papra-hq/papra/releases/tag/%40papra%2Fapp-server%400.7.0)
 

--- a/docs/content/integration/openid-connect/clients/passbolt/index.md
+++ b/docs/content/integration/openid-connect/clients/passbolt/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Passbolt]
   - [v5.3.2](https://www.passbolt.com/changelog/api-bext/somebody-to-love-browser-extension-api)
 

--- a/docs/content/integration/openid-connect/clients/plesk/index.md
+++ b/docs/content/integration/openid-connect/clients/plesk/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Plesk]
   - [v18.0.69](https://docs.plesk.com/release-notes/obsidian/change-log/#plesk-18069)
 

--- a/docs/content/integration/openid-connect/clients/proxmox/index.md
+++ b/docs/content/integration/openid-connect/clients/proxmox/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Proxmox Virtual Environment]
   - [v8.4.1](https://pve.proxmox.com/wiki/Roadmap#Proxmox_VE_8.4)
 - [Proxmox Backup Server]

--- a/docs/content/integration/openid-connect/clients/rustdesk-server-pro/index.md
+++ b/docs/content/integration/openid-connect/clients/rustdesk-server-pro/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [RustDesk Server Pro]
   - [v1.3.9](https://github.com/rustdesk/rustdesk/releases/tag/1.3.9)
 

--- a/docs/content/integration/openid-connect/clients/ryot/index.md
+++ b/docs/content/integration/openid-connect/clients/ryot/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Ryot]
   - [v8.9.0](https://github.com/IgnisDa/ryot/releases/tag/v8.9.0)
 

--- a/docs/content/integration/openid-connect/clients/semaphore/index.md
+++ b/docs/content/integration/openid-connect/clients/semaphore/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Semaphore]
   - [v2.13.14](https://github.com/semaphoreui/semaphore/releases/tag/v2.13.14)
 

--- a/docs/content/integration/openid-connect/clients/sftpgo/index.md
+++ b/docs/content/integration/openid-connect/clients/sftpgo/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [SFTPGo]
   - [v2.6.6](https://github.com/drakkan/sftpgo/releases/tag/v2.6.6)
 

--- a/docs/content/integration/openid-connect/clients/stalwart/index.md
+++ b/docs/content/integration/openid-connect/clients/stalwart/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Stalwart]
   - [v0.11.7](https://github.com/stalwartlabs/mail-server/releases/tag/v0.11.7)
 

--- a/docs/content/integration/openid-connect/clients/synapse/index.md
+++ b/docs/content/integration/openid-connect/clients/synapse/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Synapse]
   - [v1.127.1](https://github.com/element-hq/synapse/releases/tag/v1.127.1)
 

--- a/docs/content/integration/openid-connect/clients/tandoor/index.md
+++ b/docs/content/integration/openid-connect/clients/tandoor/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Tandoor]
   - [v1.5.34](https://github.com/TandoorRecipes/recipes/releases/tag/1.5.34)
 

--- a/docs/content/integration/openid-connect/clients/trillium/index.md
+++ b/docs/content/integration/openid-connect/clients/trillium/index.md
@@ -21,7 +21,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Trillium Notes]
   - [v0.97.1](https://github.com/TriliumNext/Trilium/releases/tag/v0.97.1)
 

--- a/docs/content/integration/openid-connect/clients/unreal-engine/index.md
+++ b/docs/content/integration/openid-connect/clients/unreal-engine/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Unreal Engine]
   - [v5.6](https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-5-6-release-notes)
 

--- a/docs/content/integration/openid-connect/clients/vaultwarden/index.md
+++ b/docs/content/integration/openid-connect/clients/vaultwarden/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Vaultwarden]
   - [oidcwarden development fork v2025.5.1-5](https://github.com/Timshel/OIDCWarden/releases/tag/v2025.5.1-5)
 

--- a/docs/content/integration/openid-connect/clients/wallos/index.md
+++ b/docs/content/integration/openid-connect/clients/wallos/index.md
@@ -22,7 +22,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Wallos]
   - [v4.1.1](https://github.com/ellite/Wallos/releases/tag/v4.1.1)
 

--- a/docs/content/integration/openid-connect/clients/xen-orchestra/index.md
+++ b/docs/content/integration/openid-connect/clients/xen-orchestra/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Xen Orchestra]
   - [v5.105](https://xen-orchestra.com/blog/xen-orchestra-5-105/)
 

--- a/docs/content/integration/openid-connect/clients/youtrack/index.md
+++ b/docs/content/integration/openid-connect/clients/youtrack/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [YouTrack]
   - 2025.1
 

--- a/docs/content/integration/openid-connect/clients/zammad/index.md
+++ b/docs/content/integration/openid-connect/clients/zammad/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Zammad]
   - [v6.5.0](https://github.com/zammad/zammad/releases/tag/6.5.0)
 

--- a/docs/content/integration/openid-connect/clients/zipline/index.md
+++ b/docs/content/integration/openid-connect/clients/zipline/index.md
@@ -23,7 +23,7 @@ seo:
 ## Tested Versions
 
 - [Authelia]
-  - [v4.39.6](https://github.com/authelia/authelia/releases/tag/v4.39.6)
+  - [v4.39.7](https://github.com/authelia/authelia/releases/tag/v4.39.7)
 - [Zipline]
   - [v4.2.3](https://github.com/diced/zipline/releases/tag/v4.2.3)
 

--- a/docs/data/misc.json
+++ b/docs/data/misc.json
@@ -4,7 +4,7 @@
         "development": "default-src 'self' 'unsafe-eval'; frame-src 'none'; object-src 'none'; style-src 'self' 'nonce-${NONCE}' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; frame-ancestors 'none'; base-uri 'self'",
         "nonce": "${NONCE}"
     },
-    "latest": "4.39.6",
+    "latest": "4.39.7",
     "support": {
         "traefik": [
             "v3.5.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authelia",
-  "version": "4.39.6",
+  "version": "4.39.7",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated "Tested Versions" across numerous OpenID Connect client integration pages to reflect Authelia v4.39.7 (e.g., 1Password, AdventureLog, AWX, Bitwarden, Grafana, Home Assistant, Proxmox, and many more).
  * Refreshed associated release links where applicable.
  * Note: Two pages show mixed references where the displayed version is v4.39.7 but the link still points to v4.39.6 (Miniflux, Trillium).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->