### PR TITLE
refactor: pin go development deps via go app and go.mod

### DIFF
--- a/internal/suites/example/compose/authelia/resources/entrypoint-backend.sh
+++ b/internal/suites/example/compose/authelia/resources/entrypoint-backend.sh
@@ -4,10 +4,10 @@ set -x
 
 cd /resources
 
-echo "Use hot reloaded version of Authelia backend"
-go install github.com/cespare/reflex
-go install github.com/go-delve/delve/cmd/dlv
+echo "Installing pinned CLI tools from go.mod"
+go run .
 
 cd /app
 
+echo "Use hot reloaded version of Authelia backend"
 reflex -c /resources/reflex.conf

--- a/internal/suites/example/compose/authelia/resources/main.go
+++ b/internal/suites/example/compose/authelia/resources/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	tools := []string{
+		"github.com/cespare/reflex",
+		"github.com/go-delve/delve/cmd/dlv",
+	}
+
+	for _, tool := range tools {
+		log.Printf("Installing %s", tool)
+
+		cmd := exec.Command("go", "install", tool)
+		cmd.Env = os.Environ()
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			log.Fatalf("failed to install %s: %v", tool, err)
+		}
+	}
+}


### PR DESCRIPTION
This change alters the approach for pinning dependencies utilised in the development environment for hot-reloading and debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Restored clear messaging when starting the hot-reloaded backend.
- Refactor
  - Streamlined development tool setup to run via a single command before launching hot-reload.
- Chores
  - Added a small utility to automate installation of required development tools, improving setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->