### PR TITLE
feat: Use mailAlternateAddress for password reset

### DIFF
--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -137,9 +137,7 @@ func (p *LDAPUserProvider) GetDetails(username string) (details *UserDetails, er
 		return nil, err
 	}
 
-	var (
-		groups []string
-	)
+	var groups []string
 
 	if groups, err = p.getUserGroups(client, username, profile); err != nil {
 		return nil, err
@@ -174,9 +172,7 @@ func (p *LDAPUserProvider) GetDetailsExtended(username string) (details *UserDet
 		return nil, err
 	}
 
-	var (
-		groups []string
-	)
+	var groups []string
 
 	if groups, err = p.getUserGroups(client, username, profile.ldapUserProfile); err != nil {
 		return nil, err
@@ -382,7 +378,7 @@ func (p *LDAPUserProvider) ChangePassword(username, oldPassword string, newPassw
 		err = p.modify(client, modifyRequest)
 	}
 
-	//TODO: Better inform users regarding password reuse/password history.
+	// TODO: Better inform users regarding password reuse/password history.
 	if err != nil {
 		if errorCode := getLDAPResultCode(err); errorCode != -1 {
 			switch errorCode {
@@ -538,6 +534,12 @@ func (p *LDAPUserProvider) getUserProfileResultToProfile(username string, entry 
 
 	if userProfile.DN == "" {
 		return nil, fmt.Errorf("user '%s' must have a distinguished name but the result returned an empty distinguished name", username)
+	}
+
+	alternateEmail := getValueFromEntry(entry, "mailAlternateAddress")
+
+	if len(alternateEmail) > 0 {
+		userProfile.Emails = append(userProfile.Emails, alternateEmail)
 	}
 
 	return &userProfile, nil

--- a/internal/authentication/ldap_user_provider_lifecycle.go
+++ b/internal/authentication/ldap_user_provider_lifecycle.go
@@ -128,6 +128,11 @@ func (p *LDAPUserProvider) parseDynamicUsersConfiguration() {
 		}
 	}
 
+	if !utils.IsStringInSlice("mailAlternateAddress", p.usersAttributes) {
+		p.usersAttributes = append(p.usersAttributes, "mailAlternateAddress")
+		p.usersAttributesExtended = append(p.usersAttributesExtended, "mailAlternateAddress")
+	}
+
 	attributesExtended := []string{
 		p.config.Attributes.GivenName,
 		p.config.Attributes.MiddleName,

--- a/internal/handlers/handler_reset_password.go
+++ b/internal/handlers/handler_reset_password.go
@@ -217,7 +217,6 @@ func ResetPasswordPOST(ctx *middlewares.AutheliaCtx) {
 
 func identityRetrieverFromStorage(ctx *middlewares.AutheliaCtx) (*session.Identity, error) {
 	var requestBody resetPasswordStep1RequestBody
-
 	err := json.Unmarshal(ctx.PostBody(), &requestBody)
 	if err != nil {
 		return nil, err
@@ -233,9 +232,10 @@ func identityRetrieverFromStorage(ctx *middlewares.AutheliaCtx) (*session.Identi
 	}
 
 	return &session.Identity{
-		Username:    requestBody.Username,
-		DisplayName: details.DisplayName,
-		Email:       details.Emails[0],
+		Username:        requestBody.Username,
+		DisplayName:     details.DisplayName,
+		Email:           details.Emails[0],
+		AlternateEmails: details.Emails[1:],
 	}, nil
 }
 

--- a/internal/middlewares/identity_verification.go
+++ b/internal/middlewares/identity_verification.go
@@ -109,7 +109,14 @@ func IdentityVerificationStart(args IdentityVerificationStartArgs, delayFunc Tim
 		ctx.Logger.Debugf("Sending an email to user %s (%s) to confirm identity for registering a device.",
 			identity.Username, identity.Email)
 
-		if err = ctx.Providers.Notifier.Send(ctx, identity.Address(), args.MailTitle, ctx.Providers.Templates.GetIdentityVerificationJWTEmailTemplate(), data); err != nil {
+		// Here, the identity has access to identity.AlternateEmails.  We could do a 'send' to each of them.  Or, we could modify the 'Address()' function
+		// to pick the first alternate if it exists or something like that.  But per my reading of the threads, the thing that would make the most sense,
+		// would be to has the desired email passed in on the context.  Then, modify Address() to take this as a parameter, and use that email, or, return
+		// an error.  (Or the default maybe if none is specified?).  Hard to say, but, I'm not sure how to actually get that wired in here.
+
+		ctx.Logger.Debugf("Recovery address is %s", identity.RecoveryAddress())
+
+		if err = ctx.Providers.Notifier.Send(ctx, identity.RecoveryAddress(), args.MailTitle, ctx.Providers.Templates.GetIdentityVerificationJWTEmailTemplate(), data); err != nil {
 			ctx.Error(err, messageOperationFailed)
 			return
 		}

--- a/internal/session/identity.go
+++ b/internal/session/identity.go
@@ -11,3 +11,18 @@ func (i Identity) Address() mail.Address {
 		Address: i.Email,
 	}
 }
+
+// RecoveryAddress returns the mail.Address for the identity.
+func (i Identity) RecoveryAddress() mail.Address {
+	if len(i.AlternateEmails) > 0 {
+		return mail.Address{
+			Name:    i.DisplayName,
+			Address: i.AlternateEmails[0],
+		}
+	} else {
+		return mail.Address{
+			Name:    i.DisplayName,
+			Address: i.Email,
+		}
+	}
+}

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -65,9 +65,10 @@ type WebAuthn struct {
 
 // Identity of the user who is being verified.
 type Identity struct {
-	Username    string
-	Email       string
-	DisplayName string
+	Username        string
+	Email           string
+	DisplayName     string
+	AlternateEmails []string
 }
 
 // Elevations describes various session elevations.


### PR DESCRIPTION
Quick and dirty resolution for email reset when main email is accessible over LDAP/OIDC.

I understand there's still work to do on this one, so I am happy to receive feedback. I'm not a Go programmer so this is very rough.