### PR TITLE
docs(envoy-gateway): fix wrong syntax on SecurityPolicy

### DIFF
--- a/docs/content/integration/kubernetes/envoy/gateway.md
+++ b/docs/content/integration/kubernetes/envoy/gateway.md
@@ -74,22 +74,24 @@ spec:
       kind: 'Gateway'
       name: 'eg'
   extAuth:
+    headersToExtAuth:
+      - 'accept'
+      - 'cookie'
+      - 'authorization'
+      - 'header-authorization'
+      - 'x-forwarded-proto'
+    failOpen: false
     http:
       backendRefs:
         - name: 'authelia'
           namespace: 'default'
           port: 80
       path: '/api/authz/ext-authz/'
-      failOpen: false
-      headersToExtAuth:
-        - 'accept'
-        - 'cookie'
-        - 'authorization'
-        - 'header-authorization'
-        - 'x-forwarded-proto'
       headersToBackend:
-        - 'remote-*'
-        - 'authelia-*'
+        - Remote-User
+        - Remote-Groups
+        - Remote-Name
+        - Remote-Email
 ```
 
 #### Scoped to HTTP Route
@@ -109,22 +111,24 @@ spec:
       kind: 'HTTPRoute'
       name: 'example'
   extAuth:
+    headersToExtAuth:
+      - 'accept'
+      - 'cookie'
+      - 'authorization'
+      - 'header-authorization'
+      - 'x-forwarded-proto'
+    failOpen: false
     http:
       backendRefs:
         - name: 'authelia'
           namespace: 'default'
           port: 80
       path: '/api/authz/ext-authz/'
-      failOpen: false
-      headersToExtAuth:
-        - 'accept'
-        - 'cookie'
-        - 'authorization'
-        - 'header-authorization'
-        - 'x-forwarded-proto'
       headersToBackend:
-        - 'remote-*'
-        - 'authelia-*'
+        - Remote-User
+        - Remote-Groups
+        - Remote-Name
+        - Remote-Email
 ```
 
 ##### HTTP Route


### PR DESCRIPTION
After much trial and error i found the reason why my auth headers wasn't working.

remote-* does not seem to work, whether it did previously or not i don't know? but it doesn't any more, i also tried Remote-* incase it was case sensitive


also headersToExtAuth and failOpen belongs under extAuth not http, they fail validation being under http

```
dry-run failed: failed to create typed patch object (gateway.envoyproxy.io/v1alpha1, Kind=SecurityPolicy): .spec.extAuth.http.failOpen: field not declared in schema

dry-run failed: failed to create typed patch object (gateway.envoyproxy.io/v1alpha1, Kind=SecurityPolicy): .spec.extAuth.http.headersToExtAuth: field not declared in schema
```