### PR TITLE
i18n: update pr title to include language

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,5 @@
 ---
-pull_request_title: 'i18n: update translations'
+pull_request_title: 'i18n: update translations (%language%)'
 commit_message: 'i18n: update translation for %original_file_name% (%language%)'
 append_commit_message: false
 files:


### PR DESCRIPTION
This change updates i18n pull requests from Crowdin to include the language name in the title.