### PR TITLE
ci: add required minumum release age for js dependencies

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -81,7 +81,9 @@
       ],
       "addLabels": [
         "javascript"
-      ]
+      ],
+      "minimumReleaseAge": "2 days",
+      "minimumReleaseAgeBehaviour": "timestamp-required"
     }
   ],
   "postUpdateOptions": [

--- a/.renovaterc
+++ b/.renovaterc
@@ -83,7 +83,7 @@
         "javascript"
       ],
       "minimumReleaseAge": "2 days",
-      "minimumReleaseAgeBehaviour": "timestamp-required"
+      "minimumReleaseAgeBehavior": "timestamp-required" // typos:disable-line
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
Adds a 2 day lag time for javascript dependency updates. This aims to prevent merging malicious packages soon after initial release.

Since we don't generally cut releases exclusively for dependency updates (except for critical security updates), this shouldn't effect things too much.