### PR TITLE
test(suites): traefik httpbin port label

### DIFF
--- a/internal/suites/example/compose/httpbin/compose.yml
+++ b/internal/suites/example/compose/httpbin/compose.yml
@@ -10,4 +10,5 @@ services:
       traefik.http.routers.httpbin.priority: '1000'
       traefik.http.routers.httpbin.tls: 'true'
       traefik.http.routers.httpbin.middlewares: 'authelia@docker'
+      traefik.http.services.httpbin.loadbalancer.server.port: '8080'
 ...

--- a/internal/suites/example/compose/httpbin/compose.yml
+++ b/internal/suites/example/compose/httpbin/compose.yml
@@ -4,11 +4,12 @@ services:
     image: mccutchen/go-httpbin
     networks:
       authelianet: {}
+    expose:
+      - 8080
     labels:
       traefik.enable: 'true'
       traefik.http.routers.httpbin.rule: 'Host(`public.example.com`) && Path(`/headers`)'
       traefik.http.routers.httpbin.priority: '1000'
       traefik.http.routers.httpbin.tls: 'true'
       traefik.http.routers.httpbin.middlewares: 'authelia@docker'
-      traefik.http.services.httpbin.loadbalancer.server.port: '8080'
 ...


### PR DESCRIPTION
The httpbin compose file relies on Traefik's Docker provider auto-detecting the container port, which worked with citizenstig/httpbin because its image exposed a port. After the switch to mccutchen/go-httpbin in 35b2dad9 the image no longer declares an EXPOSE, so Traefik fails to resolve a port for the service and emits `service httpbin-authelia" error: port is missing`, breaking every Traefik2 and Traefik3 based suite.

Add an explicit `traefik.http.services.httpbin.loadbalancer.server.port` label pointing at 8080 so Traefik routes `/headers` to go-httpbin's default listener, matching the update already applied to the Caddy, HAProxy, Nginx and Envoy configurations in the original refactor.