### PR TITLE
docs(oidc): update vikunja

### DIFF
--- a/docs/content/integration/openid-connect/clients/vikunja/index.md
+++ b/docs/content/integration/openid-connect/clients/vikunja/index.md
@@ -93,9 +93,9 @@ To configure [Vikunja] to utilize Authelia as an [OpenID Connect 1.0] Provider, 
 auth:
   openid:
     enabled: true
-    redirecturl: 'https://vikunja.{{< sitevar name="domain" nojs="example.com" >}}/auth/openid/'
     providers:
-      - name: 'Authelia'
+      authelia:
+        name: 'Authelia'
         authurl: 'https://{{< sitevar name="subdomain-authelia" nojs="auth" >}}.{{< sitevar name="domain" nojs="example.com" >}}'
         clientid: 'vikunja'
         clientsecret: 'insecure_secret'


### PR DESCRIPTION
Vikunja's [own documentation](https://vikunja.io/docs/openid/#step-1-configure-your-authorization-server) is even a bit convoluted and potentially out of date, but the [discussion in this thread](https://github.com/go-vikunja/vikunja/issues/1447) indicates the specific version of the config that should be used moving forward.

The `unstable` tag format outlined in the docs appears to have been released with `1.0.0-rc3` which was also tagged as `latest` - so even though this is an `rc` release, if users setup the [docker example from the official docs](https://vikunja.io/docs/full-docker-example/) which does not specify a tag (defaults to latest if undefined) then the new format will be enforced.

The current format in the Authelia docs fails to configure OIDC correctly in Vikunja's configuration file.  This change updates the new config format.