### PR TITLE
fix(metrics): go collectors not registered

### DIFF
--- a/experimental/embed/provider/general.go
+++ b/experimental/embed/provider/general.go
@@ -55,7 +55,9 @@ func NewRegulator(config *schema.Configuration, storage storage.RegulatorProvide
 
 // NewMetrics creates a new metrics.Provider.
 func NewMetrics() metrics.Provider {
-	return metrics.NewPrometheus()
+	provider, _ := metrics.NewPrometheus()
+
+	return provider
 }
 
 // NewNTP creates a new *ntp.Provider given a valid configuration.

--- a/internal/metrics/prometheus.go
+++ b/internal/metrics/prometheus.go
@@ -5,16 +5,19 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // NewPrometheus returns a new Prometheus metrics recorder.
-func NewPrometheus() (provider *Prometheus) {
+func NewPrometheus() (provider *Prometheus, err error) {
 	provider = &Prometheus{}
 
-	provider.register()
+	if err = provider.register(); err != nil {
+		return nil, err
+	}
 
-	return provider
+	return provider, nil
 }
 
 // Prometheus is a middleware for recording prometheus metrics.
@@ -72,8 +75,16 @@ func (r *Prometheus) RecordAuthenticationDuration(success bool, elapsed time.Dur
 	r.authnDuration.WithLabelValues(strconv.FormatBool(success)).Observe(elapsed.Seconds())
 }
 
-func (r *Prometheus) register() {
+func (r *Prometheus) register() (err error) {
 	r.registry = prometheus.NewRegistry()
+
+	if err = r.registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})); err != nil {
+		return err
+	}
+
+	if err = r.registry.Register(collectors.NewGoCollector()); err != nil {
+		return err
+	}
 
 	r.authnDuration = promauto.With(r.registry).NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -149,4 +160,6 @@ func (r *Prometheus) register() {
 		},
 		[]string{"success", "banned", "type"},
 	)
+
+	return nil
 }

--- a/internal/metrics/prometheus_test.go
+++ b/internal/metrics/prometheus_test.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPrometheus(t *testing.T) {
-	p := NewPrometheus()
-
-	assert.NotNil(t, p)
+	p, err := NewPrometheus()
+	assert.NoError(t, err)
+	require.NotNil(t, p)
 
 	p.RecordRequest("400", "GET", time.Second)
 	p.RecordAuthz("400")

--- a/internal/middlewares/authelia_context_blackbox_test.go
+++ b/internal/middlewares/authelia_context_blackbox_test.go
@@ -1355,7 +1355,11 @@ func TestAutheliaCtx_RecordAuthn(t *testing.T) {
 		ctx.RecordAuthn(true, true, "password")
 	})
 
-	ctx.Providers.Metrics = metrics.NewPrometheus()
+	var err error
+
+	ctx.Providers.Metrics, err = metrics.NewPrometheus()
+
+	require.NoError(t, err)
 
 	assert.NotPanics(t, func() {
 		ctx.RecordAuthn(true, true, "password")

--- a/internal/middlewares/util.go
+++ b/internal/middlewares/util.go
@@ -66,7 +66,9 @@ func NewProviders(config *schema.Configuration, caCertPool *x509.CertPool) (prov
 	providers.OpenIDConnect = oidc.NewOpenIDConnectProvider(config, providers.StorageProvider, providers.Templates)
 
 	if config.Telemetry.Metrics.Enabled {
-		providers.Metrics = metrics.NewPrometheus()
+		if providers.Metrics, err = metrics.NewPrometheus(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return providers, warns, errs

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -497,6 +497,7 @@ func handlerMetrics(provider metrics.Provider, path string) fasthttp.RequestHand
 	r := router.New()
 
 	registerer := provider.GetRegisterer()
+
 	gatherer := provider.GetGatherer()
 
 	handler := promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -241,6 +241,13 @@ func TestShouldServeProperlyWhenMutualTLSIsConfiguredAndClientIsAuthenticated(t 
 }
 
 func TestNewMetrics(t *testing.T) {
+	mustNewPrometheus := func(t *testing.T) metrics.Provider {
+		prometheus, err := metrics.NewPrometheus()
+		require.NoError(t, err)
+
+		return prometheus
+	}
+
 	testCases := []struct {
 		name           string
 		config         *schema.Configuration
@@ -270,7 +277,7 @@ func TestNewMetrics(t *testing.T) {
 				},
 			},
 			middlewares.Providers{
-				Metrics: metrics.NewPrometheus(),
+				Metrics: mustNewPrometheus(t),
 			},
 			true,
 			true,

--- a/internal/service/server_test.go
+++ b/internal/service/server_test.go
@@ -66,7 +66,8 @@ func TestNewMetricsServer(t *testing.T) {
 	providers.Templates, err = templates.New(templates.Config{})
 	require.NoError(t, err)
 
-	providers.Metrics = metrics.NewPrometheus()
+	providers.Metrics, err = metrics.NewPrometheus()
+	require.NoError(t, err)
 
 	address, err := schema.NewAddress("tcp://:9891/metrics")
 	require.NoError(t, err)


### PR DESCRIPTION
This ensures the standard go collectors are registered.