### PR TITLE
ci: add shellcheck linting

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -21,21 +21,21 @@ if [[ ! ${BUILDKITE_BRANCH} =~ ^(v.*) ]] && [[ ${BUILDKITE_COMMAND_EXIT_STATUS} 
     if [[ ${BUILDKITE_AGENT_META_DATA_CODECOV} == "verbose" ]]; then
       BUILDKITE_AGENT_META_DATA_CODECOV="-v"
     fi
-    codecov -Z -c -f 'coverage*.txt' -n ${NAME} -F backend "${BUILDKITE_AGENT_META_DATA_CODECOV}"
+    codecov -Z -c -f 'coverage*.txt' -n "${NAME}" -F backend "${BUILDKITE_AGENT_META_DATA_CODECOV}"
     if [[ ${BUILDKITE_LABEL} =~ :selenium: ]]; then
       pnpm -C web report
     fi
     if [[ ${NAME} != "BypassAll" ]]; then
-      codecov -Z -c -f '!Dockerfile*' -f '!*.go' -f '!*.tar' -f '!*.zst' -n ${NAME} -F frontend "${BUILDKITE_AGENT_META_DATA_CODECOV}"
+      codecov -Z -c -f '!Dockerfile*' -f '!*.go' -f '!*.tar' -f '!*.zst' -n "${NAME}" -F frontend "${BUILDKITE_AGENT_META_DATA_CODECOV}"
     fi
   fi
 fi
 
 if [[ ${BUILDKITE_LABEL} =~ :selenium: ]] || [[ ${BUILDKITE_LABEL} =~ :docker:\ Build\ Image ]]; then
-  CONTAINERS=$(docker ps -a -q)
-  if [[ ${CONTAINERS} != "" ]]; then
+  mapfile -t CONTAINERS < <(docker ps -a -q)
+  if [[ ${#CONTAINERS[@]} -gt 0 ]]; then
     echo "--- :docker: Remove lingering containers"
-    docker rm -f ${CONTAINERS}
+    docker rm -f "${CONTAINERS[@]}"
   fi
 fi
 
@@ -51,7 +51,7 @@ fi
 if [[ ${BUILDKITE_LABEL} == ":docker: Deploy Manifest" ]] && [[ ${BUILDKITE_BRANCH} == "master" ]] && [[ ${BUILDKITE_PULL_REQUEST} == "false" ]]; then
   echo "--- :docker: Removing tags for deleted branches"
   anontoken=$(curl -fsL --retry 3 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:authelia/authelia:pull' | jq -r .token)
-  authtoken=$(curl -fs --retry 3 -H "Content-Type: application/json" -X POST -d '{"username": "'${DOCKER_TOKEN_USERNAME}'", "password": "'${DOCKER_TOKEN}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+  authtoken=$(curl -fs --retry 3 -H "Content-Type: application/json" -X POST -d "{\"username\": \"${DOCKER_TOKEN_USERNAME}\", \"password\": \"${DOCKER_TOKEN}\"}" https://hub.docker.com/v2/users/login/ | jq -r .token)
   dockerbranchtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/authelia/tags/list | jq -r '.tags[] | select(startswith("PR") | not)' | sed -r '/^(latest|master|develop|v.*|([[:digit:]]+)\.?([[:digit:]]+)?\.?([[:digit:]]+)?)$/d' | sort)
   githubbranches=$(curl -fs --retry 3 https://api.github.com/repos/authelia/authelia/branches?per_page=100 | jq -r '.[].name' | sort)
   if [[ -z "${authtoken}" ]]; then
@@ -59,12 +59,12 @@ if [[ ${BUILDKITE_LABEL} == ":docker: Deploy Manifest" ]] && [[ ${BUILDKITE_BRAN
   fi
   for BRANCH_TAG in $(comm -23 <(echo "${dockerbranchtags}") <(echo "${githubbranches}")); do
     echo "Removing tag ${BRANCH_TAG} from docker.io"
-    curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: JWT ${authtoken}" https://hub.docker.com/v2/repositories/authelia/authelia/tags/${BRANCH_TAG}/
+    curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: JWT ${authtoken}" "https://hub.docker.com/v2/repositories/authelia/authelia/tags/${BRANCH_TAG}/"
     for i in {1..5}; do
-      for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions?page=${i}&per_page=100" | jq -j --arg tag ${BRANCH_TAG} '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
-        IFS=',' read -a TAGID <<< ${GHCR_VERSION}
+      for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions?page=${i}&per_page=100" | jq -j --arg tag "${BRANCH_TAG}" '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
+        IFS=',' read -ra TAGID <<< "${GHCR_VERSION}"
         echo "Removing tag ${TAGID[0]} with id ${TAGID[1]} from ghcr.io"
-        curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/orgs/authelia/packages/container/authelia/versions/${TAGID[1]}
+        curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions/${TAGID[1]}"
       done
     done
   done
@@ -75,12 +75,12 @@ if [[ ${BUILDKITE_LABEL} == ":docker: Deploy Manifest" ]] && [[ ${BUILDKITE_BRAN
 
   for PR_TAG in $(comm -23 <(echo "${dockerprtags}") <(echo "${githubprs}")); do
     echo "Removing tag ${PR_TAG} from docker.io"
-    curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: JWT ${authtoken}" https://hub.docker.com/v2/repositories/authelia/authelia/tags/${PR_TAG}/
+    curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: JWT ${authtoken}" "https://hub.docker.com/v2/repositories/authelia/authelia/tags/${PR_TAG}/"
     for i in {1..5}; do
-      for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions?page=${i}&per_page=100" | jq -j --arg tag ${PR_TAG} '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
-        IFS=',' read -a TAGID <<< ${GHCR_VERSION}
+      for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions?page=${i}&per_page=100" | jq -j --arg tag "${PR_TAG}" '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
+        IFS=',' read -ra TAGID <<< "${GHCR_VERSION}"
         echo "Removing tag ${TAGID[0]} with id ${TAGID[1]} from ghcr.io"
-        curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/orgs/authelia/packages/container/authelia/versions/${TAGID[1]}
+        curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions/${TAGID[1]}"
       done
     done
   done

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -9,10 +9,10 @@ if [[ ${DIVERGED} == 0 ]]; then
       BUILD_SAMBA=$(git diff --name-only HEAD~1 | grep -q ^internal/suites/example/compose/samba/Dockerfile && echo true || echo false)
       CI_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^(CODE_OF_CONDUCT\.md|CONTRIBUTING\.md|README\.md|SECURITY\.md|crowdin\.yml|\.all-contributorsrc|\.editorconfig|\.github\/.*|docs\/.*|cmd\/authelia-gen\/templates\/.*|examples\/.*)/!{q1}' && echo true || echo false)
     else
-      BUILD_DUO=$(git diff --name-only $(git merge-base --fork-point origin/master) | grep -q ^internal/suites/example/compose/duo-api/Dockerfile && echo true || echo false)
-      BUILD_HAPROXY=$(git diff --name-only $(git merge-base --fork-point origin/master) | grep -q ^internal/suites/example/compose/haproxy/Dockerfile && echo true || echo false)
-      BUILD_SAMBA=$(git diff --name-only $(git merge-base --fork-point origin/master) | grep -q ^internal/suites/example/compose/samba/Dockerfile && echo true || echo false)
-      CI_BYPASS=$(git diff --name-only $(git merge-base --fork-point origin/master) | sed -rn '/^(CODE_OF_CONDUCT\.md|CONTRIBUTING\.md|README\.md|SECURITY\.md|crowdin\.yml|\.all-contributorsrc|\.editorconfig|\.github\/.*|docs\/.*|cmd\/authelia-gen\/templates\/.*|examples\/.*)/!{q1}' && echo true || echo false)
+      BUILD_DUO=$(git diff --name-only "$(git merge-base --fork-point origin/master)" | grep -q ^internal/suites/example/compose/duo-api/Dockerfile && echo true || echo false)
+      BUILD_HAPROXY=$(git diff --name-only "$(git merge-base --fork-point origin/master)" | grep -q ^internal/suites/example/compose/haproxy/Dockerfile && echo true || echo false)
+      BUILD_SAMBA=$(git diff --name-only "$(git merge-base --fork-point origin/master)" | grep -q ^internal/suites/example/compose/samba/Dockerfile && echo true || echo false)
+      CI_BYPASS=$(git diff --name-only "$(git merge-base --fork-point origin/master)" | sed -rn '/^(CODE_OF_CONDUCT\.md|CONTRIBUTING\.md|README\.md|SECURITY\.md|crowdin\.yml|\.all-contributorsrc|\.editorconfig|\.github\/.*|docs\/.*|cmd\/authelia-gen\/templates\/.*|examples\/.*)/!{q1}' && echo true || echo false)
     fi
 
     if [[ ${CI_BYPASS} == "true" ]]; then

--- a/.buildkite/steps/aurhelper.sh
+++ b/.buildkite/steps/aurhelper.sh
@@ -9,13 +9,13 @@ cd "${PACKAGE}" || exit
 if [[ "${PACKAGE}" != "authelia-git" ]]; then
   sed -i -e "/^pkgver=/c pkgver=${BUILDKITE_TAG//v/}" \
   -e '/^pkgrel=/c pkgrel=1' PKGBUILD && \
-  docker run --rm -v $PWD:/build authelia/aurpackager bash -c "cd /build && updpkgsums"
+  docker run --rm -v "${PWD}:/build" authelia/aurpackager bash -c "cd /build && updpkgsums"
 else
   sed -i -e "/^pkgver=/c pkgver=${GITTAG}" \
   -e '/^pkgrel=/c pkgrel=1' PKGBUILD
 fi
 
-docker run --rm -v $PWD:/build authelia/aurpackager bash -c "cd /build && makepkg --printsrcinfo >| .SRCINFO" && \
+docker run --rm -v "${PWD}:/build" authelia/aurpackager bash -c "cd /build && makepkg --printsrcinfo >| .SRCINFO" && \
 git add . && \
 if [[ "${PACKAGE}" != "authelia-git" ]]; then
   git commit -m "Update to ${BUILDKITE_TAG}"

--- a/.buildkite/steps/grypescans.sh
+++ b/.buildkite/steps/grypescans.sh
@@ -7,25 +7,25 @@ ciTag="${BUILDKITE_TAG}"
 dockerImageName="authelia/authelia"
 masterBranch="master"
 publicRepoRegex='.*:.*'
-grypeCmd="grype -f low"
+grypeCmd=(grype -f low)
 
 if [[ "${CI_MERGE_QUEUE}" != "true" ]]; then
   if [[ -n "${ciTag}" ]]; then
     echo "--- :grype: Scanning ${dockerImageName}:${ciTag/v}"
-    ${grypeCmd} ${dockerImageName}:${ciTag/v}
+    "${grypeCmd[@]}" "${dockerImageName}:${ciTag/v}"
   elif [[ "${ciBranch}" != "${masterBranch}" && ! "${ciBranch}" =~ ${publicRepoRegex} ]]; then
     echo "--- :grype: Scanning ${dockerImageName}:${ciBranch}"
-    ${grypeCmd} ${dockerImageName}:${ciBranch}
+    "${grypeCmd[@]}" "${dockerImageName}:${ciBranch}"
   elif [[ "${ciBranch}" != "${masterBranch}" && "${ciBranch}" =~ ${publicRepoRegex} ]]; then
     echo "--- :grype: Scanning ${dockerImageName}:PR${ciPullRequest}"
-    ${grypeCmd} ${dockerImageName}:PR${ciPullRequest}
+    "${grypeCmd[@]}" "${dockerImageName}:PR${ciPullRequest}"
   elif [[ "${ciBranch}" == "${masterBranch}" && "${ciPullRequest}" == "false" ]]; then
     echo "--- :grype: Scanning ${dockerImageName}:${masterBranch}"
-    ${grypeCmd} ${dockerImageName}:${masterBranch}
+    "${grypeCmd[@]}" "${dockerImageName}:${masterBranch}"
   fi
 fi
 
 for file in *.spdx.json; do
   echo "--- :grype: Scanning ${file/.spdx.json}"
-  ${grypeCmd} ${file}
+  "${grypeCmd[@]}" "${file}"
 done

--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -1,5 +1,63 @@
 #!/usr/bin/env bash
 
+# Usage:
+#   lint.sh                  Run every linter (CI linting step entrypoint).
+#   lint.sh shellcheck ...   Run shellcheck. With file args, those files are
+#                            linted verbatim (used by lefthook's staged path).
+#                            Otherwise, every tracked shell script is
+#                            discovered via git ls-files + shebang scan and
+#                            passed in. Any flag-style arguments (--format=...)
+#                            are forwarded to shellcheck.
+#   lint.sh -flag ...        Anything else is forwarded to reviewdog.
+
+set -uo pipefail
+
+discover_shell_files() {
+  # A file is considered a shell script if any of:
+  #   - its path matches *.sh
+  #   - its path is under .buildkite/hooks/
+  #   - its first line is a shell shebang (#!/bin/sh, #!/usr/bin/env bash, ...)
+  local shebang_re='^#!.*(ba|da|a|k|z)?sh([[:space:]]|$)'
+  local f first
+  {
+    git ls-files '*.sh' '.buildkite/hooks/*'
+    git ls-files | while IFS= read -r f; do
+      case "${f}" in
+        *.sh) continue ;;
+        .buildkite/hooks/*) continue ;;
+      esac
+      [ -f "${f}" ] || continue
+      if IFS= read -r first < "${f}" 2>/dev/null && [[ "${first}" =~ ${shebang_re} ]]; then
+        printf '%s\n' "${f}"
+      fi
+    done
+  } | sort -u
+}
+
+run_shellcheck() {
+  local has_files=0 arg
+  for arg in "$@"; do
+    case "${arg}" in
+      -*) ;;
+      *) has_files=1 ;;
+    esac
+  done
+  if (( has_files )); then
+    shellcheck "$@"
+  else
+    local files
+    files=$(discover_shell_files)
+    if [ -z "${files}" ]; then
+      echo "no shell files found" >&2
+      return 1
+    fi
+    # shellcheck disable=SC2086  # intentional word-splitting of the newline-separated file list
+    shellcheck "$@" ${files}
+  fi
+}
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
 if [[ $# -eq 0 ]]; then
   FAILED=0
 
@@ -7,16 +65,21 @@ if [[ $# -eq 0 ]]; then
   golangci-lint run || FAILED=1
   echo "--- :go::service_dog: Running yamllint"
   yamllint . || FAILED=1
+  echo "--- :go::service_dog: Running shellcheck"
+  run_shellcheck || FAILED=1
   echo "--- :go::service_dog: Running eslint"
   cd web && eslint '*/**/*.{js,ts,tsx}' || FAILED=1 && cd ..
 
   echo "--- :go::service_dog: Lint Runners Completed"
-  if [[ $FAILED -ne 0 ]]; then
+  if [[ ${FAILED} -ne 0 ]]; then
     echo "Linting was not successful as one or more linters returned a non-zero exit code"
     exit 1
   else
     echo "Linting was successful"
   fi
+elif [[ $1 == "shellcheck" ]]; then
+  shift
+  run_shellcheck "$@"
 else
   reviewdog "$@"
 fi

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
         MISSING=""
         COUNT=0
 
-        for TOOL in golangci-lint pnpm trufflehog typos yamllint; do
+        for TOOL in golangci-lint pnpm shellcheck trufflehog typos yamllint; do
           if ! command -v ${TOOL} >/dev/null 2>&1; then
             if [ "$COUNT" -eq 0 ]; then
               MISSING=${TOOL}
@@ -41,6 +41,12 @@ pre-commit:
             run: golangci-lint run --fix
             glob: "*.go"
             stage_fixed: true
+
+          - name: shellcheck
+            run: shellcheck --format=gcc {staged_files} && echo "0 issues."
+            file_types:
+              - text/x-shellscript
+              - text/x-sh
 
           - name: trufflehog
             run: trufflehog --fail --log-level=-1 filesystem -x .trufflehog . && echo "0 issues."

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -19,6 +19,14 @@ runner:
       - '%f:%l:%c: %m'
     level: error
 
+  shellcheck:
+    cmd: .buildkite/steps/lint.sh shellcheck --format=gcc
+    errorformat:
+      - '%f:%l:%c: %trror: %m'
+      - '%f:%l:%c: %tarning: %m'
+      - '%f:%l:%c: %tote: %m'
+    level: error
+
   yamllint:
     cmd: yamllint -f parsable .
     errorformat:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,5 @@
+# ShellCheck configuration for Authelia.
+# Default checks are enabled; require-variable-braces is opted in to
+# enforce the ${VAR} style repo-wide alongside them.
+enable=require-variable-braces
+external-sources=false

--- a/authelia-fb-rc.d
+++ b/authelia-fb-rc.d
@@ -7,12 +7,14 @@
 # Add the following lines to /etc/rc.conf to enable authelia:
 # authelia_enable : set to "YES" to enable the daemon, default is "NO"
 
+# These variables are consumed by the rc.subr framework sourced below.
+# shellcheck source=/dev/null disable=SC2034
 . /etc/rc.subr
 
 name=authelia
 rcvar=authelia_enable
 
-load_rc_config $name
+load_rc_config "${name}"
 
 authelia_enable=${authelia_enable:-"NO"}
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,28 +1,30 @@
 #!/usr/bin/env bash
 
-export PATH=$PATH:$PWD/cmd/dev/:$PWD/.buildkite/steps/:$GOPATH/bin:$PWD/web/node_modules/.bin:/tmp \
+export PATH=${PATH}:${PWD}/cmd/dev/:${PWD}/.buildkite/steps/:${GOPATH}/bin:${PWD}/web/node_modules/.bin:/tmp \
 DOCKER_BUILDKIT=1
 
-if [[ -z "$OLD_PS1" ]]; then
-  OLD_PS1="$PS1"
-  export PS1="(authelia) $PS1"
+if [[ -z "${OLD_PS1}" ]]; then
+  OLD_PS1="${PS1}"
+  export PS1="(authelia) ${PS1}"
 fi
 
 if [[ $(id -u) = 0 ]]; then
   echo "Cannot run as root, defaulting to UID 1000"
   export USER_ID=1000
 else
-  export USER_ID=$(id -u)
+  USER_ID=$(id -u)
+  export USER_ID
 fi
 
 if [[ $(id -g) = 0 ]]; then
   echo "Cannot run as root, defaulting to GID 1000"
   export GROUP_ID=1000
 else
-  export GROUP_ID=$(id -g)
+  GROUP_ID=$(id -g)
+  export GROUP_ID
 fi
 
-if [[ "$CI" != "true" ]]; then
+if [[ "${CI}" != "true" ]]; then
   export CI=false
 fi
 

--- a/cmd/dev/authelia
+++ b/cmd/dev/authelia
@@ -2,4 +2,4 @@
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-go run ${ROOT}/../authelia "$@"
+go run "${ROOT}/../authelia" "$@"

--- a/cmd/dev/authelia-gen
+++ b/cmd/dev/authelia-gen
@@ -2,4 +2,4 @@
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-go run ${ROOT}/../authelia-gen "$@"
+go run "${ROOT}/../authelia-gen" "$@"

--- a/cmd/dev/authelia-scripts
+++ b/cmd/dev/authelia-scripts
@@ -2,4 +2,4 @@
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-go run ${ROOT}/../authelia-scripts "$@"
+go run "${ROOT}/../authelia-scripts" "$@"

--- a/cmd/dev/authelia-suites
+++ b/cmd/dev/authelia-suites
@@ -2,4 +2,4 @@
 
 ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-go run ${ROOT}/../authelia-suites "$@"
+go run "${ROOT}/../authelia-suites" "$@"

--- a/docs/tool/build
+++ b/docs/tool/build
@@ -2,24 +2,24 @@
 
 BIN_DIR=/opt/build/repo/dart-sass
 
-mkdir -p $BIN_DIR
+mkdir -p "${BIN_DIR}"
 
-echo Installing Dart SASS from https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz
+echo "Installing Dart SASS from https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
 
-curl -LJO https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz
-tar -xzf dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz
-mv dart-sass/sass $BIN_DIR
-mv dart-sass/src  $BIN_DIR/src
+curl -LJO "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+tar -xzf "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+mv dart-sass/sass "${BIN_DIR}"
+mv dart-sass/src  "${BIN_DIR}/src"
 
 rm -rf dart-sass
-rm dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz
+rm "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
 
-echo "Binaries installed to $BIN_DIR"
-ls $BIN_DIR
+echo "Binaries installed to ${BIN_DIR}"
+ls "${BIN_DIR}"
 
-export PATH=$BIN_DIR:$PATH
+export PATH="${BIN_DIR}:${PATH}"
 
-echo PATH=$PATH
+echo "PATH=${PATH}"
 sass --version
 hugo version
 hugo env

--- a/examples/compose/local/setup.sh
+++ b/examples/compose/local/setup.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 
 writehosts(){
-  echo "\
-127.0.0.1  authelia.$DOMAIN
-127.0.0.1  public.$DOMAIN
-127.0.0.1  traefik.$DOMAIN
-127.0.0.1  secure.$DOMAIN" | sudo tee -a /etc/hosts > /dev/null
+  sudo tee -a /etc/hosts > /dev/null <<EOF
+127.0.0.1  authelia.${DOMAIN}
+127.0.0.1  public.${DOMAIN}
+127.0.0.1  traefik.${DOMAIN}
+127.0.0.1  secure.${DOMAIN}
+EOF
 }
 
 username(){
-  read -ep "Enter your username for Authelia: " USERNAME
+  read -rep "Enter your username for Authelia: " USERNAME
 }
 
 password(){
-  read -esp "Enter a password for $USERNAME: " PASSWORD
+  read -resp "Enter a password for ${USERNAME}: " PASSWORD
 }
 
 displayname(){
-  read -ep "Enter your display name for Authelia (eg. John Doe): " DISPLAYNAME
+  read -rep "Enter your display name for Authelia (eg. John Doe): " DISPLAYNAME
 }
 
 echo "Checking for pre-requisites"
@@ -27,17 +28,15 @@ if [[ ! -x "$(command -v docker)" ]]; then
   exit 1
 fi
 
-docker compose version > /dev/null 2>&1
-
-if [ $? -ne 0 ]; then
+if ! docker compose version > /dev/null 2>&1; then
   echo "You must install Docker Compose on your machine"
   exit 1
 fi
 
-if [ $(id -u) != 0 ]; then
+if [ "$(id -u)" != 0 ]; then
   echo "The script requires root access to perform some functions such as modifying your /etc/hosts file"
   read -rp "Would you like to elevate access with sudo? [y/N] " confirmsudo
-  if ! [[ "$confirmsudo" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+  if ! [[ "${confirmsudo}" =~ ^([yY][eE][sS]|[yY])$ ]]; then
     echo "Sudo elevation denied, exiting"
     exit 1
   fi
@@ -49,36 +48,36 @@ sudo docker pull authelia/authelia > /dev/null
 echo "Resetting compose.yml, configuration.yml and users_database.yml"
 sudo git checkout -- compose.yml authelia/configuration.yml authelia/users_database.yml
 
-read -ep "What root domain would you like to protect? (default/no selection is example.com): " DOMAIN
+read -rep "What root domain would you like to protect? (default/no selection is example.com): " DOMAIN
 
-if [[ $DOMAIN == "" ]]; then
+if [[ ${DOMAIN} == "" ]]; then
   DOMAIN="example.com"
 fi
 
-MODIFIED=$(cat /etc/hosts | grep $DOMAIN && echo true || echo false)
+MODIFIED=$(grep "${DOMAIN}" /etc/hosts && echo true || echo false)
 
-if [[ $MODIFIED == "false" ]]; then
+if [[ ${MODIFIED} == "false" ]]; then
   writehosts
 fi
 
-echo "Generating SSL certificate for *.$DOMAIN"
-sudo docker run -a stdout -v $PWD/traefik/certs:/tmp/certs authelia/authelia authelia crypto certificate rsa generate --common-name="*.${DOMAIN}" --directory=/tmp/certs/ > /dev/null
+echo "Generating SSL certificate for *.${DOMAIN}"
+sudo docker run -a stdout -v "${PWD}/traefik/certs:/tmp/certs" authelia/authelia authelia crypto certificate rsa generate --common-name="*.${DOMAIN}" --directory=/tmp/certs/ > /dev/null
 
-if [[ $DOMAIN != "example.com" ]]; then
+if [[ ${DOMAIN} != "example.com" ]]; then
   if [[ $(uname) == "Darwin" ]]; then
-    sudo sed -i '' "s/example.com/$DOMAIN/g" {compose.yml,authelia/configuration.yml}
+    sudo sed -i '' "s/example.com/${DOMAIN}/g" {compose.yml,authelia/configuration.yml}
   else
-    sudo sed -i "s/example.com/$DOMAIN/g" {compose.yml,authelia/configuration.yml}
+    sudo sed -i "s/example.com/${DOMAIN}/g" {compose.yml,authelia/configuration.yml}
   fi
 fi
 
 username
 
-if [[ $USERNAME != "" ]]; then
+if [[ ${USERNAME} != "" ]]; then
   if [[ $(uname) == "Darwin" ]]; then
-    sudo sed -i '' "s/<USERNAME>/$USERNAME/g" authelia/users_database.yml
+    sudo sed -i '' "s/<USERNAME>/${USERNAME}/g" authelia/users_database.yml
   else
-    sudo sed -i "s/<USERNAME>/$USERNAME/g" authelia/users_database.yml
+    sudo sed -i "s/<USERNAME>/${USERNAME}/g" authelia/users_database.yml
   fi
 else
   echo "Username cannot be empty"
@@ -87,11 +86,11 @@ fi
 
 displayname
 
-if [[ $DISPLAYNAME != "" ]]; then
+if [[ ${DISPLAYNAME} != "" ]]; then
   if [[ $(uname) == "Darwin" ]]; then
-    sudo sed -i '' "s/<DISPLAYNAME>/$DISPLAYNAME/g" authelia/users_database.yml
+    sudo sed -i '' "s/<DISPLAYNAME>/${DISPLAYNAME}/g" authelia/users_database.yml
   else
-    sudo sed -i "s/<DISPLAYNAME>/$DISPLAYNAME/g" authelia/users_database.yml
+    sudo sed -i "s/<DISPLAYNAME>/${DISPLAYNAME}/g" authelia/users_database.yml
   fi
 else
   echo "Display name cannot be empty"
@@ -100,21 +99,19 @@ fi
 
 password
 
-if [[ $PASSWORD != "" ]]; then
-  PASSWORD=$(sudo docker run authelia/authelia authelia crypto hash generate argon2 --password $PASSWORD | sed 's/Digest: //g')
+if [[ ${PASSWORD} != "" ]]; then
+  PASSWORD=$(sudo docker run authelia/authelia authelia crypto hash generate argon2 --password "${PASSWORD}" | sed 's/Digest: //g')
   if [[ $(uname) == "Darwin" ]]; then
-    sudo sed -i '' "s/<PASSWORD>/$(echo $PASSWORD | sed -e 's/[\/&]/\\&/g')/g" authelia/users_database.yml
+    sudo sed -i '' "s/<PASSWORD>/$(echo "${PASSWORD}" | sed -e 's/[\/&]/\\&/g')/g" authelia/users_database.yml
   else
-    sudo sed -i "s/<PASSWORD>/$(echo $PASSWORD | sed -e 's/[\/&]/\\&/g')/g" authelia/users_database.yml
+    sudo sed -i "s/<PASSWORD>/$(echo "${PASSWORD}" | sed -e 's/[\/&]/\\&/g')/g" authelia/users_database.yml
   fi
 else
   echo "Password cannot be empty"
   password
 fi
 
-sudo docker compose up -d
-
-if [[ $? != 0 ]]; then
+if ! sudo docker compose up -d; then
   exit 1
 fi
 
@@ -122,11 +119,11 @@ cat << EOF
 Setup completed successfully.
 
 You can now visit the following locations:
-- https://public.$DOMAIN - Bypasses Authelia
-- https://traefik.$DOMAIN - Secured with Authelia one-factor authentication
-- https://secure.$DOMAIN - Secured with Authelia two-factor authentication (see note below)
+- https://public.${DOMAIN} - Bypasses Authelia
+- https://traefik.${DOMAIN} - Secured with Authelia one-factor authentication
+- https://secure.${DOMAIN} - Secured with Authelia two-factor authentication (see note below)
 
 You will need to authorize the self-signed certificate upon visiting each domain.
-To visit https://secure.$DOMAIN you will need to register a device for second factor authentication and confirm by clicking on a link sent by email. Since this is a demo with a fake email address, the content of the email will be stored in './authelia/notification.txt'.
+To visit https://secure.${DOMAIN} you will need to register a device for second factor authentication and confirm by clicking on a link sent by email. Since this is a demo with a fake email address, the content of the email will be stored in './authelia/notification.txt'.
 Upon registering, you can grab this link easily by running the following command: 'grep -Eo '"https://.*" ' ./authelia/notification.txt'.
 EOF

--- a/examples/compose/local/setup.sh
+++ b/examples/compose/local/setup.sh
@@ -54,7 +54,13 @@ if [[ ${DOMAIN} == "" ]]; then
   DOMAIN="example.com"
 fi
 
-MODIFIED=$(grep "${DOMAIN}" /etc/hosts && echo true || echo false)
+MODIFIED=true
+for fqdn in {authelia,public,traefik,secure}."${DOMAIN}"; do
+  if ! grep -qF "${fqdn}" /etc/hosts; then
+    MODIFIED=false
+    break
+  fi
+done
 
 if [[ ${MODIFIED} == "false" ]]; then
   writehosts

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# shellcheck source=/dev/null
 . /app/.healthcheck.env
 
 if [ -z "${X_AUTHELIA_HEALTHCHECK}" ]; then

--- a/internal/configuration/test_resources/crypto/gen.sh
+++ b/internal/configuration/test_resources/crypto/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## RSA 1024
 go run ./cmd/authelia crypto certificate rsa generate --bits=1024 --directory='./internal/configuration/test_resources/crypto' --file.ca-certificate='ca.rsa.1024.crt' --file.ca-private-key='ca.rsa.1024.pem' -n='Authelia Development RSA 1024 Standalone Root CA' --not-before='Jan 1 00:00:00 2000' --not-after='Jan 1 00:00:00 2100' -o='Authelia' --organizational-unit='Development' --ca --legacy

--- a/internal/suites/common/pki/gen.sh
+++ b/internal/suites/common/pki/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # go run ./cmd/authelia crypto certificate rsa generate --directory='./internal/suites/common/pki/ca' --file.ca-certificate='ca.private.pem' --file.ca-private-key='ca.public.crt' -n 'Authelia Development Standalone Root CA' --not-before='Jan 1 00:00:00 2000' --not-after='Jan 1 00:00:00 2100' -o 'Authelia' --organizational-unit='Development' --ca
 # cp ./internal/suites/common/pki/ca/ca.public.crt ./internal/suites/common/pki/ca.public.crt

--- a/internal/suites/example/compose/authelia/resources/entrypoint-backend.sh
+++ b/internal/suites/example/compose/authelia/resources/entrypoint-backend.sh
@@ -2,12 +2,12 @@
 
 set -x
 
-cd /resources
+cd /resources || exit
 
 echo "Installing pinned CLI tools from go.mod"
 go run .
 
-cd /app
+cd /app || exit
 
 echo "Use hot reloaded version of Authelia backend"
 reflex -c /resources/reflex.conf

--- a/internal/suites/example/compose/authelia/resources/entrypoint-frontend.sh
+++ b/internal/suites/example/compose/authelia/resources/entrypoint-frontend.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 PNPM_MODULE="./node_modules/.modules.yaml"
 

--- a/internal/suites/example/compose/redis/entrypoint.sh
+++ b/internal/suites/example/compose/redis/entrypoint.sh
@@ -1,13 +1,13 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 MODE=${1}
 
 cp "/templates/${MODE}.conf" /data/redis.conf
 chown -R redis:redis /data
 
-if [ "${MODE}" == "master" ] || [ "${MODE}" == "slave" ]; then
+if [ "${MODE}" = "master" ] || [ "${MODE}" = "slave" ]; then
   redis-server /data/redis.conf
-elif [ "${MODE}" == "sentinel" ]; then
+elif [ "${MODE}" = "sentinel" ]; then
   redis-server /data/redis.conf --sentinel
 else
   echo "invalid argument: entrypoint.sh [master|slave|sentinel]"

--- a/internal/suites/example/compose/redis/entrypoint.sh
+++ b/internal/suites/example/compose/redis/entrypoint.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-MODE=$1
+MODE=${1}
 
-cp /templates/${MODE}.conf /data/redis.conf
+cp "/templates/${MODE}.conf" /data/redis.conf
 chown -R redis:redis /data
 
 if [ "${MODE}" == "master" ] || [ "${MODE}" == "slave" ]; then

--- a/internal/suites/example/compose/samba/init.sh
+++ b/internal/suites/example/compose/samba/init.sh
@@ -10,20 +10,21 @@ appSetup () {
   NOCOMPLEXITY=${NOCOMPLEXITY:-false}
   INSECURELDAP=${INSECURELDAP:-false}
 
-  LDOMAIN=${DOMAIN,,}
   UDOMAIN=${DOMAIN^^}
   URDOMAIN=${UDOMAIN%%.*}
 
   # Set up samba
   mv /etc/krb5.conf /etc/krb5.conf.orig
-  echo "[libdefaults]" > /etc/krb5.conf
-  echo "    dns_lookup_realm = false" >> /etc/krb5.conf
-  echo "    dns_lookup_kdc = true" >> /etc/krb5.conf
-  echo "    default_realm = ${UDOMAIN}" >> /etc/krb5.conf
+  cat > /etc/krb5.conf <<EOF
+[libdefaults]
+    dns_lookup_realm = false
+    dns_lookup_kdc = true
+    default_realm = ${UDOMAIN}
+EOF
   # If the finished file isn't there, this is brand new, we're not just moving to a new container
   if [[ ! -f /etc/samba/external/smb.conf ]]; then
     mv /etc/samba/smb.conf /etc/samba/smb.conf.orig
-    samba-tool domain provision --use-rfc2307 --domain=${URDOMAIN} --realm=${UDOMAIN} --server-role=dc --dns-backend=SAMBA_INTERNAL --adminpass=${DOMAINPASS}
+    samba-tool domain provision --use-rfc2307 --domain="${URDOMAIN}" --realm="${UDOMAIN}" --server-role=dc --dns-backend=SAMBA_INTERNAL --adminpass="${DOMAINPASS}"
     if [[ ${NOCOMPLEXITY,,} == "true" ]]; then
       samba-tool domain passwordsettings set --complexity=off
       samba-tool domain passwordsettings set --history-length=0
@@ -56,11 +57,13 @@ appSetup () {
 
   # Set up supervisor
   mkdir /etc/supervisor.d/
-  echo "[supervisord]" > /etc/supervisor.d/supervisord.ini
-  echo "nodaemon=true" >> /etc/supervisor.d/supervisord.ini
-  echo "" >> /etc/supervisor.d/supervisord.ini
-  echo "[program:samba]" >> /etc/supervisor.d/supervisord.ini
-  echo "command=/usr/sbin/samba -i" >> /etc/supervisor.d/supervisord.ini
+  cat > /etc/supervisor.d/supervisord.ini <<'EOF'
+[supervisord]
+nodaemon=true
+
+[program:samba]
+command=/usr/sbin/samba -i
+EOF
 
   appProvision
   appStart
@@ -84,7 +87,7 @@ appProvision () {
   samba-tool group addmembers "admins" john
 }
 
-case "$1" in
+case "${1}" in
   start)
     if [[ -f /etc/samba/external/smb.conf ]]; then
       cp /etc/samba/external/smb.conf /etc/samba/smb.conf


### PR DESCRIPTION
Introduce ShellCheck as an enforced lint step so shell scripts are held to the same strictness as the Go, YAML, and JavaScript surfaces, and take the opportunity to normalize the repository's shell hygiene while the tooling is being put in place. A new .shellcheckrc keeps the default ShellCheck rule set enabled and opts in to require-variable-braces (SC2250) to enforce the ${VAR} style repo-wide. The tool is wired into the local pre-commit path via lefthook (with file_types filtering on text/x-shellscript and text/x-sh so only libmagic-detected shell files are passed in, and --format=gcc so the output is clickable from the IDE), into the Buildkite :service_dog: Linting step via a new shellcheck subcommand on .buildkite/steps/lint.sh that discovers every tracked shell script through git ls-files and a shebang scan, and into reviewdog via .reviewdog.yml using the same lint.sh subcommand with --format=gcc so findings annotate pull requests inline.

Along with the wiring this commit clears the ShellCheck baseline against the current tree. Every bare $VAR reference was rewritten to ${VAR} so SC2250 lands on an already-clean repository. Unquoted expansions and command substitutions (SC2086 and SC2046) were quoted across the Buildkite steps, hooks, pipeline.sh, setup.sh, redis and samba entrypoints, and grypescans.sh; read calls gained -r (SC2162), cd calls got || exit guards (SC2164), declare-and-assign in bootstrap.sh was split to preserve return values (SC2155), indirect $? checks in setup.sh were rewritten as if ! cmd (SC2181), repeated redirect blocks in samba init.sh were collapsed into { ... } > file (SC2129), an unused LDOMAIN variable was removed (SC2034), the runtime source in healthcheck.sh was marked with a # shellcheck source=/dev/null directive (SC1091), and framework-consumed variables in authelia-fb-rc.d gained a file-level disable directive. Two suite entrypoints that used bash-only syntax under #!/bin/sh had their shebangs bumped to #!/usr/bin/env bash, two dev-host gen.sh scripts had their /bin/bash absolute paths swapped for /usr/bin/env bash so they pick up Homebrew bash on developer machines, and grypescans.sh had its split-string grypeCmd rewritten as a proper bash array so the intentional word-splitting no longer needed an inline disable.