### PR TITLE
refactor(handlers): use interface for authz

### DIFF
--- a/internal/handlers/handler_authz.go
+++ b/internal/handlers/handler_authz.go
@@ -6,6 +6,9 @@ import (
 	"net"
 	"net/url"
 
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/sirupsen/logrus"
+
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/clock"
@@ -15,8 +18,6 @@ import (
 	"github.com/authelia/authelia/v4/internal/random"
 	"github.com/authelia/authelia/v4/internal/session"
 	"github.com/authelia/authelia/v4/internal/utils"
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/sirupsen/logrus"
 )
 
 type AuthzContext interface {

--- a/internal/handlers/handler_authz.go
+++ b/internal/handlers/handler_authz.go
@@ -1,26 +1,85 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"net/url"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
+	"github.com/authelia/authelia/v4/internal/clock"
+	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/expression"
 	"github.com/authelia/authelia/v4/internal/middlewares"
+	"github.com/authelia/authelia/v4/internal/random"
 	"github.com/authelia/authelia/v4/internal/session"
 	"github.com/authelia/authelia/v4/internal/utils"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/sirupsen/logrus"
 )
 
+type AuthzContext interface {
+	context.Context
+
+	GetLogger() *logrus.Entry
+	GetConfiguration() schema.Configuration
+	GetClock() clock.Provider
+	GetProviders() middlewares.Providers
+	GetUserProvider() authentication.UserProvider
+	GetRandom() (random random.Provider)
+	GetProviderUserAttributeResolver() expression.UserAttributeResolver
+	GetJWTWithTimeFuncOption() (option jwt.ParserOption)
+
+	Method() (method []byte)
+	Host() (host []byte)
+	XForwardedMethod() (method []byte)
+	XForwardedProto() (proto []byte)
+	XForwardedHost() (host []byte)
+	XForwardedURI() (uri []byte)
+	XOriginalMethod() (method []byte)
+	XOriginalURL() (uri []byte)
+	GetXOriginalURLOrXForwardedURL() (requestURI *url.URL, err error)
+	XAutheliaURL() []byte
+	QueryArgAutheliaURL() []byte
+	RootURL() (issuerURL *url.URL)
+	IssuerURL() (issuerURL *url.URL, err error)
+
+	NewSession() (userSession session.UserSession)
+	GetSession() (session session.UserSession, err error)
+	SaveSession(session session.UserSession) (err error)
+	DestroySession() (err error)
+	GetSessionConfig() (config schema.SessionCookie)
+
+	GetRequestQueryArgValue(key []byte) (value []byte)
+	GetRequestHeaderValue(key []byte) (value []byte)
+	SetResponseHeaderValue(key []byte, value string)
+	SetResponseHeaderValueBytes(key, value []byte)
+
+	AuthzPath() (uri []byte)
+	IsXHR() (xhr bool)
+	AcceptsMIME(mime string) (ok bool)
+
+	ReplyStatusCode(statusCode int)
+	ReplyUnauthorized()
+	ReplyForbidden()
+	SpecialRedirect(uri string, statusCode int)
+	SpecialRedirectNoBody(uri string, statusCode int)
+
+	RecordAuthn(success, banned bool, authType string)
+	RemoteIP() net.IP
+	GetSessionProviderByTargetURI(targetURL *url.URL) (provider *session.Session, err error)
+}
+
 // Handler is the middlewares.RequestHandler for Authz.
-func (authz *Authz) Handler(ctx *middlewares.AutheliaCtx) {
+func (authz *Authz) Handler(ctx AuthzContext) {
 	var (
 		object      authorization.Object
 		autheliaURL *url.URL
-		provider    *session.Session
 		err         error
 	)
 	if object, err = authz.handleGetObject(ctx); err != nil {
-		ctx.Logger.WithError(err).Error("Error getting Target URL and Request Method")
+		ctx.GetLogger().WithError(err).Error("Error getting Target URL and Request Method")
 
 		ctx.ReplyStatusCode(authz.config.StatusCodeBadRequest)
 
@@ -28,23 +87,24 @@ func (authz *Authz) Handler(ctx *middlewares.AutheliaCtx) {
 	}
 
 	if !utils.IsURISecure(object.URL) {
-		ctx.Logger.Errorf("Target URL '%s' has an insecure scheme '%s', only the 'https' and 'wss' schemes are supported so session cookies can be transmitted securely", object.URL.String(), object.URL.Scheme)
+		ctx.GetLogger().Errorf("Target URL '%s' has an insecure scheme '%s', only the 'https' and 'wss' schemes are supported so session cookies can be transmitted securely", object.URL.String(), object.URL.Scheme)
 
 		ctx.ReplyStatusCode(authz.config.StatusCodeBadRequest)
 
 		return
 	}
 
-	if provider, err = ctx.GetSessionProviderByTargetURI(object.URL); err != nil {
-		ctx.Logger.WithError(err).WithField("target_url", object.URL.String()).Error("Target URL does not appear to have a relevant session cookies configuration")
+	// TODO: Ensure the session handling is done purely from the target domain.
+	if config := ctx.GetSessionConfig(); config.Domain == "" {
+		ctx.GetLogger().WithError(err).WithField("target_url", object.URL.String()).Error("Target URL does not appear to have a relevant session cookies configuration")
 
 		ctx.ReplyStatusCode(authz.config.StatusCodeBadRequest)
 
 		return
 	}
 
-	if autheliaURL, err = authz.getAutheliaURL(ctx, provider); err != nil {
-		ctx.Logger.WithError(err).WithField("target_url", object.URL.String()).Error("Error occurred trying to determine the external Authelia URL for Target URL")
+	if autheliaURL, err = authz.getAutheliaURL(ctx); err != nil {
+		ctx.GetLogger().WithError(err).WithField("target_url", object.URL.String()).Error("Error occurred trying to determine the external Authelia URL for Target URL")
 
 		ctx.ReplyStatusCode(authz.config.StatusCodeBadRequest)
 
@@ -56,12 +116,12 @@ func (authz *Authz) Handler(ctx *middlewares.AutheliaCtx) {
 		strategy AuthnStrategy
 	)
 
-	authn, strategy, err = authz.authn(ctx, provider, &object)
+	authn, strategy, err = authz.authn(ctx, &object)
 
 	authn.Object = object
 	authn.Method = friendlyMethod(authn.Object.Method)
 
-	ruleHasSubject, required := ctx.Providers.Authorizer.GetRequiredLevel(
+	ruleHasSubject, required := ctx.GetProviders().Authorizer.GetRequiredLevel(
 		authorization.Subject{
 			Username: authn.Details.Username,
 			Groups:   authn.Details.Groups,
@@ -79,7 +139,7 @@ func (authz *Authz) Handler(ctx *middlewares.AutheliaCtx) {
 			case strategy == nil:
 				ctx.ReplyUnauthorized()
 			case strategy.HeaderStrategy():
-				ctx.Logger.WithError(err).Error("Error occurred while attempting to authenticate a request")
+				ctx.GetLogger().WithError(err).Error("Error occurred while attempting to authenticate a request")
 
 				strategy.HandleUnauthorized(ctx, authn, authz.getRedirectionURL(&object, autheliaURL))
 
@@ -87,12 +147,12 @@ func (authz *Authz) Handler(ctx *middlewares.AutheliaCtx) {
 			}
 		}
 
-		ctx.Logger.WithError(err).Debug("Error occurred while attempting to authenticate a request but the matched rule was a bypass rule")
+		ctx.GetLogger().WithError(err).Debug("Error occurred while attempting to authenticate a request but the matched rule was a bypass rule")
 	}
 
 	switch isAuthzResult(authn.Level, required, ruleHasSubject) {
 	case AuthzResultForbidden:
-		ctx.Logger.Infof("Access to '%s' is forbidden to user '%s'", object.URL.String(), authn.Username)
+		ctx.GetLogger().Infof("Access to '%s' is forbidden to user '%s'", object.URL.String(), authn.Username)
 		ctx.ReplyForbidden()
 	case AuthzResultUnauthorized:
 		var handler HandlerAuthzUnauthorized
@@ -109,25 +169,27 @@ func (authz *Authz) Handler(ctx *middlewares.AutheliaCtx) {
 	}
 }
 
-func (authz *Authz) getAutheliaURL(ctx *middlewares.AutheliaCtx, provider *session.Session) (autheliaURL *url.URL, err error) {
+func (authz *Authz) getAutheliaURL(ctx AuthzContext) (autheliaURL *url.URL, err error) {
 	if autheliaURL, err = authz.handleGetAutheliaURL(ctx); err != nil {
 		return nil, err
 	}
+
+	config := ctx.GetSessionConfig()
 
 	switch {
 	case authz.implementation == AuthzImplLegacy:
 		return autheliaURL, nil
 	case autheliaURL != nil:
 		switch {
-		case utils.HasURIDomainSuffix(autheliaURL, provider.Config.Domain):
+		case utils.HasURIDomainSuffix(autheliaURL, config.Domain):
 			return autheliaURL, nil
 		default:
-			return nil, fmt.Errorf("authelia url '%s' is not valid for detected domain '%s' as the url does not have the domain as a suffix", autheliaURL.String(), provider.Config.Domain)
+			return nil, fmt.Errorf("authelia url '%s' is not valid for detected domain '%s' as the url does not have the domain as a suffix", autheliaURL.String(), config.Domain)
 		}
 	}
 
-	if provider.Config.AutheliaURL != nil {
-		return provider.Config.AutheliaURL, nil
+	if config.AutheliaURL != nil {
+		return config.AutheliaURL, nil
 	}
 
 	return nil, fmt.Errorf("authelia url lookup failed")
@@ -157,9 +219,9 @@ func (authz *Authz) getRedirectionURL(object *authorization.Object, autheliaURL 
 	return redirectionURL
 }
 
-func (authz *Authz) authn(ctx *middlewares.AutheliaCtx, provider *session.Session, object *authorization.Object) (authn *Authn, strategy AuthnStrategy, err error) {
+func (authz *Authz) authn(ctx AuthzContext, object *authorization.Object) (authn *Authn, strategy AuthnStrategy, err error) {
 	for _, strategy = range authz.strategies {
-		if authn, err = strategy.Get(ctx, provider, object); err != nil {
+		if authn, err = strategy.Get(ctx, object); err != nil {
 			// Ensure an error returned can never result in an authenticated user.
 			authn.Level = authentication.NotAuthenticated
 			authn.Username = anonymous

--- a/internal/handlers/handler_authz.go
+++ b/internal/handlers/handler_authz.go
@@ -17,6 +17,7 @@ import (
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/random"
 	"github.com/authelia/authelia/v4/internal/session"
+	"github.com/authelia/authelia/v4/internal/storage"
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
@@ -24,12 +25,13 @@ type AuthzContext interface {
 	context.Context
 
 	GetLogger() *logrus.Entry
-	GetConfiguration() schema.Configuration
+	GetConfiguration() *schema.Configuration
 	GetClock() clock.Provider
 	GetProviders() middlewares.Providers
 	GetUserProvider() authentication.UserProvider
 	GetRandom() (random random.Provider)
 	GetProviderUserAttributeResolver() expression.UserAttributeResolver
+	GetProviderStorage() storage.Provider
 	GetJWTWithTimeFuncOption() (option jwt.ParserOption)
 
 	Method() (method []byte)
@@ -43,7 +45,6 @@ type AuthzContext interface {
 	GetXOriginalURLOrXForwardedURL() (requestURI *url.URL, err error)
 	XAutheliaURL() []byte
 	QueryArgAutheliaURL() []byte
-	RootURL() (issuerURL *url.URL)
 	IssuerURL() (issuerURL *url.URL, err error)
 
 	GetSessionManagerByTargetURI(targetURL *url.URL) (manager session.Manager, err error)

--- a/internal/handlers/handler_authz.go
+++ b/internal/handlers/handler_authz.go
@@ -21,51 +21,120 @@ import (
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
+// AuthzContext describes the context implementation that must be used within the Authz concrete implementation.
 type AuthzContext interface {
 	context.Context
 
-	GetLogger() *logrus.Entry
-	GetConfiguration() *schema.Configuration
-	GetClock() clock.Provider
-	GetProviders() middlewares.Providers
-	GetUserProvider() authentication.UserProvider
-	GetRandom() (random random.Provider)
-	GetProviderUserAttributeResolver() expression.UserAttributeResolver
-	GetProviderStorage() storage.Provider
+	// GetLogger should return a relevant *logrus.Entry which can be used to log information for this request.
+	GetLogger() (entry *logrus.Entry)
+
+	// GetConfiguration should return the global configuration.
+	GetConfiguration() (config *schema.Configuration)
+
+	// GetClock should return the clock.Provider.
+	GetClock() (provider clock.Provider)
+
+	// GetProviders should return the middlewares.Providers.
+	GetProviders() (providers middlewares.Providers)
+
+	// GetUserProvider should return a authentication.UserProvider.
+	GetUserProvider() (provider authentication.UserProvider)
+
+	// GetRandom should return a random.Provider.
+	GetRandom() (provider random.Provider)
+
+	// GetProviderUserAttributeResolver should return a expression.UserAttributeResolver.
+	GetProviderUserAttributeResolver() (provider expression.UserAttributeResolver)
+
+	// GetProviderStorage should return a storage.Provider.
+	GetProviderStorage() (provider storage.Provider)
+
+	// GetJWTWithTimeFuncOption should return a jwt.ParserOption.
 	GetJWTWithTimeFuncOption() (option jwt.ParserOption)
 
+	// Method should return the HTTP method used for the request.
 	Method() (method []byte)
+
+	// Host should return the Host of the request.
 	Host() (host []byte)
+
+	// XForwardedMethod should return the X-Forwarded-Method header of the request.
 	XForwardedMethod() (method []byte)
+
+	// XForwardedProto should return the X-Forwarded-Proto header of the request.
 	XForwardedProto() (proto []byte)
+
+	// XForwardedHost should return the X-Forwarded-Host header of the request.
 	XForwardedHost() (host []byte)
+
+	// XForwardedURI should return the X-Forwarded-URI header of the request.
 	XForwardedURI() (uri []byte)
+
+	// XOriginalMethod should return the X-Original-Method header of the request.
 	XOriginalMethod() (method []byte)
-	XOriginalURL() (uri []byte)
+
+	// XOriginalURL should return the X-Original-URL header of the request.
+	XOriginalURL() (url []byte)
+
+	// GetXOriginalURLOrXForwardedURL should return the X-Original-URL header or X-Forwarded-* headers of the request.
 	GetXOriginalURLOrXForwardedURL() (requestURI *url.URL, err error)
-	XAutheliaURL() []byte
-	QueryArgAutheliaURL() []byte
+
+	// XAutheliaURL should return the X-Authelia-URL header of the request.
+	XAutheliaURL() (url []byte)
+
+	// QueryArgAutheliaURL should return the authelia_url query argument from the request.
+	QueryArgAutheliaURL() (url []byte)
+
+	// IssuerURL should return the issuer URL of the request.
 	IssuerURL() (issuerURL *url.URL, err error)
 
+	// GetSessionManagerByTargetURI should return the session manager for the target URL.
 	GetSessionManagerByTargetURI(targetURL *url.URL) (manager session.Manager, err error)
 
+	// GetRequestQueryArgValue should return the request URI of the request.
 	GetRequestQueryArgValue(key []byte) (value []byte)
+
+	// GetRequestHeaderValue returns the value of the header with the given key.
 	GetRequestHeaderValue(key []byte) (value []byte)
+
+	// SetResponseHeaderValue should set the value of the header with the given key.
 	SetResponseHeaderValue(key []byte, value string)
+
+	// SetResponseHeaderValueBytes should set the value of the header with the given key.
 	SetResponseHeaderValueBytes(key, value []byte)
 
+	// AuthzPath should return the path of the authorization request.
 	AuthzPath() (uri []byte)
+
+	// IsXHR should return true if the request is an XHR.
 	IsXHR() (xhr bool)
+
+	// AcceptsMIME should return true if the request accepts the given MIME type.
 	AcceptsMIME(mime string) (ok bool)
 
+	// ReplyStatusCode should reply with the given status code.
 	ReplyStatusCode(statusCode int)
+
+	// ReplyUnauthorized should reply with the Unauthorized status code.
 	ReplyUnauthorized()
+
+	// ReplyForbidden should reply with the Forbidden status code.
 	ReplyForbidden()
+
+	// SpecialRedirect should perform a redirect to the given URI with the given status code and write a HTML body with
+	// the redirect anchor.
 	SpecialRedirect(uri string, statusCode int)
+
+	// SpecialRedirectNoBody should perform a redirect to the given URI with the given status code without a body.
 	SpecialRedirectNoBody(uri string, statusCode int)
 
+	// RecordAuthn should record the authentication of the user.
 	RecordAuthn(success, banned bool, authType string)
+
+	// RemoteIP Should return the remote IP of the request.
 	RemoteIP() net.IP
+
+	// GetSessionProviderByTargetURI should return the session provider for the target URL.
 	GetSessionProviderByTargetURI(targetURL *url.URL) (provider *session.Session, err error)
 }
 

--- a/internal/handlers/handler_authz_authn.go
+++ b/internal/handlers/handler_authz_authn.go
@@ -87,7 +87,7 @@ type CookieSessionAuthnStrategy struct {
 }
 
 // Get returns the Authn information for this AuthnStrategy.
-func (s *CookieSessionAuthnStrategy) Get(ctx AuthzContext, _ *authorization.Object) (authn *Authn, err error) {
+func (s *CookieSessionAuthnStrategy) Get(ctx AuthzContext, manager session.Manager, _ *authorization.Object) (authn *Authn, err error) {
 	var userSession session.UserSession
 
 	authn = &Authn{
@@ -96,39 +96,39 @@ func (s *CookieSessionAuthnStrategy) Get(ctx AuthzContext, _ *authorization.Obje
 		Username: anonymous,
 	}
 
-	if userSession, err = ctx.GetSession(); err != nil {
+	if userSession, err = manager.GetSession(); err != nil {
 		return authn, fmt.Errorf("failed to retrieve user session: %w", err)
 	}
 
-	if userSession.CookieDomain != ctx.GetSessionConfig().Domain {
-		ctx.GetLogger().Warnf("Destroying session cookie as the cookie domain '%s' does not match the requests detected cookie domain '%s' which may be a sign a user tried to move this cookie from one domain to another", userSession.CookieDomain, ctx.GetSessionConfig().Domain)
+	if userSession.CookieDomain != manager.GetSessionConfig().Domain {
+		ctx.GetLogger().Warnf("Destroying session cookie as the cookie domain '%s' does not match the requests detected cookie domain '%s' which may be a sign a user tried to move this cookie from one domain to another", userSession.CookieDomain, manager.GetSessionConfig().Domain)
 
-		if err = ctx.DestroySession(); err != nil {
+		if err = manager.DestroySession(); err != nil {
 			ctx.GetLogger().WithError(err).Error("Error occurred trying to destroy the session cookie")
 		}
 
-		userSession = ctx.NewSession()
+		userSession = manager.NewDefaultUserSession()
 
-		if err = ctx.SaveSession(userSession); err != nil {
+		if err = manager.SaveSession(userSession); err != nil {
 			ctx.GetLogger().WithError(err).Error("Error occurred trying to save the new session cookie")
 		}
 	}
 
-	if modified, invalid := handleAuthnCookieValidate(ctx, &userSession, s.refresh); invalid {
-		if err = ctx.DestroySession(); err != nil {
+	if modified, invalid := handleAuthnCookieValidate(ctx, manager, &userSession, s.refresh); invalid {
+		if err = manager.DestroySession(); err != nil {
 			ctx.GetLogger().WithError(err).Errorf("Unable to destroy user session")
 		}
 
-		userSession = ctx.NewSession()
+		userSession = manager.NewDefaultUserSession()
 		userSession.LastActivity = ctx.GetClock().Now().Unix()
 
-		if err = ctx.SaveSession(userSession); err != nil {
+		if err = manager.SaveSession(userSession); err != nil {
 			ctx.GetLogger().WithError(err).Error("Unable to save updated user session")
 		}
 
 		return authn, nil
 	} else if modified {
-		if err = ctx.SaveSession(userSession); err != nil {
+		if err = manager.SaveSession(userSession); err != nil {
 			ctx.GetLogger().WithError(err).Error("Unable to save updated user session")
 		}
 	}
@@ -204,7 +204,7 @@ func NewCachedBasicAuthHandler(lifespan time.Duration) BasicAuthHandler {
 }
 
 // Get returns the Authn information for this AuthnStrategy.
-func (s *HeaderAuthnStrategy) Get(ctx AuthzContext, object *authorization.Object) (authn *Authn, err error) {
+func (s *HeaderAuthnStrategy) Get(ctx AuthzContext, _ session.Manager, object *authorization.Object) (authn *Authn, err error) {
 	var value []byte
 
 	authn = &Authn{
@@ -367,7 +367,7 @@ func (s *HeaderAuthnStrategy) HandleUnauthorized(ctx AuthzContext, authn *Authn,
 type HeaderLegacyAuthnStrategy struct{}
 
 // Get returns the Authn information for this AuthnStrategy.
-func (s *HeaderLegacyAuthnStrategy) Get(ctx AuthzContext, _ *authorization.Object) (authn *Authn, err error) {
+func (s *HeaderLegacyAuthnStrategy) Get(ctx AuthzContext, _ session.Manager, _ *authorization.Object) (authn *Authn, err error) {
 	var (
 		username, password string
 		value, header      []byte
@@ -448,7 +448,7 @@ func (s *HeaderLegacyAuthnStrategy) HandleUnauthorized(ctx AuthzContext, authn *
 	handleAuthzUnauthorizedAuthorizationBasic(ctx, authn)
 }
 
-func handleAuthnCookieValidate(ctx AuthzContext, userSession *session.UserSession, refresh schema.RefreshIntervalDuration) (modified, invalid bool) {
+func handleAuthnCookieValidate(ctx AuthzContext, manager session.Manager, userSession *session.UserSession, refresh schema.RefreshIntervalDuration) (modified, invalid bool) {
 	// TODO: Remove this check as it's no longer possible i.e. ineffectual.
 	isAnonymous := userSession.Username == ""
 
@@ -458,7 +458,7 @@ func handleAuthnCookieValidate(ctx AuthzContext, userSession *session.UserSessio
 		return modified, true
 	}
 
-	if invalid = handleAuthnCookieValidateInactivity(ctx, userSession, isAnonymous); invalid {
+	if invalid = handleAuthnCookieValidateInactivity(ctx, manager, userSession, isAnonymous); invalid {
 		ctx.GetLogger().WithField("username", userSession.Username).Info("Session for user not marked as remembered has exceeded configured session inactivity")
 
 		return modified, true
@@ -483,8 +483,8 @@ func handleAuthnCookieValidate(ctx AuthzContext, userSession *session.UserSessio
 	return modified, false
 }
 
-func handleAuthnCookieValidateInactivity(ctx AuthzContext, userSession *session.UserSession, isAnonymous bool) (invalid bool) {
-	config := ctx.GetSessionConfig()
+func handleAuthnCookieValidateInactivity(ctx AuthzContext, manager session.Manager, userSession *session.UserSession, isAnonymous bool) (invalid bool) {
+	config := manager.GetSessionConfig()
 
 	if isAnonymous || userSession.KeepMeLoggedIn || int64(config.Inactivity.Seconds()) == 0 {
 		return false

--- a/internal/handlers/handler_authz_authn.go
+++ b/internal/handlers/handler_authz_authn.go
@@ -19,7 +19,6 @@ import (
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
-	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/oidc"
 	"github.com/authelia/authelia/v4/internal/regulation"
@@ -88,7 +87,7 @@ type CookieSessionAuthnStrategy struct {
 }
 
 // Get returns the Authn information for this AuthnStrategy.
-func (s *CookieSessionAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, provider *session.Session, _ *authorization.Object) (authn *Authn, err error) {
+func (s *CookieSessionAuthnStrategy) Get(ctx AuthzContext, _ *authorization.Object) (authn *Authn, err error) {
 	var userSession session.UserSession
 
 	authn = &Authn{
@@ -97,40 +96,40 @@ func (s *CookieSessionAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, provider 
 		Username: anonymous,
 	}
 
-	if userSession, err = provider.GetSession(ctx.RequestCtx); err != nil {
+	if userSession, err = ctx.GetSession(); err != nil {
 		return authn, fmt.Errorf("failed to retrieve user session: %w", err)
 	}
 
-	if userSession.CookieDomain != provider.Config.Domain {
-		ctx.Logger.Warnf("Destroying session cookie as the cookie domain '%s' does not match the requests detected cookie domain '%s' which may be a sign a user tried to move this cookie from one domain to another", userSession.CookieDomain, provider.Config.Domain)
+	if userSession.CookieDomain != ctx.GetSessionConfig().Domain {
+		ctx.GetLogger().Warnf("Destroying session cookie as the cookie domain '%s' does not match the requests detected cookie domain '%s' which may be a sign a user tried to move this cookie from one domain to another", userSession.CookieDomain, ctx.GetSessionConfig().Domain)
 
-		if err = provider.DestroySession(ctx.RequestCtx); err != nil {
-			ctx.Logger.WithError(err).Error("Error occurred trying to destroy the session cookie")
+		if err = ctx.DestroySession(); err != nil {
+			ctx.GetLogger().WithError(err).Error("Error occurred trying to destroy the session cookie")
 		}
 
-		userSession = provider.NewDefaultUserSession()
+		userSession = ctx.NewSession()
 
-		if err = provider.SaveSession(ctx.RequestCtx, userSession); err != nil {
-			ctx.Logger.WithError(err).Error("Error occurred trying to save the new session cookie")
+		if err = ctx.SaveSession(userSession); err != nil {
+			ctx.GetLogger().WithError(err).Error("Error occurred trying to save the new session cookie")
 		}
 	}
 
-	if modified, invalid := handleAuthnCookieValidate(ctx, provider, &userSession, s.refresh); invalid {
+	if modified, invalid := handleAuthnCookieValidate(ctx, &userSession, s.refresh); invalid {
 		if err = ctx.DestroySession(); err != nil {
-			ctx.Logger.WithError(err).Errorf("Unable to destroy user session")
+			ctx.GetLogger().WithError(err).Errorf("Unable to destroy user session")
 		}
 
-		userSession = provider.NewDefaultUserSession()
+		userSession = ctx.NewSession()
 		userSession.LastActivity = ctx.GetClock().Now().Unix()
 
-		if err = provider.SaveSession(ctx.RequestCtx, userSession); err != nil {
-			ctx.Logger.WithError(err).Error("Unable to save updated user session")
+		if err = ctx.SaveSession(userSession); err != nil {
+			ctx.GetLogger().WithError(err).Error("Unable to save updated user session")
 		}
 
 		return authn, nil
 	} else if modified {
-		if err = provider.SaveSession(ctx.RequestCtx, userSession); err != nil {
-			ctx.Logger.WithError(err).Error("Unable to save updated user session")
+		if err = ctx.SaveSession(userSession); err != nil {
+			ctx.GetLogger().WithError(err).Error("Unable to save updated user session")
 		}
 	}
 
@@ -142,7 +141,7 @@ func (s *CookieSessionAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, provider 
 			Emails:      userSession.Emails,
 			Groups:      userSession.Groups,
 		},
-		Level: userSession.AuthenticationLevel(ctx.Configuration.WebAuthn.EnablePasskey2FA),
+		Level: userSession.AuthenticationLevel(ctx.GetConfiguration().WebAuthn.EnablePasskey2FA),
 		Type:  AuthnTypeCookie,
 	}, nil
 }
@@ -158,7 +157,7 @@ func (s *CookieSessionAuthnStrategy) HeaderStrategy() (header bool) {
 }
 
 // HandleUnauthorized is the Unauthorized handler for the cookie AuthnStrategy.
-func (s *CookieSessionAuthnStrategy) HandleUnauthorized(_ *middlewares.AutheliaCtx, _ *Authn, _ *url.URL) {
+func (s *CookieSessionAuthnStrategy) HandleUnauthorized(_ AuthzContext, _ *Authn, _ *url.URL) {
 }
 
 // HeaderAuthnStrategy is a header AuthnStrategy.
@@ -174,7 +173,7 @@ type HeaderAuthnStrategy struct {
 }
 
 // BasicAuthHandler is a function signature that handles basic authentication. This is used to implement caching.
-type BasicAuthHandler func(ctx *middlewares.AutheliaCtx, authorization *model.Authorization) (valid, cached bool, err error)
+type BasicAuthHandler func(ctx AuthzContext, authorization *model.Authorization) (valid, cached bool, err error)
 
 // NewBasicAuthHandler creates a new BasicAuthHandler depending on the lifespan.
 func NewBasicAuthHandler(lifespan time.Duration) BasicAuthHandler {
@@ -186,8 +185,8 @@ func NewBasicAuthHandler(lifespan time.Duration) BasicAuthHandler {
 }
 
 // DefaultBasicAuthHandler is a BasicAuthHandler that just checks the username and password directly.
-func DefaultBasicAuthHandler(ctx *middlewares.AutheliaCtx, authorization *model.Authorization) (valid, cached bool, err error) {
-	valid, err = ctx.Providers.UserProvider.CheckUserPassword(authorization.Basic())
+func DefaultBasicAuthHandler(ctx AuthzContext, authorization *model.Authorization) (valid, cached bool, err error) {
+	valid, err = ctx.GetProviders().UserProvider.CheckUserPassword(authorization.Basic())
 
 	return valid, false, err
 }
@@ -197,7 +196,7 @@ func DefaultBasicAuthHandler(ctx *middlewares.AutheliaCtx, authorization *model.
 func NewCachedBasicAuthHandler(lifespan time.Duration) BasicAuthHandler {
 	cache := authentication.NewCredentialCacheHMAC(sha256.New, lifespan)
 
-	return func(ctx *middlewares.AutheliaCtx, authorization *model.Authorization) (valid, cached bool, err error) {
+	return func(ctx AuthzContext, authorization *model.Authorization) (valid, cached bool, err error) {
 		username, password := authorization.Basic()
 
 		return cache.Check(ctx, username, password)
@@ -205,7 +204,7 @@ func NewCachedBasicAuthHandler(lifespan time.Duration) BasicAuthHandler {
 }
 
 // Get returns the Authn information for this AuthnStrategy.
-func (s *HeaderAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session.Session, object *authorization.Object) (authn *Authn, err error) {
+func (s *HeaderAuthnStrategy) Get(ctx AuthzContext, object *authorization.Object) (authn *Authn, err error) {
 	var value []byte
 
 	authn = &Authn{
@@ -214,7 +213,7 @@ func (s *HeaderAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session.Sessi
 		Username: anonymous,
 	}
 
-	if value = ctx.Request.Header.PeekBytes(s.headerAuthorize); len(value) == 0 {
+	if value = ctx.GetRequestHeaderValue(s.headerAuthorize); len(value) == 0 {
 		return authn, nil
 	}
 
@@ -236,7 +235,7 @@ func (s *HeaderAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session.Sessi
 	scheme := authn.Header.Authorization.Scheme()
 
 	if !s.schemes.Has(scheme) {
-		ctx.Logger.
+		ctx.GetLogger().
 			WithFields(map[string]any{"scheme": authn.Header.Authorization.SchemeRaw(), "header": string(s.headerAuthorize)}).
 			Debug("Skipping header authorization as the scheme and header combination is unknown to this endpoint configuration")
 
@@ -249,7 +248,7 @@ func (s *HeaderAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session.Sessi
 	case model.AuthorizationSchemeBearer:
 		username, clientID, ccs, level, err = handleVerifyGETAuthorizationBearer(ctx, authn, object)
 	default:
-		ctx.Logger.
+		ctx.GetLogger().
 			WithFields(map[string]any{"scheme": authn.Header.Authorization.SchemeRaw(), "header": string(s.headerAuthorize)}).
 			Debug("Skipping header authorization as the scheme is unknown to this endpoint configuration")
 
@@ -276,9 +275,9 @@ func (s *HeaderAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session.Sessi
 	default:
 		var details *authentication.UserDetails
 
-		if details, err = ctx.Providers.UserProvider.GetDetails(username); err != nil {
+		if details, err = ctx.GetProviders().UserProvider.GetDetails(username); err != nil {
 			if errors.Is(err, authentication.ErrUserNotFound) {
-				ctx.Logger.WithField("username", username).Error("Error occurred while attempting to get user details for user: the user was not found indicating they were deleted, disabled, or otherwise no longer authorized to login")
+				ctx.GetLogger().WithField("username", username).Error("Error occurred while attempting to get user details for user: the user was not found indicating they were deleted, disabled, or otherwise no longer authorized to login")
 
 				return authn, err
 			}
@@ -295,7 +294,7 @@ func (s *HeaderAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session.Sessi
 	return authn, nil
 }
 
-func (s *HeaderAuthnStrategy) handleGetBasic(ctx *middlewares.AutheliaCtx, authn *Authn, object *authorization.Object) (username string, level authentication.Level, err error) {
+func (s *HeaderAuthnStrategy) handleGetBasic(ctx AuthzContext, authn *Authn, object *authorization.Object) (username string, level authentication.Level, err error) {
 	var (
 		ban     regulation.BanType
 		value   string
@@ -304,14 +303,14 @@ func (s *HeaderAuthnStrategy) handleGetBasic(ctx *middlewares.AutheliaCtx, authn
 
 	username = authn.Header.Authorization.BasicUsername()
 
-	if ban, value, expires, err = ctx.Providers.Regulator.BanCheck(ctx, username); err != nil {
+	if ban, value, expires, err = ctx.GetProviders().Regulator.BanCheck(ctx, username); err != nil {
 		if errors.Is(err, regulation.ErrUserIsBanned) {
 			doMarkAuthenticationAttemptWithRequest(ctx, false, regulation.NewBan(ban, value, expires), regulation.AuthType1FA, object.String(), object.Method, nil)
 
 			return "", authentication.NotAuthenticated, fmt.Errorf("failed to validate the credentials of user '%s' parsed from the %s header: %w", username, s.headerAuthorize, err)
 		}
 
-		ctx.Logger.WithError(err).Errorf(logFmtErrRegulationFail, regulation.AuthType1FA, username)
+		ctx.GetLogger().WithError(err).Errorf(logFmtErrRegulationFail, regulation.AuthType1FA, username)
 
 		return "", authentication.NotAuthenticated, fmt.Errorf("failed to check the regulation status of user '%s' during an attempt to authenticate using the %s header: %w", username, s.headerAuthorize, err)
 	}
@@ -320,7 +319,7 @@ func (s *HeaderAuthnStrategy) handleGetBasic(ctx *middlewares.AutheliaCtx, authn
 
 	if valid, cached, err = s.basic(ctx, authn.Header.Authorization); err != nil {
 		if isRegulatorSkippedErr(err) {
-			ctx.Logger.WithError(err).Errorf("Unsuccessful %s authentication attempt by user '%s'", regulation.AuthType1FA, authn.Header.Authorization.BasicUsername())
+			ctx.GetLogger().WithError(err).Errorf("Unsuccessful %s authentication attempt by user '%s'", regulation.AuthType1FA, authn.Header.Authorization.BasicUsername())
 		} else {
 			doMarkAuthenticationAttemptWithRequest(ctx, false, regulation.NewBan(regulation.BanTypeNone, username, nil), regulation.AuthType1FA, object.String(), object.Method, err)
 		}
@@ -352,15 +351,15 @@ func (s *HeaderAuthnStrategy) HeaderStrategy() (header bool) {
 }
 
 // HandleUnauthorized is the Unauthorized handler for the header AuthnStrategy.
-func (s *HeaderAuthnStrategy) HandleUnauthorized(ctx *middlewares.AutheliaCtx, authn *Authn, _ *url.URL) {
-	ctx.Logger.Debugf("Responding %d %s", s.statusAuthenticate, s.headerAuthenticate)
+func (s *HeaderAuthnStrategy) HandleUnauthorized(ctx AuthzContext, authn *Authn, _ *url.URL) {
+	ctx.GetLogger().Debugf("Responding %d %s", s.statusAuthenticate, s.headerAuthenticate)
 
 	ctx.ReplyStatusCode(s.statusAuthenticate)
 
 	if authn.Header.Authorization != nil && authn.Header.Authorization.Scheme() == model.AuthorizationSchemeBearer && authn.Header.Error != nil {
-		ctx.Response.Header.SetBytesK(s.headerAuthenticate, fmt.Sprintf(`Bearer %s`, oidc.RFC6750Header(authn.Header.Realm, authn.Header.Scope, authn.Header.Error)))
+		ctx.SetResponseHeaderValue(s.headerAuthenticate, fmt.Sprintf(`Bearer %s`, oidc.RFC6750Header(authn.Header.Realm, authn.Header.Scope, authn.Header.Error)))
 	} else if s.headerAuthenticate != nil {
-		ctx.Response.Header.SetBytesKV(s.headerAuthenticate, headerValueAuthenticateBasic)
+		ctx.SetResponseHeaderValueBytes(s.headerAuthenticate, headerValueAuthenticateBasic)
 	}
 }
 
@@ -368,7 +367,7 @@ func (s *HeaderAuthnStrategy) HandleUnauthorized(ctx *middlewares.AutheliaCtx, a
 type HeaderLegacyAuthnStrategy struct{}
 
 // Get returns the Authn information for this AuthnStrategy.
-func (s *HeaderLegacyAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session.Session, _ *authorization.Object) (authn *Authn, err error) {
+func (s *HeaderLegacyAuthnStrategy) Get(ctx AuthzContext, _ *authorization.Object) (authn *Authn, err error) {
 	var (
 		username, password string
 		value, header      []byte
@@ -379,7 +378,7 @@ func (s *HeaderLegacyAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session
 		Username: anonymous,
 	}
 
-	if qryValueAuth := ctx.QueryArgs().PeekBytes(qryArgAuth); bytes.Equal(qryValueAuth, qryValueBasic) {
+	if qryValueAuth := ctx.GetRequestQueryArgValue(qryArgAuth); bytes.Equal(qryValueAuth, qryValueBasic) {
 		authn.Type = AuthnTypeAuthorization
 		header = headerAuthorization
 	} else {
@@ -387,7 +386,7 @@ func (s *HeaderLegacyAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session
 		header = headerProxyAuthorization
 	}
 
-	value = ctx.Request.Header.PeekBytes(header)
+	value = ctx.GetRequestHeaderValue(header)
 
 	switch {
 	case value == nil && authn.Type == AuthnTypeAuthorization:
@@ -409,7 +408,7 @@ func (s *HeaderLegacyAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session
 		details *authentication.UserDetails
 	)
 
-	if valid, err = ctx.Providers.UserProvider.CheckUserPassword(username, password); err != nil {
+	if valid, err = ctx.GetProviders().UserProvider.CheckUserPassword(username, password); err != nil {
 		return authn, fmt.Errorf("failed to validate parsed credentials of %s header for user '%s': %w", header, username, err)
 	}
 
@@ -417,9 +416,9 @@ func (s *HeaderLegacyAuthnStrategy) Get(ctx *middlewares.AutheliaCtx, _ *session
 		return authn, fmt.Errorf("validated parsed credentials of %s header but they are not valid for user '%s': %w", header, username, err)
 	}
 
-	if details, err = ctx.Providers.UserProvider.GetDetails(username); err != nil {
+	if details, err = ctx.GetProviders().UserProvider.GetDetails(username); err != nil {
 		if errors.Is(err, authentication.ErrUserNotFound) {
-			ctx.Logger.WithField("username", username).Error("Error occurred while attempting to get user details for user: the user was not found indicating they were deleted, disabled, or otherwise no longer authorized to login")
+			ctx.GetLogger().WithField("username", username).Error("Error occurred while attempting to get user details for user: the user was not found indicating they were deleted, disabled, or otherwise no longer authorized to login")
 
 			return authn, err
 		}
@@ -445,22 +444,22 @@ func (s *HeaderLegacyAuthnStrategy) HeaderStrategy() (header bool) {
 }
 
 // HandleUnauthorized is the Unauthorized handler for the Legacy header AuthnStrategy.
-func (s *HeaderLegacyAuthnStrategy) HandleUnauthorized(ctx *middlewares.AutheliaCtx, authn *Authn, _ *url.URL) {
+func (s *HeaderLegacyAuthnStrategy) HandleUnauthorized(ctx AuthzContext, authn *Authn, _ *url.URL) {
 	handleAuthzUnauthorizedAuthorizationBasic(ctx, authn)
 }
 
-func handleAuthnCookieValidate(ctx *middlewares.AutheliaCtx, provider *session.Session, userSession *session.UserSession, refresh schema.RefreshIntervalDuration) (modified, invalid bool) {
+func handleAuthnCookieValidate(ctx AuthzContext, userSession *session.UserSession, refresh schema.RefreshIntervalDuration) (modified, invalid bool) {
 	// TODO: Remove this check as it's no longer possible i.e. ineffectual.
 	isAnonymous := userSession.Username == ""
 
-	if isAnonymous && userSession.AuthenticationLevel(ctx.Configuration.WebAuthn.EnablePasskey2FA) != authentication.NotAuthenticated {
-		ctx.Logger.WithFields(map[string]any{"username": anonymous, "level": userSession.AuthenticationLevel(ctx.Configuration.WebAuthn.EnablePasskey2FA).String()}).Errorf("Session for user has an invalid authentication level: this may be a sign of a compromise")
+	if isAnonymous && userSession.AuthenticationLevel(ctx.GetConfiguration().WebAuthn.EnablePasskey2FA) != authentication.NotAuthenticated {
+		ctx.GetLogger().WithFields(map[string]any{"username": anonymous, "level": userSession.AuthenticationLevel(ctx.GetConfiguration().WebAuthn.EnablePasskey2FA).String()}).Errorf("Session for user has an invalid authentication level: this may be a sign of a compromise")
 
 		return modified, true
 	}
 
-	if invalid = handleAuthnCookieValidateInactivity(ctx, provider, userSession, isAnonymous); invalid {
-		ctx.Logger.WithField("username", userSession.Username).Info("Session for user not marked as remembered has exceeded configured session inactivity")
+	if invalid = handleAuthnCookieValidateInactivity(ctx, userSession, isAnonymous); invalid {
+		ctx.GetLogger().WithField("username", userSession.Username).Info("Session for user not marked as remembered has exceeded configured session inactivity")
 
 		return modified, true
 	}
@@ -469,8 +468,8 @@ func handleAuthnCookieValidate(ctx *middlewares.AutheliaCtx, provider *session.S
 		return modified, true
 	}
 
-	if username := ctx.Request.Header.PeekBytes(headerSessionUsername); username != nil && !strings.EqualFold(string(username), userSession.Username) {
-		ctx.Logger.WithField("username", userSession.Username).Warnf("Session for user does not match the Session-Username header with value '%s' which could be a sign of a cookie hijack", username)
+	if username := ctx.GetRequestHeaderValue(headerSessionUsername); username != nil && !strings.EqualFold(string(username), userSession.Username) {
+		ctx.GetLogger().WithField("username", userSession.Username).Warnf("Session for user does not match the Session-Username header with value '%s' which could be a sign of a cookie hijack", username)
 
 		return modified, true
 	}
@@ -484,41 +483,43 @@ func handleAuthnCookieValidate(ctx *middlewares.AutheliaCtx, provider *session.S
 	return modified, false
 }
 
-func handleAuthnCookieValidateInactivity(ctx *middlewares.AutheliaCtx, provider *session.Session, userSession *session.UserSession, isAnonymous bool) (invalid bool) {
-	if isAnonymous || userSession.KeepMeLoggedIn || int64(provider.Config.Inactivity.Seconds()) == 0 {
+func handleAuthnCookieValidateInactivity(ctx AuthzContext, userSession *session.UserSession, isAnonymous bool) (invalid bool) {
+	config := ctx.GetSessionConfig()
+
+	if isAnonymous || userSession.KeepMeLoggedIn || int64(config.Inactivity.Seconds()) == 0 {
 		return false
 	}
 
-	ctx.Logger.WithField("username", userSession.Username).Tracef("Inactivity report for user. Current Time: %d, Last Activity: %d, Maximum Inactivity: %d.", ctx.GetClock().Now().Unix(), userSession.LastActivity, int(provider.Config.Inactivity.Seconds()))
+	ctx.GetLogger().WithField("username", userSession.Username).Tracef("Inactivity report for user. Current Time: %d, Last Activity: %d, Maximum Inactivity: %d.", ctx.GetClock().Now().Unix(), userSession.LastActivity, int(config.Inactivity.Seconds()))
 
-	return time.Unix(userSession.LastActivity, 0).Add(provider.Config.Inactivity).Before(ctx.GetClock().Now())
+	return time.Unix(userSession.LastActivity, 0).Add(config.Inactivity).Before(ctx.GetClock().Now())
 }
 
-func handleSessionValidateRefresh(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, refresh schema.RefreshIntervalDuration) (modified, invalid bool) {
+func handleSessionValidateRefresh(ctx AuthzContext, userSession *session.UserSession, refresh schema.RefreshIntervalDuration) (modified, invalid bool) {
 	if refresh.Never() || userSession.IsAnonymous() {
 		return false, false
 	}
 
-	ctx.Logger.WithField("username", userSession.Username).Trace("Checking if we need check the authentication backend for an updated profile for user")
+	ctx.GetLogger().WithField("username", userSession.Username).Trace("Checking if we need check the authentication backend for an updated profile for user")
 
 	if !refresh.Always() && userSession.RefreshTTL.After(ctx.GetClock().Now()) {
 		return false, false
 	}
 
-	ctx.Logger.WithField("username", userSession.Username).Debug("Checking the authentication backend for an updated profile for user")
+	ctx.GetLogger().WithField("username", userSession.Username).Debug("Checking the authentication backend for an updated profile for user")
 
 	var (
 		details *authentication.UserDetails
 		err     error
 	)
-	if details, err = ctx.Providers.UserProvider.GetDetails(userSession.Username); err != nil {
+	if details, err = ctx.GetProviders().UserProvider.GetDetails(userSession.Username); err != nil {
 		if errors.Is(err, authentication.ErrUserNotFound) {
-			ctx.Logger.WithField("username", userSession.Username).Error("Error occurred while attempting to update user details for user: the user was not found indicating they were deleted, disabled, or otherwise no longer authorized to login")
+			ctx.GetLogger().WithField("username", userSession.Username).Error("Error occurred while attempting to update user details for user: the user was not found indicating they were deleted, disabled, or otherwise no longer authorized to login")
 
 			return false, true
 		}
 
-		ctx.Logger.WithError(err).WithField("username", userSession.Username).Error("Error occurred while attempting to update user details for user")
+		ctx.GetLogger().WithError(err).WithField("username", userSession.Username).Error("Error occurred while attempting to update user details for user")
 
 		return false, false
 	}
@@ -537,14 +538,14 @@ func handleSessionValidateRefresh(ctx *middlewares.AutheliaCtx, userSession *ses
 	}
 
 	if !diffEmails && !diffGroups && !diffDisplayName {
-		ctx.Logger.WithField("username", userSession.Username).Trace("Updated profile not detected for user")
+		ctx.GetLogger().WithField("username", userSession.Username).Trace("Updated profile not detected for user")
 
 		return modified, false
 	}
 
-	ctx.Logger.WithField("username", userSession.Username).Debug("Updated profile detected for user")
+	ctx.GetLogger().WithField("username", userSession.Username).Debug("Updated profile detected for user")
 
-	if ctx.Logger.Level >= logrus.TraceLevel {
+	if ctx.GetLogger().Level >= logrus.TraceLevel {
 		generateVerifySessionHasUpToDateProfileTraceLogs(ctx, userSession, details)
 	}
 
@@ -553,20 +554,20 @@ func handleSessionValidateRefresh(ctx *middlewares.AutheliaCtx, userSession *ses
 	return true, false
 }
 
-func handleVerifyGETAuthorizationBearer(ctx *middlewares.AutheliaCtx, authn *Authn, object *authorization.Object) (username, clientID string, ccs bool, level authentication.Level, err error) {
+func handleVerifyGETAuthorizationBearer(ctx AuthzContext, authn *Authn, object *authorization.Object) (username, clientID string, ccs bool, level authentication.Level, err error) {
 	var at bool
 
 	if at, err = oidc.IsAccessToken(ctx, authn.Header.Authorization.Value()); !at {
 		if err != nil {
-			ctx.Logger.WithError(err).Debug("The bearer token does not appear to be a relevant access token")
+			ctx.GetLogger().WithError(err).Debug("The bearer token does not appear to be a relevant access token")
 		} else {
-			ctx.Logger.Debug("The bearer token does not appear to be a relevant access token")
+			ctx.GetLogger().Debug("The bearer token does not appear to be a relevant access token")
 		}
 
 		return "", "", false, authentication.NotAuthenticated, errTokenIntent
 	}
 
-	return handleVerifyGETAuthorizationBearerIntrospection(ctx, ctx.Providers.OpenIDConnect, authn, object)
+	return handleVerifyGETAuthorizationBearerIntrospection(ctx, ctx.GetProviders().OpenIDConnect, authn, object)
 }
 
 func handleVerifyGETAuthorizationBearerIntrospection(ctx context.Context, provider AuthzBearerIntrospectionProvider, authn *Authn, object *authorization.Object) (username, clientID string, ccs bool, level authentication.Level, err error) {

--- a/internal/handlers/handler_authz_impl_authrequest.go
+++ b/internal/handlers/handler_authz_impl_authrequest.go
@@ -10,7 +10,7 @@ import (
 	"github.com/authelia/authelia/v4/internal/middlewares"
 )
 
-func handleAuthzGetObjectAuthRequest(ctx *middlewares.AutheliaCtx) (object authorization.Object, err error) {
+func handleAuthzGetObjectAuthRequest(ctx AuthzContext) (object authorization.Object, err error) {
 	var (
 		targetURL *url.URL
 
@@ -36,8 +36,8 @@ func handleAuthzGetObjectAuthRequest(ctx *middlewares.AutheliaCtx) (object autho
 	return authorization.NewObjectRaw(targetURL, method), nil
 }
 
-func handleAuthzUnauthorizedAuthRequest(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL) {
-	ctx.Logger.Infof(logFmtAuthzRedirect, authn.Object.URL.String(), authn.Method, authn.Username, fasthttp.StatusUnauthorized, redirectionURL)
+func handleAuthzUnauthorizedAuthRequest(ctx AuthzContext, authn *Authn, redirectionURL *url.URL) {
+	ctx.GetLogger().Infof(logFmtAuthzRedirect, authn.Object.URL.String(), authn.Method, authn.Username, fasthttp.StatusUnauthorized, redirectionURL)
 
 	switch authn.Object.Method {
 	case fasthttp.MethodHead:

--- a/internal/handlers/handler_authz_impl_extauthz.go
+++ b/internal/handlers/handler_authz_impl_extauthz.go
@@ -7,10 +7,9 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/v4/internal/authorization"
-	"github.com/authelia/authelia/v4/internal/middlewares"
 )
 
-func handleAuthzGetObjectExtAuthz(ctx *middlewares.AutheliaCtx) (object authorization.Object, err error) {
+func handleAuthzGetObjectExtAuthz(ctx AuthzContext) (object authorization.Object, err error) {
 	protocol, host, uri := ctx.XForwardedProto(), ctx.Host(), ctx.AuthzPath()
 
 	var (
@@ -33,7 +32,7 @@ func handleAuthzGetObjectExtAuthz(ctx *middlewares.AutheliaCtx) (object authoriz
 	return authorization.NewObjectRaw(targetURL, method), nil
 }
 
-func handleAuthzUnauthorizedExtAuthz(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL) {
+func handleAuthzUnauthorizedExtAuthz(ctx AuthzContext, authn *Authn, redirectionURL *url.URL) {
 	var (
 		statusCode int
 	)
@@ -50,7 +49,7 @@ func handleAuthzUnauthorizedExtAuthz(ctx *middlewares.AutheliaCtx, authn *Authn,
 		}
 	}
 
-	ctx.Logger.Infof(logFmtAuthzRedirect, authn.Object.String(), authn.Method, authn.Username, statusCode, redirectionURL)
+	ctx.GetLogger().Infof(logFmtAuthzRedirect, authn.Object.String(), authn.Method, authn.Username, statusCode, redirectionURL)
 
 	switch authn.Object.Method {
 	case fasthttp.MethodHead:

--- a/internal/handlers/handler_authz_impl_forwardauth.go
+++ b/internal/handlers/handler_authz_impl_forwardauth.go
@@ -7,10 +7,9 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/v4/internal/authorization"
-	"github.com/authelia/authelia/v4/internal/middlewares"
 )
 
-func handleAuthzGetObjectForwardAuth(ctx *middlewares.AutheliaCtx) (object authorization.Object, err error) {
+func handleAuthzGetObjectForwardAuth(ctx AuthzContext) (object authorization.Object, err error) {
 	protocol, host, uri := ctx.XForwardedProto(), ctx.XForwardedHost(), ctx.XForwardedURI()
 
 	var (
@@ -33,7 +32,7 @@ func handleAuthzGetObjectForwardAuth(ctx *middlewares.AutheliaCtx) (object autho
 	return authorization.NewObjectRaw(targetURL, method), nil
 }
 
-func handleAuthzUnauthorizedForwardAuth(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL) {
+func handleAuthzUnauthorizedForwardAuth(ctx AuthzContext, authn *Authn, redirectionURL *url.URL) {
 	var (
 		statusCode int
 	)
@@ -50,7 +49,7 @@ func handleAuthzUnauthorizedForwardAuth(ctx *middlewares.AutheliaCtx, authn *Aut
 		}
 	}
 
-	ctx.Logger.Infof(logFmtAuthzRedirect, authn.Object.String(), authn.Method, authn.Username, statusCode, redirectionURL)
+	ctx.GetLogger().Infof(logFmtAuthzRedirect, authn.Object.String(), authn.Method, authn.Username, statusCode, redirectionURL)
 
 	switch authn.Object.Method {
 	case fasthttp.MethodHead:

--- a/internal/handlers/handler_authz_impl_legacy.go
+++ b/internal/handlers/handler_authz_impl_legacy.go
@@ -7,10 +7,9 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/v4/internal/authorization"
-	"github.com/authelia/authelia/v4/internal/middlewares"
 )
 
-func handleAuthzGetObjectLegacy(ctx *middlewares.AutheliaCtx) (object authorization.Object, err error) {
+func handleAuthzGetObjectLegacy(ctx AuthzContext) (object authorization.Object, err error) {
 	var (
 		targetURL *url.URL
 		method    []byte
@@ -31,7 +30,7 @@ func handleAuthzGetObjectLegacy(ctx *middlewares.AutheliaCtx) (object authorizat
 	return authorization.NewObjectRaw(targetURL, method), nil
 }
 
-func handleAuthzUnauthorizedLegacy(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL) {
+func handleAuthzUnauthorizedLegacy(ctx AuthzContext, authn *Authn, redirectionURL *url.URL) {
 	var (
 		statusCode int
 	)
@@ -55,7 +54,7 @@ func handleAuthzUnauthorizedLegacy(ctx *middlewares.AutheliaCtx, authn *Authn, r
 	}
 
 	if redirectionURL != nil {
-		ctx.Logger.Infof(logFmtAuthzRedirect, authn.Object.URL.String(), authn.Method, authn.Username, statusCode, redirectionURL)
+		ctx.GetLogger().Infof(logFmtAuthzRedirect, authn.Object.URL.String(), authn.Method, authn.Username, statusCode, redirectionURL)
 
 		switch authn.Object.Method {
 		case fasthttp.MethodHead:
@@ -64,7 +63,7 @@ func handleAuthzUnauthorizedLegacy(ctx *middlewares.AutheliaCtx, authn *Authn, r
 			ctx.SpecialRedirect(redirectionURL.String(), statusCode)
 		}
 	} else {
-		ctx.Logger.Infof("Access to %s (method %s) is not authorized to user %s, responding with status code %d", authn.Object.URL.String(), authn.Method, authn.Username, statusCode)
+		ctx.GetLogger().Infof("Access to %s (method %s) is not authorized to user %s, responding with status code %d", authn.Object.URL.String(), authn.Method, authn.Username, statusCode)
 		ctx.ReplyUnauthorized()
 	}
 }

--- a/internal/handlers/handler_authz_types.go
+++ b/internal/handlers/handler_authz_types.go
@@ -10,10 +10,8 @@ import (
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
-	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/oidc"
-	"github.com/authelia/authelia/v4/internal/session"
 )
 
 // Authz is a type which is a effectively is a middlewares.RequestHandler for authorization requests. This should NOT be
@@ -34,22 +32,22 @@ type Authz struct {
 }
 
 // HandlerAuthzUnauthorized is a Authz handler func that handles unauthorized responses.
-type HandlerAuthzUnauthorized func(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL)
+type HandlerAuthzUnauthorized func(ctx AuthzContext, authn *Authn, redirectionURL *url.URL)
 
 // HandlerAuthzAuthorized is a Authz handler func that handles authorized responses.
-type HandlerAuthzAuthorized func(ctx *middlewares.AutheliaCtx, authn *Authn)
+type HandlerAuthzAuthorized func(ctx AuthzContext, authn *Authn)
 
 // HandlerAuthzGetAutheliaURL is a Authz handler func that handles retrieval of the Portal URL.
-type HandlerAuthzGetAutheliaURL func(ctx *middlewares.AutheliaCtx) (portalURL *url.URL, err error)
+type HandlerAuthzGetAutheliaURL func(ctx AuthzContext) (portalURL *url.URL, err error)
 
 // HandlerAuthzGetRedirectionURL is a Authz handler func that handles retrieval of the Redirection URL.
-type HandlerAuthzGetRedirectionURL func(ctx *middlewares.AutheliaCtx, object *authorization.Object) (redirectionURL *url.URL, err error)
+type HandlerAuthzGetRedirectionURL func(ctx AuthzContext, object *authorization.Object) (redirectionURL *url.URL, err error)
 
 // HandlerAuthzGetObject is a Authz handler func that handles retrieval of the authorization.Object to authorize.
-type HandlerAuthzGetObject func(ctx *middlewares.AutheliaCtx) (object authorization.Object, err error)
+type HandlerAuthzGetObject func(ctx AuthzContext) (object authorization.Object, err error)
 
 // HandlerAuthzVerifyObject is a Authz handler func that handles authorization of the authorization.Object.
-type HandlerAuthzVerifyObject func(ctx *middlewares.AutheliaCtx, object authorization.Object) (err error)
+type HandlerAuthzVerifyObject func(ctx AuthzContext, object authorization.Object) (err error)
 
 // AuthnType is an auth type.
 type AuthnType int
@@ -107,10 +105,10 @@ type AuthzBuilder struct {
 
 // AuthnStrategy is a strategy used for Authz authentication.
 type AuthnStrategy interface {
-	Get(ctx *middlewares.AutheliaCtx, provider *session.Session, object *authorization.Object) (authn *Authn, err error)
+	Get(ctx AuthzContext, object *authorization.Object) (authn *Authn, err error)
 	CanHandleUnauthorized() (handle bool)
 	HeaderStrategy() (is bool)
-	HandleUnauthorized(ctx *middlewares.AutheliaCtx, authn *Authn, redirectionURL *url.URL)
+	HandleUnauthorized(ctx AuthzContext, authn *Authn, redirectionURL *url.URL)
 }
 
 // AuthzResult is a result for Authz response handling determination.

--- a/internal/handlers/handler_authz_types.go
+++ b/internal/handlers/handler_authz_types.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	oauthelia2 "authelia.com/provider/oauth2"
+	"github.com/authelia/authelia/v4/internal/session"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
@@ -105,7 +106,7 @@ type AuthzBuilder struct {
 
 // AuthnStrategy is a strategy used for Authz authentication.
 type AuthnStrategy interface {
-	Get(ctx AuthzContext, object *authorization.Object) (authn *Authn, err error)
+	Get(ctx AuthzContext, manager session.Manager, object *authorization.Object) (authn *Authn, err error)
 	CanHandleUnauthorized() (handle bool)
 	HeaderStrategy() (is bool)
 	HandleUnauthorized(ctx AuthzContext, authn *Authn, redirectionURL *url.URL)
@@ -115,7 +116,7 @@ type AuthnStrategy interface {
 type AuthzResult int
 
 const (
-	// AuthzResultForbidden means the user is forbidden the access to a resource.
+	// AuthzResultForbidden means the user is forbidden access to a resource.
 	AuthzResultForbidden AuthzResult = iota
 
 	// AuthzResultUnauthorized means the user can access the resource with more permissions.

--- a/internal/handlers/handler_authz_types.go
+++ b/internal/handlers/handler_authz_types.go
@@ -6,13 +6,13 @@ import (
 	"net/url"
 
 	oauthelia2 "authelia.com/provider/oauth2"
-	"github.com/authelia/authelia/v4/internal/session"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/oidc"
+	"github.com/authelia/authelia/v4/internal/session"
 )
 
 // Authz is a type which is a effectively is a middlewares.RequestHandler for authorization requests. This should NOT be

--- a/internal/handlers/handler_authz_util.go
+++ b/internal/handlers/handler_authz_util.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"
-	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/session"
 	"github.com/authelia/authelia/v4/internal/utils"
 )
@@ -45,7 +44,7 @@ func isAuthzResult(level authentication.Level, required authorization.Level, rul
 
 // generateVerifySessionHasUpToDateProfileTraceLogs is used to generate trace logs only when trace logging is enabled.
 // The information calculated in this function is completely useless other than trace for now.
-func generateVerifySessionHasUpToDateProfileTraceLogs(ctx *middlewares.AutheliaCtx, userSession *session.UserSession,
+func generateVerifySessionHasUpToDateProfileTraceLogs(ctx AuthzContext, userSession *session.UserSession,
 	details *authentication.UserDetails) {
 	groupsAdded, groupsRemoved := utils.StringSlicesDelta(userSession.Groups, details.Groups)
 	emailsAdded, emailsRemoved := utils.StringSlicesDelta(userSession.Emails, details.Emails)
@@ -66,7 +65,7 @@ func generateVerifySessionHasUpToDateProfileTraceLogs(ctx *middlewares.AutheliaC
 		msg = "User session groups were updated"
 	}
 
-	ctx.Logger.WithFields(fields).Trace(msg)
+	ctx.GetLogger().WithFields(fields).Trace(msg)
 
 	if len(emailsAdded) != 0 || len(emailsRemoved) != 0 {
 		if len(emailsAdded) != 0 {
@@ -89,10 +88,10 @@ func generateVerifySessionHasUpToDateProfileTraceLogs(ctx *middlewares.AutheliaC
 		delete(fields, "removed")
 	}
 
-	ctx.Logger.WithFields(fields).Trace(msg)
+	ctx.GetLogger().WithFields(fields).Trace(msg)
 
 	if nameDelta {
-		ctx.Logger.
+		ctx.GetLogger().
 			WithFields(map[string]any{
 				"username": userSession.Username,
 				"before":   userSession.DisplayName,
@@ -100,6 +99,6 @@ func generateVerifySessionHasUpToDateProfileTraceLogs(ctx *middlewares.AutheliaC
 			}).
 			Trace("User session display name updated")
 	} else {
-		ctx.Logger.Trace("User session display name is current")
+		ctx.GetLogger().Trace("User session display name is current")
 	}
 }

--- a/internal/handlers/handler_authz_util.go
+++ b/internal/handlers/handler_authz_util.go
@@ -42,8 +42,6 @@ func isAuthzResult(level authentication.Level, required authorization.Level, rul
 	}
 }
 
-// generateVerifySessionHasUpToDateProfileTraceLogs is used to generate trace logs only when trace logging is enabled.
-// The information calculated in this function is completely useless other than trace for now.
 func generateVerifySessionHasUpToDateProfileTraceLogs(ctx AuthzContext, userSession *session.UserSession,
 	details *authentication.UserDetails) {
 	groupsAdded, groupsRemoved := utils.StringSlicesDelta(userSession.Groups, details.Groups)

--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"net/url"
 
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
 
 	oauthelia2 "authelia.com/provider/oauth2"
@@ -476,22 +479,22 @@ func doMarkAuthenticationAttempt(ctx *middlewares.AutheliaCtx, successful bool, 
 	doMarkAuthenticationAttemptWithRequest(ctx, successful, ban, authType, requestURI, requestMethod, errAuth)
 }
 
-func doMarkAuthenticationAttemptWithRequest(ctx *middlewares.AutheliaCtx, successful bool, ban *regulation.Ban, authType, requestURI, requestMethod string, errAuth error) {
+func doMarkAuthenticationAttemptWithRequest(ctx markContext, successful bool, ban *regulation.Ban, authType, requestURI, requestMethod string, errAuth error) {
 	// We only Mark if there was no underlying error.
-	ctx.Logger.Debugf("Mark %s authentication attempt made by user '%s'", authType, ban.Value())
+	ctx.GetLogger().Debugf("Mark %s authentication attempt made by user '%s'", authType, ban.Value())
 
-	ctx.Providers.Regulator.HandleAttempt(ctx, successful, ban.IsBanned(), ban.Value(), requestURI, requestMethod, authType)
+	ctx.GetProviders().Regulator.HandleAttempt(ctx, successful, ban.IsBanned(), ban.Value(), requestURI, requestMethod, authType)
 
 	if successful {
-		ctx.Logger.Debugf("Successful %s authentication attempt made by user '%s'", authType, ban.Value())
+		ctx.GetLogger().Debugf("Successful %s authentication attempt made by user '%s'", authType, ban.Value())
 	} else {
 		switch {
 		case errAuth != nil:
-			ctx.Logger.WithError(errAuth).Errorf("Unsuccessful %s authentication attempt by user '%s'", authType, ban.Value())
+			ctx.GetLogger().WithError(errAuth).Errorf("Unsuccessful %s authentication attempt by user '%s'", authType, ban.Value())
 		case ban.IsBanned():
-			ctx.Logger.Errorf("Unsuccessful %s authentication attempt by user '%s' and they are banned until %s", authType, ban.Value(), ban.FormatExpires())
+			ctx.GetLogger().Errorf("Unsuccessful %s authentication attempt by user '%s' and they are banned until %s", authType, ban.Value(), ban.FormatExpires())
 		default:
-			ctx.Logger.Errorf("Unsuccessful %s authentication attempt by user '%s'", authType, ban.Value())
+			ctx.GetLogger().Errorf("Unsuccessful %s authentication attempt by user '%s'", authType, ban.Value())
 		}
 	}
 }
@@ -510,4 +513,13 @@ func SetStatusCodeResponse(ctx *fasthttp.RequestCtx, statusCode int) {
 
 	ctx.SetStatusCode(statusCode)
 	ctx.SetBodyString(fmt.Sprintf("%d %s", statusCode, fasthttp.StatusMessage(statusCode)))
+}
+
+type markContext interface {
+	context.Context
+
+	GetLogger() *logrus.Entry
+	GetProviders() middlewares.Providers
+	RecordAuthn(success bool, banned bool, authType string)
+	RemoteIP() (ip net.IP)
 }

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -317,6 +317,7 @@ func (ctx *AutheliaCtx) GetSessionProviderByTargetURI(targetURL *url.URL) (provi
 	return ctx.Providers.SessionProvider.Get(domain)
 }
 
+// GetSessionManagerByTargetURI returns the session manager for the Request's domain.'.
 func (ctx *AutheliaCtx) GetSessionManagerByTargetURI(targetURL *url.URL) (provider session.Manager, err error) {
 	base, err := ctx.GetSessionProviderByTargetURI(targetURL)
 	if err != nil {
@@ -343,6 +344,7 @@ func (ctx *AutheliaCtx) GetSessionProvider() (provider *session.Session, err err
 	return ctx.session, nil
 }
 
+// NewSession returns a new user session.
 func (ctx *AutheliaCtx) NewSession() (userSession session.UserSession) {
 	if provider, err := ctx.GetSessionProvider(); err != nil {
 		return session.NewDefaultUserSession()
@@ -351,6 +353,7 @@ func (ctx *AutheliaCtx) NewSession() (userSession session.UserSession) {
 	}
 }
 
+// GetSessionConfig returns the session configuration.
 func (ctx *AutheliaCtx) GetSessionConfig() (config schema.SessionCookie) {
 	if provider, err := ctx.GetSessionProvider(); err != nil {
 		return config
@@ -486,18 +489,27 @@ func (ctx *AutheliaCtx) SetJSONBody(value any) error {
 	return ctx.ReplyJSON(OKResponse{Status: "OK", Data: value}, 0)
 }
 
+// GetRequestQueryArgValue returns the value of the query argument with the given key.
 func (ctx *AutheliaCtx) GetRequestQueryArgValue(key []byte) (value []byte) {
 	return ctx.QueryArgs().PeekBytes(key)
 }
 
+// GetRequestQueryArgValues returns the values of the query argument with the given key.
+func (ctx *AutheliaCtx) GetRequestQueryArgValues(key []byte) (values [][]byte) {
+	return ctx.QueryArgs().PeekMultiBytes(key)
+}
+
+// GetRequestHeaderValue returns the value of the header with the given key.
 func (ctx *AutheliaCtx) GetRequestHeaderValue(key []byte) (value []byte) {
 	return ctx.Request.Header.PeekBytes(key)
 }
 
+// SetResponseHeaderValue sets a response header with the specified key and value.
 func (ctx *AutheliaCtx) SetResponseHeaderValue(key []byte, value string) {
 	ctx.Response.Header.SetBytesK(key, value)
 }
 
+// SetResponseHeaderValueBytes sets a response header with the specified key and value as byte slices.
 func (ctx *AutheliaCtx) SetResponseHeaderValueBytes(key, value []byte) {
 	ctx.Response.Header.SetBytesKV(key, value)
 }
@@ -679,6 +691,7 @@ func (ctx *AutheliaCtx) GetClock() (provider clock.Provider) {
 	return ctx.Providers.Clock
 }
 
+// GetJWTWithTimeFuncOption returns a jwt.ParserOption that sets the time function to the current clock's Now function.
 func (ctx *AutheliaCtx) GetJWTWithTimeFuncOption() (option jwt.ParserOption) {
 	return jwt.WithTimeFunc(ctx.GetClock().Now)
 }
@@ -709,18 +722,23 @@ func (ctx *AutheliaCtx) GetProviders() (providers Providers) {
 	return ctx.Providers
 }
 
+// GetUserProvider returns the UserProvider instance used for authentication and user management within the context.
 func (ctx *AutheliaCtx) GetUserProvider() authentication.UserProvider {
 	return ctx.Providers.UserProvider
 }
 
+// GetProviderStorage returns the storage provider associated with the current Authelia context.
 func (ctx *AutheliaCtx) GetProviderStorage() storage.Provider {
 	return ctx.Providers.StorageProvider
 }
 
+// GetProviderUserAttributeResolver returns the UserAttributeResolver provider instance from the Authelia context.
 func (ctx *AutheliaCtx) GetProviderUserAttributeResolver() expression.UserAttributeResolver {
 	return ctx.Providers.UserAttributeResolver
 }
 
+// GetWebAuthnProvider initializes and returns a WebAuthn provider instance with the configured Relying Party (RP)
+// settings.
 func (ctx *AutheliaCtx) GetWebAuthnProvider() (w *webauthn.WebAuthn, err error) {
 	var (
 		origin *url.URL

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -166,7 +166,7 @@ func (ctx *AutheliaCtx) GetXForwardedHost() (host []byte) {
 }
 
 // XForwardedURI returns the content of the X-Forwarded-URI header.
-func (ctx *AutheliaCtx) XForwardedURI() (host []byte) {
+func (ctx *AutheliaCtx) XForwardedURI() (uri []byte) {
 	return ctx.Request.Header.PeekBytes(headerXForwardedURI)
 }
 
@@ -182,12 +182,12 @@ func (ctx *AutheliaCtx) GetXForwardedURI() (uri []byte) {
 }
 
 // XOriginalMethod returns the content of the X-Original-Method header.
-func (ctx *AutheliaCtx) XOriginalMethod() []byte {
+func (ctx *AutheliaCtx) XOriginalMethod() (method []byte) {
 	return ctx.Request.Header.PeekBytes(headerXOriginalMethod)
 }
 
 // XOriginalURL returns the content of the X-Original-URL header.
-func (ctx *AutheliaCtx) XOriginalURL() []byte {
+func (ctx *AutheliaCtx) XOriginalURL() (uri []byte) {
 	return ctx.Request.Header.PeekBytes(headerXOriginalURL)
 }
 
@@ -334,6 +334,22 @@ func (ctx *AutheliaCtx) GetSessionProvider() (provider *session.Session, err err
 	return ctx.session, nil
 }
 
+func (ctx *AutheliaCtx) NewSession() (userSession session.UserSession) {
+	if provider, err := ctx.GetSessionProvider(); err != nil {
+		return session.NewDefaultUserSession()
+	} else {
+		return provider.NewDefaultUserSession()
+	}
+}
+
+func (ctx *AutheliaCtx) GetSessionConfig() (config schema.SessionCookie) {
+	if provider, err := ctx.GetSessionProvider(); err != nil {
+		return config
+	} else {
+		return provider.Config
+	}
+}
+
 // GetCookieDomainSessionProvider returns the session provider for the provided domain.
 func (ctx *AutheliaCtx) GetCookieDomainSessionProvider(domain string) (provider *session.Session, err error) {
 	if domain == "" {
@@ -389,7 +405,7 @@ func (ctx *AutheliaCtx) SaveSession(userSession session.UserSession) error {
 }
 
 // RegenerateSession regenerates a user session.
-func (ctx *AutheliaCtx) RegenerateSession() error {
+func (ctx *AutheliaCtx) RegenerateSession() (err error) {
 	provider, err := ctx.GetSessionProvider()
 	if err != nil {
 		return fmt.Errorf("unable to regenerate user session: %s", err)
@@ -399,7 +415,7 @@ func (ctx *AutheliaCtx) RegenerateSession() error {
 }
 
 // DestroySession destroys a user session.
-func (ctx *AutheliaCtx) DestroySession() error {
+func (ctx *AutheliaCtx) DestroySession() (err error) {
 	provider, err := ctx.GetSessionProvider()
 	if err != nil {
 		return fmt.Errorf("unable to destroy user session: %s", err)
@@ -459,6 +475,22 @@ func (ctx *AutheliaCtx) SetContentTypeApplicationYAML() {
 // SetJSONBody Set json body.
 func (ctx *AutheliaCtx) SetJSONBody(value any) error {
 	return ctx.ReplyJSON(OKResponse{Status: "OK", Data: value}, 0)
+}
+
+func (ctx *AutheliaCtx) GetRequestQueryArgValue(key []byte) (value []byte) {
+	return ctx.QueryArgs().PeekBytes(key)
+}
+
+func (ctx *AutheliaCtx) GetRequestHeaderValue(key []byte) (value []byte) {
+	return ctx.Request.Header.PeekBytes(key)
+}
+
+func (ctx *AutheliaCtx) SetResponseHeaderValue(key []byte, value string) {
+	ctx.Response.Header.SetBytesK(key, value)
+}
+
+func (ctx *AutheliaCtx) SetResponseHeaderValueBytes(key, value []byte) {
+	ctx.Response.Header.SetBytesKV(key, value)
 }
 
 // RemoteIP return the remote IP taking X-Forwarded-For header into account if provided.

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -317,7 +317,7 @@ func (ctx *AutheliaCtx) GetSessionProviderByTargetURI(targetURL *url.URL) (provi
 	return ctx.Providers.SessionProvider.Get(domain)
 }
 
-// GetSessionManagerByTargetURI returns the session manager for the Request's domain.'.
+// GetSessionManagerByTargetURI returns the session manager for the request's domain.
 func (ctx *AutheliaCtx) GetSessionManagerByTargetURI(targetURL *url.URL) (provider session.Manager, err error) {
 	base, err := ctx.GetSessionProviderByTargetURI(targetURL)
 	if err != nil {

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -317,6 +317,15 @@ func (ctx *AutheliaCtx) GetSessionProviderByTargetURI(targetURL *url.URL) (provi
 	return ctx.Providers.SessionProvider.Get(domain)
 }
 
+func (ctx *AutheliaCtx) GetSessionManagerByTargetURI(targetURL *url.URL) (provider session.Manager, err error) {
+	base, err := ctx.GetSessionProviderByTargetURI(targetURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return session.NewEncapsulatedSession(base, ctx.RequestCtx), nil
+}
+
 // GetSessionProvider returns the session provider for the Request's domain.
 func (ctx *AutheliaCtx) GetSessionProvider() (provider *session.Session, err error) {
 	if ctx.session == nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -230,7 +230,9 @@ func handlerMain(config *schema.Configuration, providers middlewares.Providers) 
 
 		authz := handlers.NewAuthzBuilder().WithConfig(config).WithEndpointConfig(endpoint).Build()
 
-		handlerAuthz := middlewares.Wrap(metricsVRMW, bridge(authz.Handler))
+		handlerAuthz := middlewares.Wrap(metricsVRMW, bridge(func(ctx *middlewares.AutheliaCtx) {
+			authz.Handler(ctx)
+		}))
 
 		switch name {
 		case "legacy":

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -112,3 +112,63 @@ func (p *Session) GetExpiration(ctx *fasthttp.RequestCtx) (time.Duration, error)
 
 	return store.GetExpiration(), nil
 }
+
+func NewEncapsulatedSession(base *Session, ctx *fasthttp.RequestCtx) *EncapsulatedSession {
+	return &EncapsulatedSession{base: base, ctx: ctx}
+}
+
+type EncapsulatedSession struct {
+	base *Session
+
+	ctx *fasthttp.RequestCtx
+}
+
+// NewDefaultUserSession returns a new default UserSession for this session provider.
+func (p *EncapsulatedSession) NewDefaultUserSession() (userSession UserSession) {
+	return p.base.NewDefaultUserSession()
+}
+
+// GetSession return the user session from a request.
+func (p *EncapsulatedSession) GetSession() (userSession UserSession, err error) {
+	return p.base.GetSession(p.ctx)
+}
+
+// SaveSession save the user session.
+func (p *EncapsulatedSession) SaveSession(userSession UserSession) (err error) {
+	return p.base.SaveSession(p.ctx, userSession)
+}
+
+// RegenerateSession regenerate a session ID.
+func (p *EncapsulatedSession) RegenerateSession() (err error) {
+	return p.base.RegenerateSession(p.ctx)
+}
+
+// DestroySession destroy a session ID and delete the cookie.
+func (p *EncapsulatedSession) DestroySession() (err error) {
+	return p.base.DestroySession(p.ctx)
+}
+
+// UpdateSessionExpiration update the expiration of the cookie and session.
+func (p *EncapsulatedSession) UpdateSessionExpiration(expiration time.Duration) (err error) {
+	return p.base.UpdateExpiration(p.ctx, expiration)
+}
+
+// GetSessionExpiration get the expiration of the current session.
+func (p *EncapsulatedSession) GetSessionExpiration() (expiration time.Duration, err error) {
+	return p.base.GetExpiration(p.ctx)
+}
+
+func (p *EncapsulatedSession) GetSessionConfig() (config schema.SessionCookie) {
+	return p.base.Config
+}
+
+type Manager interface {
+	NewDefaultUserSession() (userSession UserSession)
+	GetSession() (userSession UserSession, err error)
+	SaveSession(userSession UserSession) (err error)
+	RegenerateSession() (err error)
+	DestroySession() (err error)
+	UpdateSessionExpiration(expiration time.Duration) (err error)
+	GetSessionExpiration() (expiration time.Duration, err error)
+	GetSessionConfig() (config schema.SessionCookie)
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -113,10 +113,12 @@ func (p *Session) GetExpiration(ctx *fasthttp.RequestCtx) (time.Duration, error)
 	return store.GetExpiration(), nil
 }
 
+// NewEncapsulatedSession returns a new encapsulated session which contains the request context and the *Session.
 func NewEncapsulatedSession(base *Session, ctx *fasthttp.RequestCtx) *EncapsulatedSession {
 	return &EncapsulatedSession{base: base, ctx: ctx}
 }
 
+// EncapsulatedSession encapsulates a session and a request context.
 type EncapsulatedSession struct {
 	base *Session
 
@@ -158,10 +160,12 @@ func (p *EncapsulatedSession) GetSessionExpiration() (expiration time.Duration, 
 	return p.base.GetExpiration(p.ctx)
 }
 
+// GetSessionConfig returns the session configuration.
 func (p *EncapsulatedSession) GetSessionConfig() (config schema.SessionCookie) {
 	return p.base.Config
 }
 
+// Manager is the interface that wraps the basic methods of a session provider.
 type Manager interface {
 	NewDefaultUserSession() (userSession UserSession)
 	GetSession() (userSession UserSession, err error)


### PR DESCRIPTION
This drastically refactors the implementation details of the authz handler allowing the use of an interface. This is in preparation for the session rework, and introduction of the HAProxy SPOA and envoy gRPC handlers.