### PR TITLE
docs: fix bad path prefix for oidc-common links

### DIFF
--- a/docs/layouts/shortcodes/oidc-common.html
+++ b/docs/layouts/shortcodes/oidc-common.html
@@ -1,4 +1,4 @@
-{{ $faq := "../frequently-asked-questions/" }}{{ $config := "../../../configuration/identity-providers/openid-connect/" }}
+{{ $faq := "../frequently-asked-questions/" }}{{ $config := "../../../../configuration/identity-providers/openid-connect" }}
 {{- with .Get "faq" }}{{ $faq = . }}{{ end }}
 {{- with .Get "config" }}{{ $config = . }}{{ end }}
 ## Before You Begin
@@ -92,9 +92,9 @@
        [Tuning the work factors]({{ $faq }}#tuning-work-factors) guide for more information.
 3. The configuration example for Authelia:
     1. Only contains an example configuration for the client registration and you *__MUST__* also configure the required
-       elements from the [OpenID Connect 1.0 Provider Configuration]({{ printf "%s/provider.md" $config }}) guide.
+       elements from the [OpenID Connect 1.0 Provider Configuration]({{ printf "%s/provider/" $config }}) guide.
     2. Only contains a small portion of all of the available options for a registered client and users may wish to
        configure portions that are not part of this guide or configure them differently, as such it's important to
        both familiarize yourself with the other options available and the effect of each of the options configured in
-       this section by looking at the [OpenID Connect 1.0 Clients Configuration]({{ printf "%s/clients.md" $config }})
+       this section by looking at the [OpenID Connect 1.0 Clients Configuration]({{ printf "%s/clients/" $config }})
        guide.


### PR DESCRIPTION
The `$config` value points to the wrong location in the docs tree and the specific links which use the `$config` value point to `.md` files which are incorrect. This results in these two links in every client OIDC doc page to be broken and lead to 404 errors.

* Change the `$config` value to the right location and remove the trailing slash
* Change the specific links to the non `.md` suffixed values

Note that this commit is in the authelia repo instead of the authelia website repo which is where the READMEs indicate this content is meant to be. It's unclear if the READMEs are incorrect or if this file is in the incorrect location. See https://github.com/authelia/authelia/discussions/10339