### PR TITLE
feat(duo): startup check

### DIFF
--- a/internal/duo/duo.go
+++ b/internal/duo/duo.go
@@ -7,13 +7,41 @@ package duo
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
+	duoapi "github.com/duosecurity/duo_api_golang"
 	"github.com/valyala/fasthttp"
 
-	"github.com/authelia/authelia/v4/internal/middlewares"
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/session"
+	"github.com/authelia/authelia/v4/internal/utils"
 )
+
+// New returns a new Duo [Provider] given the [schema.Configuration], or nil if the Duo API is disabled.
+func New(config *schema.Configuration) Provider {
+	if config == nil || config.DuoAPI.Disable {
+		return nil
+	}
+
+	var provider BaseProvider
+
+	if utils.Dev {
+		provider = duoapi.NewDuoApi(
+			config.DuoAPI.IntegrationKey,
+			config.DuoAPI.SecretKey,
+			config.DuoAPI.Hostname, "", duoapi.SetInsecure(),
+		)
+	} else {
+		provider = duoapi.NewDuoApi(
+			config.DuoAPI.IntegrationKey,
+			config.DuoAPI.SecretKey,
+			config.DuoAPI.Hostname, "",
+		)
+	}
+
+	return &Production{BaseProvider: provider}
+}
 
 // NewDuoAPI create duo API instance.
 func NewDuoAPI(duoAPI BaseProvider) *Production {
@@ -22,8 +50,7 @@ func NewDuoAPI(duoAPI BaseProvider) *Production {
 	}
 }
 
-// Call performs a request to the DuoAPI.
-func (d *Production) Call(ctx middlewares.Context, userSession *session.UserSession, values url.Values, method string, path string) (r *Response, err error) {
+func (d *Production) call(ctx Context, userSession *session.UserSession, values url.Values, method string, path string) (r *Response, err error) {
 	var (
 		response Response
 		body     []byte
@@ -61,11 +88,31 @@ func (d *Production) Call(ctx middlewares.Context, userSession *session.UserSess
 	}
 }
 
+// StartupCheck implements the [model.StartupCheck] interface. It performs an unsigned ping request to validate
+// connectivity with the Duo API, then a signed check request to validate the configured credentials.
+func (d *Production) StartupCheck() (err error) {
+	var response *http.Response
+
+	if response, _, err = d.Call(fasthttp.MethodGet, "/auth/v2/ping", nil); err != nil {
+		return fmt.Errorf("error occurred performing duo ping request: %w", err)
+	} else if response.StatusCode != fasthttp.StatusOK {
+		return fmt.Errorf("error occurred performing duo ping request: status code %d", response.StatusCode)
+	}
+
+	if response, _, err = d.SignedCall(fasthttp.MethodGet, "/auth/v2/check", nil); err != nil {
+		return fmt.Errorf("error occurred performing duo check request: %w", err)
+	} else if response.StatusCode != fasthttp.StatusOK {
+		return fmt.Errorf("error occurred performing duo check request: status code %d", response.StatusCode)
+	}
+
+	return nil
+}
+
 // PreAuthCall performs a preauth request to the DuoAPI.
-func (d *Production) PreAuthCall(ctx middlewares.Context, userSession *session.UserSession, values url.Values) (r *PreAuthResponse, err error) {
+func (d *Production) PreAuthCall(ctx Context, userSession *session.UserSession, values url.Values) (r *PreAuthResponse, err error) {
 	var preAuthResponse PreAuthResponse
 
-	response, err := d.Call(ctx, userSession, values, fasthttp.MethodPost, "/auth/v2/preauth")
+	response, err := d.call(ctx, userSession, values, fasthttp.MethodPost, "/auth/v2/preauth")
 	if err != nil {
 		return nil, fmt.Errorf("error occurred making the preauth call to the duo api: %w", err)
 	}
@@ -78,10 +125,10 @@ func (d *Production) PreAuthCall(ctx middlewares.Context, userSession *session.U
 }
 
 // AuthCall performs an auth request to the DuoAPI.
-func (d *Production) AuthCall(ctx middlewares.Context, userSession *session.UserSession, values url.Values) (r *AuthResponse, err error) {
+func (d *Production) AuthCall(ctx Context, userSession *session.UserSession, values url.Values) (r *AuthResponse, err error) {
 	var authResponse AuthResponse
 
-	response, err := d.Call(ctx, userSession, values, fasthttp.MethodPost, "/auth/v2/auth")
+	response, err := d.call(ctx, userSession, values, fasthttp.MethodPost, "/auth/v2/auth")
 	if err != nil {
 		return nil, fmt.Errorf("error occurred making the auth call to the duo api: %w", err)
 	}

--- a/internal/duo/duo_test.go
+++ b/internal/duo/duo_test.go
@@ -40,6 +40,130 @@ func TestAPIImpl_Call(t *testing.T) {
 	assert.NotNil(t, impl.BaseProvider)
 }
 
+func TestNew(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   *schema.Configuration
+		expected bool
+	}{
+		{
+			"ShouldReturnNilOnNilConfiguration",
+			nil,
+			false,
+		},
+		{
+			"ShouldReturnNilWhenDisabled",
+			&schema.Configuration{DuoAPI: schema.DuoAPI{Disable: true, Hostname: "duo.example.com", IntegrationKey: "ABC", SecretKey: "123"}},
+			false,
+		},
+		{
+			"ShouldReturnProviderWhenEnabled",
+			&schema.Configuration{DuoAPI: schema.DuoAPI{Hostname: "duo.example.com", IntegrationKey: "ABC", SecretKey: "123"}},
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := New(tc.config)
+
+			if tc.expected {
+				assert.NotNil(t, provider)
+			} else {
+				assert.Nil(t, provider)
+			}
+		})
+	}
+}
+
+func TestProduction_StartupCheck(t *testing.T) {
+	testCases := []struct {
+		name  string
+		setup func(base *mocks.MockDuoBaseProvider)
+		err   string
+	}{
+		{
+			"ShouldPass",
+			func(base *mocks.MockDuoBaseProvider) {
+				gomock.InOrder(
+					base.EXPECT().
+						Call(fasthttp.MethodGet, "/auth/v2/ping", nil).
+						Return(&http.Response{StatusCode: fasthttp.StatusOK}, nil, nil),
+					base.EXPECT().
+						SignedCall(fasthttp.MethodGet, "/auth/v2/check", nil).
+						Return(&http.Response{StatusCode: fasthttp.StatusOK}, nil, nil),
+				)
+			},
+			"",
+		},
+		{
+			"ShouldHandlePingError",
+			func(base *mocks.MockDuoBaseProvider) {
+				base.EXPECT().
+					Call(fasthttp.MethodGet, "/auth/v2/ping", nil).
+					Return(nil, nil, fmt.Errorf("uguu"))
+			},
+			"error occurred performing duo ping request: uguu",
+		},
+		{
+			"ShouldHandlePingStatusCode",
+			func(base *mocks.MockDuoBaseProvider) {
+				base.EXPECT().
+					Call(fasthttp.MethodGet, "/auth/v2/ping", nil).
+					Return(&http.Response{StatusCode: fasthttp.StatusInternalServerError}, nil, nil)
+			},
+			"error occurred performing duo ping request: status code 500",
+		},
+		{
+			"ShouldHandleCheckError",
+			func(base *mocks.MockDuoBaseProvider) {
+				gomock.InOrder(
+					base.EXPECT().
+						Call(fasthttp.MethodGet, "/auth/v2/ping", nil).
+						Return(&http.Response{StatusCode: fasthttp.StatusOK}, nil, nil),
+					base.EXPECT().
+						SignedCall(fasthttp.MethodGet, "/auth/v2/check", nil).
+						Return(nil, nil, fmt.Errorf("uguu")),
+				)
+			},
+			"error occurred performing duo check request: uguu",
+		},
+		{
+			"ShouldHandleCheckStatusCode",
+			func(base *mocks.MockDuoBaseProvider) {
+				gomock.InOrder(
+					base.EXPECT().
+						Call(fasthttp.MethodGet, "/auth/v2/ping", nil).
+						Return(&http.Response{StatusCode: fasthttp.StatusOK}, nil, nil),
+					base.EXPECT().
+						SignedCall(fasthttp.MethodGet, "/auth/v2/check", nil).
+						Return(&http.Response{StatusCode: fasthttp.StatusUnauthorized}, nil, nil),
+				)
+			},
+			"error occurred performing duo check request: status code 401",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			base := mocks.NewMockDuoBaseProvider(ctrl)
+
+			tc.setup(base)
+
+			err := NewDuoAPI(base).StartupCheck()
+
+			if tc.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
+			}
+		})
+	}
+}
+
 func TestDuoProvider_PreAuthCall_JSONError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/duo/types.go
+++ b/internal/duo/types.go
@@ -5,26 +5,40 @@
 package duo
 
 import (
+	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/url"
 
 	duoapi "github.com/duosecurity/duo_api_golang"
+	"github.com/sirupsen/logrus"
 
-	"github.com/authelia/authelia/v4/internal/middlewares"
+	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/session"
 )
+
+// Context describes the context requirements for the duo provider. It is intentionally minimal to avoid an import
+// cycle with the middlewares package which holds this provider.
+type Context interface {
+	context.Context
+
+	GetLogger() *logrus.Entry
+	RemoteIP() net.IP
+}
 
 // BaseProvider describes the upstream provider we intend to utilize. Implemented by duoapi.
 type BaseProvider interface {
 	SignedCall(method string, uri string, params url.Values, options ...duoapi.DuoApiOption) (*http.Response, []byte, error)
+	Call(method string, uri string, params url.Values, options ...duoapi.DuoApiOption) (*http.Response, []byte, error)
 }
 
 // The Provider interface is used to describe this provider for the purpose of mock testing.
 type Provider interface {
-	Call(ctx middlewares.Context, userSession *session.UserSession, values url.Values, method string, path string) (response *Response, err error)
-	PreAuthCall(ctx middlewares.Context, userSession *session.UserSession, values url.Values) (response *PreAuthResponse, err error)
-	AuthCall(ctx middlewares.Context, userSession *session.UserSession, values url.Values) (response *AuthResponse, err error)
+	model.StartupCheck
+
+	PreAuthCall(ctx Context, userSession *session.UserSession, values url.Values) (response *PreAuthResponse, err error)
+	AuthCall(ctx Context, userSession *session.UserSession, values url.Values) (response *AuthResponse, err error)
 }
 
 // Production implementation of the Provider interface.

--- a/internal/handlers/handler_register_duo_device.go
+++ b/internal/handlers/handler_register_duo_device.go
@@ -15,64 +15,62 @@ import (
 )
 
 // DuoDevicesGET handler for retrieving available devices and capabilities from Duo API.
-func DuoDevicesGET(duoAPI duo.Provider) middlewares.RequestHandler {
-	return func(ctx *middlewares.AutheliaCtx) {
-		userSession, err := ctx.GetSession()
-		if err != nil {
-			ctx.GetLogger().WithError(err).Error(errStrUserSessionData)
-			ctx.SetJSONError(messageMFAValidationFailed)
+func DuoDevicesGET(ctx *middlewares.AutheliaCtx) {
+	userSession, err := ctx.GetSession()
+	if err != nil {
+		ctx.GetLogger().WithError(err).Error(errStrUserSessionData)
+		ctx.SetJSONError(messageMFAValidationFailed)
 
-			return
-		}
+		return
+	}
 
-		ctx.Logger.Debugf("Starting Duo PreAuth for %s", userSession.Username)
+	ctx.GetLogger().Debugf("Starting Duo PreAuth for %s", userSession.Username)
 
-		result, message, devices, enrollURL, err := DuoPreAuth(ctx, &userSession, duoAPI)
-		if err != nil {
-			ctx.GetLogger().WithError(err).Error("Error occurred performing the Duo PreAuth API call")
-			ctx.SetJSONError(messageMFAValidationFailed)
+	result, message, devices, enrollURL, err := DuoPreAuth(ctx, &userSession)
+	if err != nil {
+		ctx.GetLogger().WithError(err).Error("Error occurred performing the Duo PreAuth API call")
+		ctx.SetJSONError(messageMFAValidationFailed)
 
-			return
-		}
+		return
+	}
 
-		response := DuoDevicesResponse{}
+	response := DuoDevicesResponse{}
 
-		switch result {
-		case auth:
-			if devices == nil {
-				ctx.Logger.Debugf("No applicable device/method available for Duo user %s", userSession.Username)
-
-				response.Result = enroll
-			} else {
-				response.Result = auth
-				response.Devices = devices
-			}
-
-			SendDuoDevicesResponse(ctx, response)
-
-		case allow:
-			ctx.Logger.Debugf("Device selection not possible for user %s, because Duo authentication was bypassed - Defaults to Auto Push", userSession.Username)
-
-			response.Result = allow
-			SendDuoDevicesResponse(ctx, response)
-
-		case enroll:
-			ctx.Logger.Debugf("Duo user: %s not enrolled", userSession.Username)
+	switch result {
+	case auth:
+		if devices == nil {
+			ctx.GetLogger().Debugf("No applicable device/method available for Duo user %s", userSession.Username)
 
 			response.Result = enroll
-			response.EnrollURL = enrollURL
-			SendDuoDevicesResponse(ctx, response)
-
-		case deny:
-			ctx.Logger.Debugf("Duo User not allowed to authenticate: %s", userSession.Username)
-
-			response.Result = deny
-			SendDuoDevicesResponse(ctx, response)
-
-		default:
-			ctx.GetLogger().Errorf("Error occurred performing the Duo PreAuth API call for user '%s' which returned the result '%s' with the message '%s'", userSession.Username, result, message)
-			ctx.SetJSONError(messageMFAValidationFailed)
+		} else {
+			response.Result = auth
+			response.Devices = devices
 		}
+
+		SendDuoDevicesResponse(ctx, response)
+
+	case allow:
+		ctx.GetLogger().Debugf("Device selection not possible for user %s, because Duo authentication was bypassed - Defaults to Auto Push", userSession.Username)
+
+		response.Result = allow
+		SendDuoDevicesResponse(ctx, response)
+
+	case enroll:
+		ctx.GetLogger().Debugf("Duo user: %s not enrolled", userSession.Username)
+
+		response.Result = enroll
+		response.EnrollURL = enrollURL
+		SendDuoDevicesResponse(ctx, response)
+
+	case deny:
+		ctx.GetLogger().Debugf("Duo User not allowed to authenticate: %s", userSession.Username)
+
+		response.Result = deny
+		SendDuoDevicesResponse(ctx, response)
+
+	default:
+		ctx.GetLogger().Errorf("Error occurred performing the Duo PreAuth API call for user '%s' which returned the result '%s' with the message '%s'", userSession.Username, result, message)
+		ctx.SetJSONError(messageMFAValidationFailed)
 	}
 }
 
@@ -105,7 +103,7 @@ func DuoDevicePOST(ctx *middlewares.AutheliaCtx) {
 		return
 	}
 
-	ctx.Logger.Debugf("Save new preferred Duo device and method of user %s to %s using %s", userSession.Username, bodyJSON.Device, bodyJSON.Method)
+	ctx.GetLogger().Debugf("Save new preferred Duo device and method of user %s to %s using %s", userSession.Username, bodyJSON.Device, bodyJSON.Method)
 
 	err = ctx.Providers.StorageProvider.SavePreferredDuoDevice(ctx, model.DuoDevice{Username: userSession.Username, Device: bodyJSON.Device, Method: bodyJSON.Method})
 	if err != nil {
@@ -131,7 +129,7 @@ func DuoDeviceDELETE(ctx *middlewares.AutheliaCtx) {
 		return
 	}
 
-	ctx.Logger.Debugf("Deleting preferred Duo device and method of user %s", userSession.Username)
+	ctx.GetLogger().Debugf("Deleting preferred Duo device and method of user %s", userSession.Username)
 
 	if err = ctx.Providers.StorageProvider.DeletePreferredDuoDevice(ctx, userSession.Username); err != nil {
 		ctx.GetLogger().WithError(err).Error("Error occurred deleting the preferred Duo device and method")

--- a/internal/handlers/handler_register_duo_device_test.go
+++ b/internal/handlers/handler_register_duo_device_test.go
@@ -41,14 +41,12 @@ func (s *RegisterDuoDeviceSuite) TearDownTest() {
 }
 
 func (s *RegisterDuoDeviceSuite) TestShouldCallDuoAPIAndFail() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	values := url.Values{}
 	values.Set("username", "john")
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(nil, fmt.Errorf("Connection error"))
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(nil, fmt.Errorf("Connection error"))
 
-	DuoDevicesGET(duoMock)(s.mock.Ctx)
+	DuoDevicesGET(s.mock.Ctx)
 
 	s.mock.Assert200KO(s.T(), "Authentication failed, please retry later.")
 	s.mock.AssertLastLogMessage(s.T(), "Error occurred performing the Duo PreAuth API call", "Connection error")
@@ -56,8 +54,6 @@ func (s *RegisterDuoDeviceSuite) TestShouldCallDuoAPIAndFail() {
 }
 
 func (s *RegisterDuoDeviceSuite) TestShouldRespondWithSelection() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	var duoDevices = []duo.Device{
 		{Capabilities: []string{"auto", "push", "sms", "mobile_otp"}, Number: " ", Device: "12345ABCDEFGHIJ67890", DisplayName: "Test Device 1"},
 		{Capabilities: []string{"auto", "push", "sms", "mobile_otp"}, Number: "+123456789****", Device: "1234567890ABCDEFGHIJ", DisplayName: "Test Device 2"},
@@ -76,32 +72,28 @@ func (s *RegisterDuoDeviceSuite) TestShouldRespondWithSelection() {
 	response.Result = auth
 	response.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
 
-	DuoDevicesGET(duoMock)(s.mock.Ctx)
+	DuoDevicesGET(s.mock.Ctx)
 
 	s.mock.Assert200OK(s.T(), DuoDevicesResponse{Result: auth, Devices: apiDevices})
 }
 
 func (s *RegisterDuoDeviceSuite) TestShouldRespondWithAllowOnBypass() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	values := url.Values{}
 	values.Set("username", "john")
 
 	response := duo.PreAuthResponse{}
 	response.Result = allow
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
 
-	DuoDevicesGET(duoMock)(s.mock.Ctx)
+	DuoDevicesGET(s.mock.Ctx)
 
 	s.mock.Assert200OK(s.T(), DuoDevicesResponse{Result: allow})
 }
 
 func (s *RegisterDuoDeviceSuite) TestShouldRespondWithEnroll() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	var enrollURL = "https://api-example.duosecurity.com/portal?code=1234567890ABCDEF&akey=12345ABCDEFGHIJ67890"
 
 	values := url.Values{}
@@ -111,25 +103,23 @@ func (s *RegisterDuoDeviceSuite) TestShouldRespondWithEnroll() {
 	response.Result = enroll
 	response.EnrollPortalURL = enrollURL
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
 
-	DuoDevicesGET(duoMock)(s.mock.Ctx)
+	DuoDevicesGET(s.mock.Ctx)
 
 	s.mock.Assert200OK(s.T(), DuoDevicesResponse{Result: enroll, EnrollURL: enrollURL})
 }
 
 func (s *RegisterDuoDeviceSuite) TestShouldRespondWithDeny() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	values := url.Values{}
 	values.Set("username", "john")
 
 	response := duo.PreAuthResponse{}
 	response.Result = deny
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
 
-	DuoDevicesGET(duoMock)(s.mock.Ctx)
+	DuoDevicesGET(s.mock.Ctx)
 
 	s.mock.Assert200OK(s.T(), DuoDevicesResponse{Result: deny})
 }
@@ -175,8 +165,6 @@ func (s *RegisterDuoDeviceSuite) TestShouldRespondKOOnEmptyDevice() {
 }
 
 func (s *RegisterDuoDeviceSuite) TestShouldRespondWithEnrollWhenNoSupportedDevices() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	values := url.Values{}
 	values.Set("username", "john")
 
@@ -184,16 +172,14 @@ func (s *RegisterDuoDeviceSuite) TestShouldRespondWithEnrollWhenNoSupportedDevic
 	response.Result = auth
 	response.Devices = []duo.Device{{Capabilities: []string{"unsupported"}, Device: "12345ABCDEFGHIJ67890", DisplayName: "Test Device 1"}}
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
 
-	DuoDevicesGET(duoMock)(s.mock.Ctx)
+	DuoDevicesGET(s.mock.Ctx)
 
 	s.mock.Assert200OK(s.T(), DuoDevicesResponse{Result: enroll})
 }
 
 func (s *RegisterDuoDeviceSuite) TestShouldRespondKOOnUnknownPreAuthResult() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	values := url.Values{}
 	values.Set("username", "john")
 
@@ -201,9 +187,9 @@ func (s *RegisterDuoDeviceSuite) TestShouldRespondKOOnUnknownPreAuthResult() {
 	response.Result = "not-a-result"
 	response.StatusMessage = "a status message"
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
 
-	DuoDevicesGET(duoMock)(s.mock.Ctx)
+	DuoDevicesGET(s.mock.Ctx)
 
 	s.mock.Assert200KO(s.T(), messageMFAValidationFailed)
 	s.Assert().Equal("Error occurred performing the Duo PreAuth API call for user 'john' which returned the result 'not-a-result' with the message 'a status message'", s.mock.Hook.LastEntry().Message)
@@ -304,7 +290,7 @@ func TestDuoDevicesRegistrationSessionErrors(t *testing.T) {
 	}{
 		{
 			name:    "DuoDevicesGET",
-			handler: DuoDevicesGET(nil),
+			handler: DuoDevicesGET,
 		},
 		{
 			name:    "DuoDevicePOST",

--- a/internal/handlers/handler_sign_duo.go
+++ b/internal/handlers/handler_sign_duo.go
@@ -33,7 +33,7 @@ func DuoGET(ctx *middlewares.AutheliaCtx) {
 
 	duoDevice, err := ctx.Providers.StorageProvider.LoadPreferredDuoDevice(ctx, userSession.Username)
 	if err != nil {
-		ctx.Logger.Debugf("No preferred Duo device found for user: '%s': %v", userSession.Username, err)
+		ctx.GetLogger().Debugf("No preferred Duo device found for user: '%s': %v", userSession.Username, err)
 
 		if err := ctx.SetJSONBody(DuoDevicesResponse{Result: auth}); err != nil {
 			ctx.GetLogger().WithError(err).Error(errStrRespBody)
@@ -43,7 +43,7 @@ func DuoGET(ctx *middlewares.AutheliaCtx) {
 		return
 	}
 
-	ctx.Logger.Debugf("Found preferred Duo device '%s' and method '%s' for user: '%s'", duoDevice.Device, duoDevice.Method, userSession.Username)
+	ctx.GetLogger().Debugf("Found preferred Duo device '%s' and method '%s' for user: '%s'", duoDevice.Device, duoDevice.Method, userSession.Username)
 
 	if err := ctx.SetJSONBody(DuoDevicesResponse{Result: auth, PreferredDevice: duoDevice.Device, PreferredMethod: duoDevice.Method}); err != nil {
 		ctx.GetLogger().WithError(err).Error(errStrRespBody)
@@ -52,45 +52,43 @@ func DuoGET(ctx *middlewares.AutheliaCtx) {
 }
 
 // DuoPOST handler for sending a push notification via Duo API.
-func DuoPOST(duoAPI duo.Provider) middlewares.RequestHandler {
-	return func(ctx *middlewares.AutheliaCtx) {
-		bodyJSON := &bodySignDuoRequest{}
-		if err := ctx.ParseBody(bodyJSON); err != nil {
-			ctx.Logger.WithError(err).Errorf(logFmtErrParseRequestBody, regulation.AuthTypeDuo)
-			respondUnauthorized(ctx, messageMFAValidationFailed)
+func DuoPOST(ctx *middlewares.AutheliaCtx) {
+	bodyJSON := &bodySignDuoRequest{}
+	if err := ctx.ParseBody(bodyJSON); err != nil {
+		ctx.GetLogger().WithError(err).Errorf(logFmtErrParseRequestBody, regulation.AuthTypeDuo)
+		respondUnauthorized(ctx, messageMFAValidationFailed)
 
-			return
-		}
+		return
+	}
 
-		userSession, err := ctx.GetSession()
-		if err != nil {
-			ctx.GetLogger().WithError(err).Error(errStrUserSessionData)
-			ctx.SetJSONError(messageMFAValidationFailed)
+	userSession, err := ctx.GetSession()
+	if err != nil {
+		ctx.GetLogger().WithError(err).Error(errStrUserSessionData)
+		ctx.SetJSONError(messageMFAValidationFailed)
 
-			return
-		}
+		return
+	}
 
-		if err = HandleDuoAuthentication(ctx, &userSession, duoAPI, bodyJSON); err != nil {
-			respondUnauthorized(ctx, messageMFAValidationFailed)
+	if err = HandleDuoAuthentication(ctx, &userSession, bodyJSON); err != nil {
+		respondUnauthorized(ctx, messageMFAValidationFailed)
 
-			return
-		}
+		return
 	}
 }
 
 // PerformDuoAuthentication executes the Duo authentication call.
-func PerformDuoAuthentication(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, duoAPI duo.Provider, device, method, remoteIP string, bodyJSON *bodySignDuoRequest) error {
-	ctx.Logger.Debugf("Starting Duo Auth attempt for '%s' with device '%s' and method '%s' from IP '%s'", userSession.Username, device, method, remoteIP)
+func PerformDuoAuthentication(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, device, method, remoteIP string, bodyJSON *bodySignDuoRequest) error {
+	ctx.GetLogger().Debugf("Starting Duo Auth attempt for '%s' with device '%s' and method '%s' from IP '%s'", userSession.Username, device, method, remoteIP)
 
 	values, err := SetValues(*userSession, device, method, remoteIP, bodyJSON.TargetURL, bodyJSON.Passcode)
 	if err != nil {
-		ctx.Logger.Errorf("Failed to set values for Duo Auth Call for user '%s': %+v", userSession.Username, err)
+		ctx.GetLogger().Errorf("Failed to set values for Duo Auth Call for user '%s': %+v", userSession.Username, err)
 		return err
 	}
 
-	authResponse, err := duoAPI.AuthCall(ctx, userSession, values)
+	authResponse, err := ctx.Providers.Duo.AuthCall(ctx, userSession, values)
 	if err != nil {
-		ctx.Logger.Errorf("Failed to perform Duo Auth Call for user '%s': %+v", userSession.Username, err)
+		ctx.GetLogger().Errorf("Failed to perform Duo Auth Call for user '%s': %+v", userSession.Username, err)
 		return err
 	}
 
@@ -108,13 +106,13 @@ func PerformDuoAuthentication(ctx *middlewares.AutheliaCtx, userSession *session
 }
 
 // PerformDuoAuthenticationIfValid performs Duo authentication if device and method are valid.
-func PerformDuoAuthenticationIfValid(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, duoAPI duo.Provider, device, method string, bodyJSON *bodySignDuoRequest) error {
+func PerformDuoAuthenticationIfValid(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, device, method string, bodyJSON *bodySignDuoRequest) error {
 	if device == "" || method == "" {
 		return nil
 	}
 
 	remoteIP := ctx.RemoteIP().String()
-	if err := PerformDuoAuthentication(ctx, userSession, duoAPI, device, method, remoteIP, bodyJSON); err != nil {
+	if err := PerformDuoAuthentication(ctx, userSession, device, method, remoteIP, bodyJSON); err != nil {
 		return err
 	}
 
@@ -124,10 +122,10 @@ func PerformDuoAuthenticationIfValid(ctx *middlewares.AutheliaCtx, userSession *
 }
 
 // HandleInitialDeviceSelection handler for retrieving all available devices.
-func HandleInitialDeviceSelection(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, duoAPI duo.Provider, bodyJSON *bodySignDuoRequest) (device string, method string, err error) {
-	result, message, devices, enrollURL, err := DuoPreAuth(ctx, userSession, duoAPI)
+func HandleInitialDeviceSelection(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, bodyJSON *bodySignDuoRequest) (device string, method string, err error) {
+	result, message, devices, enrollURL, err := DuoPreAuth(ctx, userSession)
 	if err != nil {
-		ctx.Logger.Errorf("Failed to perform Duo PreAuth for user '%s': %+v", userSession.Username, err)
+		ctx.GetLogger().Errorf("Failed to perform Duo PreAuth for user '%s': %+v", userSession.Username, err)
 		respondUnauthorized(ctx, messageMFAValidationFailed)
 
 		return "", "", err
@@ -137,30 +135,30 @@ func HandleInitialDeviceSelection(ctx *middlewares.AutheliaCtx, userSession *ses
 }
 
 // HandleDuoAuthentication handles the complete Duo authentication flow.
-func HandleDuoAuthentication(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, duoAPI duo.Provider, bodyJSON *bodySignDuoRequest) error {
+func HandleDuoAuthentication(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, bodyJSON *bodySignDuoRequest) error {
 	duoDevice, err := ctx.Providers.StorageProvider.LoadPreferredDuoDevice(ctx, userSession.Username)
 	if err != nil {
-		selectedDevice, selectedMethod, err := HandleInitialDeviceSelection(ctx, userSession, duoAPI, bodyJSON)
+		selectedDevice, selectedMethod, err := HandleInitialDeviceSelection(ctx, userSession, bodyJSON)
 		if err != nil {
 			return err
 		}
 
-		return PerformDuoAuthenticationIfValid(ctx, userSession, duoAPI, selectedDevice, selectedMethod, bodyJSON)
+		return PerformDuoAuthenticationIfValid(ctx, userSession, selectedDevice, selectedMethod, bodyJSON)
 	}
 
-	selectedDevice, selectedMethod, err := HandlePreferredDeviceCheck(ctx, userSession, duoAPI, duoDevice.Device, duoDevice.Method, bodyJSON)
+	selectedDevice, selectedMethod, err := HandlePreferredDeviceCheck(ctx, userSession, duoDevice.Device, duoDevice.Method, bodyJSON)
 	if err != nil {
 		return err
 	}
 
-	return PerformDuoAuthenticationIfValid(ctx, userSession, duoAPI, selectedDevice, selectedMethod, bodyJSON)
+	return PerformDuoAuthenticationIfValid(ctx, userSession, selectedDevice, selectedMethod, bodyJSON)
 }
 
 // HandleDuoPreAuthResult processes the result of a DuoPreAuth call and handles common response logic.
 func HandleDuoPreAuthResult(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, result, message string, devices []DuoDevice, enrollURL string, bodyJSON *bodySignDuoRequest) (device, method string, err error) {
 	switch result {
 	case enroll:
-		ctx.Logger.Debugf("Duo user: '%s' not enrolled", userSession.Username)
+		ctx.GetLogger().Debugf("Duo user: '%s' not enrolled", userSession.Username)
 
 		if err := ctx.SetJSONBody(DuoSignResponse{Result: enroll, EnrollURL: enrollURL}); err != nil {
 			return "", "", errors.New(errStrRespBody)
@@ -169,7 +167,7 @@ func HandleDuoPreAuthResult(ctx *middlewares.AutheliaCtx, userSession *session.U
 		return "", "", nil
 
 	case deny:
-		ctx.Logger.Infof("Duo user: '%s' not allowed to authenticate: %s", userSession.Username, message)
+		ctx.GetLogger().Infof("Duo user: '%s' not allowed to authenticate: %s", userSession.Username, message)
 
 		if err := ctx.SetJSONBody(DuoSignResponse{Result: deny}); err != nil {
 			return "", "", errors.New(errStrRespBody)
@@ -178,7 +176,7 @@ func HandleDuoPreAuthResult(ctx *middlewares.AutheliaCtx, userSession *session.U
 		return "", "", nil
 
 	case allow:
-		ctx.Logger.Debugf("Duo authentication was bypassed for user: '%s'", userSession.Username)
+		ctx.GetLogger().Debugf("Duo authentication was bypassed for user: '%s'", userSession.Username)
 		HandleAllow(ctx, userSession, bodyJSON)
 
 		return "", "", nil
@@ -193,7 +191,7 @@ func HandleDuoPreAuthResult(ctx *middlewares.AutheliaCtx, userSession *session.U
 
 // HandleNoDevicesAvailable handles the case when no compatible devices are available.
 func HandleNoDevicesAvailable(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, storedDevice string) error {
-	ctx.Logger.Debugf("No compatible device/method available for Duo user: '%s'", userSession.Username)
+	ctx.GetLogger().Debugf("No compatible device/method available for Duo user: '%s'", userSession.Username)
 
 	if storedDevice != "" {
 		if deleteErr := ctx.Providers.StorageProvider.DeletePreferredDuoDevice(ctx, userSession.Username); deleteErr != nil {
@@ -249,10 +247,10 @@ func FindValidDevice(devices []DuoDevice, preferredDevice, preferredMethod strin
 }
 
 // HandlePreferredDeviceCheck handler to check if the saved device and method is still valid.
-func HandlePreferredDeviceCheck(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, duoAPI duo.Provider, storedDevice string, storedMethod string, bodyJSON *bodySignDuoRequest) (string, string, error) {
-	result, message, devices, enrollURL, err := DuoPreAuth(ctx, userSession, duoAPI)
+func HandlePreferredDeviceCheck(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, storedDevice string, storedMethod string, bodyJSON *bodySignDuoRequest) (string, string, error) {
+	result, message, devices, enrollURL, err := DuoPreAuth(ctx, userSession)
 	if err != nil {
-		ctx.Logger.Errorf("Failed to perform Duo PreAuth for user '%s': %+v", userSession.Username, err)
+		ctx.GetLogger().Errorf("Failed to perform Duo PreAuth for user '%s': %+v", userSession.Username, err)
 		respondUnauthorized(ctx, messageMFAValidationFailed)
 
 		return "", "", nil
@@ -260,7 +258,7 @@ func HandlePreferredDeviceCheck(ctx *middlewares.AutheliaCtx, userSession *sessi
 
 	switch result {
 	case enroll:
-		ctx.Logger.Debugf("Duo user: '%s' no longer enrolled removing preferred device", userSession.Username)
+		ctx.GetLogger().Debugf("Duo user: '%s' no longer enrolled removing preferred device", userSession.Username)
 
 		if err := ctx.Providers.StorageProvider.DeletePreferredDuoDevice(ctx, userSession.Username); err != nil {
 			return "", "", fmt.Errorf("unable to delete preferred Duo device and method for user '%s': %w", userSession.Username, err)
@@ -272,12 +270,12 @@ func HandlePreferredDeviceCheck(ctx *middlewares.AutheliaCtx, userSession *sessi
 
 		return "", "", nil
 	case deny:
-		ctx.Logger.Infof("Duo user: '%s' not allowed to authenticate: %s", userSession.Username, message)
+		ctx.GetLogger().Infof("Duo user: '%s' not allowed to authenticate: %s", userSession.Username, message)
 		ctx.ReplyUnauthorized()
 
 		return "", "", nil
 	case allow:
-		ctx.Logger.Debugf("Duo authentication was bypassed for user: '%s'", userSession.Username)
+		ctx.GetLogger().Debugf("Duo authentication was bypassed for user: '%s'", userSession.Username)
 		HandleAllow(ctx, userSession, bodyJSON)
 
 		return "", "", nil
@@ -292,7 +290,7 @@ func HandlePreferredDeviceCheck(ctx *middlewares.AutheliaCtx, userSession *sessi
 // HandleAutoSelection handler automatically selects preferred device if there is only one suitable option.
 func HandleAutoSelection(ctx *middlewares.AutheliaCtx, devices []DuoDevice, username string) (string, string, error) {
 	if devices == nil {
-		ctx.Logger.Debugf("No compatible device/method available for Duo user: '%s'", username)
+		ctx.GetLogger().Debugf("No compatible device/method available for Duo user: '%s'", username)
 
 		if err := ctx.SetJSONBody(DuoSignResponse{Result: enroll}); err != nil {
 			return "", "", errors.New(errStrRespBody)
@@ -302,7 +300,7 @@ func HandleAutoSelection(ctx *middlewares.AutheliaCtx, devices []DuoDevice, user
 	}
 
 	if len(devices) > 1 {
-		ctx.Logger.Debugf("Multiple devices available for Duo user: '%s' require manual selection", username)
+		ctx.GetLogger().Debugf("Multiple devices available for Duo user: '%s' require manual selection", username)
 
 		if err := ctx.SetJSONBody(DuoSignResponse{Result: auth, Devices: devices}); err != nil {
 			return "", "", errors.New(errStrRespBody)
@@ -312,7 +310,7 @@ func HandleAutoSelection(ctx *middlewares.AutheliaCtx, devices []DuoDevice, user
 	}
 
 	if len(devices[0].Capabilities) > 1 {
-		ctx.Logger.Debugf("Multiple methods available for Duo user: '%s' require manual selection", username)
+		ctx.GetLogger().Debugf("Multiple methods available for Duo user: '%s' require manual selection", username)
 
 		if err := ctx.SetJSONBody(DuoSignResponse{Result: auth, Devices: devices}); err != nil {
 			return "", "", errors.New(errStrRespBody)
@@ -323,7 +321,7 @@ func HandleAutoSelection(ctx *middlewares.AutheliaCtx, devices []DuoDevice, user
 
 	device := devices[0].Device
 	method := devices[0].Capabilities[0]
-	ctx.Logger.Debugf("Exactly one device: '%s' and method: '%s' found, saving as new preferred Duo device and method for user: '%s'", device, method, username)
+	ctx.GetLogger().Debugf("Exactly one device: '%s' and method: '%s' found, saving as new preferred Duo device and method for user: '%s'", device, method, username)
 
 	if err := ctx.Providers.StorageProvider.SavePreferredDuoDevice(ctx, model.DuoDevice{Username: username, Method: method, Device: device}); err != nil {
 		return "", "", fmt.Errorf("unable to save new preferred Duo device and method for user '%s': %w", username, err)
@@ -338,7 +336,7 @@ func HandleAllow(ctx *middlewares.AutheliaCtx, userSession *session.UserSession,
 		err error
 	)
 	if err = ctx.RegenerateSession(); err != nil {
-		ctx.Logger.WithError(err).Errorf(logFmtErrSessionRegenerate, regulation.AuthTypeDuo, userSession.Username)
+		ctx.GetLogger().WithError(err).Errorf(logFmtErrSessionRegenerate, regulation.AuthTypeDuo, userSession.Username)
 
 		respondUnauthorized(ctx, messageMFAValidationFailed)
 
@@ -348,7 +346,7 @@ func HandleAllow(ctx *middlewares.AutheliaCtx, userSession *session.UserSession,
 	userSession.SetTwoFactorDuo(ctx.GetClock().Now())
 
 	if err = ctx.SaveSession(*userSession); err != nil {
-		ctx.Logger.WithError(err).Errorf(logFmtErrSessionSave, "authentication time", regulation.AuthTypeTOTP, logFmtActionAuthentication, userSession.Username)
+		ctx.GetLogger().WithError(err).Errorf(logFmtErrSessionSave, "authentication time", regulation.AuthTypeTOTP, logFmtActionAuthentication, userSession.Username)
 
 		respondUnauthorized(ctx, messageMFAValidationFailed)
 

--- a/internal/handlers/handler_sign_duo_misc_test.go
+++ b/internal/handlers/handler_sign_duo_misc_test.go
@@ -27,7 +27,7 @@ func TestDuoPOST(t *testing.T) {
 
 		mock.Ctx.Request.SetBodyString("not json")
 
-		DuoPOST(nil)(mock.Ctx)
+		DuoPOST(mock.Ctx)
 
 		mock.Assert401KO(t, messageMFAValidationFailed)
 
@@ -172,9 +172,7 @@ func TestDuoDevicesGETMisc(t *testing.T) {
 		mock := mocks.NewMockAutheliaCtx(t)
 		defer mock.Close()
 
-		duoMock := mocks.NewMockDuoProvider(mock.Ctrl)
-
-		duoMock.EXPECT().
+		mock.DuoMock.EXPECT().
 			PreAuthCall(mock.Ctx, gomock.Any(), gomock.Any()).
 			Return(&duo.PreAuthResponse{Result: enroll, EnrollPortalURL: "https://api-example.duosecurity.com/portal?abcdef"}, nil)
 
@@ -188,7 +186,7 @@ func TestDuoDevicesGETMisc(t *testing.T) {
 			AnyTimes().
 			Return(&model.DuoDevice{Username: testUsername, Device: "ABC", Method: duo.Push}, nil)
 
-		DuoDevicesGET(duoMock)(mock.Ctx)
+		DuoDevicesGET(mock.Ctx)
 
 		body := DuoDevicesResponse{}
 
@@ -207,7 +205,7 @@ func TestDuoPOSTMisc(t *testing.T) {
 		mock.Ctx.Request.Header.Set("X-Original-URL", "https://auth.notexample.com")
 		mock.Ctx.Request.SetBodyString(`{}`)
 
-		DuoPOST(nil)(mock.Ctx)
+		DuoPOST(mock.Ctx)
 
 		mock.Assert200KO(t, messageMFAValidationFailed)
 
@@ -222,7 +220,7 @@ func TestPerformDuoAuthenticationMisc(t *testing.T) {
 
 		userSession := &session.UserSession{Username: testUsername}
 
-		err := PerformDuoAuthentication(mock.Ctx, userSession, nil, "ABC", duo.OTP, "127.0.0.1", &bodySignDuoRequest{})
+		err := PerformDuoAuthentication(mock.Ctx, userSession, "ABC", duo.OTP, "127.0.0.1", &bodySignDuoRequest{})
 
 		assert.EqualError(t, err, "no passcode received from user: john")
 	})
@@ -305,9 +303,7 @@ func TestHandlePreferredDeviceCheckMisc(t *testing.T) {
 		mock := mocks.NewMockAutheliaCtx(t)
 		defer mock.Close()
 
-		duoMock := mocks.NewMockDuoProvider(mock.Ctrl)
-
-		duoMock.EXPECT().
+		mock.DuoMock.EXPECT().
 			PreAuthCall(mock.Ctx, gomock.Any(), gomock.Any()).
 			Return(&duo.PreAuthResponse{Result: enroll}, nil)
 
@@ -315,7 +311,7 @@ func TestHandlePreferredDeviceCheckMisc(t *testing.T) {
 			DeletePreferredDuoDevice(mock.Ctx, testUsername).
 			Return(errors.New("failed to delete"))
 
-		device, method, err := HandlePreferredDeviceCheck(mock.Ctx, newSession(), duoMock, "ABC", duo.Push, &bodySignDuoRequest{})
+		device, method, err := HandlePreferredDeviceCheck(mock.Ctx, newSession(), "ABC", duo.Push, &bodySignDuoRequest{})
 
 		assert.EqualError(t, err, "unable to delete preferred Duo device and method for user 'john': failed to delete")
 		assert.Empty(t, device)
@@ -326,13 +322,11 @@ func TestHandlePreferredDeviceCheckMisc(t *testing.T) {
 		mock := mocks.NewMockAutheliaCtx(t)
 		defer mock.Close()
 
-		duoMock := mocks.NewMockDuoProvider(mock.Ctrl)
-
-		duoMock.EXPECT().
+		mock.DuoMock.EXPECT().
 			PreAuthCall(mock.Ctx, gomock.Any(), gomock.Any()).
 			Return(&duo.PreAuthResponse{Result: "not-a-result"}, nil)
 
-		device, method, err := HandlePreferredDeviceCheck(mock.Ctx, newSession(), duoMock, "ABC", duo.Push, &bodySignDuoRequest{})
+		device, method, err := HandlePreferredDeviceCheck(mock.Ctx, newSession(), "ABC", duo.Push, &bodySignDuoRequest{})
 
 		assert.EqualError(t, err, "unknown result: not-a-result")
 		assert.Empty(t, device)

--- a/internal/handlers/handler_sign_duo_test.go
+++ b/internal/handlers/handler_sign_duo_test.go
@@ -46,8 +46,6 @@ func (s *SecondFactorDuoPostSuite) TearDownTest() {
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldEnroll() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(nil, errors.New("no Duo device and method saved"))
@@ -61,13 +59,13 @@ func (s *SecondFactorDuoPostSuite) TestShouldEnroll() {
 	preAuthResponse.Result = enroll
 	preAuthResponse.EnrollPortalURL = enrollURL
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	s.mock.Assert200OK(s.T(), DuoSignResponse{
 		Result:    enroll,
@@ -76,8 +74,6 @@ func (s *SecondFactorDuoPostSuite) TestShouldEnroll() {
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldAutoSelect() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().LoadPreferredDuoDevice(s.mock.Ctx, "john").Return(nil, errors.New("no Duo device and method saved"))
 
 	var duoDevices = []duo.Device{
@@ -92,7 +88,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldAutoSelect() {
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	s.mock.StorageMock.EXPECT().
 		SavePreferredDuoDevice(s.mock.Ctx, model.DuoDevice{Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}).
@@ -120,19 +116,17 @@ func (s *SecondFactorDuoPostSuite) TestShouldAutoSelect() {
 	authResponse := duo.AuthResponse{}
 	authResponse.Result = allow
 
-	duoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&authResponse, nil)
+	s.mock.DuoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&authResponse, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{TargetURL: "https://target.example.com"})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 	assert.Equal(s.T(), fasthttp.StatusOK, s.mock.Ctx.Response.StatusCode())
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldDenyAutoSelect() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(nil, errors.New("no Duo device and method saved"))
@@ -143,7 +137,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldDenyAutoSelect() {
 	preAuthResponse := duo.PreAuthResponse{}
 	preAuthResponse.Result = deny
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	values = url.Values{}
 	values.Set("username", "john")
@@ -155,7 +149,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldDenyAutoSelect() {
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	s.mock.Assert200OK(s.T(), DuoSignResponse{
 		Result: deny,
@@ -163,26 +157,22 @@ func (s *SecondFactorDuoPostSuite) TestShouldDenyAutoSelect() {
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldFailAutoSelect() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(nil, errors.New("no Duo device and method saved"))
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(nil, fmt.Errorf("Connection error"))
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(nil, fmt.Errorf("Connection error"))
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{TargetURL: "https://target.example.com"})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	s.mock.Assert401KO(s.T(), "Authentication failed, please retry later.")
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldDeleteOldDeviceAndEnroll() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "NOTEXISTENT", Method: "push"}, nil)
@@ -196,7 +186,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldDeleteOldDeviceAndEnroll() {
 	preAuthResponse.Result = enroll
 	preAuthResponse.EnrollPortalURL = enrollURL
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	s.mock.StorageMock.EXPECT().DeletePreferredDuoDevice(s.mock.Ctx, "john").Return(nil)
 
@@ -204,7 +194,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldDeleteOldDeviceAndEnroll() {
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	s.mock.Assert200OK(s.T(), DuoSignResponse{
 		Result:    enroll,
@@ -213,8 +203,6 @@ func (s *SecondFactorDuoPostSuite) TestShouldDeleteOldDeviceAndEnroll() {
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldDeleteOldDeviceAndCallPreauthAPIWithInvalidDevicesAndEnroll() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "NOTEXISTENT", Method: "push"}, nil)
@@ -230,7 +218,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldDeleteOldDeviceAndCallPreauthAPIWit
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	s.mock.StorageMock.EXPECT().DeletePreferredDuoDevice(s.mock.Ctx, "john").Return(nil)
 
@@ -238,7 +226,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldDeleteOldDeviceAndCallPreauthAPIWit
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	s.mock.Assert200OK(s.T(), DuoSignResponse{
 		Result: enroll,
@@ -246,8 +234,6 @@ func (s *SecondFactorDuoPostSuite) TestShouldDeleteOldDeviceAndCallPreauthAPIWit
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldUseOldDeviceAndSelect() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "NOTEXISTENT", Method: "push"}, nil)
@@ -270,19 +256,17 @@ func (s *SecondFactorDuoPostSuite) TestShouldUseOldDeviceAndSelect() {
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 	s.mock.Assert200OK(s.T(), DuoDevicesResponse{Result: auth, Devices: apiDevices})
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldUseInvalidMethodAndAutoSelect() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "invalidmethod"}, nil)
@@ -310,7 +294,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldUseInvalidMethodAndAutoSelect() {
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	s.mock.StorageMock.EXPECT().
 		SavePreferredDuoDevice(s.mock.Ctx, model.DuoDevice{Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}).
@@ -326,19 +310,17 @@ func (s *SecondFactorDuoPostSuite) TestShouldUseInvalidMethodAndAutoSelect() {
 	authResponse := duo.AuthResponse{}
 	authResponse.Result = allow
 
-	duoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&authResponse, nil)
+	s.mock.DuoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&authResponse, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{TargetURL: "https://target.example.com"})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 	assert.Equal(s.T(), fasthttp.StatusOK, s.mock.Ctx.Response.StatusCode())
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldCallDuoPreauthAPIAndAllowAccess() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}, nil)
@@ -349,20 +331,18 @@ func (s *SecondFactorDuoPostSuite) TestShouldCallDuoPreauthAPIAndAllowAccess() {
 	preAuthResponse := duo.PreAuthResponse{}
 	preAuthResponse.Result = allow
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{TargetURL: "https://target.example.com"})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	assert.Equal(s.T(), fasthttp.StatusOK, s.mock.Ctx.Response.StatusCode())
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldCallDuoPreauthAPIAndDenyAccess() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}, nil)
@@ -373,7 +353,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldCallDuoPreauthAPIAndDenyAccess() {
 	preAuthResponse := duo.PreAuthResponse{}
 	preAuthResponse.Result = deny
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	values = url.Values{}
 	values.Set("username", "john")
@@ -385,32 +365,28 @@ func (s *SecondFactorDuoPostSuite) TestShouldCallDuoPreauthAPIAndDenyAccess() {
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	assert.Equal(s.T(), fasthttp.StatusUnauthorized, s.mock.Ctx.Response.StatusCode())
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldCallDuoPreauthAPIAndFail() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}, nil)
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(nil, fmt.Errorf("Connection error"))
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(nil, fmt.Errorf("Connection error"))
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	s.mock.Assert401KO(s.T(), "Authentication failed, please retry later.")
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldCallDuoAPIAndDenyAccess() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}, nil)
@@ -438,7 +414,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldCallDuoAPIAndDenyAccess() {
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	values = url.Values{}
 	values.Set("username", "john")
@@ -449,20 +425,18 @@ func (s *SecondFactorDuoPostSuite) TestShouldCallDuoAPIAndDenyAccess() {
 	response := duo.AuthResponse{}
 	response.Result = deny
 
-	duoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&response, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	assert.Equal(s.T(), fasthttp.StatusUnauthorized, s.mock.Ctx.Response.StatusCode())
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldCallDuoAPIAndFail() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}, nil)
@@ -478,22 +452,20 @@ func (s *SecondFactorDuoPostSuite) TestShouldCallDuoAPIAndFail() {
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
-	duoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(nil, fmt.Errorf("Connection error"))
+	s.mock.DuoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(nil, fmt.Errorf("Connection error"))
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 
 	s.mock.Assert401KO(s.T(), "Authentication failed, please retry later.")
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldRedirectUserToDefaultURL() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}, nil)
@@ -521,12 +493,12 @@ func (s *SecondFactorDuoPostSuite) TestShouldRedirectUserToDefaultURL() {
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	response := duo.AuthResponse{}
 	response.Result = allow
 
-	duoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
 
 	s.mock.Ctx.Configuration.Session.Cookies[0].DefaultRedirectionURL = testRedirectionURL
 
@@ -534,15 +506,13 @@ func (s *SecondFactorDuoPostSuite) TestShouldRedirectUserToDefaultURL() {
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 	s.mock.Assert200OK(s.T(), redirectResponse{
 		Redirect: testRedirectionURLString,
 	})
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldNotReturnRedirectURL() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}, nil)
@@ -570,24 +540,22 @@ func (s *SecondFactorDuoPostSuite) TestShouldNotReturnRedirectURL() {
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	response := duo.AuthResponse{}
 	response.Result = allow
 
-	duoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{})
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 	s.mock.Assert200OK(s.T(), &redirectResponse{Redirect: "https://www.example.com"})
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldRedirectUserToSafeTargetURL() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.Ctx.Configuration.Session.Cookies = []schema.SessionCookie{
 		{
 			Domain: "example.com",
@@ -623,12 +591,12 @@ func (s *SecondFactorDuoPostSuite) TestShouldRedirectUserToSafeTargetURL() {
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	response := duo.AuthResponse{}
 	response.Result = allow
 
-	duoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{
 		TargetURL: "https://example.com",
@@ -636,15 +604,13 @@ func (s *SecondFactorDuoPostSuite) TestShouldRedirectUserToSafeTargetURL() {
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 	s.mock.Assert200OK(s.T(), redirectResponse{
 		Redirect: "https://example.com",
 	})
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldNotRedirectToUnsafeURL() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}, nil)
@@ -672,12 +638,12 @@ func (s *SecondFactorDuoPostSuite) TestShouldNotRedirectToUnsafeURL() {
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	response := duo.AuthResponse{}
 	response.Result = allow
 
-	duoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{
 		TargetURL: "http://example.com",
@@ -685,13 +651,11 @@ func (s *SecondFactorDuoPostSuite) TestShouldNotRedirectToUnsafeURL() {
 	s.Require().NoError(err)
 	s.mock.Ctx.Request.SetBody(bodyBytes)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 	s.mock.Assert200OK(s.T(), nil)
 }
 
 func (s *SecondFactorDuoPostSuite) TestShouldRegenerateSessionForPreventingSessionFixation() {
-	duoMock := mocks.NewMockDuoProvider(s.mock.Ctrl)
-
 	s.mock.StorageMock.EXPECT().
 		LoadPreferredDuoDevice(s.mock.Ctx, "john").
 		Return(&model.DuoDevice{ID: 1, Username: "john", Device: "12345ABCDEFGHIJ67890", Method: "push"}, nil)
@@ -719,12 +683,12 @@ func (s *SecondFactorDuoPostSuite) TestShouldRegenerateSessionForPreventingSessi
 	preAuthResponse.Result = auth
 	preAuthResponse.Devices = duoDevices
 
-	duoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
+	s.mock.DuoMock.EXPECT().PreAuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Eq(values)).Return(&preAuthResponse, nil)
 
 	response := duo.AuthResponse{}
 	response.Result = allow
 
-	duoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
+	s.mock.DuoMock.EXPECT().AuthCall(s.mock.Ctx, &session.UserSession{CookieDomain: "example.com", Username: "john"}, gomock.Any()).Return(&response, nil)
 
 	bodyBytes, err := json.Marshal(bodySignDuoRequest{
 		TargetURL: "http://example.com",
@@ -735,7 +699,7 @@ func (s *SecondFactorDuoPostSuite) TestShouldRegenerateSessionForPreventingSessi
 	r := regexp.MustCompile("^authelia_session=(.*); path=")
 	res := r.FindAllStringSubmatch(string(s.mock.Ctx.Response.Header.PeekCookie("authelia_session")), -1)
 
-	DuoPOST(duoMock)(s.mock.Ctx)
+	DuoPOST(s.mock.Ctx)
 	s.mock.Assert200OK(s.T(), nil)
 
 	s.NotEqual(

--- a/internal/handlers/handler_sign_duopreauth.go
+++ b/internal/handlers/handler_sign_duopreauth.go
@@ -14,11 +14,11 @@ import (
 )
 
 // DuoPreAuth helper function for retrieving supported devices and capabilities from Duo API.
-func DuoPreAuth(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, duoAPI duo.Provider) (result, message string, devices []DuoDevice, enrollURL string, err error) {
+func DuoPreAuth(ctx *middlewares.AutheliaCtx, userSession *session.UserSession) (result, message string, devices []DuoDevice, enrollURL string, err error) {
 	values := url.Values{}
 	values.Set("username", userSession.Username)
 
-	preAuthResponse, err := duoAPI.PreAuthCall(ctx, userSession, values)
+	preAuthResponse, err := ctx.Providers.Duo.PreAuthCall(ctx, userSession, values)
 	if err != nil {
 		return "", "", nil, "", err
 	}

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -130,6 +130,7 @@ const (
 	ProviderNameSession          = "session"
 	ProviderNameNotification     = "notification"
 	ProviderNameExpressions      = "expressions"
+	ProviderNameDuo              = "duo"
 	ProviderNameWebAuthnMetaData = "webauthn-metadata"
 )
 

--- a/internal/middlewares/startup.go
+++ b/internal/middlewares/startup.go
@@ -54,6 +54,10 @@ func (p *Providers) StartupChecks(ctx ServiceContext, log bool) (err error) {
 	disable = !ctx.GetConfiguration().WebAuthn.Metadata.Enabled || ctx.GetProviders().MetaDataService == nil
 	doStartupCheck(ctx, ProviderNameWebAuthnMetaData, provider, []string{ProviderNameStorage}, disable, log, e.errors)
 
+	provider = ctx.GetProviders().Duo
+	disable = ctx.GetConfiguration().DuoAPI.Disable || provider == nil
+	doStartupCheck(ctx, ProviderNameDuo, provider, nil, disable, log, e.errors)
+
 	var filters []string
 
 	if ctx.GetConfiguration().NTP.DisableFailure {

--- a/internal/middlewares/types.go
+++ b/internal/middlewares/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/clock"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/duo"
 	"github.com/authelia/authelia/v4/internal/expression"
 	"github.com/authelia/authelia/v4/internal/metrics"
 	"github.com/authelia/authelia/v4/internal/notification"
@@ -56,6 +57,7 @@ type Providers struct {
 	PasswordPolicy        PasswordPolicyProvider
 	UserAttributeResolver expression.UserAttributeResolver
 	MetaDataService       webauthn.MetaDataProvider
+	Duo                   duo.Provider
 
 	GarbageCollector *GarbageCollector
 

--- a/internal/middlewares/util.go
+++ b/internal/middlewares/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/clock"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/duo"
 	"github.com/authelia/authelia/v4/internal/expression"
 	"github.com/authelia/authelia/v4/internal/metrics"
 	"github.com/authelia/authelia/v4/internal/notification"
@@ -63,6 +64,7 @@ func NewProviders(config *schema.Configuration, caCertPool *x509.CertPool) (prov
 	providers.TOTP = totp.NewTimeBasedProvider(config.TOTP)
 	providers.UserAttributeResolver = expression.NewUserAttributes(config)
 	providers.UserProvider = NewAuthenticationProvider(config, caCertPool)
+	providers.Duo = duo.New(config)
 
 	switch {
 	case config.Notifier.SMTP != nil:

--- a/internal/mocks/authelia_context.go
+++ b/internal/mocks/authelia_context.go
@@ -43,6 +43,7 @@ type MockAutheliaCtx struct {
 	NotifierMock     *MockNotifier
 	TOTPMock         *MockTOTP
 	RandomMock       *MockRandom
+	DuoMock          *MockDuoProvider
 
 	Clock clock.Fixed
 }
@@ -216,6 +217,9 @@ func NewMockAutheliaCtx(t *testing.T) *MockAutheliaCtx {
 	providers.SessionProvider = session.NewProvider(config.Session, nil)
 
 	providers.Regulator = regulation.NewRegulator(config.Regulation, providers.StorageProvider, &mockAuthelia.Clock)
+
+	mockAuthelia.DuoMock = NewMockDuoProvider(mockAuthelia.Ctrl)
+	providers.Duo = mockAuthelia.DuoMock
 
 	mockAuthelia.TOTPMock = NewMockTOTP(mockAuthelia.Ctrl)
 	providers.TOTP = mockAuthelia.TOTPMock

--- a/internal/mocks/duo_api.go
+++ b/internal/mocks/duo_api.go
@@ -18,7 +18,6 @@ import (
 	reflect "reflect"
 
 	duo "github.com/authelia/authelia/v4/internal/duo"
-	middlewares "github.com/authelia/authelia/v4/internal/middlewares"
 	session "github.com/authelia/authelia/v4/internal/session"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -48,7 +47,7 @@ func (m *MockDuoProvider) EXPECT() *MockDuoProviderMockRecorder {
 }
 
 // AuthCall mocks base method.
-func (m *MockDuoProvider) AuthCall(ctx middlewares.Context, userSession *session.UserSession, values url.Values) (*duo.AuthResponse, error) {
+func (m *MockDuoProvider) AuthCall(ctx duo.Context, userSession *session.UserSession, values url.Values) (*duo.AuthResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AuthCall", ctx, userSession, values)
 	ret0, _ := ret[0].(*duo.AuthResponse)
@@ -62,23 +61,8 @@ func (mr *MockDuoProviderMockRecorder) AuthCall(ctx, userSession, values any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthCall", reflect.TypeOf((*MockDuoProvider)(nil).AuthCall), ctx, userSession, values)
 }
 
-// Call mocks base method.
-func (m *MockDuoProvider) Call(ctx middlewares.Context, userSession *session.UserSession, values url.Values, method, path string) (*duo.Response, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Call", ctx, userSession, values, method, path)
-	ret0, _ := ret[0].(*duo.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Call indicates an expected call of Call.
-func (mr *MockDuoProviderMockRecorder) Call(ctx, userSession, values, method, path any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockDuoProvider)(nil).Call), ctx, userSession, values, method, path)
-}
-
 // PreAuthCall mocks base method.
-func (m *MockDuoProvider) PreAuthCall(ctx middlewares.Context, userSession *session.UserSession, values url.Values) (*duo.PreAuthResponse, error) {
+func (m *MockDuoProvider) PreAuthCall(ctx duo.Context, userSession *session.UserSession, values url.Values) (*duo.PreAuthResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreAuthCall", ctx, userSession, values)
 	ret0, _ := ret[0].(*duo.PreAuthResponse)
@@ -90,4 +74,18 @@ func (m *MockDuoProvider) PreAuthCall(ctx middlewares.Context, userSession *sess
 func (mr *MockDuoProviderMockRecorder) PreAuthCall(ctx, userSession, values any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreAuthCall", reflect.TypeOf((*MockDuoProvider)(nil).PreAuthCall), ctx, userSession, values)
+}
+
+// StartupCheck mocks base method.
+func (m *MockDuoProvider) StartupCheck() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartupCheck")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartupCheck indicates an expected call of StartupCheck.
+func (mr *MockDuoProviderMockRecorder) StartupCheck() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartupCheck", reflect.TypeOf((*MockDuoProvider)(nil).StartupCheck))
 }

--- a/internal/mocks/duo_base_api.go
+++ b/internal/mocks/duo_base_api.go
@@ -46,6 +46,27 @@ func (m *MockDuoBaseProvider) EXPECT() *MockDuoBaseProviderMockRecorder {
 	return m.recorder
 }
 
+// Call mocks base method.
+func (m *MockDuoBaseProvider) Call(method, uri string, params url.Values, options ...duoapi.DuoApiOption) (*http.Response, []byte, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{method, uri, params}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Call", varargs...)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Call indicates an expected call of Call.
+func (mr *MockDuoBaseProviderMockRecorder) Call(method, uri, params any, options ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{method, uri, params}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockDuoBaseProvider)(nil).Call), varargs...)
+}
+
 // SignedCall mocks base method.
 func (m *MockDuoBaseProvider) SignedCall(method, uri string, params url.Values, options ...duoapi.DuoApiOption) (*http.Response, []byte, error) {
 	m.ctrl.T.Helper()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	duoapi "github.com/duosecurity/duo_api_golang"
 	"github.com/fasthttp/router"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -23,7 +22,6 @@ import (
 	"github.com/valyala/fasthttp/pprofhandler"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
-	"github.com/authelia/authelia/v4/internal/duo"
 	"github.com/authelia/authelia/v4/internal/handlers"
 	"github.com/authelia/authelia/v4/internal/logging"
 	"github.com/authelia/authelia/v4/internal/metrics"
@@ -337,28 +335,14 @@ func handlerMain(config *schema.Configuration, providers middlewares.Providers) 
 	}
 
 	if !config.DuoAPI.Disable {
-		var duoAPI duo.Provider
-
-		if utils.Dev {
-			duoAPI = duo.NewDuoAPI(duoapi.NewDuoApi(
-				config.DuoAPI.IntegrationKey,
-				config.DuoAPI.SecretKey,
-				config.DuoAPI.Hostname, "", duoapi.SetInsecure()))
-		} else {
-			duoAPI = duo.NewDuoAPI(duoapi.NewDuoApi(
-				config.DuoAPI.IntegrationKey,
-				config.DuoAPI.SecretKey,
-				config.DuoAPI.Hostname, ""))
-		}
-
 		middlewareRateLimitDuo := middlewares.NewBridgeBuilder(*config, providers).
 			WithPreMiddlewares(middlewares.SecurityHeadersBase, middlewares.SecurityHeadersNoStore, middlewares.SecurityHeadersCSPNone).
 			WithPostMiddlewares(middlewares.NewRateLimiter(middlewares.WithRateLimitConfig(config.Server.Endpoints.RateLimits.SecondFactorDuo), middlewares.WithRateLimitCollector(providers.GarbageCollector)).Middleware(), middlewares.Require1FA).
 			Build()
 
 		r.GET("/api/secondfactor/duo", middleware1FA(handlers.DuoGET))
-		r.GET("/api/secondfactor/duo_devices", middleware1FA(handlers.DuoDevicesGET(duoAPI)))
-		r.POST("/api/secondfactor/duo", middlewareRateLimitDuo(handlers.DuoPOST(duoAPI)))
+		r.GET("/api/secondfactor/duo_devices", middleware1FA(handlers.DuoDevicesGET))
+		r.POST("/api/secondfactor/duo", middlewareRateLimitDuo(handlers.DuoPOST))
 		r.POST("/api/secondfactor/duo_device", middleware1FA(handlers.DuoDevicePOST))
 	}
 

--- a/internal/suites/example/compose/duo-api/duo_api.js
+++ b/internal/suites/example/compose/duo-api/duo_api.js
@@ -16,14 +16,17 @@
  */
 
 const express = require("express");
-const app = express();
+const crypto = require("crypto");
+
 const port = 3000;
+
+const INTEGRATION_KEY = "ABCDEFGHIJKL";
+const SECRET_KEY = "abcdefghijklmnopqrstuvwxyz123456789";
+
+const app = express();
 
 app.use(express.json());
 app.set("trust proxy", true);
-
-// Auth API
-let permission = "allow";
 
 app.post("/allow", (req, res) => {
     permission = "allow";
@@ -37,10 +40,18 @@ app.post("/deny", (req, res) => {
     res.send("DENIED");
 });
 
+app.get("/auth/v2/ping", (req, res) => {
+    res.status(200).json(status());
+});
+
+app.get("/auth/v2/check", auth, (req, res) => {
+    res.status(200).json(status());
+});
+
 app.post("/auth/v2/auth", (req, res) => {
     setTimeout(() => {
         let response;
-        if (permission == "allow") {
+        if (permission === "allow") {
             response = {
                 response: {
                     result: "allow",
@@ -64,12 +75,6 @@ app.post("/auth/v2/auth", (req, res) => {
     }, 2000);
 });
 
-// PreAuth API
-let preauth = {
-    result: "allow",
-    status_msg: "Allowing unknown user",
-};
-
 app.post("/preauth", (req, res) => {
     preauth = req.body;
     console.log("set result to: %s", preauth);
@@ -91,6 +96,15 @@ app.post("/auth/v2/preauth", (req, res) => {
 
 app.listen(port, () => console.log(`Duo API listening on port ${port}!`));
 
+// Auth API
+let permission = "allow";
+
+// PreAuth API
+let preauth = {
+    result: "allow",
+    status_msg: "Allowing unknown user",
+};
+
 // The signals we want to handle
 // NOTE: although it is tempting, the SIGKILL signal (9) cannot be intercepted and handled
 var signals = {
@@ -98,6 +112,7 @@ var signals = {
     SIGINT: 2,
     SIGTERM: 15,
 };
+
 // Create a listener for each of the signals that we want to handle
 Object.keys(signals).forEach((signal) => {
     process.on(signal, () => {
@@ -105,3 +120,62 @@ Object.keys(signals).forEach((signal) => {
         process.exit(128 + signals[signal]);
     });
 });
+
+/*
+ * Duo signs requests with a HMAC-SHA512 of the canonical request which is transmitted via the Basic scheme of the
+ * Authorization header as the password, with the integration key as the username. See the signature documentation at
+ * https://duo.com/docs/authapi#authentication.
+ */
+function canonicalize(method, host, uri, params, date) {
+    return [date, method.toUpperCase(), host.toLowerCase(), uri, params].join("\n");
+}
+
+function sign(method, host, uri, params, date) {
+    return crypto.createHmac("sha512", SECRET_KEY).update(canonicalize(method, host, uri, params, date)).digest("hex");
+}
+
+function unauthorized(res) {
+    res.set("WWW-Authenticate", 'Basic realm="Restricted"');
+
+    return res.status(401).send("Authentication required");
+}
+
+function auth(req, res, next) {
+    const header = req.headers.authorization;
+
+    if (!header || !header.startsWith("Basic ")) {
+        return unauthorized(res);
+    }
+
+    let integration_key = "", signature = "";
+
+    try {
+        const [, raw] = header.split(" ");
+        const [i, s] = Buffer.from(raw, "base64").toString("utf8").split(":");
+
+        integration_key = i || "";
+        signature = s || "";
+    } catch {
+        return res.status(400).send("Bad Request");
+    }
+
+    if (integration_key !== INTEGRATION_KEY) {
+        return unauthorized(res);
+    }
+
+    // The canonical request percent encodes spaces rather than encoding them as a plus.
+    const [, query = ""] = req.originalUrl.split("?");
+    const params = query.replace(/\+/g, "%20");
+
+    const expected = sign(req.method, req.headers.host || "", req.path, params, req.headers.date || "");
+
+    if (signature.length !== expected.length || !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) {
+        return unauthorized(res);
+    }
+
+    return next();
+}
+
+function status() {
+    return {stat: "OK", response: {time: Math.floor(Date.now() / 1000)}}
+}

--- a/internal/suites/example/compose/duo-api/duo_client.js
+++ b/internal/suites/example/compose/duo-api/duo_client.js
@@ -8,17 +8,21 @@
 
 const DuoApi = require("@duosecurity/duo_api");
 
+const client = new DuoApi.Client("ABCDEFGHIJKL", "abcdefghijklmnopqrstuvwxyz123456789", "duo.example.com");
+
 process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
 
-const client = new DuoApi.Client("ABCDEFG", "SECRET", "duo.example.com");
 console.log("Testing Auth API first");
+
 client.jsonApiCall(
     "POST",
     "/auth/v2/auth",
     { username: "john", factor: "push", device: "auto" },
     console.log,
 );
+
 console.log("Testing PreAuth API second");
+
 client.jsonApiCall(
     "POST",
     "/auth/v2/preauth",


### PR DESCRIPTION
This adds a startup check for the Duo provider which validates connectivity and the configured credentials via the ping and check endpoints. The provider is now provisioned with the other providers and accessed via the context rather than being constructed while registering the handlers.