### PR TITLE
fix(web): dynamically set html lang tag

### DIFF
--- a/.trufflehog
+++ b/.trufflehog
@@ -1,3 +1,4 @@
+^authelia$
 ^.git\/
 ^.github\/workflows\/.*\.yml
 ^.idea\/

--- a/internal/suites/suite_multi_cookie_domain_test.go
+++ b/internal/suites/suite_multi_cookie_domain_test.go
@@ -19,15 +19,15 @@ type MultiCookieDomainSuite struct {
 }
 
 func (s *MultiCookieDomainSuite) TestMultiCookieDomainFirstDomainScenario() {
-	suite.Run(s.T(), NewMultiCookieDomainScenario(BaseDomain, Example2DotCom, []string{"authelia_session"}, true))
+	suite.Run(s.T(), NewMultiCookieDomainScenario(BaseDomain, Example2DotCom, []string{"authelia_session", "language"}, true))
 }
 
 func (s *MultiCookieDomainSuite) TestMultiCookieDomainSecondDomainScenario() {
-	suite.Run(s.T(), NewMultiCookieDomainScenario(Example2DotCom, BaseDomain, []string{"example2_session"}, false))
+	suite.Run(s.T(), NewMultiCookieDomainScenario(Example2DotCom, BaseDomain, []string{"example2_session", "language"}, false))
 }
 
 func (s *MultiCookieDomainSuite) TestMultiCookieDomainThirdDomainScenario() {
-	suite.Run(s.T(), NewMultiCookieDomainScenario(Example3DotCom, BaseDomain, []string{"authelia_session"}, true))
+	suite.Run(s.T(), NewMultiCookieDomainScenario(Example3DotCom, BaseDomain, []string{"authelia_session", "language"}, true))
 }
 
 func TestMultiCookieDomainSuite(t *testing.T) {

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -87,6 +87,6 @@ export default [
     prettierPluginRecommended,
 
     {
-        ignores: ["build/*", "coverage/*", "!**/.*.js"],
+        ignores: [".pnpm-store", "build", "coverage", "!**/.*.js"],
     },
 ];

--- a/web/index.html
+++ b/web/index.html
@@ -6,10 +6,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Authelia login portal for your apps" />
   <link rel="manifest" href="/manifest.json" />
   <link rel="icon" href="/favicon.ico" />
-  <title>Login - Authelia</title>
 </head>
 
 <body
@@ -25,7 +23,7 @@
     data-theme="%VITE_THEME%"
 >
   <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
+  <div id="root" translate="no"></div>
   <script type="module" src="/src/index.tsx"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,29 +1,30 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <base href="{{ .BaseURL }}" />
-  <meta property="csp-nonce" content="{{ .CSPNonce }}" />
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#000000" />
-  <link rel="manifest" href="/manifest.json" />
-  <link rel="icon" href="/favicon.ico" />
-</head>
+<!doctype html>
+<html lang="{{ .Language }}">
+    <head>
+        <base href="{{ .BaseURL }}" />
+        <meta property="csp-nonce" content="{{ .CSPNonce }}" />
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
+        <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" href="/favicon.ico" />
+        <title></title>
+    </head>
 
-<body
-    data-basepath="%VITE_BASEPATH%"
-    data-duoselfenrollment="%VITE_DUO_SELF_ENROLLMENT%"
-    data-logooverride="%VITE_LOGO_OVERRIDE%"
-    data-privacypolicyurl="%VITE_PRIVACY_POLICY_URL%"
-    data-privacypolicyaccept="%VITE_PRIVACY_POLICY_ACCEPT%"
-    data-passkeylogin="%VITE_PASSKEY_LOGIN%"
-    data-rememberme="%VITE_REMEMBER_ME%"
-    data-resetpassword="%VITE_RESET_PASSWORD%"
-    data-resetpasswordcustomurl="%VITE_RESET_PASSWORD_CUSTOM_URL%"
-    data-theme="%VITE_THEME%"
->
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root" translate="no"></div>
-  <script type="module" src="/src/index.tsx"></script>
-</body>
+    <body
+        data-basepath="%VITE_BASEPATH%"
+        data-duoselfenrollment="%VITE_DUO_SELF_ENROLLMENT%"
+        data-logooverride="%VITE_LOGO_OVERRIDE%"
+        data-privacypolicyurl="%VITE_PRIVACY_POLICY_URL%"
+        data-privacypolicyaccept="%VITE_PRIVACY_POLICY_ACCEPT%"
+        data-passkeylogin="%VITE_PASSKEY_LOGIN%"
+        data-rememberme="%VITE_REMEMBER_ME%"
+        data-resetpassword="%VITE_RESET_PASSWORD%"
+        data-resetpasswordcustomurl="%VITE_RESET_PASSWORD_CUSTOM_URL%"
+        data-theme="%VITE_THEME%"
+    >
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        <div id="root"></div>
+        <script type="module" src="/src/index.tsx"></script>
+    </body>
 </html>

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -27,8 +27,10 @@ i18n.use(Backend)
     .use(initReactI18next)
     .init({
         detection: {
-            order: ["querystring", "localStorageCustom", "navigator"],
-            lookupQuerystring: "lng",
+            order: ["localStorageCustom", "navigator"],
+            caches: ["cookie"],
+            cookieOptions: { path: "/", sameSite: "strict", secure: true },
+            lookupCookie: "language",
             lookupLocalStorage: LocalStorageLanguageCurrent,
         },
         backend: {


### PR DESCRIPTION
This change dynamically sets the HTML `lang` tag based on the selected language of the Authelia portal.
This resolves issues relating to incorrect automatic translations if enabled within the browser, and should support screen readers as expected.

Fixes #8729.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now respects a user-selected language via cookie across server-rendered pages and the web client.
  * Page language attribute set dynamically for improved localization.

* **Improvements**
  * Language detection now prioritizes saved preference and browser settings.
  * Updated document declaration to modern doctype and removed page title/meta description in the head.

* **Chores**
  * Expanded secret-scanning rules and adjusted lint ignore patterns.

* **Tests**
  * Tests updated to include the language cookie.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->