### PR TITLE
refactor(web): data-1p-ignore on buttons

### DIFF
--- a/internal/templates/src/emails/IdentityVerificationJWT.tsx
+++ b/internal/templates/src/emails/IdentityVerificationJWT.tsx
@@ -80,6 +80,7 @@ export const IdentityVerificationJWT = ({
                                 id="link"
                                 href={link}
                                 className="bg-[#1976d2] rounded text-white text-[12px] font-semibold no-underline text-center px-5 py-3"
+								data-1p-ignore
                             >
                                 {linkText}
                             </Button>
@@ -121,6 +122,7 @@ export const IdentityVerificationJWT = ({
                                 id="link-revoke"
                                 href={revocationLinkURL}
                                 className="bg-[#f50057] rounded text-white text-[12px] font-semibold no-underline text-center px-5 py-3"
+								data-1p-ignore
                             >
                                 {revocationLinkText}
                             </Button>

--- a/internal/templates/src/emails/IdentityVerificationOTC.tsx
+++ b/internal/templates/src/emails/IdentityVerificationOTC.tsx
@@ -107,6 +107,7 @@ export const IdentityVerificationOTC = ({
                                 id="link-revoke"
                                 href={revocationLinkURL}
                                 className="bg-[#f50057] rounded text-white text-[12px] font-semibold no-underline text-center px-5 py-3"
+								data-1p-ignore
                             >
                                 {revocationLinkText}
                             </Button>

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -56,6 +56,7 @@ const CopyButton = function (props: Props) {
             startIcon={
                 isCopying ? <CircularProgress color="inherit" size={20} /> : isCopied ? <Check /> : <ContentCopy />
             }
+            data-1p-ignore
         >
             {isCopied && props.childrenCopied ? props.childrenCopied : props.children}
         </Button>
@@ -67,6 +68,7 @@ const CopyButton = function (props: Props) {
                 onClick={isCopying ? undefined : handleCopyToClipboard}
                 sx={props.sx}
                 fullWidth={props.fullWidth}
+                data-1p-ignore
                 startIcon={
                     isCopying ? <CircularProgress color="inherit" size={20} /> : isCopied ? <Check /> : <ContentCopy />
                 }

--- a/web/src/components/HomeButton.tsx
+++ b/web/src/components/HomeButton.tsx
@@ -18,7 +18,7 @@ const HomeButton = function (props: Props) {
     };
 
     return (
-        <Button id={"home-button"} color={"secondary"} onClick={handleHomeClick}>
+        <Button id={"home-button"} color={"secondary"} onClick={handleHomeClick} data-1p-ignore>
             {translate("Home")}
         </Button>
     );

--- a/web/src/components/PrivacyPolicyDrawer.tsx
+++ b/web/src/components/PrivacyPolicyDrawer.tsx
@@ -48,6 +48,7 @@ const PrivacyPolicyDrawer = function (props: DrawerProps) {
                         onClick={() => {
                             setAccepted(true);
                         }}
+                        data-1p-ignore
                     >
                         {translate("Accept")}
                     </Button>

--- a/web/src/components/SignOutButton.tsx
+++ b/web/src/components/SignOutButton.tsx
@@ -23,12 +23,12 @@ const SignOutButton = function (props: Props) {
 
     return props.tooltip ? (
         <Tooltip title={props.tooltip}>
-            <Button id={props.id} color={"secondary"} onClick={handleSignOutClick}>
+            <Button id={props.id} color={"secondary"} onClick={handleSignOutClick} data-1p-ignore>
                 {translate(props.text)}
             </Button>
         </Tooltip>
     ) : (
-        <Button id={props.id} color={"secondary"} onClick={handleSignOutClick}>
+        <Button id={props.id} color={"secondary"} onClick={handleSignOutClick} data-1p-ignore>
             {translate(props.text)}
         </Button>
     );

--- a/web/src/components/WebAuthnTryIcon.tsx
+++ b/web/src/components/WebAuthnTryIcon.tsx
@@ -45,7 +45,7 @@ const WebAuthnTryIcon = function (props: Props) {
             icon={<FailureIcon />}
             className={props.webauthnTouchState === WebAuthnTouchState.Failure ? undefined : "hidden"}
         >
-            <Button color="secondary" onClick={handleRetryClick}>
+            <Button color="secondary" onClick={handleRetryClick} data-1p-ignore>
                 {translate("Retry")}
             </Button>
         </IconWithContext>

--- a/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormView.tsx
+++ b/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormView.tsx
@@ -459,6 +459,7 @@ const DecisionFormView: React.FC<Props> = (props: Props) => {
                                                         onClick={handleAcceptConsent}
                                                         color={"primary"}
                                                         variant={"contained"}
+                                                        data-1p-ignore
                                                         endIcon={loadingAccept ? <CircularProgress size={20} /> : null}
                                                     >
                                                         {translate("Accept", { ns: "portal" })}
@@ -476,6 +477,7 @@ const DecisionFormView: React.FC<Props> = (props: Props) => {
                                                         onClick={handleRejectConsent}
                                                         color={"secondary"}
                                                         variant={"contained"}
+                                                        data-1p-ignore
                                                         endIcon={loadingReject ? <CircularProgress size={20} /> : null}
                                                     >
                                                         {translate("Deny", { ns: "portal" })}

--- a/web/src/views/ConsentPortal/OpenIDConnect/DeviceAuthorizationFormView.tsx
+++ b/web/src/views/ConsentPortal/OpenIDConnect/DeviceAuthorizationFormView.tsx
@@ -109,6 +109,7 @@ const DeviceAuthorizationFormView: React.FC<Props> = (props: Props) => {
                                     fullWidth
                                     onClick={() => handleCode(code)}
                                     disabled={code === ""}
+                                    data-1p-ignore
                                 >
                                     {translate("Confirm", { ns: "settings" })}
                                 </Button>

--- a/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
+++ b/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
@@ -348,7 +348,8 @@ const FirstFactorForm = function (props: Props) {
                             id="sign-in-button"
                             variant="contained"
                             color="primary"
-                            fullWidth={true}
+                            fullWidth
+                            data-1p-ignore
                             endIcon={loading ? <CircularProgress size={20} /> : null}
                             disabled={disabled}
                             onClick={handleSignIn}

--- a/web/src/views/LoginPortal/FirstFactor/PasskeyForm.tsx
+++ b/web/src/views/LoginPortal/FirstFactor/PasskeyForm.tsx
@@ -144,6 +144,7 @@ const PasskeyForm = function (props: Props) {
                     onClick={handleSignIn}
                     startIcon={<PasskeyIcon />}
                     disabled={props.disabled}
+                    data-1p-ignore
                     endIcon={loading ? <CircularProgress size={20} /> : null}
                 >
                     {translate("Sign in with a passkey")}

--- a/web/src/views/LoginPortal/SecondFactor/DeviceSelectionContainer.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/DeviceSelectionContainer.tsx
@@ -85,7 +85,7 @@ const DefaultDeviceSelectionContainer = function (props: Props) {
     return (
         <Container>
             {container}
-            <Button color="primary" onClick={props.onBack} id="device-selection-back">
+            <Button color="primary" onClick={props.onBack} id="device-selection-back" data-1p-ignore>
                 back
             </Button>
         </Container>
@@ -112,6 +112,7 @@ const DeviceItem = function (props: DeviceItemProps) {
                 classes={{ root: classes.buttonRoot }}
                 variant="contained"
                 onClick={props.onSelect}
+                data-1p-ignore
             >
                 <Box className={classes.icon}>
                     <PushNotificationIcon width={32} height={32} />
@@ -144,6 +145,7 @@ const MethodItem = function (props: MethodItemProps) {
                 classes={{ root: classes.buttonRoot }}
                 variant="contained"
                 onClick={props.onSelect}
+                data-1p-ignore
             >
                 <Box className={classes.icon}>
                     <PushNotificationIcon width={32} height={32} />

--- a/web/src/views/LoginPortal/SecondFactor/MethodSelectionDialog.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/MethodSelectionDialog.tsx
@@ -59,7 +59,7 @@ const MethodSelectionDialog = function (props: Props) {
                 </Grid>
             </DialogContent>
             <DialogActions>
-                <Button color="primary" onClick={props.onClose}>
+                <Button color="primary" onClick={props.onClose} data-1p-ignore>
                     {translate("Close")}
                 </Button>
             </DialogActions>
@@ -86,6 +86,7 @@ function MethodItem(props: MethodItemProps) {
                 classes={{ root: classes.buttonRoot }}
                 variant="contained"
                 onClick={props.onClick}
+                data-1p-ignore
             >
                 <Box className={classes.icon}>{props.icon}</Box>
                 <Box>

--- a/web/src/views/LoginPortal/SecondFactor/PasswordForm.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/PasswordForm.tsx
@@ -173,10 +173,11 @@ const PasswordForm = function (props: Props) {
                         id="sign-in-button"
                         variant="contained"
                         color="primary"
-                        fullWidth={true}
+                        fullWidth
                         endIcon={loading ? <CircularProgress size={20} /> : null}
                         disabled={loading}
                         onClick={handleSignIn}
+                        data-1p-ignore
                     >
                         {translate("Authenticate", { ns: "settings" })}
                     </Button>

--- a/web/src/views/LoginPortal/SecondFactor/PushNotificationMethod.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/PushNotificationMethod.tsx
@@ -275,7 +275,7 @@ const PushNotificationMethod = function (props: Props) {
         >
             <Box className={classes.icon}>{icon}</Box>
             <Box className={state !== State.Failure ? "hidden" : ""}>
-                <Button color="secondary" onClick={handleSignIn}>
+                <Button color="secondary" onClick={handleSignIn} data-1p-ignore>
                     {translate("Retry")}
                 </Button>
             </Box>

--- a/web/src/views/LoginPortal/SecondFactor/SecondFactorForm.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/SecondFactorForm.tsx
@@ -109,7 +109,12 @@ const SecondFactorForm = function (props: Props) {
                     {flowPresent ? <SwitchUserButton /> : null}
                     {showMethods ? " | " : null}
                     {showMethods ? (
-                        <Button id={"methods-button"} color="secondary" onClick={handleMethodSelectionClick}>
+                        <Button
+                            id={"methods-button"}
+                            color="secondary"
+                            onClick={handleMethodSelectionClick}
+                            data-1p-ignore
+                        >
                             {translate("Methods")}
                         </Button>
                     ) : null}

--- a/web/src/views/ResetPassword/ResetPasswordStep1.tsx
+++ b/web/src/views/ResetPassword/ResetPasswordStep1.tsx
@@ -113,6 +113,7 @@ const ResetPasswordStep1 = function () {
                                 variant="contained"
                                 disabled={loading || rateLimited}
                                 color="primary"
+                                data-1p-ignore
                                 fullWidth
                                 onClick={handleResetClick}
                                 startIcon={loading ? <CircularProgress color="inherit" size={20} /> : <></>}
@@ -127,6 +128,7 @@ const ResetPasswordStep1 = function () {
                             variant="contained"
                             disabled={loading}
                             color="primary"
+                            data-1p-ignore
                             fullWidth
                             onClick={handleCancelClick}
                         >

--- a/web/src/views/ResetPassword/ResetPasswordStep2.tsx
+++ b/web/src/views/ResetPassword/ResetPasswordStep2.tsx
@@ -218,6 +218,7 @@ const ResetPasswordStep2 = function () {
                             disabled={formDisabled}
                             onClick={handleResetClick}
                             className={classes.fullWidth}
+                            data-1p-ignore
                         >
                             {translate("Reset")}
                         </Button>
@@ -230,6 +231,7 @@ const ResetPasswordStep2 = function () {
                             name="password2"
                             onClick={handleCancelClick}
                             className={classes.fullWidth}
+                            data-1p-ignore
                         >
                             {translate("Cancel")}
                         </Button>

--- a/web/src/views/Settings/Common/IdentityVerificationDialog.tsx
+++ b/web/src/views/Settings/Common/IdentityVerificationDialog.tsx
@@ -219,6 +219,7 @@ const IdentityVerificationDialog = function (props: Props) {
                         color={"error"}
                         disabled={loading}
                         onClick={handleCancelled}
+                        data-1p-ignore
                     >
                         {translate("Cancel")}
                     </Button>
@@ -229,6 +230,7 @@ const IdentityVerificationDialog = function (props: Props) {
                         disabled={loading}
                         startIcon={loading ? <CircularProgress color="inherit" size={20} /> : undefined}
                         onClick={handleSubmit}
+                        data-1p-ignore
                     >
                         {translate("Verify")}
                     </Button>

--- a/web/src/views/Settings/Common/SecondFactorDialog.tsx
+++ b/web/src/views/Settings/Common/SecondFactorDialog.tsx
@@ -172,7 +172,7 @@ const SecondFactorDialog = function (props: Props) {
                     <Stack alignContent={"center"} justifyContent={"center"} alignItems={"center"} spacing={2} my={8}>
                         {props.elevation.can_skip_second_factor ? (
                             <Fragment>
-                                <Button variant={"outlined"} onClick={handleOneTimeCode}>
+                                <Button variant={"outlined"} onClick={handleOneTimeCode} data-1p-ignore>
                                     {translate("Email One-Time Code")}
                                 </Button>
                                 <Divider />
@@ -181,17 +181,17 @@ const SecondFactorDialog = function (props: Props) {
                             </Fragment>
                         ) : null}
                         {props.info.has_totp ? (
-                            <Button variant={"outlined"} onClick={handleClickOneTimePassword}>
+                            <Button variant={"outlined"} onClick={handleClickOneTimePassword} data-1p-ignore>
                                 {translate("One-Time Password")}
                             </Button>
                         ) : null}
                         {props.info.has_webauthn && browserSupportsWebAuthn() ? (
-                            <Button variant={"outlined"} onClick={handleClickWebAuthn}>
+                            <Button variant={"outlined"} onClick={handleClickWebAuthn} data-1p-ignore>
                                 {translate("WebAuthn")}
                             </Button>
                         ) : null}
                         {props.info.has_duo ? (
-                            <Button variant={"outlined"} onClick={handleClickMobilePush}>
+                            <Button variant={"outlined"} onClick={handleClickMobilePush} data-1p-ignore>
                                 {translate("Mobile Push")}
                             </Button>
                         ) : null}
@@ -227,7 +227,13 @@ const SecondFactorDialog = function (props: Props) {
                 )}
             </DialogContent>
             <DialogActions>
-                <Button variant={"outlined"} color={"error"} disabled={loading} onClick={handleCancelled}>
+                <Button
+                    variant={"outlined"}
+                    color={"error"}
+                    disabled={loading}
+                    onClick={handleCancelled}
+                    data-1p-ignore
+                >
                     {translate("Cancel")}
                 </Button>
             </DialogActions>

--- a/web/src/views/Settings/Common/SecondFactorMethodMobilePush.tsx
+++ b/web/src/views/Settings/Common/SecondFactorMethodMobilePush.tsx
@@ -202,7 +202,7 @@ const SecondFactorMethodMobilePush = function (props: Props) {
             <Box className={classes.container}>
                 <Box className={classes.icon}>{icon}</Box>
                 <Box className={state !== State.Failure ? "hidden" : ""}>
-                    <Button color="secondary" onClick={handleDuoPush}>
+                    <Button color="secondary" onClick={handleDuoPush} data-1p-ignore>
                         Retry
                     </Button>
                 </Box>

--- a/web/src/views/Settings/Security/ChangePasswordDialog.tsx
+++ b/web/src/views/Settings/Security/ChangePasswordDialog.tsx
@@ -284,7 +284,7 @@ const ChangePasswordDialog = (props: Props) => {
                 </FormControl>
             </DialogContent>
             <DialogActions>
-                <Button id={"password-change-dialog-cancel"} color={"error"} onClick={handleClose}>
+                <Button id={"password-change-dialog-cancel"} color={"error"} onClick={handleClose} data-1p-ignore>
                     {translate("Cancel")}
                 </Button>
                 <Button
@@ -293,6 +293,7 @@ const ChangePasswordDialog = (props: Props) => {
                     onClick={handlePasswordChange}
                     disabled={!(oldPassword.length && newPassword.length && repeatNewPassword.length) || loading}
                     startIcon={loading ? <CircularProgress color="inherit" size={20} /> : <></>}
+                    data-1p-ignore
                 >
                     {translate("Submit")}
                 </Button>

--- a/web/src/views/Settings/Security/SecurityView.tsx
+++ b/web/src/views/Settings/Security/SecurityView.tsx
@@ -133,6 +133,7 @@ const SettingsView = function () {
                 sx={{ p: 1, width: "100%" }}
                 onClick={handleChangePassword}
                 disabled={configuration?.password_change_disabled || false}
+                data-1p-ignore
             >
                 {translate("Change Password")}
             </Button>

--- a/web/src/views/Settings/TwoFactorAuthentication/DeleteDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/DeleteDialog.tsx
@@ -29,7 +29,7 @@ const DeleteDialog = function (props: Props) {
                 <DialogContentText my={2}>{props.text}</DialogContentText>
             </DialogContent>
             <DialogActions>
-                <Button id={"dialog-cancel"} onClick={handleCancel}>
+                <Button id={"dialog-cancel"} onClick={handleCancel} data-1p-ignore>
                     {translate("Cancel")}
                 </Button>
                 <Button
@@ -38,6 +38,7 @@ const DeleteDialog = function (props: Props) {
                     color={"error"}
                     startIcon={<Delete />}
                     onClick={handleDelete}
+                    data-1p-ignore
                 >
                     {translate("Remove")}
                 </Button>

--- a/web/src/views/Settings/TwoFactorAuthentication/OneTimePasswordInformationDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/OneTimePasswordInformationDialog.tsx
@@ -89,7 +89,7 @@ const OneTimePasswordInformationDialog = function (props: Props) {
                 )}
             </DialogContent>
             <DialogActions>
-                <Button id={"dialog-close"} onClick={props.handleClose}>
+                <Button id={"dialog-close"} onClick={props.handleClose} data-1p-ignore>
                     {translate("Close")}
                 </Button>
             </DialogActions>

--- a/web/src/views/Settings/TwoFactorAuthentication/OneTimePasswordPanel.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/OneTimePasswordPanel.tsx
@@ -212,6 +212,7 @@ const OneTimePasswordPanel = function (props: Props) {
                                     endIcon={
                                         dialogRegisterOpening ? <CircularProgress color="inherit" size={20} /> : null
                                     }
+                                    data-1p-ignore
                                 >
                                     {translate("Add")}
                                 </Button>

--- a/web/src/views/Settings/TwoFactorAuthentication/OneTimePasswordRegisterDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/OneTimePasswordRegisterDialog.tsx
@@ -455,7 +455,7 @@ const OneTimePasswordRegisterDialog = function (props: Props) {
                                         tooltip={translate("Click to Copy")}
                                         value={secretURL}
                                         childrenCopied={translate("Copied")}
-                                        fullWidth={true}
+                                        fullWidth
                                     >
                                         {translate("URI")}
                                     </CopyButton>
@@ -465,7 +465,7 @@ const OneTimePasswordRegisterDialog = function (props: Props) {
                                         tooltip={translate("Click to Copy")}
                                         value={secretValue}
                                         childrenCopied={translate("Copied")}
-                                        fullWidth={true}
+                                        fullWidth
                                     >
                                         {translate("Secret")}
                                     </CopyButton>
@@ -526,7 +526,7 @@ const OneTimePasswordRegisterDialog = function (props: Props) {
     }
 
     return (
-        <Dialog open={props.open} onClose={handleOnClose} fullWidth={true}>
+        <Dialog open={props.open} onClose={handleOnClose} fullWidth>
             <DialogTitle>{translate("Register {{item}}", { item: translate("One-Time Password") })}</DialogTitle>
             <DialogContent>
                 <DialogContentText sx={{ mb: 3 }}>
@@ -563,10 +563,11 @@ const OneTimePasswordRegisterDialog = function (props: Props) {
                     color={"primary"}
                     onClick={handleSetStepPrevious}
                     disabled={activeStep === 0}
+                    data-1p-ignore
                 >
                     {translate("Previous")}
                 </Button>
-                <Button id={"dialog-cancel"} color={"error"} onClick={handleClose}>
+                <Button id={"dialog-cancel"} color={"error"} onClick={handleClose} data-1p-ignore>
                     {translate("Cancel")}
                 </Button>
                 <Button
@@ -574,6 +575,7 @@ const OneTimePasswordRegisterDialog = function (props: Props) {
                     color={"primary"}
                     onClick={handleSetStepNext}
                     disabled={activeStep === steps.length - 1}
+                    data-1p-ignore
                 >
                     {translate("Next")}
                 </Button>

--- a/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialEditDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialEditDialog.tsx
@@ -129,10 +129,10 @@ const WebAuthnCredentialEditDialog = function (props: Props) {
                 />
             </DialogContent>
             <DialogActions>
-                <Button id={"dialog-cancel"} onClick={handleCancel}>
+                <Button id={"dialog-cancel"} onClick={handleCancel} data-1p-ignore>
                     {translate("Cancel")}
                 </Button>
-                <Button id={"dialog-update"} onClick={handleUpdate}>
+                <Button id={"dialog-update"} onClick={handleUpdate} data-1p-ignore>
                     {translate("Update")}
                 </Button>
             </DialogActions>

--- a/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialInformationDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialInformationDialog.tsx
@@ -157,7 +157,7 @@ const WebAuthnCredentialInformationDialog = function (props: Props) {
                         </CopyButton>
                     </Fragment>
                 ) : undefined}
-                <Button id={"dialog-close"} onClick={props.handleClose}>
+                <Button id={"dialog-close"} onClick={props.handleClose} data-1p-ignore>
                     {translate("Close")}
                 </Button>
             </DialogActions>

--- a/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialRegisterDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialRegisterDialog.tsx
@@ -253,7 +253,7 @@ const WebAuthnCredentialRegisterDialog = function (props: Props) {
     };
 
     return (
-        <Dialog open={props.open} onClose={handleOnClose} maxWidth={"xs"} fullWidth={true}>
+        <Dialog open={props.open} onClose={handleOnClose} maxWidth={"xs"} fullWidth>
             <DialogTitle>{translate("Register {{item}}", { item: translate("WebAuthn Credential") })}</DialogTitle>
             <DialogContent>
                 <DialogContentText sx={{ mb: 3 }}>
@@ -286,6 +286,7 @@ const WebAuthnCredentialRegisterDialog = function (props: Props) {
                     color={activeStep === 1 && state !== WebAuthnTouchState.Failure ? "primary" : "error"}
                     disabled={activeStep === 1 && state !== WebAuthnTouchState.Failure}
                     onClick={handleClose}
+                    data-1p-ignore
                 >
                     {translate("Cancel")}
                 </Button>
@@ -297,6 +298,7 @@ const WebAuthnCredentialRegisterDialog = function (props: Props) {
                         onClick={async () => {
                             handleNext();
                         }}
+                        data-1p-ignore
                     >
                         {translate("Next")}
                     </Button>

--- a/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialsPanel.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialsPanel.tsx
@@ -253,6 +253,7 @@ const WebAuthnCredentialsPanel = function (props: Props) {
                                 onClick={handleRegister}
                                 disabled={dialogRegisterOpening || dialogRegisterOpen}
                                 endIcon={dialogRegisterOpening ? <CircularProgress color="inherit" size={20} /> : null}
+                                data-1p-ignore
                             >
                                 {translate("Add")}
                             </Button>


### PR DESCRIPTION
This introduces the data-1p-ignore on all buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Added UI data attributes to buttons across login, second-factor, reset password, consent, settings, and related dialogs, as well as email templates and common components (Copy, Home, Sign Out, Privacy Policy).
  - Simplified boolean prop syntax (fullWidth) in select dialogs and forms; no visual or behavioral changes.

- Chores
  - Consistent attribute application to action buttons (Accept, Deny, Confirm, Retry, Add, Cancel, Update, Next/Previous/Close) for uniform UI markup across portals and settings views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->