### PR TITLE
test(suites): dedicated pnpm script without live reload for docs suite

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "create": "hugo new",
     "dev": "hugo server --disableFastRender --noHTTPCache",
+    "ci": "hugo server --disableFastRender --noHTTPCache --disableLiveReload",
     "format": "prettier **/** -w -c",
     "build": "hugo --minify --gc",
     "preview": "vite preview --outDir public"

--- a/internal/suites/external_devserver.go
+++ b/internal/suites/external_devserver.go
@@ -34,6 +34,7 @@ type DevServerConfig struct {
 	Port          int
 	ReadinessPath string
 	StartTimeout  time.Duration
+	Script        string
 }
 
 // HugoDocsDevServer is the DevServerConfig for the Hugo documentation site at docs/.
@@ -41,6 +42,7 @@ var HugoDocsDevServer = DevServerConfig{
 	Name:       "hugo-docs",
 	ProjectDir: "docs",
 	Port:       1313,
+	Script:     "ci",
 }
 
 // ReactEmailTemplatesDevServer is the DevServerConfig for the react-email template source at
@@ -49,6 +51,7 @@ var ReactEmailTemplatesDevServer = DevServerConfig{
 	Name:       "email-templates",
 	ProjectDir: "internal/templates/src",
 	Port:       3000,
+	Script:     "dev",
 }
 
 // StartDevServer installs the project's dependencies, spawns `pnpm dev`, and blocks until the
@@ -89,7 +92,7 @@ func StartDevServer(ctx context.Context, repoRoot string, cfg DevServerConfig, o
 
 	// Spawn the dev server in its own process group so teardown can signal the whole
 	// pnpm/node/<binary> tree with a single call.
-	cmd := exec.Command("pnpm", "--silent", "-C", projectDir, "dev")
+	cmd := exec.Command("pnpm", "--silent", "-C", projectDir, cfg.Script)
 	cmd.Stdout = stdoutWriter
 	cmd.Stderr = stderrWriter
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/internal/suites/external_devserver.go
+++ b/internal/suites/external_devserver.go
@@ -92,7 +92,7 @@ func StartDevServer(ctx context.Context, repoRoot string, cfg DevServerConfig, o
 
 	// Spawn the dev server in its own process group so teardown can signal the whole
 	// pnpm/node/<binary> tree with a single call.
-	cmd := exec.Command("pnpm", "--silent", "-C", projectDir, cfg.Script)
+	cmd := exec.Command("pnpm", "--silent", "-C", projectDir, "run", cfg.Script)
 	cmd.Stdout = stdoutWriter
 	cmd.Stderr = stderrWriter
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}


### PR DESCRIPTION
The docs external suite spawned the same `pnpm dev` script that developers use, which runs `hugo server` with live reload enabled. Hugo's watcher can pick up its own build artifacts (e.g. hugo_stats.json) and fire a rebuild mid-test; the live-reload WebSocket then pushes a browser reload and the tab navigates out from under the element handles the test is driving, surfacing as "Inspected target navigated or closed" on the next interaction.

Add a separate `ci` script in docs/package.json that appends `--disableLiveReload` so rebuilds no longer reload the test browser, and let `DevServerConfig` select which pnpm script to run.