### PR TITLE
fix: ignore node modules for vite watchers

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -106,6 +106,9 @@ export default defineConfig(({ mode }) => {
             allowedHosts: ["login.example.com", ...allowedHosts],
             open: false,
             port: 3000,
+            watch: {
+                ignored: ["**/node_modules/**", "**/dist/**", "**/.*/**"],
+            },
         },
         test: {
             coverage: {


### PR DESCRIPTION
I should note, I am not sure that the last item `"**/.*/**"` is a good idea since it probably excludes the `.env.*` files.