### PR TITLE
fix(authentication): excessive filter escape

### DIFF
--- a/internal/authentication/const.go
+++ b/internal/authentication/const.go
@@ -121,10 +121,6 @@ var (
 
 const fileAuthenticationMode = 0600
 
-// OWASP recommends to escape some special characters.
-// https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md
-const specialLDAPRunes = ",#+<>;\"="
-
 var (
 	encodingUTF16LittleEndian = unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
 )

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -715,7 +715,7 @@ func (p *LDAPUserProvider) resolveUsersFilter(input string) (filter string) {
 
 	if p.usersFilterReplacementInput {
 		// The {input} placeholder is replaced by the username input.
-		filter = strings.ReplaceAll(filter, ldapPlaceholderInput, ldapEscape(input))
+		filter = strings.ReplaceAll(filter, ldapPlaceholderInput, ldap.EscapeFilter(input))
 	}
 
 	if p.usersFilterReplacementDateTimeGeneralized {
@@ -740,7 +740,7 @@ func (p *LDAPUserProvider) resolveGroupsFilter(input string, profile *ldapUserPr
 
 	if p.groupsFilterReplacementInput {
 		// The {input} placeholder is replaced by the users username input.
-		filter = strings.ReplaceAll(p.config.GroupsFilter, ldapPlaceholderInput, ldapEscape(input))
+		filter = strings.ReplaceAll(p.config.GroupsFilter, ldapPlaceholderInput, ldap.EscapeFilter(input))
 	}
 
 	if profile != nil {

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -168,21 +168,21 @@ func TestShouldCreateTLSConnectionWhenSchemeIsLDAPS(t *testing.T) {
 
 func TestEscapeSpecialCharsFromUserInput(t *testing.T) {
 	// No escape.
-	assert.Equal(t, "xyz", ldapEscape("xyz"))
+	assert.Equal(t, "xyz", ldap.EscapeFilter("xyz"))
 
 	// Escape.
-	assert.Equal(t, "test\\,abc", ldapEscape("test,abc"))
-	assert.Equal(t, "test\\5cabc", ldapEscape("test\\abc"))
-	assert.Equal(t, "test\\2aabc", ldapEscape("test*abc"))
-	assert.Equal(t, "test \\28abc\\29", ldapEscape("test (abc)"))
-	assert.Equal(t, "test\\#abc", ldapEscape("test#abc"))
-	assert.Equal(t, "test\\+abc", ldapEscape("test+abc"))
-	assert.Equal(t, "test\\<abc", ldapEscape("test<abc"))
-	assert.Equal(t, "test\\>abc", ldapEscape("test>abc"))
-	assert.Equal(t, "test\\;abc", ldapEscape("test;abc"))
-	assert.Equal(t, "test\\\"abc", ldapEscape("test\"abc"))
-	assert.Equal(t, "test\\=abc", ldapEscape("test=abc"))
-	assert.Equal(t, "test\\,\\5c\\28abc\\29", ldapEscape("test,\\(abc)"))
+	assert.Equal(t, "test,abc", ldap.EscapeFilter("test,abc"))
+	assert.Equal(t, "test\\5cabc", ldap.EscapeFilter("test\\abc"))
+	assert.Equal(t, "test\\2aabc", ldap.EscapeFilter("test*abc"))
+	assert.Equal(t, "test \\28abc\\29", ldap.EscapeFilter("test (abc)"))
+	assert.Equal(t, "test#abc", ldap.EscapeFilter("test#abc"))
+	assert.Equal(t, "test+abc", ldap.EscapeFilter("test+abc"))
+	assert.Equal(t, "test<abc", ldap.EscapeFilter("test<abc"))
+	assert.Equal(t, "test>abc", ldap.EscapeFilter("test>abc"))
+	assert.Equal(t, "test;abc", ldap.EscapeFilter("test;abc"))
+	assert.Equal(t, "test\"abc", ldap.EscapeFilter("test\"abc"))
+	assert.Equal(t, "test=abc", ldap.EscapeFilter("test=abc"))
+	assert.Equal(t, "test,\\5c\\28abc\\29", ldap.EscapeFilter("test,\\(abc)"))
 }
 
 func TestEscapeSpecialCharsInGroupsFilter(t *testing.T) {
@@ -211,7 +211,7 @@ func TestEscapeSpecialCharsInGroupsFilter(t *testing.T) {
 	assert.Equal(t, "(|(member=cn=john \\28external\\29,dc=example,dc=com)(uid=john)(uid=john))", filter)
 
 	filter = provider.resolveGroupsFilter("john#=(abc,def)", &profile)
-	assert.Equal(t, "(|(member=cn=john \\28external\\29,dc=example,dc=com)(uid=john)(uid=john\\#\\=\\28abc\\,def\\29))", filter)
+	assert.Equal(t, "(|(member=cn=john \\28external\\29,dc=example,dc=com)(uid=john)(uid=john#=\\28abc,def\\29))", filter)
 }
 
 func TestResolveGroupsFilter(t *testing.T) {
@@ -585,7 +585,7 @@ func TestShouldEscapeUserInput(t *testing.T) {
 
 	mockClient.EXPECT().
 		// Here we ensure that the input has been correctly escaped.
-		Search(NewSearchRequestMatcher("(|(uid=john\\=abc)(mail=john\\=abc))")).
+		Search(NewSearchRequestMatcher("(|(uid=john=abc)(mail=john=abc))")).
 		Return(&ldap.SearchResult{}, nil)
 
 	_, err := provider.getUserProfile(mockClient, "john=abc")

--- a/internal/authentication/ldap_util.go
+++ b/internal/authentication/ldap_util.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/go-ldap/ldap/v3"
 
@@ -79,15 +78,6 @@ func ldapGetFeatureSupportFromEntry(entry *ldap.Entry) (features LDAPSupportedFe
 	}
 
 	return features
-}
-
-func ldapEscape(inputUsername string) string {
-	inputUsername = ldap.EscapeFilter(inputUsername)
-	for _, c := range specialLDAPRunes {
-		inputUsername = strings.ReplaceAll(inputUsername, string(c), fmt.Sprintf("\\%c", c))
-	}
-
-	return inputUsername
 }
 
 func getLDAPResultCode(err error) int {


### PR DESCRIPTION
This fixes an issue where Authelia excessively escapes characters in filters.

Fixes #11284