### PR TITLE
fix(handlers): webauthn experimental 2fa default redirection

### DIFF
--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -135,6 +135,7 @@ func Handle2FAResponse(ctx *middlewares.AutheliaCtx, targetURI string) {
 func HandlePasskeyResponse(ctx *middlewares.AutheliaCtx, targetURI, requestMethod, username string, groups []string, isTwoFactor bool) {
 	if isTwoFactor {
 		Handle2FAResponse(ctx, targetURI)
+		return
 	}
 
 	Handle1FAResponse(ctx, targetURI, requestMethod, username, groups)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the passkey sign-in flow where, when two-factor authentication (2FA) was required, the app could continue into single-factor handling. The flow now stops correctly after completing 2FA, preventing duplicate prompts, inconsistent states, and potential timeouts. This improves reliability and provides a smoother, more predictable login experience for users using passkeys with 2FA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->