### PR TITLE
Add missing options for Homarr config

### DIFF
--- a/docs/content/integration/openid-connect/clients/homarr/index.md
+++ b/docs/content/integration/openid-connect/clients/homarr/index.md
@@ -76,6 +76,7 @@ identity_providers:
         access_token_signed_response_alg: 'none'
         userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'client_secret_basic'
+        consent_mode: 'implicit'
 ```
 
 ### Application


### PR DESCRIPTION
consent_mode

OIDC with Homarr wasn't working for me until I added the `consent_mode: 'implicit'` option. [Homarr's OIDC documentation](https://homarr.dev/docs/next/advanced/single-sign-on/) includes this in their documentation for OIDC with Authelia.