### PR TITLE
ci(buildkite): simplify pipeline scripts

### DIFF
--- a/.buildkite/annotations/artifacts.sh
+++ b/.buildkite/annotations/artifacts.sh
@@ -38,20 +38,20 @@ for T in "${TARGETS[@]}"; do
   elif [[ "${T}" == "checksums" ]]; then
     artifact_links "checksums.sha256"
   else
-  	for OS in "${!BUILDS[@]}"; do
-  	  for B in ${BUILDS[${OS}]}; do
-  	  	case "${B}" in
-  	      	"${T}"|"${T}-musl")
-  	      		artifact_links "${PREFIX}-${OS}-${B}.tar.gz"
-  	      		;;
-  	    	esac
-  	  done
-  	done
+    for OS in "${!BUILDS[@]}"; do
+      for B in ${BUILDS[${OS}]}; do
+        case "${B}" in
+          "${T}"|"${T}-musl")
+            artifact_links "${PREFIX}-${OS}-${B}.tar.gz"
+            ;;
+        esac
+      done
+    done
 
-  DEB_PREFIX=$(echo "${PREFIX}" | sed -e 's/v//' -e 's/-/_/' -e '/[0-9]$/s/$/-1/')
-  DEB_ARCH="${T}"
-  [[ "${T}" == "arm" ]] && DEB_ARCH="armhf"
-  artifact_links "${DEB_PREFIX}_${DEB_ARCH}.deb"
+    DEB_PREFIX=$(echo "${PREFIX}" | sed -e 's/v//' -e 's/-/_/' -e '/[0-9]$/s/$/-1/')
+    DEB_ARCH="${T}"
+    [[ "${T}" == "arm" ]] && DEB_ARCH="armhf"
+    artifact_links "${DEB_PREFIX}_${DEB_ARCH}.deb"
   fi
 
   echo '    </dd>'

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
-
 set +eu
 
-if [[ ${BUILDKITE_PULL_REQUEST} != "false" ]]; then
+cleanup_tags() {
+  local docker_list="${1}" github_list="${2}"
+  local tag i ghcr_version
+  local -a tagid
+  for tag in $(comm -23 <(echo "${docker_list}") <(echo "${github_list}")); do
+    echo "Removing tag ${tag} from docker.io"
+    curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: JWT ${authtoken}" "https://hub.docker.com/v2/repositories/authelia/authelia/tags/${tag}/"
+    for i in {1..5}; do
+      for ghcr_version in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions?page=${i}&per_page=100" | jq -j --arg tag "${tag}" '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
+        IFS=',' read -ra tagid <<< "${ghcr_version}"
+        echo "Removing tag ${tagid[0]} with id ${tagid[1]} from ghcr.io"
+        curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions/${tagid[1]}"
+      done
+    done
+  done
+}
+
+if [[ ${BUILDKITE_PULL_REQUEST} != "false" ]] && [[ ${CI_PRIVATE} != "true" ]]; then
   if [[ ${BUILDKITE_LABEL} == ":service_dog: Linting" ]]; then
     echo "--- :go::service_dog: Provide in-line commentary for pull request"
     lint.sh -reporter=github-pr-review
@@ -49,39 +65,19 @@ if [[ ${BUILDKITE_LABEL} =~ :docker:\ Deploy ]]; then
 fi
 
 if [[ ${BUILDKITE_LABEL} == ":docker: Deploy Manifest" ]] && [[ ${BUILDKITE_BRANCH} == "master" ]] && [[ ${BUILDKITE_PULL_REQUEST} == "false" ]]; then
-  echo "--- :docker: Removing tags for deleted branches"
   anontoken=$(curl -fsL --retry 3 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:authelia/authelia:pull' | jq -r .token)
   authtoken=$(curl -fs --retry 3 -H "Content-Type: application/json" -X POST -d "{\"username\": \"${DOCKER_TOKEN_USERNAME}\", \"password\": \"${DOCKER_TOKEN}\"}" https://hub.docker.com/v2/users/login/ | jq -r .token)
-  dockerbranchtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/authelia/tags/list | jq -r '.tags[] | select(startswith("PR") | not)' | sed -r '/^(latest|master|develop|v.*|([[:digit:]]+)\.?([[:digit:]]+)?\.?([[:digit:]]+)?)$/d' | sort)
-  githubbranches=$(curl -fs --retry 3 https://api.github.com/repos/authelia/authelia/branches?per_page=100 | jq -r '.[].name' | sort)
   if [[ -z "${authtoken}" ]]; then
     echo ":warning: docker.io auth token not acquired; DockerHub tag deletions will fail." >&2
   fi
-  for BRANCH_TAG in $(comm -23 <(echo "${dockerbranchtags}") <(echo "${githubbranches}")); do
-    echo "Removing tag ${BRANCH_TAG} from docker.io"
-    curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: JWT ${authtoken}" "https://hub.docker.com/v2/repositories/authelia/authelia/tags/${BRANCH_TAG}/"
-    for i in {1..5}; do
-      for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions?page=${i}&per_page=100" | jq -j --arg tag "${BRANCH_TAG}" '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
-        IFS=',' read -ra TAGID <<< "${GHCR_VERSION}"
-        echo "Removing tag ${TAGID[0]} with id ${TAGID[1]} from ghcr.io"
-        curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions/${TAGID[1]}"
-      done
-    done
-  done
+
+  echo "--- :docker: Removing tags for deleted branches"
+  dockerbranchtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/authelia/tags/list | jq -r '.tags[] | select(startswith("PR") | not)' | sed -r '/^(latest|master|develop|v.*|([[:digit:]]+)\.?([[:digit:]]+)?\.?([[:digit:]]+)?)$/d' | sort)
+  githubbranches=$(curl -fs --retry 3 https://api.github.com/repos/authelia/authelia/branches?per_page=100 | jq -r '.[].name' | sort)
+  cleanup_tags "${dockerbranchtags}" "${githubbranches}"
 
   echo "--- :docker: Removing tags for merged or closed pull requests"
   dockerprtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/authelia/tags/list | jq -r '.tags[] | select(startswith("PR"))' | sort)
   githubprs=$(curl -fs --retry 3 https://api.github.com/repos/authelia/authelia/pulls?per_page=100 | jq -r '.[].number' | sed -e 's/^/PR/' | sort)
-
-  for PR_TAG in $(comm -23 <(echo "${dockerprtags}") <(echo "${githubprs}")); do
-    echo "Removing tag ${PR_TAG} from docker.io"
-    curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: JWT ${authtoken}" "https://hub.docker.com/v2/repositories/authelia/authelia/tags/${PR_TAG}/"
-    for i in {1..5}; do
-      for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions?page=${i}&per_page=100" | jq -j --arg tag "${PR_TAG}" '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
-        IFS=',' read -ra TAGID <<< "${GHCR_VERSION}"
-        echo "Removing tag ${TAGID[0]} with id ${TAGID[1]} from ghcr.io"
-        curl -fsL --retry 3 -o /dev/null -X DELETE -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/authelia/versions/${TAGID[1]}"
-      done
-    done
-  done
+  cleanup_tags "${dockerprtags}" "${githubprs}"
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -52,19 +52,27 @@ if [[ "${BUILDKITE_LABEL}" =~ :selenium: ]]; then
     zstdcat "authelia-image-coverage.tar.zst" | docker load
   fi
 
-  if [[ "${BUILD_DUO}" == "true" ]] && [[ "${SUITE}" == "DuoPush" ]]; then
-    CONTAINER="integration-duo"
-    FILE="internal/suites/example/compose/duo-api/compose.yml"
-    INTEGRATION
-  elif [[ "${BUILD_HAPROXY}" == "true" ]] && [[ "${SUITE}" == "HAProxy" ]]; then
-    CONTAINER="integration-haproxy"
-    FILE="internal/suites/example/compose/haproxy/compose.yml"
-    INTEGRATION
-  elif [[ "${BUILD_SAMBA}" == "true" ]] && [[ "${SUITE}" == "ActiveDirectory" ]]; then
-    CONTAINER="integration-samba"
-    FILE="internal/suites/example/compose/samba/compose.yml"
-    INTEGRATION
-  fi
+  BUILD_FLAG=""
+  CONTAINER=""
+  FILE=""
+  case "${SUITE}" in
+    DuoPush)
+      BUILD_FLAG="${BUILD_DUO}"
+      CONTAINER="integration-duo"
+      FILE="internal/suites/example/compose/duo-api/compose.yml"
+      ;;
+    HAProxy)
+      BUILD_FLAG="${BUILD_HAPROXY}"
+      CONTAINER="integration-haproxy"
+      FILE="internal/suites/example/compose/haproxy/compose.yml"
+      ;;
+    ActiveDirectory)
+      BUILD_FLAG="${BUILD_SAMBA}"
+      CONTAINER="integration-samba"
+      FILE="internal/suites/example/compose/samba/compose.yml"
+      ;;
+  esac
+  [[ "${BUILD_FLAG}" == "true" ]] && INTEGRATION
 fi
 
 if [[ "${BUILDKITE_LABEL}" == ":docker: Build and Deploy" ]]; then

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -18,6 +18,7 @@ CI_BYPASS="false"
 CI_MERGE_QUEUE="false"
 CI_MERGE_QUEUE_BYPASS="false"
 CI_PRIVATE="false"
+LINT_REPORTER="github-check"
 
 if [[ ${DIVERGED} == 0 ]] && [[ ${BUILDKITE_TAG} == "" ]]; then
   if [[ ${BUILDKITE_BRANCH} == "master" ]]; then
@@ -50,6 +51,7 @@ fi
 
 if [[ ${BUILDKITE_PIPELINE_SLUG} == "authelia-cve" ]]; then
   CI_PRIVATE="true"
+  LINT_REPORTER="local"
 fi
 
 cat << EOF
@@ -64,7 +66,7 @@ env:
 
 steps:
   - label: ":service_dog: Linting"
-    command: "lint.sh -reporter=github-check -filter-mode=nofilter -fail-level=error"
+    command: "lint.sh -reporter=${LINT_REPORTER} -filter-mode=nofilter -fail-level=error"
     if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.message !~ /\[(skip test|test skip)\]/
 
   - label: ":chrome: External Tests"

--- a/.buildkite/steps/e2etests.sh
+++ b/.buildkite/steps/e2etests.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -eu
 
+declare -A SUITE_AGENTS=(
+  [ActiveDirectory]="activedirectory"
+  [HighAvailability]="highavailability"
+  [Kubernetes]="kubernetes"
+  [Standalone]="standalone"
+)
+
 for SUITE_NAME in $(authelia-scripts suites list); do
+  AGENT="${SUITE_AGENTS[${SUITE_NAME}]:-all}"
 cat << EOF
   - label: ":selenium: ${SUITE_NAME} Suite"
     command: "authelia-scripts --log-level debug suites test ${SUITE_NAME} --failfast --headless"
@@ -9,34 +17,8 @@ cat << EOF
       automatic: true
       manual:
         permit_on_passed: true
-EOF
-if [[ "${SUITE_NAME}" = "ActiveDirectory" ]]; then
-cat << EOF
     agents:
-      suite: "activedirectory"
-EOF
-elif [[ "${SUITE_NAME}" = "HighAvailability" ]]; then
-cat << EOF
-    agents:
-      suite: "highavailability"
-EOF
-elif [[ "${SUITE_NAME}" = "Kubernetes" ]]; then
-cat << EOF
-    agents:
-      suite: "kubernetes"
-EOF
-elif [[ "${SUITE_NAME}" = "Standalone" ]]; then
-cat << EOF
-    agents:
-      suite: "standalone"
-EOF
-else
-cat << EOF
-    agents:
-      suite: "all"
-EOF
-fi
-cat << EOF
+      suite: "${AGENT}"
     env:
       SUITE: "${SUITE_NAME}"
 EOF

--- a/.buildkite/steps/grypescans.sh
+++ b/.buildkite/steps/grypescans.sh
@@ -9,20 +9,22 @@ masterBranch="master"
 publicRepoRegex='.*:.*'
 grypeCmd=(grype -f low)
 
+IMAGE=""
 if [[ "${CI_MERGE_QUEUE}" != "true" ]]; then
   if [[ -n "${ciTag}" ]]; then
-    echo "--- :grype: Scanning ${dockerImageName}:${ciTag/v}"
-    "${grypeCmd[@]}" "${dockerImageName}:${ciTag/v}"
+    IMAGE="${dockerImageName}:${ciTag/v}"
   elif [[ "${ciBranch}" != "${masterBranch}" && ! "${ciBranch}" =~ ${publicRepoRegex} ]]; then
-    echo "--- :grype: Scanning ${dockerImageName}:${ciBranch}"
-    "${grypeCmd[@]}" "${dockerImageName}:${ciBranch}"
+    IMAGE="${dockerImageName}:${ciBranch}"
   elif [[ "${ciBranch}" != "${masterBranch}" && "${ciBranch}" =~ ${publicRepoRegex} ]]; then
-    echo "--- :grype: Scanning ${dockerImageName}:PR${ciPullRequest}"
-    "${grypeCmd[@]}" "${dockerImageName}:PR${ciPullRequest}"
+    IMAGE="${dockerImageName}:PR${ciPullRequest}"
   elif [[ "${ciBranch}" == "${masterBranch}" && "${ciPullRequest}" == "false" ]]; then
-    echo "--- :grype: Scanning ${dockerImageName}:${masterBranch}"
-    "${grypeCmd[@]}" "${dockerImageName}:${masterBranch}"
+    IMAGE="${dockerImageName}:${masterBranch}"
   fi
+fi
+
+if [[ -n "${IMAGE}" ]]; then
+  echo "--- :grype: Scanning ${IMAGE}"
+  "${grypeCmd[@]}" "${IMAGE}"
 fi
 
 for file in *.spdx.json; do


### PR DESCRIPTION
Several of the `.buildkite/` scripts still carried near-identical logic after the earlier `pipeline.sh` cleanup: the DockerHub and GHCR tag-cleanup loops in post-command repeated an identical inner flow, `e2etests.sh` fanned out selenium agent selection across five almost-identical heredoc arms, `pre-command` expanded the per-suite compose rewrite into an elif chain, and `grypescans.sh` echoed and invoked grype once per arm rather than resolving a single `IMAGE` first. Collapse each concern behind one helper, lookup, or dispatch (cleanup_tags, an associative array, a case statement, a single `IMAGE` assignment) so a rule change only needs one edit.

Also guard the recently-introduced private authelia-cve pipeline against leaking linting output to public GitHub: flip `LINT_REPORTER` to reviewdog's local reporter when `CI_PRIVATE` is true, and skip the `post-command` github-pr-review step entirely. Minor drive-by: reflow the tab/space-mixed indentation in `annotations/artifacts.sh`.