### PR TITLE
fix(authentication): fix ldapv3 version check

### DIFF
--- a/internal/authentication/ldap_user_provider_lifecycle.go
+++ b/internal/authentication/ldap_user_provider_lifecycle.go
@@ -59,7 +59,7 @@ func (p *LDAPUserProvider) logStartupCheckDiscovery(discovery LDAPDiscovery) {
 	if discovery.Successful {
 		if discovery.LDAPVersion == nil {
 			p.log.Warn("The configured LDAP server does not advertise the version of LDAP it supports or does not advertise the version it supports correctly. This server is not supported.")
-		} else if utils.IsIntegerInSlice(3, discovery.LDAPVersion) {
+		} else if !utils.IsIntegerInSlice(3, discovery.LDAPVersion) {
 			p.log.Warnf("The configured LDAP server advertises it supports LDAPv%d but only LDAPv3 is supported. This server is not supported.", discovery.LDAPVersion)
 		}
 	} else {


### PR DESCRIPTION
After updating to v4.39.16, I'm getting "The configured LDAP server advertises it supports LDAPv[3] but only LDAPv3 is supported." warning messages.

I'm using LLDAP, which does support LDAPv3, and I've never had any issues before. So I just did a quick search for the message in the code, and found that its condition was inverted.