### PR TITLE
ci(buildkite): sync master and tags to authelia-cve on release

### DIFF
--- a/.buildkite/steps/ghartifacts.sh
+++ b/.buildkite/steps/ghartifacts.sh
@@ -14,9 +14,17 @@ done
 echo "--- :github: Deploy artifacts for release: ${BUILDKITE_TAG}"
 hub release create "${BUILDKITE_TAG}" "${artifacts[@]}" -F <(echo -e "${BUILDKITE_TAG}\n$(conventional-changelog -p angular -o /dev/stdout -r 2 | sed -e '1,3d')\n\n### Docker Container\n* \`docker pull authelia/authelia:${BUILDKITE_TAG//v}\`\n* \`docker pull ghcr.io/authelia/authelia:${BUILDKITE_TAG//v}\`"); EXIT=$?
 
-if [[ "${EXIT}" == 0 ]];
-  then
-    exit
-  else
-    hub release delete "${BUILDKITE_TAG}" && false
+if [[ "${EXIT}" == 0 ]]; then
+  echo "--- :github: Sync master and tags to authelia/authelia-cve"
+  # shellcheck disable=SC2016 # ${GITHUB_TOKEN} is expanded by git's helper subshell, not here.
+  cveHelper='!f() { echo "username=x-access-token"; echo "password=${GITHUB_TOKEN}"; }; f'
+  git remote remove cve 2>/dev/null || true
+  git remote add cve https://github.com/authelia/authelia-cve.git
+  git fetch origin master --tags
+  git -c "credential.helper=${cveHelper}" push cve refs/remotes/origin/master:refs/heads/master --force || echo ":warning: Failed to sync master to authelia/authelia-cve"
+  git -c "credential.helper=${cveHelper}" push cve --tags --force || echo ":warning: Failed to sync tags to authelia/authelia-cve"
+  git remote remove cve
+  exit
+else
+  hub release delete "${BUILDKITE_TAG}" && false
 fi


### PR DESCRIPTION
After `hub release create` succeeds push `master` and all tags from `authelia/authelia` to `authelia/authelia-cve` so the private CVE fork stays aligned with upstream git metadata on every release. Without this the CVE fork's history drifts, which makes Go's `-buildvcs` stamping and Authelia's `BuildTag` resolution fall back to whatever stale tag the fork happens to have reachable.

Feed `GITHUB_TOKEN` through a git credential helper rather than embedding it in the remote URL so the token never lands in argv, git's stderr, or on-disk config. Sync failures log a `:warning:` line but do not fail the step, since the release itself has already been published and should not be held hostage to a transient push error against the mirror.