### PR TITLE
docs(oidc): add opengist

### DIFF
--- a/docs/content/integration/openid-connect/clients/opengist/index.md
+++ b/docs/content/integration/openid-connect/clients/opengist/index.md
@@ -126,6 +126,6 @@ external-url: https://opengist.{{< sitevar name="domain" nojs="example.com" >}}
 - [Opengist 'Use OAuth providers' documentation](https://opengist.io/docs/configuration/oauth-providers.html#openid-connect)
 
 [Authelia]: https://www.authelia.com
-[Opengist]: [https://opengist.io](https://opengist.io)
+[Opengist]: https://opengist.io
 [OpenID Connect 1.0]: ../../introduction.md
 [client configuration]: ../../../../configuration/identity-providers/openid-connect/clients.md


### PR DESCRIPTION
Hi,

Based this off the current Linkding `index.md`. There were a couple of client properties I did not find were required for Opengist but an Authelia maintainer added them in a nits commit (`a7a67dc`) to Linkding's docs (e.g. `require_pkce: false`). Not sure what the policy around those is, so I've left them out, but please feel free to adjust as you see fit.

Cheers,
Tom