### PR TITLE
refactor(authentication): disable generated user for file backend

### DIFF
--- a/internal/authentication/users_database.template.yml
+++ b/internal/authentication/users_database.template.yml
@@ -8,7 +8,7 @@
 
 users:
   authelia:
-    disabled: false
+    disabled: true
     displayname: "Test User"
     password: "$argon2id$v=19$m=32768,t=1,p=8$eUhVT1dQa082YVk2VUhDMQ$E8QI4jHbUBt3EdsU1NFDu4Bq5jObKNx7nBKSn1EYQxk"  # Password is 'authelia'
     email: authelia@authelia.com


### PR DESCRIPTION
When the file based backend cannot be found and is therefore auto-generated by Authelia, it uses a template to bootstrap the instance for administrators. This change disables said generated user by default.