### PR TITLE
fix(web): ui stuck state enrolling 2fa

### DIFF
--- a/internal/handlers/handler_session_elevation.go
+++ b/internal/handlers/handler_session_elevation.go
@@ -196,11 +196,6 @@ func UserSessionElevationPOST(ctx *middlewares.AutheliaCtx) {
 	if err = ctx.Providers.Notifier.Send(ctx, identity.Address(), data.Title, ctx.Providers.Templates.GetIdentityVerificationOTCEmailTemplate(), data); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred creating user session elevation One-Time Code challenge for user '%s': error occurred sending the user the notification", userSession.Username)
 
-		// Revoke the one-time code since the notification was not sent.
-		if errRevoke := ctx.Providers.StorageProvider.RevokeOneTimeCode(ctx, otp.PublicID, model.NewIP(ctx.RemoteIP())); errRevoke != nil {
-			ctx.Logger.WithError(errRevoke).Errorf("Error occurred revoking user session elevation One-Time Code challenge for user '%s': error occurred revoking the challenge from the storage backend", userSession.Username)
-		}
-
 		ctx.SetStatusCode(fasthttp.StatusForbidden)
 		ctx.SetJSONError(messageOperationFailed)
 

--- a/internal/handlers/handler_session_elevation_test.go
+++ b/internal/handlers/handler_session_elevation_test.go
@@ -420,7 +420,6 @@ func TestUserSessionElevationPOST(t *testing.T) {
 						OneTimeCode:        "ABC123ABC1",
 					}).
 						Return(fmt.Errorf("rejected")),
-						mock.StorageMock.EXPECT().RevokeOneTimeCode(mock.Ctx, uuid.Must(uuid.Parse("01020304-0506-4722-8910-111213141500")), model.NewIP(net.ParseIP("0.0.0.0"))).Return(nil),
 				)
 			},
 			`{"status":"KO","message":"Operation failed."}`,


### PR DESCRIPTION
Fixes #10859

## Summary

Fixes #10859: enrolling 2FA to unknown email recipient result in 403 and UI being stuck
