### PR TITLE
build(deps): update dependency postcss to v8.5.10 [security]

### DIFF
--- a/internal/templates/src/package.json
+++ b/internal/templates/src/package.json
@@ -29,9 +29,9 @@
   },
   "pnpm": {
     "overrides": {
-      "@babel/traverse": "7.29.0",
       "@babel/helpers": "7.29.2",
       "@babel/runtime": "7.29.2",
+      "@babel/traverse": "7.29.0",
       "ajv": "8.20.0",
       "brace-expansion": "5.0.5",
       "flatted": "3.4.2",
@@ -40,6 +40,7 @@
       "minimatch": "10.2.5",
       "nanoid": "5.1.9",
       "picomatch": "4.0.4",
+      "postcss": "8.5.12",
       "prismjs": "1.30.0",
       "rollup": "4.60.2",
       "socket.io-parser": "4.2.6",


### PR DESCRIPTION
## 🛡️ Security Vulnerability Overrides

Adds `pnpm.overrides` entries to pin transitive deps to their latest published version, then regenerates each affected lockfile.

### Vulnerabilities Addressed

| Severity | Package | Override | Advisory | Manifest |
|----------|---------|----------|----------|----------|
| 🟡 medium | `postcss` | `8.5.10` | [GHSA-qx2v-qp2m-jg93](https://github.com/authelia/authelia/security/dependabot/226) | `internal/templates/src/pnpm-lock.yaml` |

### Changed Files

- `internal/templates/src/package.json`

### Review Checklist

1. Verify overrides in each `package.json`.
2. Confirm each `pnpm-lock.yaml` resolves patched versions.
3. Run CI for regressions.