### PR TITLE
ci: add sbom with goreleaser for authelia binaries and frontend

### DIFF
--- a/.buildkite/annotations/artifacts.sh
+++ b/.buildkite/annotations/artifacts.sh
@@ -2,13 +2,21 @@
 set -euo pipefail
 
 artifact_links() {
-  for EXT in "" ".sha256" ".sha256.sig"; do
+  EXTENSIONS=("")
+
+  if [[ ${1} == "checksums.sha256" ]]; then
+    EXTENSIONS+=(".sig")
+  elif [[ ${1} =~ \.tar.gz$ ]]; then
+    EXTENSIONS+=(".cdx.json" ".spdx.json")
+  fi
+
+  for EXT in "${EXTENSIONS[@]}"; do
   	echo "      <a href=\"artifact://${1}${EXT}\">${1}${EXT}</a><br>"
   done
 }
 
 ARCH=("amd64" "arm" "arm64")
-TARGETS=("${ARCH[@]}" "public_html")
+TARGETS=("${ARCH[@]}" "public_html" "checksums")
 declare -A BUILDS=(
   ["linux"]="amd64 arm arm64 amd64-musl arm-musl arm64-musl"
   ["freebsd"]="amd64"
@@ -27,6 +35,8 @@ for T in "${TARGETS[@]}"; do
 
   if [[ "${T}" == "public_html" ]]; then
     artifact_links "${PREFIX}-public_html.tar.gz"
+  elif [[ "${T}" == "checksums" ]]; then
+    artifact_links "checksums.sha256"
   else
   	for OS in "${!BUILDS[@]}"; do
   	  for B in ${BUILDS[${OS}]}; do

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -57,6 +57,7 @@ steps:
       - "*.deb"
       - "*.sha256"
       - "*.sig"
+      - "*.{c,sp}dx.json"
     key: "unit-test"
     env:
       NODE_OPTIONS: "--no-deprecation"

--- a/.buildkite/steps/ghartifacts.sh
+++ b/.buildkite/steps/ghartifacts.sh
@@ -4,8 +4,9 @@ set -eu
 artifacts=()
 
 for FILE in \
-  authelia-${BUILDKITE_TAG}-{linux-{amd64,arm,arm64,amd64-musl,arm-musl,arm64-musl},freebsd-amd64,public_html}.{tar.gz,tar.gz.sha256,tar.gz.sha256.sig} \
-  authelia_${BUILDKITE_TAG/v/}-1_{amd64,armhf,arm64}.{deb,deb.sha256,deb.sha256.sig}
+  checksums.sha256{,.sig} \
+  authelia-${BUILDKITE_TAG}-{linux-{amd64,arm,arm64,amd64-musl,arm-musl,arm64-musl},freebsd-amd64,public_html}.{tar.gz,tar.gz.{c,sp}dx.json} \
+  authelia_${BUILDKITE_TAG/v/}-1_{amd64,armhf,arm64}.deb
 do
   artifacts+=(-a "${FILE}")
 done

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -181,6 +181,35 @@ nfpms:
       signature:
         key_file: '{{ .Env.GPG_KEY_PATH }}'
 
+sboms:
+  - id: cdx-backend
+    ids: [linux-glibc, linux-musl, freebsd]
+    documents:
+      - "${artifact}.cdx.json"
+    args: ["$artifact", "-o", "cyclonedx-json=$document"]
+    disable: false
+
+  - id: spdx-backend
+    ids: [linux-glibc, linux-musl, freebsd]
+    documents:
+      - "${artifact}.spdx.json"
+    args: ["$artifact", "-o", "spdx-json=$document"]
+    disable: false
+
+  - id: cdx-frontend
+    ids: [public_html]
+    documents:
+      - "${artifact}.cdx.json"
+    args: ["../web", "--source-name", "$artifact", "-o", "cyclonedx-json=$document"]
+    disable: false
+
+  - id: spdx-frontend
+    ids: [public_html]
+    documents:
+      - "${artifact}.spdx.json"
+    args: ["../web", "--source-name", "$artifact", "-o", "spdx-json=$document"]
+    disable: false
+
 signs:
   - id: gpg
     signature: '${artifact}.sig'
@@ -191,10 +220,8 @@ signs:
       "--output", "${signature}",
       "--detach-sign", "${artifact}",
     ]
-    artifacts: all
+    artifacts: checksum
 
 checksum:
-  name_template: '{{ .ArtifactName }}.{{ .Algorithm }}'
-  algorithm: sha256
-  split: true
+  name_template: 'checksums.sha256'
 ...

--- a/cmd/authelia-scripts/cmd/build.go
+++ b/cmd/authelia-scripts/cmd/build.go
@@ -95,6 +95,7 @@ func buildAutheliaBinaryCI(xflags []string) {
 		"-v", "/buildkite/.gnupg:/tmp/.gnupg",
 		"-v", "/buildkite/.go:/tmp/go",
 		"-v", "/buildkite/.sign:/tmp/sign",
+		"-v", "/usr/local/bin/syft:/usr/local/bin/syft",
 		"-v", "/usr/local/include:/usr/local/include",
 		"authelia/crossbuild",
 		"goreleaser", "release", "--skip=publish,validate",


### PR DESCRIPTION
This change includes SBOM manifests for the Authelia backend binaries and frontend React application in CDX and SPDX formats.
This also consolidates all checksums into a single file and signature: `checksums.sha256` and `checksums.sha256.sig`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases now include a consolidated checksums artifact (checksums.sha256) with a detached signature (.sig).
  * tar.gz assets now ship with Software Bill of Materials files (CycloneDX and SPDX) alongside the tarball.

* **Changes**
  * Debian release artifacts no longer include separate checksum/signature files; only the .deb is provided.
  * Artifact links in release notes are more consistent and cover related metadata files.

* **Chores**
  * CI updated to publish the new checksums and BOM files as release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->