### PR TITLE
feat(configuration): [wip] added separate recovery email

### DIFF
--- a/internal/authentication/file_user_provider_database.go
+++ b/internal/authentication/file_user_provider_database.go
@@ -236,6 +236,7 @@ type FileUserDatabaseUserDetails struct {
 	PhoneNumber    string                 `json:"phone_number,omitempty" jsonschema:"title=Phone Number" jsonschema_description:"The phone number for the user."`
 	PhoneExtension string                 `json:"phone_extension,omitempty" jsonschema:"title=Phone Extension" jsonschema_description:"The phone extension for the user."`
 	Email          string                 `json:"email" jsonschema:"title=Email" jsonschema_description:"The email for the user."`
+	RecoveryEmail  string                 `json:"recovery_email,omitempty" jsonschema:"title=Recovery Email" jsonschema_description:"The recovery email for the user."`
 	Groups         []string               `json:"groups" jsonschema:"title=Groups" jsonschema_description:"The groups list for the user."`
 	Disabled       bool                   `json:"disabled" jsonschema:"default=false,title=Disabled" jsonschema_description:"The disabled status for the user."`
 
@@ -261,10 +262,11 @@ func (m FileUserDatabaseUserDetails) ToUserDetails() (details *UserDetails) {
 	}
 
 	return &UserDetails{
-		Username:    m.Username,
-		DisplayName: m.DisplayName,
-		Emails:      emails,
-		Groups:      m.Groups,
+		Username:      m.Username,
+		DisplayName:   m.DisplayName,
+		Emails:        emails,
+		Groups:        m.Groups,
+		RecoveryEmail: m.RecoveryEmail,
 	}
 }
 
@@ -316,6 +318,7 @@ func (m FileUserDatabaseUserDetails) ToUserDetailsModel() (model FileDatabaseUse
 		PhoneNumber:    m.PhoneNumber,
 		PhoneExtension: m.PhoneExtension,
 		Email:          m.Email,
+		RecoveryEmail:  m.RecoveryEmail,
 		Groups:         m.Groups,
 		Address:        m.Address,
 		Extra:          m.Extra,
@@ -416,6 +419,7 @@ type FileDatabaseUserDetailsModel struct {
 	Password       string   `yaml:"password" valid:"required"`
 	DisplayName    string   `yaml:"displayname" valid:"required"`
 	Email          string   `yaml:"email"`
+	RecoveryEmail  string   `yaml:"recovery_email"`
 	Groups         []string `yaml:"groups"`
 	GivenName      string   `yaml:"given_name"`
 	MiddleName     string   `yaml:"middle_name"`
@@ -511,6 +515,7 @@ func (m FileDatabaseUserDetailsModel) ToDatabaseUserDetailsModel(username string
 		Disabled:       m.Disabled,
 		DisplayName:    m.DisplayName,
 		Email:          m.Email,
+		RecoveryEmail:  m.RecoveryEmail,
 		GivenName:      m.GivenName,
 		MiddleName:     m.MiddleName,
 		FamilyName:     m.FamilyName,

--- a/internal/authentication/types.go
+++ b/internal/authentication/types.go
@@ -17,10 +17,11 @@ import (
 
 // UserDetails represent the details retrieved for a given user.
 type UserDetails struct {
-	Username    string
-	DisplayName string
-	Emails      []string
-	Groups      []string
+	Username      string
+	DisplayName   string
+	Emails        []string
+	Groups        []string
+	RecoveryEmail string
 }
 
 // Addresses returns the Emails []string as []mail.Address formatted with DisplayName as the Name attribute.
@@ -29,13 +30,30 @@ func (d *UserDetails) Addresses() (addresses []mail.Address) {
 		return nil
 	}
 
-	addresses = make([]mail.Address, len(d.Emails))
+	hasRecoveryEmail := len(d.RecoveryEmail) != 0
+
+	getEmailIndex := func(idx int) int {
+		if hasRecoveryEmail {
+			return idx + 1
+		}
+
+		return idx
+	}
+
+	makeMailAddress := func(address string) mail.Address {
+		return mail.Address{
+			Name:    d.DisplayName,
+			Address: address,
+		}
+	}
+	addresses = make([]mail.Address, getEmailIndex(len(d.Emails)))
+
+	if hasRecoveryEmail {
+		addresses[0] = makeMailAddress(d.RecoveryEmail)
+	}
 
 	for i, email := range d.Emails {
-		addresses[i] = mail.Address{
-			Name:    d.DisplayName,
-			Address: email,
-		}
+		addresses[getEmailIndex(i)] = makeMailAddress(email)
 	}
 
 	return addresses


### PR DESCRIPTION
DO NOT MERGE
Work in progress for the introduction of a recovery mail, separate from the mail of the user that is shared with openid clients. 
proof of concept for https://github.com/authelia/authelia/discussions/11540

The main point is to have a separate recovery email address where mails to reset password are sent, this is usefull for configurations which include domain mail which is accessed through authelia, and which should be returned as well to other openid clients. There is a need to allow the users to have an external email, different from the domain one, where they can receive password reset links and two factors one time codes.

still missing:
- ldap integration
- unit tests