### PR TITLE
refactor(authentication): format ldap versions

### DIFF
--- a/internal/authentication/ldap_user_provider_lifecycle.go
+++ b/internal/authentication/ldap_user_provider_lifecycle.go
@@ -57,10 +57,10 @@ func (p *LDAPUserProvider) logStartupCheckDiscovery(discovery LDAPDiscovery) {
 	}
 
 	if discovery.Successful {
-		if discovery.LDAPVersion == nil {
+		if len(discovery.LDAPVersion) == 0 {
 			p.log.Warn("The configured LDAP server does not advertise the version of LDAP it supports or does not advertise the version it supports correctly. This server is not supported.")
 		} else if !utils.IsIntegerInSlice(3, discovery.LDAPVersion) {
-			p.log.Warnf("The configured LDAP server advertises it supports LDAPv%d but only LDAPv3 is supported. This server is not supported.", discovery.LDAPVersion)
+			p.log.Warnf("The configured LDAP server advertises it supports %s but only LDAPv3 is supported. This server is not supported.", fmtLDAPVersions(discovery.LDAPVersion))
 		}
 	} else {
 		p.log.Warn("The configured LDAP server does not support discovery via searching the RootDSE.")

--- a/internal/authentication/ldap_util.go
+++ b/internal/authentication/ldap_util.go
@@ -248,3 +248,22 @@ func ldapNewSearchRequestRootDSE() *ldap.SearchRequest {
 	return ldap.NewSearchRequest("", ldap.ScopeBaseObject, ldap.NeverDerefAliases,
 		1, 0, false, ldapBaseObjectFilter, []string{ldapObjectClassAttribute, ldapSupportedLDAPVersionAttribute, ldapSupportedExtensionAttribute, ldapSupportedControlAttribute, ldapSupportedFeaturesAttribute, ldapSupportedSASLMechanismsAttribute, ldapVendorNameAttribute, ldapVendorVersionAttribute, ldapDomainFunctionalityAttribute, ldapForestFunctionalityAttribute}, nil)
 }
+
+func fmtLDAPVersions(versions []int) string {
+	n := len(versions)
+
+	switch n {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("LDAPv%d", versions[0])
+	default:
+		parts := make([]string, n)
+
+		for i, v := range versions {
+			parts[i] = fmt.Sprintf("LDAPv%d", v)
+		}
+
+		return strings.Join(parts[:n-1], ", ") + ", and " + parts[n-1]
+	}
+}

--- a/internal/authentication/ldap_util_test.go
+++ b/internal/authentication/ldap_util_test.go
@@ -312,3 +312,48 @@ func TestLDAPDiscovery_Strings(t *testing.T) {
 		})
 	}
 }
+
+func TestFmtLDAPVersions(t *testing.T) {
+	testCases := []struct {
+		name     string
+		versions []int
+		expected string
+	}{
+		{
+			"ShouldReturnEmptyForNil",
+			nil,
+			"",
+		},
+		{
+			"ShouldReturnEmptyForEmpty",
+			[]int{},
+			"",
+		},
+		{
+			"ShouldFormatSingleVersion",
+			[]int{3},
+			"LDAPv3",
+		},
+		{
+			"ShouldFormatTwoVersions",
+			[]int{3, 2},
+			"LDAPv3, and LDAPv2",
+		},
+		{
+			"ShouldFormatThreeVersions",
+			[]int{3, 2, 1},
+			"LDAPv3, LDAPv2, and LDAPv1",
+		},
+		{
+			"ShouldFormatFourVersions",
+			[]int{4, 3, 2, 1},
+			"LDAPv4, LDAPv3, LDAPv2, and LDAPv1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, fmtLDAPVersions(tc.versions))
+		})
+	}
+}


### PR DESCRIPTION
This ensures the ldap versions are nicely formatted in the logs.