### PR TITLE
feat: custom scope descriptions

### DIFF
--- a/internal/configuration/schema/identity_providers.go
+++ b/internal/configuration/schema/identity_providers.go
@@ -72,7 +72,8 @@ type IdentityProvidersOpenIDConnectCustomClaim struct {
 }
 
 type IdentityProvidersOpenIDConnectScope struct {
-	Claims []string `koanf:"claims" yaml:"claims,omitempty" toml:"claims,omitempty" json:"claims,omitempty" jsonschema:"title=Claims" jsonschema_description:"The list of claims that this scope includes. When this scope is used by a client the clients claim policy must satisfy every claim."`
+	Claims      []string `koanf:"claims" yaml:"claims,omitempty" toml:"claims,omitempty" json:"claims,omitempty" jsonschema:"title=Claims" jsonschema_description:"The list of claims that this scope includes. When this scope is used by a client the clients claim policy must satisfy every claim."`
+	Description string   `koanf:"description" yaml:"description,omitempty" toml:"description,omitempty" json:"description,omitempty" jsonschema:"title=Description" jsonschema_description:"The user-friendly description of this scope, displayed on the consent screen."`
 }
 
 // IdentityProvidersOpenIDConnectPolicy configuration for OpenID Connect 1.0 authorization policies.

--- a/internal/oidc/client.go
+++ b/internal/oidc/client.go
@@ -104,6 +104,15 @@ func NewClient(config schema.IdentityProvidersOpenIDConnectClient, c *schema.Ide
 		registered.ResponseModes = append(registered.ResponseModes, oauthelia2.ResponseModeType(mode))
 	}
 
+	if c != nil && c.Scopes != nil {
+		registered.ScopeDescriptions = make(map[string]string)
+		for scopeName, scope := range c.Scopes {
+			if scope.Description != "" {
+				registered.ScopeDescriptions[scopeName] = scope.Description
+			}
+		}
+	}
+
 	return registered
 }
 
@@ -540,6 +549,7 @@ func (c *RegisteredClient) GetConsentResponseBody(session RequesterFormSession, 
 	body := ConsentGetResponseBody{
 		ClientID:          c.ID,
 		ClientDescription: c.Name,
+		ScopeDescriptions: c.ScopeDescriptions,
 		PreConfiguration:  c.ConsentPolicy.Mode == ClientConsentModePreConfigured && !disablePreConf,
 	}
 

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -138,6 +138,8 @@ type RegisteredClient struct {
 	RequestURIs    []string
 	JSONWebKeys    *jose.JSONWebKeySet
 	JSONWebKeysURI *url.URL
+
+	ScopeDescriptions map[string]string
 }
 
 // Client represents the internal client definitions.
@@ -299,14 +301,15 @@ type UserDetailer interface {
 
 // ConsentGetResponseBody schema of the response body of the consent GET endpoint.
 type ConsentGetResponseBody struct {
-	ClientID          string   `json:"client_id"`
-	ClientDescription string   `json:"client_description"`
-	Scopes            []string `json:"scopes"`
-	Audience          []string `json:"audience"`
-	PreConfiguration  bool     `json:"pre_configuration"`
-	Claims            []string `json:"claims"`
-	EssentialClaims   []string `json:"essential_claims"`
-	RequireLogin      bool     `json:"require_login"`
+	ClientID          string            `json:"client_id"`
+	ClientDescription string            `json:"client_description"`
+	Scopes            []string          `json:"scopes"`
+	ScopeDescriptions map[string]string `json:"scope_descriptions"`
+	Audience          []string          `json:"audience"`
+	PreConfiguration  bool              `json:"pre_configuration"`
+	Claims            []string          `json:"claims"`
+	EssentialClaims   []string          `json:"essential_claims"`
+	RequireLogin      bool              `json:"require_login"`
 }
 
 // ConsentPostRequestBody schema of the request body of the consent POST endpoint.

--- a/web/src/services/ConsentOpenIDConnect.ts
+++ b/web/src/services/ConsentOpenIDConnect.ts
@@ -24,6 +24,7 @@ export interface ConsentGetResponseBody {
     client_id: string;
     client_description: string;
     scopes: string[];
+    scope_descriptions: null | Record<string, string>;
     audience: string[];
     pre_configuration: boolean;
     claims: null | string[];

--- a/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormScopes.tsx
+++ b/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormScopes.tsx
@@ -10,6 +10,7 @@ import { formatScope } from "@services/ConsentOpenIDConnect";
 
 export interface Props {
     scopes: string[];
+    scopeDescriptions: null | Record<string, string>;
 }
 
 const DecisionFormScopes: FC<Props> = (props: Props) => {
@@ -17,12 +18,19 @@ const DecisionFormScopes: FC<Props> = (props: Props) => {
 
     const { classes } = useStyles();
 
+    const getDescription = (scope: string): string => {
+        if (props.scopeDescriptions?.[scope]) {
+            return props.scopeDescriptions[scope];
+        }
+        return translate("Scope", { name: scope });
+    };
+
     return (
         <Grid size={{ xs: 12 }}>
             <Box className={classes.scopesListContainer}>
                 <List className={classes.scopesList}>
                     {props.scopes.map((scope: string) => (
-                        <Tooltip key={scope} title={translate("Scope", { name: scope })}>
+                        <Tooltip key={scope} title={getDescription(scope)}>
                             <ListItem id={"scope-" + scope} key={scope} dense>
                                 <ListItemIcon>{ScopeAvatar(scope)}</ListItemIcon>
                                 <ListItemText primary={formatScope(translate(`scopes.${scope}`), scope)} />

--- a/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormView.tsx
+++ b/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormView.tsx
@@ -333,7 +333,7 @@ const DecisionFormView: FC<Props> = (props: Props) => {
                                         {translate("The above application is requesting the following permissions")}:
                                     </Box>
                                 </Grid>
-                                <DecisionFormScopes scopes={response.scopes} />
+                                <DecisionFormScopes scopes={response.scopes} scopeDescriptions={response.scope_descriptions} />
                                 <DecisionFormClaims
                                     claims={claims}
                                     essential_claims={response.essential_claims}


### PR DESCRIPTION
Allows administrators to define user-friendly descriptions for custom scopes that are displayed on the consent screen.