### PR TITLE
docs(oidc): update bookstack

### DIFF
--- a/docs/content/integration/openid-connect/clients/bookstack/index.md
+++ b/docs/content/integration/openid-connect/clients/bookstack/index.md
@@ -68,6 +68,7 @@ identity_providers:
           - 'openid'
           - 'profile'
           - 'email'
+          - 'groups'
         response_types:
           - 'code'
         grant_types:


### PR DESCRIPTION
Groups are required as per example configuration given in the same file. With current example configuration, the error is displayed, that client is not allowed to request scope groups