### PR TITLE
test(suites): adjust multicookiedomain matcher

### DIFF
--- a/internal/suites/scenario_multiple_cookie_domain_test.go
+++ b/internal/suites/scenario_multiple_cookie_domain_test.go
@@ -71,7 +71,7 @@ func (s *MultiCookieDomainScenario) TestCookieName() {
 
 	cookieNames := s.GetCookieNames()
 
-	s.Assert().Equalf(s.cookieNames, cookieNames, "cookie names should include '%s' (only and all of) but includes '%s'", strings.Join(s.cookieNames, ","), strings.Join(cookieNames, ","))
+	s.Assert().ElementsMatchf(s.cookieNames, cookieNames, "cookie names should include '%s' (only and all of) but includes '%s'", strings.Join(s.cookieNames, ","), strings.Join(cookieNames, ","))
 }
 
 func (s *MultiCookieDomainScenario) TestRememberMe() {


### PR DESCRIPTION
Replaced `Equalf` with `ElementsMatchf`. This testify assertion checks that both slices contain the same elements regardless of order, which is the correct behaviour since cookie ordering isn't guaranteed.