### PR TITLE
ci: add cve exclusion for lefthook dev dependency

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -13,13 +13,11 @@ ignore:
   - vulnerability: CVE-2025-61727
     package:
       name: stdlib
+      version: go1.25.4
       type: go-module
-    fix-state: not-fixed
-    reason: "Lefthook dev dependency built with Go 1.25.0"
   - vulnerability: CVE-2025-61729
     package:
       name: stdlib
+      version: go1.25.4
       type: go-module
-    fix-state: not-fixed
-    reason: "Lefthook dev dependency built with Go 1.25.0"
 ...


### PR DESCRIPTION
Adds the go v1.25.5> stdlib vulnerabilities to grype exclusions.

Attempts to fix lefthook (frontend dev-dependency) from blocking deps updates.