### PR TITLE
build(deps): update dependency postcss to v8.5.10 [security]

### DIFF
--- a/internal/templates/src/package.json
+++ b/internal/templates/src/package.json
@@ -29,9 +29,9 @@
   },
   "pnpm": {
     "overrides": {
-      "@babel/traverse": "7.29.0",
       "@babel/helpers": "7.29.2",
       "@babel/runtime": "7.29.2",
+      "@babel/traverse": "7.29.0",
       "ajv": "8.20.0",
       "brace-expansion": "5.0.5",
       "flatted": "3.4.2",
@@ -40,6 +40,7 @@
       "minimatch": "10.2.5",
       "nanoid": "5.1.9",
       "picomatch": "4.0.4",
+      "postcss": "8.5.12",
       "prismjs": "1.30.0",
       "rollup": "4.60.2",
       "socket.io-parser": "4.2.6",

--- a/internal/templates/src/pnpm-lock.yaml
+++ b/internal/templates/src/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@babel/traverse': 7.29.0
   '@babel/helpers': 7.29.2
   '@babel/runtime': 7.29.2
+  '@babel/traverse': 7.29.0
   ajv: 8.20.0
   brace-expansion: 5.0.5
   flatted: 3.4.2
@@ -16,6 +16,7 @@ overrides:
   minimatch: 10.2.5
   nanoid: 5.1.9
   picomatch: 4.0.4
+  postcss: 8.5.12
   prismjs: 1.30.0
   rollup: 4.60.2
   socket.io-parser: 4.2.6
@@ -1522,12 +1523,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2965,7 +2962,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001759
-      postcss: 8.4.31
+      postcss: 8.5.12
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(react@19.2.5)
@@ -3050,13 +3047,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 5.1.9
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.10:
+  postcss@8.5.12:
     dependencies:
       nanoid: 5.1.9
       picocolors: 1.1.1
@@ -3325,7 +3316,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.12
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## 🛡️ Security Vulnerability Overrides

Adds `pnpm.overrides` entries to pin transitive deps to their latest published version, then regenerates each affected lockfile.

### Vulnerabilities Addressed

| Severity | Package | Override | Advisory | Manifest |
|----------|---------|----------|----------|----------|
| 🟡 medium | `postcss` | `8.5.10` | [GHSA-qx2v-qp2m-jg93](https://github.com/authelia/authelia/security/dependabot/226) | `internal/templates/src/pnpm-lock.yaml` |

### Changed Files

- `internal/templates/src/package.json`
- `internal/templates/src/pnpm-lock.yaml`

### Review Checklist

1. Verify overrides in each `package.json`.
2. Confirm each `pnpm-lock.yaml` resolves patched versions.
3. Run CI for regressions.