### PR TITLE
docs: move about, contact, and policies to overview

### DIFF
--- a/docs/config/_default/menus/menus.en.toml
+++ b/docs/config/_default/menus/menus.en.toml
@@ -61,30 +61,30 @@
 
 [[footer]]
   name = "Privacy Policy"
-  url = "/policies/privacy"
+  url = "/overview/project/policies/privacy"
   weight = 10
 
 [[footer]]
   name = "Security Policy"
-  url = "/policies/security"
+  url = "/overview/project/policies/security"
   weight = 20
 
 [[footer]]
   name = "Versioning Policy"
-  url = "/policies/versioning"
+  url = "/overview/project/policies/versioning"
   weight = 30
 
 [[footer]]
   name = "Code of Conduct"
-  url = "/code-of-conduct"
+  url = "/overview/project/policies/code-of-conduct"
   weight = 40
 
 [[footer]]
   name = "About"
-  url = "/information/about"
+  url = "/overview/project/about"
   weight = 50
 
 [[footer]]
   name = "Contact"
-  url = "/information/contact"
+  url = "/overview/project/contact"
   weight = 60

--- a/docs/content/blog/we-are-now-openid-certified/index.md
+++ b/docs/content/blog/we-are-now-openid-certified/index.md
@@ -142,7 +142,7 @@ including a similar chart.
 # Join the Discussion and Show Your Support
 
 Feel free to discuss this awesome news in our [Discussion Forum](https://github.com/authelia/authelia/discussions/9525),
-or in one of our many [Chat Methods](../../information/contact.md#chat).
+or in one of our many [Chat Methods](../../overview/project/contact.md#chat).
 
 You can show your support for the Authelia project by giving us a star on [GitHub](https://www.github.com/authelia/authelia).
 

--- a/docs/content/configuration/methods/files.md
+++ b/docs/content/configuration/methods/files.md
@@ -190,7 +190,7 @@ information.
 
 File filters exist which allow modification of all configuration files after reading them from the
 filesystem but before parsing their content. Unless explicitly specified these filters are _**NOT**_ covered by our
-[Standard Versioning Policy](../../policies/versioning.md) and
+[Standard Versioning Policy](../../overview/project/policies/versioning.md) and
 
 There __*WILL*__ be a point where:
 
@@ -263,7 +263,7 @@ See the [Templating Reference Guide](../../reference/guides/templating.md) for m
 {{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
 The Expand Environment Variable filter (i.e. `expand-env`) is officially deprecated. It will be removed in v4.40.0 and
 will result in a startup error. This removal is done based on the experimental introduction of this feature and our
-[Versioning Policy](../../policies/versioning.md). The removal decision was made due to the fact the
+[Versioning Policy](../../overview/project/policies/versioning.md). The removal decision was made due to the fact the
 [Go Template Filter](#go-template-filter) can effectively do everything this filter can do without the
 [Known Limitations](#known-limitations) which should be read carefully before usage of this filter.
 {{< /callout >}}

--- a/docs/content/contributing/development/introduction.md
+++ b/docs/content/contributing/development/introduction.md
@@ -15,7 +15,7 @@ seo:
 ---
 
 We encourage anyone who wishes to contribute via development to utilize GitHub [Issues] or [Discussions] or one of the
-[other contact methods](../../information/contact.md) to discuss their contribution in advance and come up with a design
+[other contact methods](../../overview/project/contact.md) to discuss their contribution in advance and come up with a design
 plan.
 
 It's also important that you read guidelines and try to follow them. The development section is arranged in the order

--- a/docs/content/contributing/guidelines/testing.md
+++ b/docs/content/contributing/guidelines/testing.md
@@ -23,7 +23,7 @@ The following outlines the specific requirements we have for testing the Autheli
 - It's required for bug fixes that contributors create a test that fails prior to and passes
   subsequent to the fix being applied, this test must be included in the contribution, excluding this test will likely
   result in the fix being rejected unless explicitly agreed and advised otherwise by the
-  [core team](../../information/about.md#core-team)
+  [core team](../../overview/project/about.md#core-team)
 - It's strongly encouraged for features that contributors create have as much testing as is reasonable i.e. any line
   that can be tested should be tested, if the line can't be tested generally this is an indication a refactor may be
   required

--- a/docs/content/contributing/guidelines/testing.md
+++ b/docs/content/contributing/guidelines/testing.md
@@ -23,7 +23,7 @@ The following outlines the specific requirements we have for testing the Autheli
 - It's required for bug fixes that contributors create a test that fails prior to and passes
   subsequent to the fix being applied, this test must be included in the contribution, excluding this test will likely
   result in the fix being rejected unless explicitly agreed and advised otherwise by the
-  [core team](../../overview/project/about.md#core-team)
+  [core team](../../overview/project/team-governance/#core-team)
 - It's strongly encouraged for features that contributors create have as much testing as is reasonable i.e. any line
   that can be tested should be tested, if the line can't be tested generally this is an indication a refactor may be
   required

--- a/docs/content/contributing/prologue/financial.md
+++ b/docs/content/contributing/prologue/financial.md
@@ -26,7 +26,7 @@ was not prompted by any bug bounty program as we do not have one, but we hope to
 
 Potential usage for the money, ranked in order of priority:
 
-1. Put Authelia through a comprehensive [Security Audit](../../policies/security.md#help-wanted).
+1. Put Authelia through a comprehensive [Security Audit](../../overview/project/policies/security.md#help-wanted).
    1. Audit of Code Security via Analysis.
    2. Audit via Penetration Testing.
 2. Obtain formal accreditations.
@@ -42,7 +42,7 @@ Authelia is sponsored by several companies via indirect means. These companies d
 contributions are very important to us but not easily visible.
 
 If you feel you have a product or service that Authelia could benefit from please feel free to
-[contact](../../information/contact.md) us.
+[contact](../../overview/project/contact.md) us.
 
 In the event that an entity decides to sponsor an entire or large part of a formal and industry recognized audit we
 would be willing to discuss terms including but not limited to making formal acknowledgement in the form of a blog post,
@@ -55,8 +55,8 @@ the Authelia binary itself.
 
 We are currently directly looking for someone to sponsor:
 
-* [Security Audit](../../policies/security.md#help-wanted)
+* [Security Audit](../../overview/project/policies/security.md#help-wanted)
 
-To see a list of our sponsors please see the [sponsors section](../../information/about.md#sponsors) on the about page.
+To see a list of our sponsors please see the [sponsors section](../../overview/project/about.md#sponsors) on the about page.
 
 [Open Collective]: https://opencollective.com/authelia-sponsors

--- a/docs/content/contributing/prologue/introduction.md
+++ b/docs/content/contributing/prologue/introduction.md
@@ -25,7 +25,7 @@ Contributions to __Authelia__ have four main forms:
 
 We encourage our community to be part of __Authelia__ by contributing in these ways. We encourage anyone who wishes to
 contribute via development to utilize GitHub [Issues] or [Discussions] or one of the
-[other contact methods](../../information/contact.md) to discuss their contribution in advance and come up with a design
+[other contact methods](../../overview/project/contact.md) to discuss their contribution in advance and come up with a design
 plan.
 
 [Issues]: https://github.com/authelia/authelia/issues

--- a/docs/content/contributing/prologue/translations.md
+++ b/docs/content/contributing/prologue/translations.md
@@ -24,7 +24,7 @@ The way the translation process is facilitated is via [Crowdin]. We encourage me
 If the language you wish to translate is not on [Crowdin] then you have a few options:
 
 1. Ask for the language to be added via the [Crowdin] interface.
-2. Ask a maintainer to add it via one of the [contact options](../../information/contact.md).
+2. Ask a maintainer to add it via one of the [contact options](../../overview/project/contact.md).
 3. Make a pull request directly on GitHub modifying the translation files within
 [this directory](https://github.com/authelia/authelia/tree/master/internal/server/locales).
 

--- a/docs/content/overview/project/_index.md
+++ b/docs/content/overview/project/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Project"
+description: "Overview Project"
+summary: "Information about the Authelia project, team, governance, sponsors, and policies"
+date: 2024-03-14T06:00:14+11:00
+draft: false
+images: []
+weight: 500
+---

--- a/docs/content/overview/project/about.md
+++ b/docs/content/overview/project/about.md
@@ -1,0 +1,26 @@
+---
+title: "About"
+description: "About Authelia and the Authelia Team"
+summary: ""
+date: 2024-03-14T06:00:14+11:00
+draft: false
+images: []
+toc: true
+aliases:
+  - '/about'
+  - '/about.html'
+  - '/information/about'
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## What is Authelia?
+
+Authelia is a project with several open source developers who contribute to the project in their free time. We are not
+a company or another type of incorporated entity, and do not have any monetization model. Individuals and Organizations
+are free to contribute [financially](../../contributing/prologue/financial.md) or with their time to the
+[documentation](../../contributing/prologue/documentation-contributions.md) or
+[code base](../../contributing/development/introduction.md).

--- a/docs/content/overview/project/contact.md
+++ b/docs/content/overview/project/contact.md
@@ -6,11 +6,11 @@ date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 toc: true
-type: legal
 aliases:
   - '/contact'
   - '/contact.html'
   - '/docs/community/'
+  - '/information/contact'
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)
@@ -21,7 +21,7 @@ seo:
 ## Security
 
 If you believe you have identified a security vulnerability or security related bug with __Authelia__ please view our
-[security policy](../policies/security.md).
+[security policy](../project/policies/security.md).
 
 ## Individual Team Members
 

--- a/docs/content/overview/project/policies/_index.md
+++ b/docs/content/overview/project/policies/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Policies"
+description: "Overview Project Policies"
+summary: "Authelia's privacy policy, security policy, code of conduct, and versioning policy"
+date: 2024-03-14T06:00:14+11:00
+draft: false
+images: []
+weight: 500
+---

--- a/docs/content/overview/project/policies/code-of-conduct.md
+++ b/docs/content/overview/project/policies/code-of-conduct.md
@@ -7,7 +7,6 @@ draft: false
 images: []
 weight: 100
 toc: true
-type: legal
 aliases:
   - '/code-of-conduct'
   - '/code-of-conduct.html'

--- a/docs/content/overview/project/policies/privacy.md
+++ b/docs/content/overview/project/policies/privacy.md
@@ -6,12 +6,12 @@ date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 toc: false
-type: legal
 aliases:
-  - /privacy-policy
-  - /privacy-policy.html
-  - /privacy
-  - /privacy.html
+  - '/privacy-policy'
+  - '/privacy-policy.html'
+  - '/privacy'
+  - '/privacy.html'
+  - '/policies/privacy'
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)
@@ -63,6 +63,6 @@ information is only stored in the local SQL database and is NOT sent to any exte
 
 ## Contact us
 
-[Contact us](../information/contact.md) if you have any questions.
+[Contact us](../contact.md) if you have any questions.
 
 __Effective Date:__ *16th May 2022*

--- a/docs/content/overview/project/policies/security.md
+++ b/docs/content/overview/project/policies/security.md
@@ -6,11 +6,11 @@ date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 toc: false
-type: legal
 aliases:
-  - /security-policy
-  - /security
-  - /security.html
+  - '/security-policy'
+  - '/security'
+  - '/security.html'
+  - '/policies/security'
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)
@@ -56,14 +56,14 @@ vulnerabilities and issues within the __Authelia__ code base.
 ### Chat
 
 If you wish to chat directly instead of sending an email please use one of the
-[chat options](../information/contact.md#chat) to direct / private message one of the [core team] members.
+[chat options](../contact.md#chat) to direct / private message one of the [core team] members.
 
 Please avoid this method unless absolutely necessary. We generally prefer that users use either the
 [GitHub Security](#github-security) or [Email](#email) option rather than this option as it both allows multiple team
 members to deal with the report and prevents mistakes when contacting a [core team] member.
 
-The [core team] members are identified in [Matrix](../information/contact.md#matrix) as room admins, and in
-[Discord](../information/contact.md#discord) with the `Core Team` role.
+The [core team] members are identified in [Matrix](../contact.md#matrix) as room admins, and in
+[Discord](../contact.md#discord) with the `Core Team` role.
 
 ## Process
 
@@ -108,5 +108,5 @@ willing to make a financial contribution towards this then please feel free to c
 [coordinated vulnerability disclosure]: https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure
 [security advisory]: https://github.com/authelia/authelia/security/advisories
 [report a vulnerability]: https://github.com/authelia/authelia/security/advisories/new
-[core team]: ../information/about.md#core-team
+[core team]: ../about.md#core-team
 [all contributors]: https://github.com/authelia/authelia/blob/master/README.md#contribute

--- a/docs/content/overview/project/policies/versioning.md
+++ b/docs/content/overview/project/policies/versioning.md
@@ -6,10 +6,10 @@ date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 toc: false
-type: legal
 aliases:
-  - /versioning-policy
-  - /versioning
+  - '/versioning-policy'
+  - '/versioning'
+  - '/policies/versioning'
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)
@@ -107,7 +107,7 @@ This exception applies to all features which are described as:
 
 Notable examples:
 
-- [OpenID Connect 1.0](../configuration/identity-providers/openid-connect/provider.md)
-- [File Filters](../configuration/methods/files.md#file-filters)
+- [OpenID Connect 1.0](../../../configuration/identity-providers/openid-connect/provider.md)
+- [File Filters](../../../configuration/methods/files.md#file-filters)
 
 

--- a/docs/content/overview/project/sponsors.md
+++ b/docs/content/overview/project/sponsors.md
@@ -1,5 +1,5 @@
 ---
-title: "About"
+title: "Sponsors"
 description: "About Authelia and the Authelia Team"
 summary: ""
 date: 2024-03-14T06:00:14+11:00
@@ -7,42 +7,21 @@ draft: false
 images: []
 toc: true
 aliases:
-  - /about
-  - /about.html
+  - /sponsors
+  - /sponsors.html
 seo:
   title: "" # custom title (optional)
   description: "" # custom description (recommended)
   canonical: "" # custom canonical URL (optional)
   noindex: false # false (default) or true
 ---
-
-## What is Authelia?
-
-Authelia is a project with several open source developers who contribute to the project in their free time. We are not
-a company or another type of incorporated entity, and do not have any monetization model. Individuals and Organizations
-are free to contribute [financially](../contributing/prologue/financial.md) or with their time to the
-[documentation](../contributing/prologue/documentation-contributions.md) or
-[code base](../contributing/development/introduction.md).
-
-## Teams
-
-The following section describes the various teams within the Authelia project.
-
-### Core Team
-
-{{% profile-team name="core" %}}
-
-### Maintainers Team
-
-{{% profile-team name="maintainers" %}}
-
 ## Sponsors
 
 Authelia is sponsored by the organizations listed below. The organizations below sponsor us completely voluntarily
 and do not expect anything additional other than us mentioning them or having a code of conduct, and some do not even
 require either of those things.
 
-Please see the [sponsorship section](../contributing/prologue/financial.md#sponsorship) of the financial contributing
+Please see the [sponsorship section](../../contributing/prologue/financial.md#sponsorship) of the financial contributing
 page for more information on how to become a sponsor.
 
 ### Balto
@@ -86,30 +65,3 @@ Our [website and documentation](https://www.authelia.com) are built and hosted b
 [Netlify](https://www.netlify.com/?from=Authelia).
 
 [Open Collective]: https://opencollective.com/authelia-sponsors
-
-## Governance and Affiliations
-
-Authelia is free from any outside governance and is entirely governed as outlined on this page, in addition we do not
-have any affiliations which have ever asked this of us.
-
-Our affiliations with external companies will be transparently communicated in this section and the
-[sponsors](#sponsors) section.
-
-## Compliance
-
-The following section contains various compliance related information.
-
-### Key Individuals
-
-There is no key individual who if they were incapacitated or unavailable would prevent future operations of the project.
-
-All of the following areas can be reset or are otherwise accessible to all of the members of the [Core Team](#core-team):
-
-- Private Keys
-- Access Rights
-- Passwords
-
-### Bus Factor
-
-The Authelia team has a bus factor of 3. Meaning that the project would stall if 3 team members were suddenly hit by a
-bus.

--- a/docs/content/overview/project/sponsors.md
+++ b/docs/content/overview/project/sponsors.md
@@ -1,6 +1,6 @@
 ---
 title: "Sponsors"
-description: "About Authelia and the Authelia Team"
+description: "Organizations sponsoring the Authelia Project"
 summary: ""
 date: 2024-03-14T06:00:14+11:00
 draft: false

--- a/docs/content/overview/project/team-governance.md
+++ b/docs/content/overview/project/team-governance.md
@@ -1,0 +1,119 @@
+---
+title: "Team & Governance"
+description: "About the Authelia Team and Project Governance"
+summary: ""
+date: 2024-03-14T06:00:14+11:00
+draft: false
+images: []
+toc: true
+aliases:
+  - '/team'
+  - '/governance'
+  - '/team-governance'
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Teams
+
+The following section describes the various teams within the Authelia project.
+
+### Core Team
+
+{{% profile-team name="core" %}}
+
+### Maintainers Team
+
+{{% profile-team name="maintainers" %}}
+
+## Access and Permissions
+
+The following section describes how team membership and access permissions are managed within the Authelia project.
+
+
+### Access Levels
+
+**External Contributors**
+
+- Submit pull requests via forked repositories
+- No direct repository access
+- CI/CD workflow runs require approval from team members
+
+**Maintainers Team**
+
+- Push access to feature branches (not main/master)
+- Can approve CI/CD workflow runs for external contributions
+- Can review and approve pull requests
+- Subject to all branch protection and approval requirements
+- Access to specific infrastructure as needed for their responsibilities
+
+**Core Team**
+
+- Full repository access subject to branch protection rules
+- Access to infrastructure, hosting, and deployment systems
+- Access to release signing credentials
+- Handle security vulnerabilities and incidents
+- All operations still subject to multi-person approval requirements
+
+### Team Growth Process
+
+New team members are identified through their contributions and community involvement:
+
+1. **Contribution Period**: Potential members demonstrate quality work through external contributions
+2. **Invitation**: Core Team members may invite consistent contributors to join as Maintainers
+3. **Gradual Access**: Access is granted incrementally based on responsibilities and trust
+4. **Consensus**: All team additions are discussed and approved by Core Team members
+
+### Security Controls
+
+To protect against account compromise and ensure code quality, we implement multiple safeguards:
+
+- **Multi-Person Approval**: All pull requests require approval from 2 team members before merge (excluding automated dependency updates and minor maintenance)
+- **Release Protection**: All releases require approval from 2 members with write access.
+- **Branch Protection**: The main branch cannot be pushed to directly; all changes require pull requests
+- **Two-Factor Authentication**: Required for all team members to perform sensitive operations
+- **No Unilateral Access**: Even with write permissions, no single team member can make changes alone
+
+These controls guard against compromised accounts, accidental errors, and ensure all changes receive peer review.
+
+### Access Review
+
+- Team access is reviewed as needed
+- Inactive members may have access removed after Core Team discussion
+- Access can be revoked immediately for security concerns or code of conduct violations
+- All access changes are discussed among Core Team members
+
+## Governance
+
+Authelia is free from any outside governance and is entirely governed as outlined on this page. We do not have any affiliations which have ever asked us to modify our governance structure.
+
+Our affiliations with external companies are transparently communicated on the [Sponsors](./sponsors.md) page.
+
+### Decision-Making
+
+- Core Team makes governance decisions unanimously
+- Technical decisions follow consensus-based discussion
+- Major changes are discussed openly in issues and discussions
+- Community input is valued and considered in decision-making
+
+## Compliance
+
+The following section contains various compliance related information.
+
+### Key Individuals
+
+There is no key individual who if they were incapacitated or unavailable would prevent future operations of the project.
+
+All of the following areas can be reset or are otherwise accessible to all of the members of the [Core Team](#core-team):
+
+- Private Keys
+- Access Rights
+- Passwords
+
+### Bus Factor
+
+The Authelia team has a bus factor of 3. Meaning that the project would stall if 3 team members were suddenly hit by a
+bus.

--- a/docs/content/overview/security/introduction.md
+++ b/docs/content/overview/security/introduction.md
@@ -26,7 +26,7 @@ was previously known as responsible disclosure. We strongly urge anyone reportin
 other project to follow this model as it is considered as a best practice by many in the security industry.
 
 If you believe you have identified a security vulnerability or security related bug with __Authelia__ please make every
-effort to contact us privately using one of the [contact options](../../policies/security.md#contact-options) below.
+effort to contact us privately using one of the [contact options](../project/policies/security.md#contact-options) below.
 Please do not open an issue, do not notify us in public, and do not disclose this issue to third parties.
 
 Using this process helps ensure that users affected have an avenue to fixing the issue as close to the issue being
@@ -35,6 +35,6 @@ diligent administrators simply via the act of disclosing the security issue.
 
 ## Policy
 
-Please view our [security policy](../../policies/security.md) for more information.
+Please view our [security policy](../project/policies/security.md) for more information.
 
 [coordinated vulnerability disclosure]: https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure

--- a/docs/content/reference/guides/notification-templates.md
+++ b/docs/content/reference/guides/notification-templates.md
@@ -86,4 +86,4 @@ The original template content can be found on
 Several functions are implemented with the email templates. See the
 [Templating Reference Guide](../../reference/guides/templating.md) for more information.
 
-[Versioning Policy]: ../../policies/versioning.md
+[Versioning Policy]: ../../overview/project/policies/versioning.md

--- a/docs/content/reference/guides/server-asset-overrides.md
+++ b/docs/content/reference/guides/server-asset-overrides.md
@@ -44,7 +44,7 @@ to make a PR. We also encourage people to make PR's for variants where the diffe
 
 {{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
 Users wishing to override the locales files should be aware that we do not provide any guarantee
-that the file will not change in a breaking way between releases as per our [Versioning Policy](../../policies/versioning.md). Users who are planning to
+that the file will not change in a breaking way between releases as per our [Versioning Policy](../../overview/project/policies/versioning.md). Users who are planning to
 utilize these overrides should either check for changes to the files in the
 [en](https://github.com/authelia/authelia/tree/master/internal/server/locales/en) translation prior to upgrading or
 [Contribute](../../contributing/prologue/translations.md) their translation to ensure it is maintained.

--- a/docs/content/roadmap/active/openid-connect-1.0-provider.md
+++ b/docs/content/roadmap/active/openid-connect-1.0-provider.md
@@ -157,7 +157,7 @@ Feature List:
 
 {{< callout context="danger" title="Important Notes" icon="outline/alert-octagon" >}}
 This version will contain one or more breaking changes per our
-[Versioning Policy](../../policies/versioning.md#experimental-features).
+[Versioning Policy](../../overview/project/policies/versioning.md#experimental-features).
 {{< /callout >}}
 
 Breaking Changes:
@@ -190,7 +190,7 @@ See [OpenID Connect Core 1.0 (Mandatory to Implement Features for All OpenID Pro
 
 {{< callout context="danger" title="Important Notes" icon="outline/alert-octagon" >}}
 This version will contain one or more breaking changes per our
-[Versioning Policy](../../policies/versioning.md#experimental-features).
+[Versioning Policy](../../overview/project/policies/versioning.md#experimental-features).
 {{< /callout >}}
 
 Breaking Changes:
@@ -254,7 +254,7 @@ This stage lists features which individually do not fit into a specific stage an
 
 {{< callout context="danger" title="Important Notes" icon="outline/alert-octagon" >}}
 This will be a planned breaking-change as per our
-[Versioning Policy](../../policies/versioning.md#experimental-features).
+[Versioning Policy](../../overview/project/policies/versioning.md#experimental-features).
 {{< /callout >}}
 
 The initial design of our [OpenID Connect 1.0] implementation was before


### PR DESCRIPTION
This change aims to make important details like info about the maintainers team, project policies, and sponsorship easier to find.

Also, this adds information regarding:
- the process of becoming a maintainer
- access that members of the different teams have to various aspects of the project's infrastructure

Both of the above items need to be reviewed by @james-d-elliott and @nightah 

<img width="314" height="520" alt="image" src="https://github.com/user-attachments/assets/bf940e1c-ced8-4b44-a527-381747a9301a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a Project overview section with About, Policies, Team Governance, and contact pages.
  - Renamed/simplified Sponsors page and moved governance content into overview/project.
  - Added aliases for backward compatibility (contact, privacy, security, versioning).
  - Updated numerous internal links across blog, contributing, configuration, guides, roadmap, and reference content to new overview/project paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->