### PR TITLE
fix(expression): add missing extensions

### DIFF
--- a/docs/content/configuration/definitions/user-attributes.md
+++ b/docs/content/configuration/definitions/user-attributes.md
@@ -15,9 +15,20 @@ seo:
 ---
 
 The user attributes section allows you to define custom attributes for your users using Common Expression Language (CEL).
+
 These attributes can be used at the current time to:
 
 - Enhance [OpenID Connect 1.0 claims](../../integration/openid-connect/openid-connect-1.0-claims.md) with dynamic values
+
+The following extensions are enabled by default:
+
+- `strings`
+- `lists`
+- `sets`
+- `math`
+- `encoders`
+- `bindings`
+- `regex`
 
 ## Configuration
 

--- a/internal/expression/user_attributes.go
+++ b/internal/expression/user_attributes.go
@@ -58,7 +58,7 @@ func (e *UserAttributesExpressions) StartupCheck() (err error) {
 
 //nolint:gocyclo
 func (e *UserAttributesExpressions) ldapStartupCheck() (err error) {
-	opts := []cel.EnvOption{
+	opts := withBaseCELEnvOpts(
 		newAttributeUserUsername(),
 		newAttributeUserGroups(),
 		newAttributeUserDisplayName(),
@@ -67,7 +67,7 @@ func (e *UserAttributesExpressions) ldapStartupCheck() (err error) {
 		newAttributeUserEmails(),
 		newAttributeUserEmailsExtra(),
 		newAttributeUpdatedAt(),
-	}
+	)
 
 	if e.config.AuthenticationBackend.LDAP.Attributes.GivenName != "" {
 		opts = append(opts, newAttributeUserGivenName())

--- a/internal/expression/util.go
+++ b/internal/expression/util.go
@@ -4,6 +4,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/ext"
 )
 
 func optExtra(name string, attribute ExtraAttribute) (opt cel.EnvOption) {
@@ -208,8 +209,27 @@ func toNativeValueRefValMap(in map[ref.Val]ref.Val) (out map[string]any) {
 	return out
 }
 
+func withBaseCELEnvOpts(extra ...cel.EnvOption) (opts []cel.EnvOption) {
+	opts = make([]cel.EnvOption, 0, 8+len(extra))
+
+	opts = append(opts,
+		cel.OptionalTypes(),
+		ext.Lists(),
+		ext.Sets(),
+		ext.Strings(),
+		ext.Bindings(),
+		ext.Math(),
+		ext.Encoders(),
+		ext.Regex(),
+	)
+
+	opts = append(opts, extra...)
+
+	return opts
+}
+
 func getStandardCELEnvOpts() []cel.EnvOption {
-	return []cel.EnvOption{
+	return withBaseCELEnvOpts(
 		newAttributeUserUsername(),
 		newAttributeUserGroups(),
 		newAttributeUserDisplayName(),
@@ -241,5 +261,5 @@ func getStandardCELEnvOpts() []cel.EnvOption {
 		newAttributeUpdatedAt(),
 		newAttributeOAuth2AuthorizationRequestClaimValue(),
 		newAttributeOAuth2AuthorizationRequestClaimValues(),
-	}
+	)
 }


### PR DESCRIPTION
This adds the strings, lists and sets extensions to the CEL expression evaluation environment.