### PR TITLE
feat(web): add custom_css configuration option

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -23,6 +23,9 @@
 ## The theme to display: light, dark, grey, auto.
 # theme: 'light'
 
+## The URL to a custom CSS file to apply to the web UI.
+# custom_css: ''
+
 ## Set the default 2FA method for new users and for when a user has a preferred method configured that has been
 ## disabled. This setting must be a method that is enabled.
 ## Options are totp, webauthn, mobile_push.

--- a/config.template.yml
+++ b/config.template.yml
@@ -23,7 +23,7 @@
 ## The theme to display: light, dark, grey, auto.
 # theme: 'light'
 
-## The URL to a custom CSS file to apply to the web UI.
+## The URL to a custom CSS file to apply to the web UI. Must be an absolute path (starting with /) or an https URL.
 # custom_css: ''
 
 ## Set the default 2FA method for new users and for when a user has a preferred method configured that has been

--- a/docs/content/configuration/miscellaneous/custom-css.md
+++ b/docs/content/configuration/miscellaneous/custom-css.md
@@ -1,0 +1,80 @@
+---
+title: "Custom CSS"
+description: "Custom CSS Configuration."
+summary: "This describes the configuration for applying a custom CSS file to the Authelia portal."
+date: 2024-03-14T06:00:14+11:00
+draft: false
+images: []
+weight: 199110
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## Configuration
+
+{{< config-alert-example >}}
+
+```yaml {title="configuration.yml"}
+custom_css: ''
+```
+
+## Options
+
+This section describes the individual configuration options.
+
+### custom_css
+
+{{< confkey type="string" default="''" required="no" >}}
+
+The `custom_css` option allows administrators to provide a URL to a custom CSS file that will be loaded by the Authelia
+portal. This is useful for customizing the look and feel of the portal without needing to rebuild the frontend assets.
+
+This value must be an absolute path (starting with `/`) or an `https://` URL. We **highly recommend** using an absolute
+URL as it makes it easier to include images or other assets while complying with the
+[Content Security Policy](#content-security-policy).
+
+#### Content Security Policy
+
+When using an external `https://` URL for `custom_css`, *Authelia* will automatically attempt to add the host of that URL
+to the `style-src` directive of the default [Content Security Policy](server.md#content-security-policy) (CSP).
+
+However, if you are using a custom `server.headers.csp_template`, or if your custom CSS references other assets such as
+images or fonts from an external host, you must manually update your CSP template to allow these hosts in the relevant
+directives (e.g., `img-src`, `font-src`).
+
+#### Docker Example
+
+When running *Authelia* in Docker, you can provide a custom CSS file by serving it through your reverse proxy.
+
+##### Nginx Example
+
+1. Mount your custom CSS file into your Nginx container:
+    ```yaml {title="docker-compose.yml"}
+    services:
+      nginx:
+        image: nginx
+        volumes:
+          - ./authelia.css:/usr/share/nginx/html/authelia.css:ro
+    ```
+2. Configure Nginx to serve the file:
+    ```nginx {title="nginx.conf"}
+    location /authelia.css {
+        alias /usr/share/nginx/html/authelia.css;
+    }
+    ```
+3. Configure *Authelia* to use the path:
+    ```yaml {title="configuration.yml"}
+    custom_css: /authelia.css
+    ```
+
+##### External URL Example
+
+Alternatively, you can host the CSS file on a CDN or any other public web server:
+
+```yaml {title="configuration.yml"}
+custom_css: 'https://cdn.{{< sitevar name="domain" nojs="example.com" >}}/authelia.css'
+```

--- a/docs/content/configuration/miscellaneous/custom-css.md
+++ b/docs/content/configuration/miscellaneous/custom-css.md
@@ -33,8 +33,14 @@ This section describes the individual configuration options.
 The `custom_css` option allows administrators to provide a URL to a custom CSS file that will be loaded by the Authelia
 portal. This is useful for customizing the look and feel of the portal without needing to rebuild the frontend assets.
 
-This value must be an absolute path (starting with `/`) or an `https://` URL. We **highly recommend** using an absolute
-URL as it makes it easier to include images or other assets while complying with the
+{{< callout context="caution" title="Important Note" icon="outline/alert-triangle" >}}
+Users wishing to utilize this feature should be aware that we do not provide any guarantee that the CSS selectors or
+the portal structure will not change in a breaking way between releases as per our
+[Versioning Policy](../../policies/versioning.md).
+{{< /callout >}}
+
+This value must be an absolute path (starting with `/`) or an `https://` URL. Using an absolute
+URL makes it easier to include images or other assets while complying with the
 [Content Security Policy](#content-security-policy).
 
 #### Content Security Policy
@@ -46,35 +52,3 @@ However, if you are using a custom `server.headers.csp_template`, or if your cus
 images or fonts from an external host, you must manually update your CSP template to allow these hosts in the relevant
 directives (e.g., `img-src`, `font-src`).
 
-#### Docker Example
-
-When running *Authelia* in Docker, you can provide a custom CSS file by serving it through your reverse proxy.
-
-##### Nginx Example
-
-1. Mount your custom CSS file into your Nginx container:
-    ```yaml {title="docker-compose.yml"}
-    services:
-      nginx:
-        image: nginx
-        volumes:
-          - ./authelia.css:/usr/share/nginx/html/authelia.css:ro
-    ```
-2. Configure Nginx to serve the file:
-    ```nginx {title="nginx.conf"}
-    location /authelia.css {
-        alias /usr/share/nginx/html/authelia.css;
-    }
-    ```
-3. Configure *Authelia* to use the path:
-    ```yaml {title="configuration.yml"}
-    custom_css: /authelia.css
-    ```
-
-##### External URL Example
-
-Alternatively, you can host the CSS file on a CDN or any other public web server:
-
-```yaml {title="configuration.yml"}
-custom_css: 'https://cdn.{{< sitevar name="domain" nojs="example.com" >}}/authelia.css'
-```

--- a/docs/content/policies/versioning.md
+++ b/docs/content/policies/versioning.md
@@ -91,6 +91,7 @@ Notable Advanced Customizations:
   - Email
   - Content Security Policy header
 - Localization / Internationalization Assets
+- Custom CSS
 
 ### Experimental Features
 

--- a/docs/data/configkeys.json
+++ b/docs/data/configkeys.json
@@ -395,6 +395,11 @@
         "env": "AUTHELIA_CERTIFICATES_DIRECTORY"
     },
     {
+        "path": "custom_css",
+        "secret": false,
+        "env": "AUTHELIA_CUSTOM_CSS"
+    },
+    {
         "path": "default_2fa_method",
         "secret": false,
         "env": "AUTHELIA_DEFAULT_2FA_METHOD"

--- a/docs/static/schemas/latest/json-schema/configuration.json
+++ b/docs/static/schemas/latest/json-schema/configuration.json
@@ -1073,7 +1073,7 @@
         "custom_css": {
           "type": "string",
           "title": "Custom CSS URL",
-          "description": "The URL to a custom CSS file to apply to the web UI."
+          "description": "The URL to a custom CSS file to apply to the web UI. Must be an absolute path (starting with /) or an https URL."
         },
         "certificates_directory": {
           "type": "string",

--- a/docs/static/schemas/latest/json-schema/configuration.json
+++ b/docs/static/schemas/latest/json-schema/configuration.json
@@ -1070,6 +1070,11 @@
           "description": "The name of the theme to apply to the web UI.",
           "default": "light"
         },
+        "custom_css": {
+          "type": "string",
+          "title": "Custom CSS URL",
+          "description": "The URL to a custom CSS file to apply to the web UI."
+        },
         "certificates_directory": {
           "type": "string",
           "title": "Certificates Directory Path",

--- a/docs/static/schemas/v4.39/json-schema/configuration.json
+++ b/docs/static/schemas/v4.39/json-schema/configuration.json
@@ -1073,7 +1073,7 @@
         "custom_css": {
           "type": "string",
           "title": "Custom CSS URL",
-          "description": "The URL to a custom CSS file to apply to the web UI."
+          "description": "The URL to a custom CSS file to apply to the web UI. Must be an absolute path (starting with /) or an https URL."
         },
         "certificates_directory": {
           "type": "string",

--- a/docs/static/schemas/v4.39/json-schema/configuration.json
+++ b/docs/static/schemas/v4.39/json-schema/configuration.json
@@ -1070,6 +1070,11 @@
           "description": "The name of the theme to apply to the web UI.",
           "default": "light"
         },
+        "custom_css": {
+          "type": "string",
+          "title": "Custom CSS URL",
+          "description": "The URL to a custom CSS file to apply to the web UI."
+        },
         "certificates_directory": {
           "type": "string",
           "title": "Certificates Directory Path",

--- a/examples/custom.css
+++ b/examples/custom.css
@@ -1,0 +1,41 @@
+/* Corporate Muted Style */
+body {
+    /* Muted grey to blue-grey gradient */
+    background: linear-gradient(135deg, #f1f5f9 0%, #cbd5e1 100%) !important;
+    background-attachment: fixed !important;
+    min-height: 100vh;
+}
+
+/* Hide the default User SVG icon */
+#UserSvg {
+    display: none !important;
+}
+
+/* Replace the icon with Corporate Text */
+/* Targeting the container of the logo using :has for precision */
+div.MuiGrid-root:has(> #UserSvg) {
+    display: flex !important;
+    justify-content: center !important;
+    align-items: center !important;
+    padding: 20px 0 !important;
+}
+
+div.MuiGrid-root:has(> #UserSvg)::before {
+    content: "ACME CORP";
+    font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 1.75rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    color: #1e293b; /* Dark slate blue */
+    text-transform: uppercase;
+    border-bottom: 3px solid #334155;
+    padding-bottom: 4px;
+}
+
+/* Optional: Slightly soften the login paper/container */
+.MuiContainer-root {
+    background-color: rgba(255, 255, 255, 0.8) !important;
+    backdrop-filter: blur(10px);
+    border-radius: 8px;
+    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1) !important;
+}

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -23,6 +23,9 @@
 ## The theme to display: light, dark, grey, auto.
 # theme: 'light'
 
+## The URL to a custom CSS file to apply to the web UI.
+# custom_css: ''
+
 ## Set the default 2FA method for new users and for when a user has a preferred method configured that has been
 ## disabled. This setting must be a method that is enabled.
 ## Options are totp, webauthn, mobile_push.

--- a/internal/configuration/config.template.yml
+++ b/internal/configuration/config.template.yml
@@ -23,7 +23,7 @@
 ## The theme to display: light, dark, grey, auto.
 # theme: 'light'
 
-## The URL to a custom CSS file to apply to the web UI.
+## The URL to a custom CSS file to apply to the web UI. Must be an absolute path (starting with /) or an https URL.
 # custom_css: ''
 
 ## Set the default 2FA method for new users and for when a user has a preferred method configured that has been

--- a/internal/configuration/schema/configuration.go
+++ b/internal/configuration/schema/configuration.go
@@ -7,6 +7,7 @@ import (
 // Configuration object extracted from YAML configuration file.
 type Configuration struct {
 	Theme                 string `koanf:"theme" yaml:"theme,omitempty" toml:"theme,omitempty" json:"theme,omitempty" jsonschema:"default=light,enum=auto,enum=light,enum=dark,enum=grey,enum=oled,title=Theme Name" jsonschema_description:"The name of the theme to apply to the web UI."`
+	CustomCSS             string `koanf:"custom_css" yaml:"custom_css,omitempty" toml:"custom_css,omitempty" json:"custom_css,omitempty" jsonschema:"title=Custom CSS URL" jsonschema_description:"The URL to a custom CSS file to apply to the web UI."`
 	CertificatesDirectory string `koanf:"certificates_directory" yaml:"certificates_directory,omitempty" toml:"certificates_directory,omitempty" json:"certificates_directory,omitempty" jsonschema:"title=Certificates Directory Path" jsonschema_description:"The path to a directory which is used to determine the certificates that are trusted."`
 	Default2FAMethod      string `koanf:"default_2fa_method" yaml:"default_2fa_method,omitempty" toml:"default_2fa_method,omitempty" json:"default_2fa_method,omitempty" jsonschema:"enum=totp,enum=webauthn,enum=mobile_push,title=Default 2FA method" jsonschema_description:"When a user logs in for the first time this is the 2FA method configured for them."`
 

--- a/internal/configuration/schema/configuration.go
+++ b/internal/configuration/schema/configuration.go
@@ -7,7 +7,7 @@ import (
 // Configuration object extracted from YAML configuration file.
 type Configuration struct {
 	Theme                 string `koanf:"theme" yaml:"theme,omitempty" toml:"theme,omitempty" json:"theme,omitempty" jsonschema:"default=light,enum=auto,enum=light,enum=dark,enum=grey,enum=oled,title=Theme Name" jsonschema_description:"The name of the theme to apply to the web UI."`
-	CustomCSS             string `koanf:"custom_css" yaml:"custom_css,omitempty" toml:"custom_css,omitempty" json:"custom_css,omitempty" jsonschema:"title=Custom CSS URL" jsonschema_description:"The URL to a custom CSS file to apply to the web UI."`
+	CustomCSS             string `koanf:"custom_css" yaml:"custom_css,omitempty" toml:"custom_css,omitempty" json:"custom_css,omitempty" jsonschema:"title=Custom CSS URL" jsonschema_description:"The URL to a custom CSS file to apply to the web UI. Must be an absolute path (starting with /) or an https URL."`
 	CertificatesDirectory string `koanf:"certificates_directory" yaml:"certificates_directory,omitempty" toml:"certificates_directory,omitempty" json:"certificates_directory,omitempty" jsonschema:"title=Certificates Directory Path" jsonschema_description:"The path to a directory which is used to determine the certificates that are trusted."`
 	Default2FAMethod      string `koanf:"default_2fa_method" yaml:"default_2fa_method,omitempty" toml:"default_2fa_method,omitempty" json:"default_2fa_method,omitempty" jsonschema:"enum=totp,enum=webauthn,enum=mobile_push,title=Default 2FA method" jsonschema_description:"When a user logs in for the first time this is the 2FA method configured for them."`
 

--- a/internal/configuration/schema/configuration.go
+++ b/internal/configuration/schema/configuration.go
@@ -7,7 +7,8 @@ import (
 // Configuration object extracted from YAML configuration file.
 type Configuration struct {
 	Theme                 string `koanf:"theme" yaml:"theme,omitempty" toml:"theme,omitempty" json:"theme,omitempty" jsonschema:"default=light,enum=auto,enum=light,enum=dark,enum=grey,enum=oled,title=Theme Name" jsonschema_description:"The name of the theme to apply to the web UI."`
-	CustomCSS             string `koanf:"custom_css" yaml:"custom_css,omitempty" toml:"custom_css,omitempty" json:"custom_css,omitempty" jsonschema:"title=Custom CSS URL" jsonschema_description:"The URL to a custom CSS file to apply to the web UI. Must be an absolute path (starting with /) or an https URL."`
+	CustomCSS             string   `koanf:"custom_css" yaml:"custom_css,omitempty" toml:"custom_css,omitempty" json:"custom_css,omitempty" jsonschema:"title=Custom CSS URL" jsonschema_description:"The URL to a custom CSS file to apply to the web UI. Must be an absolute path (starting with /) or an https URL."`
+	CustomCSSURL          *url.URL `koanf:"-"`
 	CertificatesDirectory string `koanf:"certificates_directory" yaml:"certificates_directory,omitempty" toml:"certificates_directory,omitempty" json:"certificates_directory,omitempty" jsonschema:"title=Certificates Directory Path" jsonschema_description:"The path to a directory which is used to determine the certificates that are trusted."`
 	Default2FAMethod      string `koanf:"default_2fa_method" yaml:"default_2fa_method,omitempty" toml:"default_2fa_method,omitempty" json:"default_2fa_method,omitempty" jsonschema:"enum=totp,enum=webauthn,enum=mobile_push,title=Default 2FA method" jsonschema_description:"When a user logs in for the first time this is the 2FA method configured for them."`
 

--- a/internal/configuration/schema/keys.go
+++ b/internal/configuration/schema/keys.go
@@ -116,6 +116,7 @@ var Keys = []string{
 	"authentication_backend.password_reset.disable",
 	"authentication_backend.refresh_interval",
 	"certificates_directory",
+	"custom_css",
 	"default_2fa_method",
 	"default_redirection_url",
 	"definitions.network",

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -365,7 +365,8 @@ const (
 
 // Theme Error constants.
 const (
-	errFmtThemeName = "option 'theme' must be one of %s but it's configured as '%s'"
+	errFmtThemeName     = "option 'theme' must be one of %s but it's configured as '%s'"
+	errFmtCustomCSSURL  = "option 'custom_css' with value '%s' is invalid: %w"
 )
 
 // NTP Error constants.

--- a/internal/configuration/validator/const.go
+++ b/internal/configuration/validator/const.go
@@ -365,8 +365,9 @@ const (
 
 // Theme Error constants.
 const (
-	errFmtThemeName     = "option 'theme' must be one of %s but it's configured as '%s'"
-	errFmtCustomCSSURL  = "option 'custom_css' with value '%s' is invalid: %w"
+	errFmtThemeName                          = "option 'theme' must be one of %s but it's configured as '%s'"
+	errFmtCustomCSSURL                       = "option 'custom_css' with value '%s' is invalid: %w"
+	errFmtCustomCSSCSPTemplateIncompatibility = "option 'custom_css' with value '%s' appears to have a host which is not explicitly allowed in the 'server.headers.csp_template' which may prevent it from loading"
 )
 
 // NTP Error constants.

--- a/internal/configuration/validator/theme.go
+++ b/internal/configuration/validator/theme.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/utils"
@@ -15,5 +16,11 @@ func ValidateTheme(config *schema.Configuration, validator *schema.StructValidat
 
 	if !utils.IsStringInSlice(config.Theme, validThemeNames) {
 		validator.Push(fmt.Errorf(errFmtThemeName, utils.StringJoinOr(validThemeNames), config.Theme))
+	}
+
+	if config.CustomCSS != "" {
+		if _, err := url.Parse(config.CustomCSS); err != nil {
+			validator.Push(fmt.Errorf(errFmtCustomCSSURL, config.CustomCSS, err))
+		}
 	}
 }

--- a/internal/configuration/validator/theme.go
+++ b/internal/configuration/validator/theme.go
@@ -27,6 +27,12 @@ func ValidateTheme(config *schema.Configuration, validator *schema.StructValidat
 			if u.Scheme != schemeHTTPS && (u.Scheme != "" || u.Host != "" || !strings.HasPrefix(u.Path, "/")) {
 				validator.Push(fmt.Errorf(errFmtCustomCSSURL, config.CustomCSS, errors.New("must be an absolute path or an https URL")))
 			}
+
+			config.CustomCSSURL = u
+
+			if config.Server.Headers.CSPTemplate != "" && u.Host != "" && !strings.Contains(string(config.Server.Headers.CSPTemplate), u.Host) {
+				validator.PushWarning(fmt.Errorf(errFmtCustomCSSCSPTemplateIncompatibility, config.CustomCSS))
+			}
 		}
 	}
 }

--- a/internal/configuration/validator/theme.go
+++ b/internal/configuration/validator/theme.go
@@ -24,14 +24,14 @@ func ValidateTheme(config *schema.Configuration, validator *schema.StructValidat
 		if u, err := url.Parse(config.CustomCSS); err != nil {
 			validator.Push(fmt.Errorf(errFmtCustomCSSURL, config.CustomCSS, err))
 		} else {
-			if u.Scheme != schemeHTTPS && (u.Scheme != "" || u.Host != "" || !strings.HasPrefix(u.Path, "/")) {
+			if (u.Scheme == "" && u.Host == "" && strings.HasPrefix(u.Path, "/")) || (u.Scheme == schemeHTTPS && u.Host != "") {
+				config.CustomCSSURL = u
+
+				if config.Server.Headers.CSPTemplate != "" && u.Host != "" && !isHostAllowedInCSP(string(config.Server.Headers.CSPTemplate), u.Host) {
+					validator.PushWarning(fmt.Errorf(errFmtCustomCSSCSPTemplateIncompatibility, config.CustomCSS))
+				}
+			} else {
 				validator.Push(fmt.Errorf(errFmtCustomCSSURL, config.CustomCSS, errors.New("must be an absolute path or an https URL")))
-			}
-
-			config.CustomCSSURL = u
-
-			if config.Server.Headers.CSPTemplate != "" && u.Host != "" && !isHostAllowedInCSP(string(config.Server.Headers.CSPTemplate), u.Host) {
-				validator.PushWarning(fmt.Errorf(errFmtCustomCSSCSPTemplateIncompatibility, config.CustomCSS))
 			}
 		}
 	}

--- a/internal/configuration/validator/theme.go
+++ b/internal/configuration/validator/theme.go
@@ -1,8 +1,10 @@
 package validator
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/utils"
@@ -19,8 +21,12 @@ func ValidateTheme(config *schema.Configuration, validator *schema.StructValidat
 	}
 
 	if config.CustomCSS != "" {
-		if _, err := url.Parse(config.CustomCSS); err != nil {
+		if u, err := url.Parse(config.CustomCSS); err != nil {
 			validator.Push(fmt.Errorf(errFmtCustomCSSURL, config.CustomCSS, err))
+		} else {
+			if u.Scheme != schemeHTTPS && (u.Scheme != "" || u.Host != "" || !strings.HasPrefix(u.Path, "/")) {
+				validator.Push(fmt.Errorf(errFmtCustomCSSURL, config.CustomCSS, errors.New("must be an absolute path or an https URL")))
+			}
 		}
 	}
 }

--- a/internal/configuration/validator/theme.go
+++ b/internal/configuration/validator/theme.go
@@ -30,9 +30,54 @@ func ValidateTheme(config *schema.Configuration, validator *schema.StructValidat
 
 			config.CustomCSSURL = u
 
-			if config.Server.Headers.CSPTemplate != "" && u.Host != "" && !strings.Contains(string(config.Server.Headers.CSPTemplate), u.Host) {
+			if config.Server.Headers.CSPTemplate != "" && u.Host != "" && !isHostAllowedInCSP(string(config.Server.Headers.CSPTemplate), u.Host) {
 				validator.PushWarning(fmt.Errorf(errFmtCustomCSSCSPTemplateIncompatibility, config.CustomCSS))
 			}
 		}
 	}
+}
+
+func isHostAllowedInCSP(csp, host string) bool {
+	directives := strings.Split(csp, ";")
+	var styleSrc, defaultSrc string
+
+	for _, d := range directives {
+		d = strings.TrimSpace(d)
+		if strings.HasPrefix(d, "style-src ") {
+			styleSrc = d
+		} else if strings.HasPrefix(d, "default-src ") {
+			defaultSrc = d
+		}
+	}
+
+	if styleSrc != "" {
+		return checkDirective(styleSrc, host)
+	}
+
+	if defaultSrc != "" {
+		return checkDirective(defaultSrc, host)
+	}
+
+	return false
+}
+
+func checkDirective(directive, host string) bool {
+	parts := strings.Fields(directive)
+	if len(parts) < 2 {
+		return false
+	}
+
+	for _, p := range parts[1:] {
+		if p == host || p == "*" || p == "https:*" || p == "https://*" {
+			return true
+		}
+
+		if strings.HasPrefix(p, "https://") {
+			if strings.TrimPrefix(p, "https://") == host {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/internal/configuration/validator/theme.go
+++ b/internal/configuration/validator/theme.go
@@ -68,7 +68,7 @@ func checkDirective(directive, host string) bool {
 	}
 
 	for _, p := range parts[1:] {
-		if p == host || p == "*" || p == "https:*" || p == "https://*" {
+		if p == host || p == "*" || p == "https:" || p == "https:*" || p == "https://*" {
 			return true
 		}
 

--- a/internal/configuration/validator/theme_test.go
+++ b/internal/configuration/validator/theme_test.go
@@ -39,6 +39,54 @@ func (suite *Theme) TestShouldRaiseErrorWhenInvalidThemeProvided() {
 	suite.Assert().EqualError(suite.validator.Errors()[0], "option 'theme' must be one of 'light', 'dark', 'grey', 'oled', or 'auto' but it's configured as 'invalid'")
 }
 
+func (suite *Theme) TestShouldRaiseErrorWhenInvalidCustomCSSProvided() {
+	testCases := []struct {
+		name     string
+		have     string
+		expected string
+	}{
+		{"ShouldNotValidateOnProtocolRelative", "//example.com/test.css", "option 'custom_css' with value '//example.com/test.css' is invalid: must be an absolute path or an https URL"},
+		{"ShouldNotValidateOnHTTP", "http://example.com/test.css", "option 'custom_css' with value 'http://example.com/test.css' is invalid: must be an absolute path or an https URL"},
+		{"ShouldNotValidateOnJavascript", "javascript:alert(1)", "option 'custom_css' with value 'javascript:alert(1)' is invalid: must be an absolute path or an https URL"},
+		{"ShouldNotValidateOnRelativePath", "custom.css", "option 'custom_css' with value 'custom.css' is invalid: must be an absolute path or an https URL"},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(t *testing.T) {
+			suite.SetupTest()
+			suite.config.CustomCSS = tc.have
+
+			ValidateTheme(suite.config, suite.validator)
+
+			suite.Assert().Len(suite.validator.Warnings(), 0)
+			suite.Require().Len(suite.validator.Errors(), 1)
+			suite.Assert().EqualError(suite.validator.Errors()[0], tc.expected)
+		})
+	}
+}
+
+func (suite *Theme) TestShouldValidateValidCustomCSS() {
+	testCases := []struct {
+		name string
+		have string
+	}{
+		{"ShouldValidateOnHTTPS", "https://example.com/test.css"},
+		{"ShouldValidateOnAbsolutePath", "/custom-assets/styles.css"},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.name, func(t *testing.T) {
+			suite.SetupTest()
+			suite.config.CustomCSS = tc.have
+
+			ValidateTheme(suite.config, suite.validator)
+
+			suite.Assert().Len(suite.validator.Warnings(), 0)
+			suite.Assert().Len(suite.validator.Errors(), 0)
+		})
+	}
+}
+
 func TestThemes(t *testing.T) {
 	suite.Run(t, new(Theme))
 }

--- a/internal/configuration/validator/theme_test.go
+++ b/internal/configuration/validator/theme_test.go
@@ -104,11 +104,48 @@ func (suite *Theme) TestShouldWarnOnCSPTemplateIncompatibility() {
 
 func (suite *Theme) TestShouldNotWarnOnCSPTemplateCompatibility() {
 	suite.config.CustomCSS = "https://example.com/test.css"
-	suite.config.Server.Headers.CSPTemplate = "default-src 'self'; style-src 'self' example.com"
+	testCases := []string{
+		"default-src 'self'; style-src 'self' example.com",
+		"default-src 'self'; style-src 'self' https://example.com",
+		"default-src 'self'; style-src 'self' *",
+		"default-src 'self'; style-src 'self' https://*",
+		"style-src example.com",
+		"default-src example.com",
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc, func(t *testing.T) {
+			suite.SetupTest()
+			suite.config.CustomCSS = "https://example.com/test.css"
+			suite.config.Server.Headers.CSPTemplate = schema.CSPTemplate(tc)
+
+			ValidateTheme(suite.config, suite.validator)
+
+			suite.Assert().Len(suite.validator.Warnings(), 0)
+			suite.Assert().Len(suite.validator.Errors(), 0)
+		})
+	}
+}
+
+func (suite *Theme) TestShouldWarnWhenHostOnlyInNonStyleDirective() {
+	suite.config.CustomCSS = "https://example.com/test.css"
+	suite.config.Server.Headers.CSPTemplate = "default-src 'self'; img-src example.com"
 
 	ValidateTheme(suite.config, suite.validator)
 
-	suite.Assert().Len(suite.validator.Warnings(), 0)
+	suite.Require().Len(suite.validator.Warnings(), 1)
+	suite.Assert().EqualError(suite.validator.Warnings()[0], "option 'custom_css' with value 'https://example.com/test.css' appears to have a host which is not explicitly allowed in the 'server.headers.csp_template' which may prevent it from loading")
+	suite.Assert().Len(suite.validator.Errors(), 0)
+}
+
+func (suite *Theme) TestShouldWarnWhenHostIsSuffixOfAllowedHost() {
+	suite.config.CustomCSS = "https://example.com/test.css"
+	suite.config.Server.Headers.CSPTemplate = "default-src 'self'; style-src 'self' foo.example.com"
+
+	ValidateTheme(suite.config, suite.validator)
+
+	suite.Require().Len(suite.validator.Warnings(), 1)
+	suite.Assert().EqualError(suite.validator.Warnings()[0], "option 'custom_css' with value 'https://example.com/test.css' appears to have a host which is not explicitly allowed in the 'server.headers.csp_template' which may prevent it from loading")
 	suite.Assert().Len(suite.validator.Errors(), 0)
 }
 

--- a/internal/configuration/validator/theme_test.go
+++ b/internal/configuration/validator/theme_test.go
@@ -83,8 +83,33 @@ func (suite *Theme) TestShouldValidateValidCustomCSS() {
 
 			suite.Assert().Len(suite.validator.Warnings(), 0)
 			suite.Assert().Len(suite.validator.Errors(), 0)
+			if tc.have == "https://example.com/test.css" {
+				suite.Assert().NotNil(suite.config.CustomCSSURL)
+				suite.Assert().Equal("example.com", suite.config.CustomCSSURL.Host)
+			}
 		})
 	}
+}
+
+func (suite *Theme) TestShouldWarnOnCSPTemplateIncompatibility() {
+	suite.config.CustomCSS = "https://example.com/test.css"
+	suite.config.Server.Headers.CSPTemplate = "default-src 'self'"
+
+	ValidateTheme(suite.config, suite.validator)
+
+	suite.Require().Len(suite.validator.Warnings(), 1)
+	suite.Assert().EqualError(suite.validator.Warnings()[0], "option 'custom_css' with value 'https://example.com/test.css' appears to have a host which is not explicitly allowed in the 'server.headers.csp_template' which may prevent it from loading")
+	suite.Assert().Len(suite.validator.Errors(), 0)
+}
+
+func (suite *Theme) TestShouldNotWarnOnCSPTemplateCompatibility() {
+	suite.config.CustomCSS = "https://example.com/test.css"
+	suite.config.Server.Headers.CSPTemplate = "default-src 'self'; style-src 'self' example.com"
+
+	ValidateTheme(suite.config, suite.validator)
+
+	suite.Assert().Len(suite.validator.Warnings(), 0)
+	suite.Assert().Len(suite.validator.Errors(), 0)
 }
 
 func TestThemes(t *testing.T) {

--- a/internal/configuration/validator/theme_test.go
+++ b/internal/configuration/validator/theme_test.go
@@ -47,6 +47,7 @@ func (suite *Theme) TestShouldRaiseErrorWhenInvalidCustomCSSProvided() {
 	}{
 		{"ShouldNotValidateOnProtocolRelative", "//example.com/test.css", "option 'custom_css' with value '//example.com/test.css' is invalid: must be an absolute path or an https URL"},
 		{"ShouldNotValidateOnHTTP", "http://example.com/test.css", "option 'custom_css' with value 'http://example.com/test.css' is invalid: must be an absolute path or an https URL"},
+		{"ShouldNotValidateOnHTTPSNoHost", "https:///test.css", "option 'custom_css' with value 'https:///test.css' is invalid: must be an absolute path or an https URL"},
 		{"ShouldNotValidateOnJavascript", "javascript:alert(1)", "option 'custom_css' with value 'javascript:alert(1)' is invalid: must be an absolute path or an https URL"},
 		{"ShouldNotValidateOnRelativePath", "custom.css", "option 'custom_css' with value 'custom.css' is invalid: must be an absolute path or an https URL"},
 	}

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1" //nolint:gosec
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -60,14 +61,24 @@ func ServeTemplatedFile(t templates.Template, opts *TemplatedFileOptions) middle
 
 		nonce := ctx.Providers.Random.StringCustom(32, random.CharSetAlphaNumeric)
 
+		var csp string
+
 		switch {
 		case ctx.Configuration.Server.Headers.CSPTemplate != "":
-			ctx.Response.Header.Add(fasthttp.HeaderContentSecurityPolicy, strings.ReplaceAll(string(ctx.Configuration.Server.Headers.CSPTemplate), placeholderCSPNonce, nonce))
+			csp = strings.ReplaceAll(string(ctx.Configuration.Server.Headers.CSPTemplate), placeholderCSPNonce, nonce)
 		case utils.Dev:
-			ctx.Response.Header.Add(fasthttp.HeaderContentSecurityPolicy, fmt.Sprintf(tmplCSPDevelopment, nonce))
+			csp = fmt.Sprintf(tmplCSPDevelopment, nonce)
 		default:
-			ctx.Response.Header.Add(fasthttp.HeaderContentSecurityPolicy, fmt.Sprintf(tmplCSPDefault, nonce))
+			csp = fmt.Sprintf(tmplCSPDefault, nonce)
 		}
+
+		if ctx.Configuration.CustomCSS != "" && ctx.Configuration.Server.Headers.CSPTemplate == "" {
+			if parsed, err := url.Parse(ctx.Configuration.CustomCSS); err == nil && parsed.Host != "" {
+				csp = strings.Replace(csp, "style-src ", fmt.Sprintf("style-src %s://%s ", parsed.Scheme, parsed.Host), 1)
+			}
+		}
+
+		ctx.Response.Header.Add(fasthttp.HeaderContentSecurityPolicy, csp)
 
 		var (
 			rememberMe string
@@ -231,6 +242,7 @@ func NewTemplatedFileOptions(config *schema.Configuration) (opts *TemplatedFileO
 		PrivacyPolicyAccept:     strFalse,
 		Session:                 "",
 		Theme:                   config.Theme,
+		CustomCSS:               config.CustomCSS,
 		EndpointsPasswordReset:  !config.AuthenticationBackend.PasswordReset.Disable && config.AuthenticationBackend.PasswordReset.CustomURL.String() == "",
 		EndpointsPasswordChange: !config.AuthenticationBackend.PasswordChange.Disable,
 		EndpointsWebAuthn:       !config.WebAuthn.Disable,
@@ -266,6 +278,7 @@ type TemplatedFileOptions struct {
 	PrivacyPolicyAccept    string
 	Session                string
 	Theme                  string
+	CustomCSS              string
 
 	EndpointsPasswordReset  bool
 	EndpointsPasswordChange bool
@@ -301,6 +314,7 @@ func (options *TemplatedFileOptions) CommonData(base, baseURL, domain, nonce, la
 		PrivacyPolicyAccept:    options.PrivacyPolicyAccept,
 		Session:                options.Session,
 		Theme:                  options.Theme,
+		CustomCSS:              options.CustomCSS,
 	}
 }
 
@@ -322,6 +336,7 @@ func (options *TemplatedFileOptions) commonDataWithRememberMe(base, baseURL, dom
 		PrivacyPolicyAccept:    options.PrivacyPolicyAccept,
 		Session:                options.Session,
 		Theme:                  options.Theme,
+		CustomCSS:              options.CustomCSS,
 	}
 }
 
@@ -361,6 +376,7 @@ type TemplatedFileCommonData struct {
 	PrivacyPolicyAccept    string
 	Session                string
 	Theme                  string
+	CustomCSS              string
 }
 
 // TemplatedFileOpenAPIData is a struct which is used for the OpenAPI spec file.

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha1" //nolint:gosec
 	"encoding/hex"
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -72,10 +72,11 @@ func ServeTemplatedFile(t templates.Template, opts *TemplatedFileOptions) middle
 			csp = fmt.Sprintf(tmplCSPDefault, nonce)
 		}
 
-		if ctx.Configuration.CustomCSS != "" && ctx.Configuration.Server.Headers.CSPTemplate == "" {
-			if parsed, err := url.Parse(ctx.Configuration.CustomCSS); err == nil && parsed.Host != "" {
-				csp = strings.Replace(csp, "style-src ", fmt.Sprintf("style-src %s://%s ", parsed.Scheme, parsed.Host), 1)
-			}
+		// If custom_css is an external URL and no custom CSPTemplate is provided, we automatically
+		// append the host to the style-src directive of the default templates.
+		// Note: This relies on the literal "style-src " string being present in tmplCSPDefault/tmplCSPDevelopment.
+		if ctx.Configuration.CustomCSSURL != nil && ctx.Configuration.CustomCSSURL.Scheme != "" && ctx.Configuration.CustomCSSURL.Host != "" && ctx.Configuration.Server.Headers.CSPTemplate == "" {
+			csp = strings.Replace(csp, "style-src ", fmt.Sprintf("style-src %s://%s ", ctx.Configuration.CustomCSSURL.Scheme, ctx.Configuration.CustomCSSURL.Host), 1)
 		}
 
 		ctx.Response.Header.Add(fasthttp.HeaderContentSecurityPolicy, csp)

--- a/internal/server/template_test.go
+++ b/internal/server/template_test.go
@@ -89,55 +89,78 @@ func TestServeTemplatedFile(t *testing.T) {
 		name               string
 		method             string
 		language           string
+		customCSS          string
 		cspTemplate        string
 		expectedStatusCode int
 		expectBody         bool
 		expectCSP          bool
+		expectedCSPStyle   string
 	}{
 		{
 			"ShouldServeIndexWithDefaultLanguage",
 			fasthttp.MethodGet,
 			"",
 			"",
+			"",
 			fasthttp.StatusOK,
 			true,
 			true,
+			"",
+		},
+		{
+			"ShouldServeIndexWithCustomCSSCSP",
+			fasthttp.MethodGet,
+			"",
+			"https://example.com/custom.css",
+			"",
+			fasthttp.StatusOK,
+			true,
+			true,
+			"https://example.com",
 		},
 		{
 			"ShouldServeIndexWithCustomLanguage",
 			fasthttp.MethodGet,
 			"fr",
 			"",
+			"",
 			fasthttp.StatusOK,
 			true,
 			true,
+			"",
 		},
 		{
 			"ShouldServeIndexWithInvalidLanguageFallback",
 			fasthttp.MethodGet,
 			"<script>alert(1)</script>",
 			"",
+			"",
 			fasthttp.StatusOK,
 			true,
 			true,
+			"",
 		},
 		{
 			"ShouldHandleHEADRequest",
 			fasthttp.MethodHead,
 			"",
 			"",
+			"",
 			fasthttp.StatusOK,
 			false,
 			true,
+			"",
 		},
 		{
 			"ShouldUseCustomCSPTemplate",
 			fasthttp.MethodGet,
 			"",
+			"",
 			"default-src 'self'; script-src 'nonce-${NONCE}'",
 			fasthttp.StatusOK,
 			true,
 			true,
+			"",
 		},
 	}
 
@@ -147,6 +170,7 @@ func TestServeTemplatedFile(t *testing.T) {
 			defer mock.Close()
 
 			mock.Ctx.Configuration.Server = schema.DefaultServerConfiguration
+			mock.Ctx.Configuration.CustomCSS = tc.customCSS
 			mock.Ctx.Configuration.Server.Headers.CSPTemplate = schema.CSPTemplate(tc.cspTemplate)
 			mock.Ctx.Configuration.Session = schema.Session{
 				Cookies: []schema.SessionCookie{
@@ -179,6 +203,10 @@ func TestServeTemplatedFile(t *testing.T) {
 			if tc.expectCSP {
 				csp := string(mock.Ctx.Response.Header.Peek(fasthttp.HeaderContentSecurityPolicy))
 				assert.NotEmpty(t, csp)
+
+				if tc.expectedCSPStyle != "" {
+					assert.Contains(t, csp, "style-src "+tc.expectedCSPStyle)
+				}
 			}
 		})
 	}
@@ -271,6 +299,7 @@ func TestNewTemplatedFileOptions(t *testing.T) {
 		expectedResetPassword  string
 		expectedPasswordChange string
 		expectedTheme          string
+		expectedCustomCSS      string
 		expectedPasskeyLogin   string
 	}{
 		{
@@ -278,6 +307,7 @@ func TestNewTemplatedFileOptions(t *testing.T) {
 			&schema.Configuration{},
 			"true",
 			"true",
+			"",
 			"",
 			"false",
 		},
@@ -293,6 +323,7 @@ func TestNewTemplatedFileOptions(t *testing.T) {
 			"false",
 			"true",
 			"",
+			"",
 			"false",
 		},
 		{
@@ -305,6 +336,7 @@ func TestNewTemplatedFileOptions(t *testing.T) {
 			"true",
 			"true",
 			"",
+			"",
 			"true",
 		},
 		{
@@ -315,6 +347,18 @@ func TestNewTemplatedFileOptions(t *testing.T) {
 			"true",
 			"true",
 			"dark",
+			"",
+			"false",
+		},
+		{
+			"ShouldSetCustomCSS",
+			&schema.Configuration{
+				CustomCSS: "https://example.com/custom.css",
+			},
+			"true",
+			"true",
+			"",
+			"https://example.com/custom.css",
 			"false",
 		},
 		{
@@ -329,6 +373,7 @@ func TestNewTemplatedFileOptions(t *testing.T) {
 			"true",
 			"false",
 			"",
+			"",
 			"false",
 		},
 	}
@@ -341,6 +386,7 @@ func TestNewTemplatedFileOptions(t *testing.T) {
 			assert.Equal(t, tc.expectedResetPassword, opts.ResetPassword)
 			assert.Equal(t, tc.expectedPasswordChange, opts.PasswordChange)
 			assert.Equal(t, tc.expectedTheme, opts.Theme)
+			assert.Equal(t, tc.expectedCustomCSS, opts.CustomCSS)
 			assert.Equal(t, tc.expectedPasskeyLogin, opts.PasskeyLogin)
 		})
 	}

--- a/internal/server/template_test.go
+++ b/internal/server/template_test.go
@@ -119,6 +119,17 @@ func TestServeTemplatedFile(t *testing.T) {
 			"https://example.com",
 		},
 		{
+			"ShouldServeIndexWithRelativeCustomCSS",
+			fasthttp.MethodGet,
+			"",
+			"/authelia-custom/style.css",
+			"",
+			fasthttp.StatusOK,
+			true,
+			true,
+			"",
+		},
+		{
 			"ShouldServeIndexWithCustomLanguage",
 			fasthttp.MethodGet,
 			"fr",

--- a/web/index.html
+++ b/web/index.html
@@ -9,6 +9,7 @@
         <link rel="manifest" href="/manifest.json" />
         <link rel="icon" href="/favicon.ico" />
         <title></title>
+        {{ if .CustomCSS }}<link rel="stylesheet" type="text/css" href="{{ .CustomCSS }}">{{ end }}
     </head>
 
     <body


### PR DESCRIPTION
This PR introduces a new root-level configuration option, `custom_css`, allowing administrators to customize the Authelia portal's appearance without requiring a custom build. This supports both local file paths and external URLs.

This feature enables common branding requests, such as adding company names to the login page or setting custom background images, directly addressing two of the project's top 5 most upvoted discussions: [#7469](https://github.com/authelia/authelia/discussions/7469) and [#5169](https://github.com/authelia/authelia/discussions/5169)

## Key Changes

  * **Configuration:** Added `custom_css` to the root configuration schema.
  * **Security & CSP:** If an external URL is provided, the domain is appended to the `style-src` Content Security Policy directive. This ensures the custom stylesheet is loaded without requiring manual CSP overrides.
    * *Other resources*,  like images referenced in the CSS must be hosted on the same origin as Authelia (e.g., by mounting an assets folder into the Docker container and using a relative path), due to the existing CSP policy.
  * **Frontend:** Renders the `<link>` tag server-side via Go templates at the end of the `<head>` section.

## Example Customization

<img width="844" height="971" alt="authelia customized login page with custom_css" src="https://github.com/user-attachments/assets/668743f2-03d3-4f11-8343-77bcf7dc2ddb" />