### PR TITLE
fix: prevent vite from watching node_modules

### DIFF
--- a/internal/suites/example/compose/authelia/Dockerfile.frontend
+++ b/internal/suites/example/compose/authelia/Dockerfile.frontend
@@ -6,7 +6,9 @@ ARG GROUP_ID
 RUN yarn global add pnpm && \
     deluser node && \
     addgroup --gid ${GROUP_ID} dev && \
-    adduser --uid ${USER_ID} -G dev -D dev
+    adduser --uid ${USER_ID} -G dev -D dev && \
+    mkdir -p /app/node_modules && \
+    chown -R ${USER_ID}:${GROUP_ID} /app
 
 USER dev
 

--- a/internal/suites/example/compose/authelia/compose.frontend.dev.yml
+++ b/internal/suites/example/compose/authelia/compose.frontend.dev.yml
@@ -14,6 +14,7 @@ services:
       - './example/compose/authelia/resources/:/resources'
       - '../../web:/app'
       - '~/.local/share/pnpm/store:/app/.pnpm-store'
+      - '/app/node_modules'
     labels:
       traefik.enable: 'true'
       traefik.http.routers.authelia_frontend.rule: 'Host(`login.example.com`) || Host(`login.example.com`) && PathPrefix(`${PathPrefix}/`)'  # yamllint disable-line rule:line-length


### PR DESCRIPTION
This mounts an anonymous docker volume to the `/app/node_modules` directory in the container, shadowing the host bind mount (`../../web:/app`). This takes advantage of an [inotify feature ](https://manpages.ubuntu.com/manpages/bionic/man7/inotify.7.html).
> If a filesystem is mounted on top of a monitored directory, no event is  generated,  and  no  events  are generated  for  objects  immediately  under  the  new  mount  point.

This appears to prevent chokidar (Vite's file watcher library) from receiving events about file changes. It also seems to prevent chokidar from creating FSWatcher instances for those files at all.

This should significantly lower the memory usage of the `MainThread` process for the frontend authelia container, and prevent unbounded growth.