### PR TITLE
ci: remove enabling automerge with renovate

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -6,9 +6,6 @@
     ":separatePatchReleases",
     "workarounds:doNotUpgradeFromAlpineStableToEdge"
   ],
-  "ignoreDeps": [
-    "vite-plugin-checker"
-  ],
   "ignorePaths": [
     "docs/**"
   ],
@@ -33,16 +30,6 @@
     "dependencies"
   ],
   "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "digest",
-        "minor",
-        "patch"
-      ],
-      "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
-    },
     {
       "matchDatasources": [
         "docker"


### PR DESCRIPTION
This change removes Renovate from setting auto-merge to drop its repo branch overriding capabilities, instead auto-merging is set by our Autheliabot CI. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dependency update automation settings to improve reliability and control.
  - Removed an exception that previously skipped certain tooling updates to ensure they’re tracked.
  - Adjusted auto-merge behavior for routine updates to favor review and visibility.
  - Expect clearer dependency PRs and a more predictable update cadence.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->