### PR TITLE
ci: fix slsa attestation workflow

### DIFF
--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -5,12 +5,20 @@ on:  # yamllint disable-line rule:truthy
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  contents: read
+
 jobs:
   buildkite:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911  # v2.13.0
+        with:
+          egress-policy: audit
+
       - name: Fetch artifact metadata and prepare hashes
         id: hash
         shell: bash
@@ -22,6 +30,8 @@ jobs:
         # yamllint disable rule:indentation
         run: |
           # Fetch artifact metadata and prepare hashes
+          initial=true
+
           echo "Looking up Buildkite build for commit: ${COMMIT}"
           build_url=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" \
             "https://api.buildkite.com/v2/organizations/${ORG}/pipelines/${PIPELINE}/builds?commit=${COMMIT}" \
@@ -29,21 +39,28 @@ jobs:
           echo "Found Buildkite Build URL: ${build_url}"
 
           echo "Polling for artifact metadata..."
-          sleep 600
           while true; do
             state=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" "${build_url}" | jq -r '.state')
             if [ "${state}" = "passed" ]; then
               break
+            elif [ "${initial}" = "true" ]; then
+              sleep 600
+              initial=false
+            else
+              sleep 300
             fi
-            sleep 300
           done
           echo "Artifact metadata retrieved"
 
           hashes=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" \
-            "${build_url}/artifacts" | jq -r '
+            "${build_url}/artifacts" | jq -r --arg tag "${GITHUB_REF_NAME}" '
               .[]
               | select(.filename | test("\\.(deb|tar\\.gz)$"))
-              | "\(.sha256sum) \(.filename)"
+              | if .filename | test("\\.deb$") then
+                  "\(.sha256sum) \(.filename | sub("authelia_"; "authelia_" + $tag + "_"))"
+                else
+                  "\(.sha256sum) \(.filename | sub("authelia-"; "authelia-" + $tag + "-"))"
+                end
             ' | base64 -w0)
 
           echo "hashes=${hashes}" >> "${GITHUB_OUTPUT}"
@@ -57,7 +74,7 @@ jobs:
       contents: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
-      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      base64-subjects: "${{ needs.buildkite.outputs.hashes }}"
       provenance-name: authelia.intoto.jsonl
       upload-assets: true
 ...


### PR DESCRIPTION
This change fixes an incorrect workflow reference and attempts to check the build state before the initial polling of 10 minutes.

Closes #10190.