### PR TITLE
Add environment variable and templating support to users.yaml

### DIFF
--- a/experimental/embed/context.go
+++ b/experimental/embed/context.go
@@ -33,7 +33,7 @@ func New(paths []string, filterNames []string) (ctx Context, val *schema.StructV
 		return nil, val, fmt.Errorf("configuration validation errors")
 	}
 
-	providers, warns, errs := provider.New(config, nil)
+	providers, warns, errs := provider.New(config, nil, nil)
 
 	for _, warn := range warns {
 		val.PushWarning(warn)

--- a/experimental/embed/provider/authentication.go
+++ b/experimental/embed/provider/authentication.go
@@ -4,14 +4,15 @@ import (
 	"crypto/x509"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
+	"github.com/authelia/authelia/v4/internal/configuration"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 )
 
 // NewAuthenticationFile directly instantiates a new authentication.UserProvider using a *authentication.FileUserProvider.
 //
 // Warning: This method may panic if the provided configuration isn't validated.
-func NewAuthenticationFile(config *schema.Configuration) authentication.UserProvider {
-	return authentication.NewFileUserProvider(config.AuthenticationBackend.File)
+func NewAuthenticationFile(config *schema.Configuration, filters []configuration.BytesFilter) authentication.UserProvider {
+	return authentication.NewFileUserProvider(config.AuthenticationBackend.File, filters)
 }
 
 // NewAuthenticationLDAP directly instantiates a new authentication.UserProvider using a *authentication.LDAPUserProvider.

--- a/experimental/embed/provider/general.go
+++ b/experimental/embed/provider/general.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/clock"
+	"github.com/authelia/authelia/v4/internal/configuration"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/expression"
 	"github.com/authelia/authelia/v4/internal/metrics"
@@ -23,8 +24,8 @@ import (
 // New returns a completely new set of providers using the internal API. It is expected you'll check the errs return
 // value for any errors, and handle any warnings in a graceful way. If errors are returned the providers should not be
 // utilized to run anything.
-func New(config *schema.Configuration, caCertPool *x509.CertPool) (providers middlewares.Providers, warns []error, errs []error) {
-	return middlewares.NewProviders(config, caCertPool)
+func New(config *schema.Configuration, caCertPool *x509.CertPool, filters []configuration.BytesFilter) (providers middlewares.Providers, warns []error, errs []error) {
+	return middlewares.NewProviders(config, caCertPool, filters)
 }
 
 // NewClock creates a new clock provider.

--- a/internal/authentication/file_user_provider_database_test.go
+++ b/internal/authentication/file_user_provider_database_test.go
@@ -25,13 +25,13 @@ func TestDatabaseModel_Read(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.EqualError(t, model.Read(filepath.Join(dir, "users_database.yml")), "no file content")
+	assert.EqualError(t, model.Read(filepath.Join(dir, "users_database.yml"), nil), "no file content")
 
 	assert.NoError(t, os.Mkdir(filepath.Join(dir, "x"), 0000))
 
 	f := filepath.Join(dir, "x", "users_database.yml")
 
-	assert.EqualError(t, model.Read(f), fmt.Sprintf("failed to read the '%s' file: open %s: permission denied", f, f))
+	assert.EqualError(t, model.Read(f, nil), fmt.Sprintf("failed to read the '%s' file: open %s: permission denied", f, f))
 
 	f = filepath.Join(dir, "schema.yml")
 
@@ -42,7 +42,7 @@ func TestDatabaseModel_Read(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.EqualError(t, model.Read(f), "could not parse the YAML database: yaml: line 2: found character that cannot start any token")
+	assert.EqualError(t, model.Read(f, nil), "could not parse the YAML database: yaml: line 2: found character that cannot start any token")
 }
 
 func TestDatabaseModelExtended(t *testing.T) {

--- a/internal/authentication/file_user_provider_test.go
+++ b/internal/authentication/file_user_provider_test.go
@@ -49,7 +49,7 @@ func TestShouldErrorFailCreateDB(t *testing.T) {
 
 	f := filepath.Join(dir, "x", "users.yml")
 
-	provider := NewFileUserProvider(&schema.AuthenticationBackendFile{Path: f, Password: schema.DefaultPasswordConfig})
+	provider := NewFileUserProvider(&schema.AuthenticationBackendFile{Path: f, Password: schema.DefaultPasswordConfig}, nil)
 
 	require.NotNil(t, provider)
 
@@ -70,7 +70,7 @@ func TestShouldErrorBadPasswordConfig(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(f, UserDatabaseContent, 0600))
 
-	provider := NewFileUserProvider(&schema.AuthenticationBackendFile{Path: f})
+	provider := NewFileUserProvider(&schema.AuthenticationBackendFile{Path: f}, nil)
 
 	require.NotNil(t, provider)
 
@@ -145,7 +145,7 @@ func TestShouldReloadDatabase(t *testing.T) {
 
 				provider.config.Path = p
 
-				provider.database = NewFileUserDatabase(p, provider.config.Search.Email, provider.config.Search.CaseInsensitive, nil)
+				provider.database = NewFileUserDatabase(p, provider.config.Search.Email, provider.config.Search.CaseInsensitive, nil, nil)
 			},
 			false,
 			"",
@@ -164,7 +164,7 @@ func TestShouldReloadDatabase(t *testing.T) {
 						ValueType: "string",
 					},
 				},
-			})
+			}, nil)
 
 			tc.setup(t, provider)
 
@@ -185,7 +185,7 @@ func TestShouldCheckUserArgon2idPasswordIsCorrect(t *testing.T) {
 	WithDatabase(t, UserDatabaseContent, func(path string) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -201,7 +201,7 @@ func TestShouldCheckUserSHA512PasswordIsCorrect(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -217,7 +217,7 @@ func TestShouldCheckUserPasswordIsWrong(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -233,7 +233,7 @@ func TestShouldCheckUserPasswordIsWrongForEnumerationCompare(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -248,7 +248,7 @@ func TestShouldCheckUserPasswordOfUserThatDoesNotExist(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -264,7 +264,7 @@ func TestShouldRetrieveUserDetails(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -287,7 +287,7 @@ func TestShouldErrOnUserDetailsNoUser(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -310,7 +310,7 @@ func TestShouldUpdatePassword(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -318,7 +318,7 @@ func TestShouldUpdatePassword(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Reset the provider to force a read from disk.
-		provider = NewFileUserProvider(&config)
+		provider = NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -334,7 +334,7 @@ func TestShouldUpdatePasswordHashingAlgorithmToArgon2id(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -347,7 +347,7 @@ func TestShouldUpdatePasswordHashingAlgorithmToArgon2id(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Reset the provider to force a read from disk.
-		provider = NewFileUserProvider(&config)
+		provider = NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -365,7 +365,7 @@ func TestShouldUpdatePasswordHashingAlgorithmToSHA512(t *testing.T) {
 		config.Password.Algorithm = "sha2crypt"
 		config.Password.SHA2Crypt.Iterations = 50000
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -378,7 +378,7 @@ func TestShouldUpdatePasswordHashingAlgorithmToSHA512(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Reset the provider to force a read from disk.
-		provider = NewFileUserProvider(&config)
+		provider = NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -394,7 +394,7 @@ func TestShouldErrOnUpdatePasswordNoUser(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -408,7 +408,7 @@ func TestShouldRaiseWhenLoadingMalformedDatabaseForFirstTime(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.EqualError(t, provider.StartupCheck(), "error reading the authentication database: could not parse the YAML database: yaml: line 4: mapping values are not allowed in this context")
 	})
@@ -419,7 +419,7 @@ func TestShouldRaiseWhenLoadingDatabaseWithBadSchemaForFirstTime(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.EqualError(t, provider.StartupCheck(), "error reading the authentication database: could not validate the schema: users: non zero value required")
 	})
@@ -430,7 +430,7 @@ func TestShouldRaiseWhenLoadingDatabaseWithBadSHA512HashesForTheFirstTime(t *tes
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.EqualError(t, provider.StartupCheck(), "error decoding the authentication database: error occurred decoding the password hash for 'john': shacrypt decode error: parameter pair 'rounds00000' is not properly encoded: does not contain kv separator '='")
 	})
@@ -441,7 +441,7 @@ func TestShouldRaiseWhenLoadingDatabaseWithBadArgon2idHashSettingsForTheFirstTim
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.EqualError(t, provider.StartupCheck(), "error decoding the authentication database: error occurred decoding the password hash for 'john': argon2 decode error: parameter pair 'm65536' is not properly encoded: does not contain kv separator '='")
 	})
@@ -452,7 +452,7 @@ func TestShouldRaiseWhenLoadingDatabaseWithBadArgon2idHashKeyForTheFirstTime(t *
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.EqualError(t, provider.StartupCheck(), "error decoding the authentication database: error occurred decoding the password hash for 'john': argon2 decode error: provided encoded hash has a key value that can't be decoded: illegal base64 data at input byte 0")
 	})
@@ -463,7 +463,7 @@ func TestShouldRaiseWhenLoadingDatabaseWithBadArgon2idHashSaltForTheFirstTime(t 
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.EqualError(t, provider.StartupCheck(), "error decoding the authentication database: error occurred decoding the password hash for 'john': argon2 decode error: provided encoded hash has a salt value that can't be decoded: illegal base64 data at input byte 0")
 	})
@@ -474,7 +474,7 @@ func TestShouldSupportHashPasswordWithoutCRYPT(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -490,7 +490,7 @@ func TestShouldNotAllowLoginOfDisabledUsers(t *testing.T) {
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -508,7 +508,7 @@ func TestShouldErrorOnInvalidCaseSensitiveFile(t *testing.T) {
 		config.Search.Email = false
 		config.Search.CaseInsensitive = true
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.EqualError(t, provider.StartupCheck(), "error loading authentication database: username 'JOHN' is not lowercase but this is required when case-insensitive search is enabled")
 	})
@@ -521,7 +521,7 @@ func TestShouldErrorOnDuplicateEmail(t *testing.T) {
 		config.Search.Email = true
 		config.Search.CaseInsensitive = false
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		err := provider.StartupCheck()
 		assert.Regexp(t, regexp.MustCompile(`^error loading authentication database: email 'john.doe@authelia.com' is configured for for more than one user \(users are '(harry|john)', '(harry|john)'\) which isn't allowed when email search is enabled$`), err.Error())
@@ -535,7 +535,7 @@ func TestShouldNotErrorOnEmailAsUsername(t *testing.T) {
 		config.Search.Email = true
 		config.Search.CaseInsensitive = false
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 	})
@@ -548,7 +548,7 @@ func TestShouldErrorOnEmailAsUsernameWithDuplicateEmail(t *testing.T) {
 		config.Search.Email = true
 		config.Search.CaseInsensitive = false
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.EqualError(t, provider.StartupCheck(), "error loading authentication database: email 'john.doe@authelia.com' is also a username which isn't allowed when email search is enabled")
 	})
@@ -561,7 +561,7 @@ func TestShouldErrorOnEmailAsUsernameWithDuplicateEmailCase(t *testing.T) {
 		config.Search.Email = false
 		config.Search.CaseInsensitive = true
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.EqualError(t, provider.StartupCheck(), "error loading authentication database: username 'john.doe@authelia.com' is configured as an email for user with username 'john' which isn't allowed when case-insensitive search is enabled")
 	})
@@ -573,7 +573,7 @@ func TestShouldAllowLookupByEmail(t *testing.T) {
 		config.Path = path
 		config.Search.Email = true
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -600,7 +600,7 @@ func TestShouldAllowLookupCI(t *testing.T) {
 		config.Path = path
 		config.Search.CaseInsensitive = true
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -703,7 +703,7 @@ func TestHashError(t *testing.T) {
 		config.Search.CaseInsensitive = true
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -721,14 +721,14 @@ func TestHashError(t *testing.T) {
 
 func TestDatabaseError(t *testing.T) {
 	WithDatabase(t, UserDatabaseContent, func(path string) {
-		db := NewFileUserDatabase(path, false, false, nil)
+		db := NewFileUserDatabase(path, false, false, nil, nil)
 		assert.NoError(t, db.Load())
 
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Search.CaseInsensitive = true
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 
@@ -751,14 +751,14 @@ func TestDatabaseError(t *testing.T) {
 
 func TestDatabaseErrorExtended(t *testing.T) {
 	WithDatabase(t, UserDatabaseContent, func(path string) {
-		db := NewFileUserDatabase(path, false, false, nil)
+		db := NewFileUserDatabase(path, false, false, nil, nil)
 		assert.NoError(t, db.Load())
 
 		config := DefaultFileAuthenticationBackendConfiguration
 		config.Search.CaseInsensitive = true
 		config.Path = path
 
-		provider := NewFileUserProvider(&config)
+		provider := NewFileUserProvider(&config, nil)
 
 		assert.NoError(t, provider.StartupCheck())
 

--- a/internal/commands/context.go
+++ b/internal/commands/context.go
@@ -145,7 +145,14 @@ func (ctx *CmdCtx) LoadProviders() (warns, errs []error) {
 		return warns, errs
 	}
 
-	ctx.providers, warns, errs = middlewares.NewProviders(ctx.config, ctx.trusted)
+	filters, err := configuration.NewFileFilters(ctx.cconfig.filters)
+
+	if err != nil {
+		errs = append(errs, err)
+		return warns, errs
+	}
+
+	ctx.providers, warns, errs = middlewares.NewProviders(ctx.config, ctx.trusted, filters)
 
 	return warns, errs
 }

--- a/internal/commands/debug.go
+++ b/internal/commands/debug.go
@@ -16,6 +16,7 @@ import (
 	goyaml "go.yaml.in/yaml/v4"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
+	"github.com/authelia/authelia/v4/internal/configuration"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/expression"
 	"github.com/authelia/authelia/v4/internal/middlewares"
@@ -130,7 +131,13 @@ func newDebugOIDCClaimsCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 
 //nolint:gocyclo
 func (ctx *CmdCtx) DebugOIDCClaimsRunE(cmd *cobra.Command, args []string) (err error) {
-	provider := middlewares.NewAuthenticationProvider(ctx.config, ctx.trusted)
+	filters, err := configuration.NewFileFilters(ctx.cconfig.filters)
+
+	if err != nil {
+		return fmt.Errorf("error occurred initializing user authentication provider: filters could not be initialized")
+	}
+
+	provider := middlewares.NewAuthenticationProvider(ctx.config, ctx.trusted, filters)
 
 	if provider == nil {
 		return fmt.Errorf("error occurred initializing user authentication provider: a provider is not configured")
@@ -234,7 +241,8 @@ func (ctx *CmdCtx) DebugOIDCClaimsRunE(cmd *cobra.Command, args []string) (err e
 }
 
 func (ctx *CmdCtx) DebugExpressionRunE(cmd *cobra.Command, args []string) (err error) {
-	provider := middlewares.NewAuthenticationProvider(ctx.config, ctx.trusted)
+	filters, _ := configuration.NewFileFilters(ctx.cconfig.filters)
+	provider := middlewares.NewAuthenticationProvider(ctx.config, ctx.trusted, filters)
 
 	if provider == nil {
 		return fmt.Errorf("error occurred initializing user authentication provider: a provider is not configured")

--- a/internal/middlewares/util_test.go
+++ b/internal/middlewares/util_test.go
@@ -54,7 +54,7 @@ func TestNewAuthenticationProvider(t *testing.T) {
 	for i := range testCases {
 		t.Run(testCases[i].name, func(t *testing.T) {
 			tc := testCases[i]
-			provider := NewAuthenticationProvider(&tc.config, nil)
+			provider := NewAuthenticationProvider(&tc.config, nil, nil)
 			require.Nil(t, provider)
 		})
 	}

--- a/internal/service/file_watcher_test.go
+++ b/internal/service/file_watcher_test.go
@@ -66,7 +66,7 @@ func TestProvisionUsersFileWatcher(t *testing.T) {
 	assert.EqualError(t, err, "error occurred asserting user provider")
 	assert.Nil(t, watcher)
 
-	ctx.Providers.UserProvider = authentication.NewFileUserProvider(config.AuthenticationBackend.File)
+	ctx.Providers.UserProvider = authentication.NewFileUserProvider(config.AuthenticationBackend.File, nil)
 
 	config.AuthenticationBackend.File = &schema.AuthenticationBackendFile{
 		Watch: true,


### PR DESCRIPTION
 This PR adds support for environment variables and templating in the users database file (`users.yaml`), using the same filtering mechanism (`X_AUTHELIA_CONFIG_FILTERS`) that already exists and is used for the main configuration files.

When `X_AUTHELIA_CONFIG_FILTERS=template` is set, users.yaml now supports templating:

```nix
  users:
    john:
      displayname: '{{ env "JOHN_DISPLAY_NAME" }}'
      password: '{{ secret "/run/secrets/john_password_hash" }}'
      email: '{{ env "JOHN_EMAIL" }}'
      groups:
        - admins
        - developers

    service-account:
      displayname: "Service Account"
      password: '{{ secret "/run/secrets/service_account_hash" }}'
      email: '{{ env "SERVICE_ACCOUNT_EMAIL" }}'
      groups:
        - services
```

This enables:
  - Reading pre-hashed passwords from Docker/Kubernetes/NixOS secrets
  - Injecting user emails from environment variables
  - Managing user configuration dynamically without hardcoding sensitive values
  
I'm running this configuration on NixOS, providing the secrets via systemd's `LoadCredential` directive.