### PR TITLE
test(utils): use deterministic directory suffix

### DIFF
--- a/internal/utils/exec_test.go
+++ b/internal/utils/exec_test.go
@@ -6,10 +6,18 @@ import (
 	"testing"
 	"time"
 
+	"os"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestShouldExecCommandOnAutheliaRootPath(t *testing.T) {
+	suffix := "authelia"
+
+	if pipeline := os.Getenv("BUILDKITE_PIPELINE_SLUG"); pipeline != "" {
+		suffix = pipeline
+	}
+
 	cmd := Command("pwd")
 	result, err := cmd.CombinedOutput()
 	assert.NoError(t, err, "")
@@ -17,7 +25,7 @@ func TestShouldExecCommandOnAutheliaRootPath(t *testing.T) {
 	str := strings.Trim(string(result), "\n")
 
 	assert.NoError(t, err, "")
-	assert.Equal(t, true, strings.HasSuffix(str, "authelia"))
+	assert.Equal(t, true, strings.HasSuffix(str, suffix))
 }
 
 func TestCommandShouldOutputResult(t *testing.T) {

--- a/internal/utils/exec_test.go
+++ b/internal/utils/exec_test.go
@@ -2,11 +2,10 @@ package utils
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
-
-	"os"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
This ensures regardless of the pipeline dir in Buildkite that this test passes.