### PR TITLE
ci: fix missing slsa provenance

### DIFF
--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -53,7 +53,7 @@ jobs:
           echo "Artifact metadata retrieved"
 
           hashes=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" \
-            "${build_url}/artifacts" | jq -r '
+            "${build_url}/artifacts?per_page=100" | jq -r '
               .[]
               | select(.filename | test("\\.(deb|tar\\.gz)$"))
               | "\(.sha256sum) \(.filename)"


### PR DESCRIPTION
This change fixes the number of artifacts returned by the Buildkite API to ensure the relevant artifacts aren't missed in the SLSA Provenance step.