### PR TITLE
ci(buildkite): diff queue commits against immediate parent for bypass

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -42,7 +42,7 @@ fi
 if [[ ${BUILDKITE_BRANCH} =~ ^gh-readonly-queue/.* ]]; then
   CI_BYPASS="true"
   CI_MERGE_QUEUE="true"
-  CI_MERGE_QUEUE_BYPASS=$(git diff --name-only "$(git merge-base origin/master HEAD)" | sed -rn '/^(CODE_OF_CONDUCT\.md|CONTRIBUTING\.md|README\.md|SECURITY\.md|crowdin\.yml|\.all-contributorsrc|\.editorconfig|\.github\/.*|docs\/.*|cmd\/authelia-gen\/templates\/.*|examples\/.*)/!{q1}' && echo true || echo false)
+  CI_MERGE_QUEUE_BYPASS=$(git diff --name-only HEAD^ HEAD | sed -rn '/^(CODE_OF_CONDUCT\.md|CONTRIBUTING\.md|README\.md|SECURITY\.md|crowdin\.yml|\.all-contributorsrc|\.editorconfig|\.github\/.*|docs\/.*|cmd\/authelia-gen\/templates\/.*|examples\/.*)/!{q1}' && echo true || echo false)
   buildkite-agent annotate --style "info" --context "ctx-info" < .buildkite/annotations/merge-queue
 fi
 


### PR DESCRIPTION
The merge-queue bypass check diffed against `git merge-base origin/master HEAD`, which relies on the Buildkite agent's cached `origin/master` being current. When the agent's `origin/master` lagged even one commit behind the actual queue base, the merge-base resolved to an older ancestor and the diff picked up files from unrelated PRs that had landed in between, flipping `CI_MERGE_QUEUE_BYPASS` to `false` for docs-only PRs and triggering steps (e.g. grype vulnerability scanning) that expect SBOM artifacts that were never produced upstream.

Since `gh-readonly-queue/*/pr-N-*` branches are always a single commit on top of the queue base, diff against `HEAD^ HEAD` instead. This scopes the bypass check to just the PR's own changes and removes the dependency on `origin/master` freshness on the agent.