### PR TITLE
ci(buildkite): target cve image for vulnerability scanning

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -64,6 +64,10 @@ if [[ ${BUILDKITE_LABEL} =~ :docker:\ Deploy ]]; then
   docker logout ghcr.io
 fi
 
+if [[ ${BUILDKITE_LABEL} == ":grype: Vulnerability Scanning" ]] && [[ ${CI_PRIVATE} == "true" ]]; then
+  docker logout
+fi
+
 if [[ ${BUILDKITE_LABEL} == ":docker: Deploy Manifest" ]] && [[ ${BUILDKITE_BRANCH} == "master" ]] && [[ ${BUILDKITE_PULL_REQUEST} == "false" ]]; then
   anontoken=$(curl -fsL --retry 3 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:authelia/authelia:pull' | jq -r .token)
   authtoken=$(curl -fs --retry 3 -H "Content-Type: application/json" -X POST -d "{\"username\": \"${DOCKER_TOKEN_USERNAME}\", \"password\": \"${DOCKER_TOKEN}\"}" https://hub.docker.com/v2/users/login/ | jq -r .token)

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -17,6 +17,10 @@ if [[ "${BUILDKITE_LABEL}" == ":service_dog: Linting" ]]; then
 fi
 
 if [[ "${BUILDKITE_LABEL}" == ":grype: Vulnerability Scanning" ]]; then
+  if [[ "${CI_PRIVATE}" == "true" ]]; then
+    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+  fi
+
   if [[ "${CI_MERGE_QUEUE}" == "true" ]]; then
     PR_NUMBER=$(echo "${BUILDKITE_BRANCH}" | sed -E 's|^gh-readonly-queue/.*/pr-([0-9]+)-.*|\1|')
     PR_HEAD=$(curl -fsL --retry 3 "https://api.github.com/repos/authelia/authelia/pulls/${PR_NUMBER}")

--- a/.buildkite/steps/grypescans.sh
+++ b/.buildkite/steps/grypescans.sh
@@ -9,6 +9,10 @@ masterBranch="master"
 publicRepoRegex='.*:.*'
 grypeCmd=(grype -f low)
 
+if [[ "${CI_PRIVATE}" == "true" ]]; then
+  dockerImageName="${dockerImageName}-cve"
+fi
+
 IMAGE=""
 if [[ "${CI_MERGE_QUEUE}" != "true" ]]; then
   if [[ -n "${ciTag}" ]]; then


### PR DESCRIPTION
Grype failed with `MANIFEST_UNKNOWN` on the `authelia-cve` pipeline because `grypescans.sh` hardcoded `authelia/authelia` while the private pipeline publishes the image to `authelia/authelia-cve`. Append the `-cve` suffix to the image name when `CI_PRIVATE` is set so grype scans the tag that actually exists.

Since `authelia/authelia-cve` is a private repository grype also needs registry credentials to pull the manifest. Add a `docker login` to the grype `pre-command` hook and a matching `docker logout` to `post-command`, both gated on `CI_PRIVATE`, reusing the `DOCKER_USERNAME` and `DOCKER_PASSWORD` variables already wired up for the public deploy step.