### PR TITLE
feat: allow asset override to define custom descriptions for scopes

### DIFF
--- a/web/src/services/ConsentOpenIDConnect.ts
+++ b/web/src/services/ConsentOpenIDConnect.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { useTranslation } from "react-i18next";
 
 import { ScopeDescription } from "@components/OpenIDConnect";
 import { FlowID, UserCode } from "@constants/SearchParams";
@@ -88,12 +89,17 @@ export function postConsentResponseReject(clientID: string, flowID?: string, sub
     return Post<ConsentPostResponseBody>(OpenIDConnectConsentPath, body);
 }
 
-export function formatScope(scope: string, fallback: string): string {
-    if (!scope.startsWith("scopes.") && scope !== "") {
-        return scope;
-    } else {
-        return ScopeDescription(fallback);
+export function formatScope(scope: string): string {
+    const { t: translate } = useTranslation(["consent"]);
+
+    const translationKey = `scopes.${scope}`;
+    const translatedValue = translate(translationKey);
+
+    if (translatedValue && translatedValue !== translationKey) {
+        return translatedValue;
     }
+
+    return scope.replace(/[_:.-]/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
 }
 
 export function formatClaim(claim: string, fallback: string): string {

--- a/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormScopes.tsx
+++ b/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormScopes.tsx
@@ -25,7 +25,7 @@ const DecisionFormScopes: React.FC<Props> = (props: Props) => {
                         <Tooltip key={scope} title={translate("Scope", { name: scope })}>
                             <ListItem id={"scope-" + scope} key={scope} dense>
                                 <ListItemIcon>{ScopeAvatar(scope)}</ListItemIcon>
-                                <ListItemText primary={formatScope(translate(`scopes.${scope}`), scope)} />
+                                <ListItemText primary={formatScope(scope)} />
                             </ListItem>
                         </Tooltip>
                     ))}


### PR DESCRIPTION
This allows descriptions to be defined for custom scopes by using locale-asset overrides.
`locales/en/consent.json`:
```json
{
	"scopes": {
		"address": "Access your address",
		"authelia.bearer.authz": "Access protected resources logged in as you",
		"email": "Access your email addresses",
		"groups": "Access your group memberships",
		"offline_access": "Automatically refresh these permissions without user interaction",
		"openid": "Use OpenID to verify your identity",
		"phone": "Access your phone number",
		"profile": "Access your profile information",
+		"testing": "This scope is for testing!!!"
	}
}
```
This adds a description for the `testing` scope as shown below.

<img width="669" height="724" alt="image" src="https://github.com/user-attachments/assets/a83f5286-7876-4566-80ab-74fb14f9d9b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Scope names in the Consent portal are now localized based on your selected language.
  - When a translation isn’t available, scope names are automatically humanized for clearer, readable titles.

- Refactor
  - Unified scope label handling to rely on the translation system, improving consistency across screens and simplifying display logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->