### PR TITLE
test(commands): regex to validate build-info unit test

### DIFF
--- a/internal/commands/build_info_test.go
+++ b/internal/commands/build_info_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,32 +10,30 @@ import (
 
 func TestRunBuildInfo(t *testing.T) {
 	testCases := []struct {
-		name     string
-		verbose  bool
-		expected string
-		err      string
+		name    string
+		verbose bool
+		err     string
 	}{
 		{
 			"Successful",
 			false,
-			"Last Tag: unknown\nState: untagged dirty\nBranch: master\nCommit: unknown\nBuild Number: 0\nBuild OS: linux\nBuild Arch: amd64\nBuild Compiler: gc\nBuild Date: \nDevelopment: false\nExtra: \n\nGo:\n    Version: go1.25.0\n    Module Path: github.com/authelia/authelia/v4\n    Executable Path: github.com/authelia/authelia/v4/internal/commands.test\n",
 			"",
 		},
 		{
 			"SuccessfulVerbose",
 			true,
-			"Last Tag: unknown\nState: untagged dirty\nBranch: master\nCommit: unknown\nBuild Number: 0\nBuild OS: linux\nBuild Arch: amd64\nBuild Compiler: gc\nBuild Date: \nDevelopment: false\nExtra: \n\nGo:\n    Version: go1.25.0\n    Module Path: github.com/authelia/authelia/v4\n    Executable Path: github.com/authelia/authelia/v4/internal/commands.test\n",
 			"",
 		},
 	}
 
+	r := regexp.MustCompile(`^Last Tag: (v\d+\.\d+\.\d+|unknown)\nState: (tagged|untagged) (clean|dirty)\nBranch: [^\s\n]+\nCommit: ([0-9a-f]{40}|unknown)\nBuild Number: \d+\nBuild OS: (linux|darwin|windows|freebsd)\nBuild Arch: (amd64|arm|arm64)\nBuild Compiler: gc\nBuild Date: \nDevelopment: (true|false)\nExtra: \n\nGo:\n\s+Version: go\d+\.\d+\.\d+\n\s+Module Path: github.com/authelia/authelia/v4\n\s+Executable Path: github.com/authelia/authelia/v4/internal/commands.test`)
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			buf := new(bytes.Buffer)
-
 			err := runBuildInfo(buf, tc.verbose)
 
-			assert.Contains(t, buf.String(), tc.expected)
+			assert.Regexp(t, r, buf.String())
 
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened build info command tests by validating the entire output format with regular expressions, improving robustness against dynamic fields.
  * Consolidated test scaffolding for efficiency while preserving existing scenarios (standard and verbose outputs).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->