### PR TITLE
ci(buildkite): skip package validation steps during merge queue builds

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -62,11 +62,11 @@ steps:
 
   - label: ":nodejs: Package Validation [docs]"
     command: "pkgvalidate.sh docs"
-    if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.message !~ /\[(skip test|test skip)\]/
+    if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.message !~ /\[(skip test|test skip)\]/ && build.env("CI_MERGE_QUEUE") != "true"
 
   - label: ":nodejs: Package Validation [templates]"
     command: "pkgvalidate.sh templates"
-    if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.message !~ /\[(skip test|test skip)\]/
+    if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.message !~ /\[(skip test|test skip)\]/ && build.env("CI_MERGE_QUEUE") != "true"
 
   - label: ":hammer_and_wrench: Unit Test"
     command: "authelia-scripts --log-level debug ci --buildkite"


### PR DESCRIPTION
The docs and templates package validation steps were running unnecessarily during merge queue builds. This adds the CI_MERGE_QUEUE condition to their step filters, consistent with how other non-essential steps are already skipped in the merge queue.