### PR TITLE
docs: remove reference to authelia website repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,5 @@ representation of it.
 
 # Contributing
 
-Please:
-
-- Only edit the `/content` folder via the main Authelia [monorepo](https://github.com/authelia/authelia/tree/master/docs)
-- Edit everything else via the Authelia [website repo](https://github.com/authelia/website)
-
 See the [Documentation Contributing Guide](https://www.authelia.com/contributing/prologue/documentation-contributions/) for more
 information.


### PR DESCRIPTION
The authelia website repo is no longer used. This corrects the `docs/README.md` by removing the instructions that say to make all non `/content` changes in the authelia website repo.

See https://github.com/authelia/authelia/discussions/10339#discussioncomment-14449753 for context and https://github.com/authelia/website/pull/5 for the matching PR in the authelia website repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the inline contributing guidance from the README.
  * Retained a single link to the Documentation Contributing Guide for contribution instructions.
  * Consolidated contribution information to reduce duplication.
  * Provides a cleaner README and a consistent source for how to contribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->