### PR TITLE
ci: add goimports-reviser linter

### DIFF
--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -61,13 +61,15 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 if [[ $# -eq 0 ]]; then
   FAILED=0
 
+  echo "--- :go::service_dog: Running goimports-reviser"
+  goimports-reviser -rm-unused -format -excludes '*/node_modules,*/*/*/node_modules' -company-prefixes authelia.com,github.com/authelia ./... || FAILED=1
   echo "--- :go::service_dog: Running golangci-lint"
   golangci-lint run || FAILED=1
-  echo "--- :go::service_dog: Running yamllint"
+  echo "--- :yaml::service_dog: Running yamllint"
   yamllint . || FAILED=1
-  echo "--- :go::service_dog: Running shellcheck"
+  echo "--- :shellcheck::service_dog: Running shellcheck"
   run_shellcheck || FAILED=1
-  echo "--- :go::service_dog: Running eslint"
+  echo "--- :eslint::service_dog: Running eslint"
   cd web && eslint '*/**/*.{js,ts,tsx}' || FAILED=1 && cd ..
 
   echo "--- :go::service_dog: Lint Runners Completed"

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
         MISSING=""
         COUNT=0
 
-        for TOOL in golangci-lint pnpm shellcheck trufflehog typos yamllint; do
+        for TOOL in goimports-reviser golangci-lint pnpm shellcheck trufflehog typos yamllint; do
           if ! command -v ${TOOL} >/dev/null 2>&1; then
             if [ "$COUNT" -eq 0 ]; then
               MISSING=${TOOL}
@@ -35,6 +35,14 @@ pre-commit:
             run: pnpm lint && echo "0 issues."
             root: "web/"
             glob: "*.{js,jsx,ts,tsx}"
+            stage_fixed: true
+
+          - name: goimports-reviser
+            run: |
+              goimports-reviser -rm-unused -format \
+              -company-prefixes authelia.com,github.com/authelia {staged_files} 2>/dev/null \
+              && echo "0 issues."
+            glob: "*.go"
             stage_fixed: true
 
           - name: golangci-lint

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -5,6 +5,15 @@ runner:
     format: rdjson
     level: error
 
+  goimports-reviser:
+    cmd: >-
+      goimports-reviser -rm-unused -format
+      -excludes '*/node_modules,*/*/*/node_modules'
+      -company-prefixes authelia.com,github.com/authelia ./...
+      ; git diff --no-prefix -- '*.go'
+    format: diff
+    level: error
+
   golangci:
     cmd: golangci-lint run
     errorformat:

--- a/cmd/authelia-gen/cmd_docs_jsonschema.go
+++ b/cmd/authelia-gen/cmd_docs_jsonschema.go
@@ -9,8 +9,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/authelia/jsonschema"
 	"github.com/spf13/cobra"
+
+	"github.com/authelia/jsonschema"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"

--- a/internal/commands/debug.go
+++ b/internal/commands/debug.go
@@ -12,10 +12,11 @@ import (
 	"strings"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	goyaml "go.yaml.in/yaml/v4"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"

--- a/internal/configuration/schema/types.go
+++ b/internal/configuration/schema/types.go
@@ -15,12 +15,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/authelia/jsonschema"
 	"github.com/go-crypt/crypt"
 	"github.com/go-crypt/crypt/algorithm"
 	"github.com/go-crypt/crypt/algorithm/plaintext"
 	"github.com/valyala/fasthttp"
 	"go.yaml.in/yaml/v4"
+
+	"github.com/authelia/jsonschema"
 )
 
 var cdecoder algorithm.DecoderRegister

--- a/internal/configuration/schema/types_test.go
+++ b/internal/configuration/schema/types_test.go
@@ -20,11 +20,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/authelia/jsonschema"
 	"github.com/go-crypt/crypt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
+
+	"github.com/authelia/jsonschema"
 )
 
 func TestPasswordDigest_MarshalYAML(t *testing.T) {

--- a/internal/expression/activation_user_whitebox_test.go
+++ b/internal/expression/activation_user_whitebox_test.go
@@ -63,27 +63,50 @@ func TestUserDetailerActivationResolveNameWithParent(t *testing.T) {
 
 type testDetailer struct{}
 
-func (d *testDetailer) GetUsername() string           { return "testuser" }
-func (d *testDetailer) GetGroups() []string           { return nil }
-func (d *testDetailer) GetDisplayName() string        { return "" }
-func (d *testDetailer) GetEmails() []string           { return nil }
-func (d *testDetailer) GetGivenName() string          { return "" }
-func (d *testDetailer) GetFamilyName() string         { return "" }
-func (d *testDetailer) GetMiddleName() string         { return "" }
-func (d *testDetailer) GetNickname() string           { return "" }
-func (d *testDetailer) GetProfile() string            { return "" }
-func (d *testDetailer) GetPicture() string            { return "" }
-func (d *testDetailer) GetWebsite() string            { return "" }
-func (d *testDetailer) GetGender() string             { return "" }
-func (d *testDetailer) GetBirthdate() string          { return "" }
-func (d *testDetailer) GetZoneInfo() string           { return "" }
-func (d *testDetailer) GetLocale() string             { return "" }
-func (d *testDetailer) GetPhoneNumber() string        { return "" }
-func (d *testDetailer) GetPhoneExtension() string     { return "" }
+func (d *testDetailer) GetUsername() string { return "testuser" }
+
+func (d *testDetailer) GetGroups() []string { return nil }
+
+func (d *testDetailer) GetDisplayName() string { return "" }
+
+func (d *testDetailer) GetEmails() []string { return nil }
+
+func (d *testDetailer) GetGivenName() string { return "" }
+
+func (d *testDetailer) GetFamilyName() string { return "" }
+
+func (d *testDetailer) GetMiddleName() string { return "" }
+
+func (d *testDetailer) GetNickname() string { return "" }
+
+func (d *testDetailer) GetProfile() string { return "" }
+
+func (d *testDetailer) GetPicture() string { return "" }
+
+func (d *testDetailer) GetWebsite() string { return "" }
+
+func (d *testDetailer) GetGender() string { return "" }
+
+func (d *testDetailer) GetBirthdate() string { return "" }
+
+func (d *testDetailer) GetZoneInfo() string { return "" }
+
+func (d *testDetailer) GetLocale() string { return "" }
+
+func (d *testDetailer) GetPhoneNumber() string { return "" }
+
+func (d *testDetailer) GetPhoneExtension() string { return "" }
+
 func (d *testDetailer) GetPhoneNumberRFC3966() string { return "" }
-func (d *testDetailer) GetStreetAddress() string      { return "" }
-func (d *testDetailer) GetLocality() string           { return "" }
-func (d *testDetailer) GetRegion() string             { return "" }
-func (d *testDetailer) GetPostalCode() string         { return "" }
-func (d *testDetailer) GetCountry() string            { return "" }
-func (d *testDetailer) GetExtra() map[string]any      { return nil }
+
+func (d *testDetailer) GetStreetAddress() string { return "" }
+
+func (d *testDetailer) GetLocality() string { return "" }
+
+func (d *testDetailer) GetRegion() string { return "" }
+
+func (d *testDetailer) GetPostalCode() string { return "" }
+
+func (d *testDetailer) GetCountry() string { return "" }
+
+func (d *testDetailer) GetExtra() map[string]any { return nil }

--- a/internal/handlers/handler_authz_authn.go
+++ b/internal/handlers/handler_authz_authn.go
@@ -11,9 +11,10 @@ import (
 	"strings"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"

--- a/internal/handlers/handler_oauth2_authorization_consent_core.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_core.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/middlewares"

--- a/internal/handlers/handler_oauth2_authorization_consent_core_test.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_core_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/mocks"

--- a/internal/handlers/handler_oauth2_authorization_consent_explicit.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_explicit.go
@@ -4,8 +4,9 @@ import (
 	"net/http"
 	"net/url"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/model"

--- a/internal/handlers/handler_oauth2_authorization_consent_implicit.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_implicit.go
@@ -4,8 +4,9 @@ import (
 	"net/http"
 	"net/url"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/model"

--- a/internal/handlers/handler_oauth2_authorization_consent_preconfigured.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_preconfigured.go
@@ -6,8 +6,9 @@ import (
 	"net/url"
 	"strings"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/model"

--- a/internal/handlers/handler_oauth2_consent.go
+++ b/internal/handlers/handler_oauth2_consent.go
@@ -6,8 +6,9 @@ import (
 	"net/url"
 	"time"
 
-	"authelia.com/provider/oauth2"
 	"github.com/google/uuid"
+
+	"authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/logging"

--- a/internal/handlers/handler_oauth2_oidc_userinfo.go
+++ b/internal/handlers/handler_oauth2_oidc_userinfo.go
@@ -6,12 +6,13 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/valyala/fasthttp"
+
 	oauthelia2 "authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/handler/oauth2"
 	"authelia.com/provider/oauth2/token/jwt"
 	"authelia.com/provider/oauth2/x/errorsx"
-	"github.com/google/uuid"
-	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/oidc"

--- a/internal/handlers/handler_oauth2_oidc_wellknown.go
+++ b/internal/handlers/handler_oauth2_oidc_wellknown.go
@@ -4,9 +4,10 @@ import (
 	"net/url"
 	"time"
 
-	"authelia.com/provider/oauth2/token/jwt"
 	"github.com/google/uuid"
 	"github.com/valyala/fasthttp"
+
+	"authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/oidc"

--- a/internal/handlers/handler_oauth2_wellknown.go
+++ b/internal/handlers/handler_oauth2_wellknown.go
@@ -4,9 +4,10 @@ import (
 	"net/url"
 	"time"
 
-	"authelia.com/provider/oauth2/token/jwt"
 	"github.com/google/uuid"
 	"github.com/valyala/fasthttp"
+
+	"authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/oidc"

--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"net/url"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
 	"github.com/valyala/fasthttp"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"

--- a/internal/handlers/types.go
+++ b/internal/handlers/types.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"net/url"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/middlewares"

--- a/internal/model/oidc.go
+++ b/internal/model/oidc.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/utils"
 )

--- a/internal/model/oidc_test.go
+++ b/internal/model/oidc_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
-	"authelia.com/provider/oauth2/handler/openid"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+
+	oauthelia2 "authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/handler/openid"
 
 	"github.com/authelia/authelia/v4/internal/mocks"
 	"github.com/authelia/authelia/v4/internal/model"

--- a/internal/model/totp_configuration.go
+++ b/internal/model/totp_configuration.go
@@ -9,8 +9,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/authelia/otp"
 	"go.yaml.in/yaml/v4"
+
+	"github.com/authelia/otp"
 )
 
 type TOTPOptions struct {

--- a/internal/oidc/claims_test.go
+++ b/internal/oidc/claims_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/model"

--- a/internal/oidc/client.go
+++ b/internal/oidc/client.go
@@ -5,10 +5,11 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
+
 	oauthelia2 "authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/token/jwt"
 	"authelia.com/provider/oauth2/x/errorsx"
-	"github.com/go-jose/go-jose/v4"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"

--- a/internal/oidc/client_test.go
+++ b/internal/oidc/client_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"

--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
+
 	oauthelia2 "authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/handler/oauth2"
 	"authelia.com/provider/oauth2/handler/openid"
@@ -17,7 +19,6 @@ import (
 	"authelia.com/provider/oauth2/handler/rfc8628"
 	"authelia.com/provider/oauth2/i18n"
 	"authelia.com/provider/oauth2/token/jwt"
-	"github.com/hashicorp/go-retryablehttp"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/logging"

--- a/internal/oidc/config_test.go
+++ b/internal/oidc/config_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"authelia.com/provider/oauth2/handler/oauth2"
-	"authelia.com/provider/oauth2/token/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"authelia.com/provider/oauth2/handler/oauth2"
+	"authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/clock"
@@ -486,12 +487,18 @@ type testConfigContext struct {
 	context.Context
 }
 
-func (t *testConfigContext) IssuerURL() (issuerURL *url.URL, err error)   { return nil, nil }
-func (t *testConfigContext) GetClock() clock.Provider                     { return nil }
-func (t *testConfigContext) GetRandom() random.Provider                   { return nil }
-func (t *testConfigContext) GetConfiguration() *schema.Configuration      { return nil }
-func (t *testConfigContext) GetProviderStorage() storage.Provider         { return nil }
+func (t *testConfigContext) IssuerURL() (issuerURL *url.URL, err error) { return nil, nil }
+
+func (t *testConfigContext) GetClock() clock.Provider { return nil }
+
+func (t *testConfigContext) GetRandom() random.Provider { return nil }
+
+func (t *testConfigContext) GetConfiguration() *schema.Configuration { return nil }
+
+func (t *testConfigContext) GetProviderStorage() storage.Provider { return nil }
+
 func (t *testConfigContext) GetUserProvider() authentication.UserProvider { return nil }
+
 func (t *testConfigContext) GetProviderUserAttributeResolver() expression.UserAttributeResolver {
 	return nil
 }

--- a/internal/oidc/errors.go
+++ b/internal/oidc/errors.go
@@ -7,8 +7,9 @@ import (
 	"net/url"
 	"strconv"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/valyala/fasthttp"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 )
 
 var (

--- a/internal/oidc/errors_test.go
+++ b/internal/oidc/errors_test.go
@@ -8,8 +8,9 @@ import (
 	"net/url"
 	"testing"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/stretchr/testify/assert"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 )
 
 func TestRedirectAuthorizeErrorFieldResponseStrategy(t *testing.T) {

--- a/internal/oidc/issuer.go
+++ b/internal/oidc/issuer.go
@@ -5,8 +5,9 @@ import (
 	"crypto"
 	"sort"
 
-	"authelia.com/provider/oauth2/token/jwt"
 	"github.com/go-jose/go-jose/v4"
+
+	"authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 )

--- a/internal/oidc/issuer_test.go
+++ b/internal/oidc/issuer_test.go
@@ -404,12 +404,18 @@ type issuerTestContext struct {
 	context.Context
 }
 
-func (c *issuerTestContext) IssuerURL() (*url.URL, error)                 { return nil, nil }
-func (c *issuerTestContext) GetClock() clock.Provider                     { return nil }
-func (c *issuerTestContext) GetRandom() random.Provider                   { return nil }
-func (c *issuerTestContext) GetConfiguration() *schema.Configuration      { return nil }
-func (c *issuerTestContext) GetProviderStorage() storage.Provider         { return nil }
+func (c *issuerTestContext) IssuerURL() (*url.URL, error) { return nil, nil }
+
+func (c *issuerTestContext) GetClock() clock.Provider { return nil }
+
+func (c *issuerTestContext) GetRandom() random.Provider { return nil }
+
+func (c *issuerTestContext) GetConfiguration() *schema.Configuration { return nil }
+
+func (c *issuerTestContext) GetProviderStorage() storage.Provider { return nil }
+
 func (c *issuerTestContext) GetUserProvider() authentication.UserProvider { return nil }
+
 func (c *issuerTestContext) GetProviderUserAttributeResolver() expression.UserAttributeResolver {
 	return nil
 }

--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -4,11 +4,12 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/mohae/deepcopy"
+
 	oauthelia2 "authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/handler/openid"
 	"authelia.com/provider/oauth2/token/jwt"
-	"github.com/google/uuid"
-	"github.com/mohae/deepcopy"
 
 	"github.com/authelia/authelia/v4/internal/model"
 )

--- a/internal/oidc/session_test.go
+++ b/internal/oidc/session_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"authelia.com/provider/oauth2/handler/openid"
-	"authelia.com/provider/oauth2/token/jwt"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"authelia.com/provider/oauth2/handler/openid"
+	"authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/oidc"

--- a/internal/oidc/store.go
+++ b/internal/oidc/store.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+
 	oauthelia2 "authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/handler/oauth2"
 	"authelia.com/provider/oauth2/handler/openid"
 	"authelia.com/provider/oauth2/handler/rfc8628"
 	ostorage "authelia.com/provider/oauth2/storage"
-	"github.com/google/uuid"
 
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"

--- a/internal/oidc/store_test.go
+++ b/internal/oidc/store_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"

--- a/internal/oidc/subject.go
+++ b/internal/oidc/subject.go
@@ -3,8 +3,9 @@ package oidc
 import (
 	"fmt"
 
-	oauthelia2 "authelia.com/provider/oauth2"
 	"github.com/google/uuid"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/model"

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -6,9 +6,10 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
+
 	oauthelia2 "authelia.com/provider/oauth2"
 	fjwt "authelia.com/provider/oauth2/token/jwt"
-	"github.com/go-jose/go-jose/v4"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/authorization"

--- a/internal/oidc/types_test.go
+++ b/internal/oidc/types_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
-	xjwt "authelia.com/provider/oauth2/token/jwt"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	oauthelia2 "authelia.com/provider/oauth2"
+	xjwt "authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/authentication"
 	"github.com/authelia/authelia/v4/internal/clock"

--- a/internal/oidc/util.go
+++ b/internal/oidc/util.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
-	"authelia.com/provider/oauth2/handler/openid"
-	fjwt "authelia.com/provider/oauth2/token/jwt"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/text/language"
+
+	oauthelia2 "authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/handler/openid"
+	fjwt "authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/utils"
 )

--- a/internal/oidc/util_blackbox_test.go
+++ b/internal/oidc/util_blackbox_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 	"time"
 
-	oauthelia2 "authelia.com/provider/oauth2"
-	"authelia.com/provider/oauth2/handler/openid"
-	fjwt "authelia.com/provider/oauth2/token/jwt"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/language"
+
+	oauthelia2 "authelia.com/provider/oauth2"
+	"authelia.com/provider/oauth2/handler/openid"
+	fjwt "authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/clock"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -366,6 +366,8 @@ func TestHandlerMainWithOptionalFeatures(t *testing.T) {
 
 type timeoutError struct{}
 
-func (e *timeoutError) Error() string   { return "i/o timeout" }
-func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Error() string { return "i/o timeout" }
+
+func (e *timeoutError) Timeout() bool { return true }
+
 func (e *timeoutError) Temporary() bool { return true }

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -5,8 +5,9 @@ import (
 	"database/sql"
 	"time"
 
-	"authelia.com/provider/oauth2/storage"
 	"github.com/google/uuid"
+
+	"authelia.com/provider/oauth2/storage"
 
 	"github.com/authelia/authelia/v4/internal/model"
 )

--- a/internal/storage/sql_provider_test.go
+++ b/internal/storage/sql_provider_test.go
@@ -3,11 +3,10 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"net"
 	"path/filepath"
 	"testing"
 	"time"
-
-	"net"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/internal/suites/action_totp.go
+++ b/internal/suites/action_totp.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/authelia/otp"
-	"github.com/authelia/otp/totp"
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/input"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/authelia/otp"
+	"github.com/authelia/otp/totp"
 )
 
 type OptionsTOTP struct {

--- a/internal/suites/suite_pathprefix_test.go
+++ b/internal/suites/suite_pathprefix_test.go
@@ -37,6 +37,7 @@ func (s *PathPrefixSuite) TestCustomHeaders() {
 func (s *PathPrefixSuite) TestResetPasswordScenario() {
 	suite.Run(s.T(), NewResetPasswordScenario())
 }
+
 func (s *PathPrefixSuite) TestChangePasswordScenario() {
 	suite.Run(s.T(), NewChangePasswordScenario())
 }

--- a/internal/suites/suites_credentials.go
+++ b/internal/suites/suites_credentials.go
@@ -4,8 +4,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/authelia/otp/totp"
 	"github.com/go-rod/rod/lib/proto"
+
+	"github.com/authelia/otp/totp"
 )
 
 func NewRodSuiteCredentials() *RodSuiteCredentials {

--- a/internal/totp/helpers_test.go
+++ b/internal/totp/helpers_test.go
@@ -3,8 +3,9 @@ package totp
 import (
 	"testing"
 
-	"github.com/authelia/otp"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/authelia/otp"
 )
 
 func TestOTPStringToAlgo(t *testing.T) {

--- a/internal/utils/time_test.go
+++ b/internal/utils/time_test.go
@@ -366,6 +366,7 @@ func TestParseDurationString_NumericEdgeCases(t *testing.T) {
 		})
 	}
 }
+
 func TestStandardizeDurationString_AtoiErrors(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
Wire goimports-reviser into the three existing lint paths (pre-commit via lefthook, CI review comments via reviewdog, and the manual runner in `.buildkite/steps/lint.sh`) so import ordering, grouping, and unused-import removal are enforced consistently across local and CI workflows.

The runner is configured with `-rm-unused -format -company-prefixes authelia.com,github.com/authelia`, grouping first-party Authelia packages into their own block after third-party imports. `-set-alias` is intentionally omitted; imports work without an alias, and we do not want one added automatically.