### PR TITLE
refactor(suites): pin container versions

### DIFF
--- a/internal/suites/example/compose/smtp/compose.yml
+++ b/internal/suites/example/compose/smtp/compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   smtp:
-    image: 'axllent/mailpit'
+    image: 'axllent/mailpit:v1.29.6'
     volumes:
       - './common/pki:/pki'
     environment:

--- a/internal/suites/example/kube/apps/nginx.yml
+++ b/internal/suites/example/kube/apps/nginx.yml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: nginx-backend
-          image: nginx:alpine
+          image: nginx:1.30.0-alpine
           ports:
             - containerPort: 80
           volumeMounts:

--- a/internal/suites/example/kube/mail/mail.yml
+++ b/internal/suites/example/kube/mail/mail.yml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: mailpit
-          image: axllent/mailpit
+          image: axllent/mailpit:v1.29.6
           ports:
             - containerPort: 1025
             - containerPort: 8025


### PR DESCRIPTION
Pin the mailpit and nginx images used by the integration suites to explicit version tags rather than floating references. The Docker Compose mailpit service and the Kubernetes mailpit deployment both previously pulled axllent/mailpit with no tag, and the Kubernetes nginx-backend deployment pulled nginx:alpine; all three now target specific versions so suite runs are reproducible and only move when intentionally bumped by renovate.