### PR TITLE
ci: pin dockerfile base images for ossf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # ===================================
 # ===== Authelia official image =====
 # ===================================
-ARG BASE="authelia/base:latest"
+ARG TAG
+ARG SHA
 
-FROM ${BASE}
+FROM authelia/base:${TAG}@sha256:${SHA}
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -43,7 +43,7 @@ RUN \
 # ===================================
 # ===== Authelia official image =====
 # ===================================
-FROM authelia/base:latest
+FROM authelia/base:latest@sha256:931856987c8a23ee306e5bfb20cfe096d5509a7b2323fef971d4303510507588
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -42,7 +42,7 @@ RUN \
 # ===================================
 # ===== Authelia official image =====
 # ===================================
-FROM authelia/base:latest
+FROM authelia/base:latest@sha256:931856987c8a23ee306e5bfb20cfe096d5509a7b2323fef971d4303510507588
 
 WORKDIR /app
 

--- a/cmd/authelia-scripts/cmd/helpers_docker.go
+++ b/cmd/authelia-scripts/cmd/helpers_docker.go
@@ -74,7 +74,9 @@ func (d *Docker) Manifest(tags []string) error {
 		return err
 	}
 
-	args = append(args, "--label", "org.opencontainers.image.base.name=docker.io/"+BaseImageName+":"+indexDigest, "--build-arg", "BASE="+BaseImageName+":"+indexDigest)
+	_, sha, _ := strings.Cut(indexDigest, ":")
+
+	args = append(args, "--label", "org.opencontainers.image.base.name=docker.io/"+BaseImageName+":"+indexDigest, "--build-arg", "TAG="+baseImageTag, "--build-arg", "SHA="+sha)
 
 	digestAMD64, digestARM, digestARM64, err := getBaseImageDigests(baseImageTag)
 	if err != nil {


### PR DESCRIPTION
This change alters the approach for pinning Dockerfile base image dependencies to conform to OSSF scanning standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned Docker base images using explicit tag and digest to ensure deterministic, reproducible builds.
  * Applied image pinning across primary, development, and coverage build images for consistency.
* **Refactor**
  * Standardized build arguments for base image selection, simplifying configuration and alignment across build stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->