### PR TITLE
docs: update systemd-socket-activate address example

### DIFF
--- a/docs/content/configuration/miscellaneous/server.md
+++ b/docs/content/configuration/miscellaneous/server.md
@@ -86,7 +86,7 @@ server:
 ```yaml
 # When running "systemd-socket-activate -l 9091 go run ./cmd/authelia", the connections to port 9091 will be forwarded to file descriptor 3.
 server:
-  address: fd://:3
+  address: fd://3
 ```
 
 ### asset_path


### PR DESCRIPTION
The example in the [Server section](https://www.authelia.com/configuration/miscellaneous/server/#examples) of the documentation uses an invalid syntax for systemd-socket-activated sockets.

In the [Common section](https://www.authelia.com/configuration/prologue/common/#format), the syntax is correct.