### PR TITLE
feat(notification): support fifo destinations for filesystem notifier

### DIFF
--- a/docs/content/configuration/notifications/file.md
+++ b/docs/content/configuration/notifications/file.md
@@ -41,3 +41,15 @@ This section describes the individual configuration options.
 {{< confkey type="string" required="yes" >}}
 
 The file to add email text to. If it doesn't exist it will be created.
+
+If `filename` points to an existing FIFO (named pipe), Authelia detects this from the file mode and writes notifications
+to the pipe instead of a regular file. The startup check leaves the FIFO untouched and the per-notification write skips
+the disk sync that is unsupported on pipes. The byte stream written to the pipe is identical to the regular-file format,
+so any tooling that already parses notifications continues to work.
+
+The FIFO must be created by the operator with `mkfifo` before Authelia starts; Authelia will not create one. A reader
+must be attached on the other end of the pipe. If no reader is connected when a notification is generated, the write
+blocks until one is.
+
+Use the `authelia debug notification` subcommand to verify the configured notifier (file, FIFO, or SMTP) without
+exercising the full identity verification flow.

--- a/docs/content/reference/cli/authelia/authelia_debug.md
+++ b/docs/content/reference/cli/authelia/authelia_debug.md
@@ -2,7 +2,7 @@
 title: "authelia debug"
 description: "Reference for the authelia debug command."
 lead: ""
-date: 2026-04-02T15:48:21+11:00
+date: 2025-04-20T03:35:43+00:00
 draft: false
 images: []
 weight: 905
@@ -47,6 +47,7 @@ authelia debug --help
 
 * [authelia](authelia.md)	 - authelia untagged-unknown-dirty (master, unknown)
 * [authelia debug expression](authelia_debug_expression.md)	 - Perform a user attribute expression debug operation
+* [authelia debug notification](authelia_debug_notification.md)	 - Perform a notifier debug operation
 * [authelia debug oidc](authelia_debug_oidc.md)	 - Perform a OpenID Connect 1.0 debug operation
 * [authelia debug tls](authelia_debug_tls.md)	 - Perform a TLS debug operation
 

--- a/docs/content/reference/cli/authelia/authelia_debug_notification.md
+++ b/docs/content/reference/cli/authelia/authelia_debug_notification.md
@@ -1,0 +1,55 @@
+---
+title: "authelia debug notification"
+description: "Reference for the authelia debug notification command."
+lead: ""
+date: 2026-04-30T14:44:59+10:00
+draft: false
+images: []
+weight: 905
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia debug notification
+
+Perform a notifier debug operation
+
+### Synopsis
+
+Perform a notifier debug operation.
+
+This subcommand loads the Authelia configuration, runs the notifier startup check, and dispatches a single test notification. It is useful for verifying that the SMTP server, filesystem path, or named-pipe consumer is reachable.
+
+```
+authelia debug notification [flags]
+```
+
+### Examples
+
+```
+authelia debug notification --recipient admin@example.com --subject "Test"
+```
+
+### Options
+
+```
+  -h, --help               help for notification
+      --recipient string   recipient email address used for the test notification (default "test@example.com")
+      --subject string     subject line for the test notification (default "Authelia notifier debug")
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config strings                        configuration files or directories to load, for more information run 'authelia -h authelia config' (default [configuration.yml])
+      --config.experimental.filters strings   list of filters to apply to all configuration files, for more information run 'authelia -h authelia filters'
+```
+
+### SEE ALSO
+
+* [authelia debug](authelia_debug.md)	 - Perform debug functions
+

--- a/internal/commands/const.go
+++ b/internal/commands/const.go
@@ -741,6 +741,14 @@ This subcommand allows checking certain OpenID Connect 1.0 scenarios.`
 This subcommand allows checking an OpenID Connect 1.0 claims hydration scenario by providing certain information about a request.`
 
 	cmdAutheliaDebugOIDCClaimsExample = `authelia debug oidc claims --help`
+
+	cmdAutheliaDebugNotificationShort = "Perform a notifier debug operation"
+
+	cmdAutheliaDebugNotificationLong = `Perform a notifier debug operation.
+
+This subcommand loads the Authelia configuration, runs the notifier startup check, and dispatches a single test notification. It is useful for verifying that the SMTP server, filesystem path, or named-pipe consumer is reachable.`
+
+	cmdAutheliaDebugNotificationExample = `authelia debug notification --recipient admin@example.com --subject "Test"`
 )
 
 const (

--- a/internal/commands/debug.go
+++ b/internal/commands/debug.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/mail"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,7 +24,9 @@ import (
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/expression"
 	"github.com/authelia/authelia/v4/internal/middlewares"
+	"github.com/authelia/authelia/v4/internal/notification"
 	"github.com/authelia/authelia/v4/internal/oidc"
+	"github.com/authelia/authelia/v4/internal/templates"
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
@@ -41,9 +45,88 @@ func newDebugCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 		newDebugTLSCmd(ctx),
 		newDebugExpressionCmd(ctx),
 		newDebugOIDCCmd(ctx),
+		newDebugNotificationCmd(ctx),
 	)
 
 	return cmd
+}
+
+func newDebugNotificationCmd(ctx *CmdCtx) (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:     "notification",
+		Short:   cmdAutheliaDebugNotificationShort,
+		Long:    cmdAutheliaDebugNotificationLong,
+		Example: cmdAutheliaDebugNotificationExample,
+		Args:    cobra.NoArgs,
+		RunE:    ctx.DebugNotificationRunE,
+		PreRunE: ctx.ChainRunE(
+			ctx.HelperConfigLoadRunE,
+			ctx.HelperConfigValidateKeysRunE,
+			ctx.HelperConfigValidateRunE,
+			ctx.LoadTrustedCertificatesRunE,
+		),
+		DisableAutoGenTag: true,
+	}
+
+	cmd.Flags().String("recipient", "test@example.com", "recipient email address used for the test notification")
+	cmd.Flags().String("subject", "Authelia notifier debug", "subject line for the test notification")
+
+	return cmd
+}
+
+func (ctx *CmdCtx) DebugNotificationRunE(cmd *cobra.Command, _ []string) (err error) {
+	return runDebugNotification(cmd.OutOrStdout(), cmd.Flags(), ctx.config, ctx.trusted)
+}
+
+func runDebugNotification(w io.Writer, flags *pflag.FlagSet, config *schema.Configuration, caCertPool *x509.CertPool) (err error) {
+	var (
+		recipientRaw, subject string
+	)
+
+	if recipientRaw, err = flags.GetString("recipient"); err != nil {
+		return err
+	}
+
+	if subject, err = flags.GetString("subject"); err != nil {
+		return err
+	}
+
+	rcpt, err := mail.ParseAddress(recipientRaw)
+	if err != nil {
+		return fmt.Errorf("invalid recipient: %w", err)
+	}
+
+	var n notification.Notifier
+
+	switch {
+	case config.Notifier.SMTP != nil:
+		n = notification.NewSMTPNotifier(config.Notifier.SMTP, caCertPool)
+	case config.Notifier.FileSystem != nil:
+		n = notification.NewFileNotifier(*config.Notifier.FileSystem)
+	default:
+		return errors.New("no notifier is configured")
+	}
+
+	_, _ = fmt.Fprintf(w, "Running notifier startup check...\n")
+
+	if err = n.StartupCheck(); err != nil {
+		return fmt.Errorf("notifier startup check failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(w, "Startup check OK.\n")
+
+	tmpl := template.Must(template.New("text").Parse("This is a test notification from `authelia debug notification`.\n"))
+	et := &templates.EmailTemplate{Text: tmpl}
+
+	_, _ = fmt.Fprintf(w, "Sending test notification to %s...\n", rcpt.Address)
+
+	if err = n.Send(context.Background(), *rcpt, subject, et, nil); err != nil {
+		return fmt.Errorf("notifier send failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(w, "Notification sent successfully.\n")
+
+	return nil
 }
 
 func newDebugTLSCmd(ctx *CmdCtx) (cmd *cobra.Command) {

--- a/internal/commands/debug.go
+++ b/internal/commands/debug.go
@@ -8,10 +8,11 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	th "html/template"
 	"io"
 	"net/mail"
 	"strings"
-	"text/template"
+	tt "text/template"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -115,8 +116,12 @@ func runDebugNotification(w io.Writer, flags *pflag.FlagSet, config *schema.Conf
 
 	_, _ = fmt.Fprintf(w, "Startup check OK.\n")
 
-	tmpl := template.Must(template.New("text").Parse("This is a test notification from `authelia debug notification`.\n"))
-	et := &templates.EmailTemplate{Text: tmpl}
+	const body = "This is a test notification from `authelia debug notification`.\n"
+
+	et := &templates.EmailTemplate{
+		Text: tt.Must(tt.New("text").Parse(body)),
+		HTML: th.Must(th.New("html").Parse(body)),
+	}
 
 	_, _ = fmt.Fprintf(w, "Sending test notification to %s...\n", rcpt.Address)
 

--- a/internal/commands/debug_test.go
+++ b/internal/commands/debug_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509/pkix"
 	"math/big"
 	"net"
+	"net/mail"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,6 +43,157 @@ func TestNewDebugCmds(t *testing.T) {
 
 	cmd = newDebugTLSCmd(&CmdCtx{})
 	assert.NotNil(t, cmd)
+
+	cmd = newDebugNotificationCmd(&CmdCtx{})
+	assert.NotNil(t, cmd)
+}
+
+func TestDebugNotificationRunE(t *testing.T) {
+	testCases := []struct {
+		name     string
+		setup    func(t *testing.T) (*pflag.FlagSet, *schema.Configuration)
+		err      string
+		expected []string
+	}{
+		{
+			"ShouldErrFlagRecipientNotDefined",
+			func(t *testing.T) (*pflag.FlagSet, *schema.Configuration) {
+				flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+				flags.String("subject", "Test", "")
+
+				return flags, &schema.Configuration{}
+			},
+			"flag accessed but not defined: recipient",
+			nil,
+		},
+		{
+			"ShouldErrFlagSubjectNotDefined",
+			func(t *testing.T) (*pflag.FlagSet, *schema.Configuration) {
+				flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+				flags.String("recipient", "test@example.com", "")
+
+				return flags, &schema.Configuration{}
+			},
+			"flag accessed but not defined: subject",
+			nil,
+		},
+		{
+			"ShouldErrInvalidRecipient",
+			func(t *testing.T) (*pflag.FlagSet, *schema.Configuration) {
+				return newNotificationFlags("not-an-email", "Test"), &schema.Configuration{}
+			},
+			"invalid recipient",
+			nil,
+		},
+		{
+			"ShouldErrNoNotifierConfigured",
+			func(t *testing.T) (*pflag.FlagSet, *schema.Configuration) {
+				return newNotificationFlags("test@example.com", "Test"), &schema.Configuration{}
+			},
+			"no notifier is configured",
+			nil,
+		},
+		{
+			"ShouldErrFileSystemStartupCheckFailure",
+			func(t *testing.T) (*pflag.FlagSet, *schema.Configuration) {
+				dir := t.TempDir()
+				regfile := filepath.Join(dir, "regfile")
+				require.NoError(t, os.WriteFile(regfile, []byte("x"), 0o600))
+
+				return newNotificationFlags("test@example.com", "Test"), &schema.Configuration{
+					Notifier: schema.Notifier{
+						FileSystem: &schema.NotifierFileSystem{
+							Filename: filepath.Join(regfile, "sub", "notify.log"),
+						},
+					},
+				}
+			},
+			"notifier startup check failed",
+			nil,
+		},
+		{
+			"ShouldErrSMTPNotifierStartupCheckFailure",
+			func(t *testing.T) (*pflag.FlagSet, *schema.Configuration) {
+				return newNotificationFlags("test@example.com", "Test"), &schema.Configuration{
+					Notifier: schema.Notifier{
+						SMTP: &schema.NotifierSMTP{
+							Address: schema.NewSMTPAddress("smtp", "127.0.0.1", 1),
+							Sender:  mail.Address{Address: "authelia@example.com"},
+						},
+					},
+				}
+			},
+			"notifier startup check failed",
+			nil,
+		},
+		{
+			"ShouldSucceedFileSystemNotifier",
+			func(t *testing.T) (*pflag.FlagSet, *schema.Configuration) {
+				dir := t.TempDir()
+
+				return newNotificationFlags("john.doe@authelia.com", "DebugTest"), &schema.Configuration{
+					Notifier: schema.Notifier{
+						FileSystem: &schema.NotifierFileSystem{Filename: filepath.Join(dir, "notify.log")},
+					},
+				}
+			},
+			"",
+			[]string{
+				"Running notifier startup check...",
+				"Startup check OK.",
+				"Sending test notification to john.doe@authelia.com",
+				"Notification sent successfully.",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags, config := tc.setup(t)
+
+			buf := new(bytes.Buffer)
+
+			err := runDebugNotification(buf, flags, config, nil)
+
+			if tc.err == "" {
+				assert.NoError(t, err)
+
+				for _, s := range tc.expected {
+					assert.Contains(t, buf.String(), s)
+				}
+			} else {
+				assert.ErrorContains(t, err, tc.err)
+			}
+		})
+	}
+
+	t.Run("ShouldSucceedRunECmd", func(t *testing.T) {
+		dir := t.TempDir()
+
+		cmdCtx := NewCmdCtx()
+		cmdCtx.config = &schema.Configuration{
+			Notifier: schema.Notifier{
+				FileSystem: &schema.NotifierFileSystem{Filename: filepath.Join(dir, "notify.log")},
+			},
+		}
+
+		cmd, buf := newTestCmdWithBuf()
+		cmd.Flags().String("recipient", "john.doe@authelia.com", "")
+		cmd.Flags().String("subject", "Test", "")
+
+		err := cmdCtx.DebugNotificationRunE(cmd, []string{})
+
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "Notification sent successfully.")
+	})
+}
+
+func newNotificationFlags(recipient, subject string) *pflag.FlagSet {
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("recipient", recipient, "")
+	flags.String("subject", subject, "")
+
+	return flags
 }
 
 // testUserDatabaseContent is a minimal user database for testing.

--- a/internal/notification/file_notifier.go
+++ b/internal/notification/file_notifier.go
@@ -77,6 +77,13 @@ func (n *FileNotifier) Send(_ context.Context, recipient mail.Address, subject s
 
 	defer f.Close()
 
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	fifo = info.Mode()&os.ModeNamedPipe != 0
+
 	w := bufio.NewWriter(f)
 
 	if _, err = fmt.Fprintf(w, fileNotifierHeader, time.Now(), recipient, subject); err != nil {

--- a/internal/notification/file_notifier.go
+++ b/internal/notification/file_notifier.go
@@ -37,10 +37,15 @@ func (n *FileNotifier) StartupCheck() (err error) {
 		} else {
 			return err
 		}
-	} else if _, err = os.Stat(n.path); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
+	}
+
+	fifo, err := isFIFO(n.path)
+	if err != nil {
+		return err
+	}
+
+	if fifo {
+		return nil
 	}
 
 	return os.WriteFile(n.path, []byte(""), fileNotifierMode)
@@ -48,11 +53,18 @@ func (n *FileNotifier) StartupCheck() (err error) {
 
 // Send send a identity verification link to a user.
 func (n *FileNotifier) Send(_ context.Context, recipient mail.Address, subject string, et *templates.EmailTemplate, data any) (err error) {
+	fifo, err := isFIFO(n.path)
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
 	var f *os.File
 
 	var flag int
 
 	switch {
+	case fifo:
+		flag = os.O_WRONLY
 	case n.append:
 		flag = os.O_APPEND | os.O_CREATE | os.O_WRONLY
 	default:
@@ -83,9 +95,24 @@ func (n *FileNotifier) Send(_ context.Context, recipient mail.Address, subject s
 		return fmt.Errorf("failed to flush buffer: %w", err)
 	}
 
-	if err = f.Sync(); err != nil {
-		return fmt.Errorf("failed to sync the file: %w", err)
+	if !fifo {
+		if err = f.Sync(); err != nil {
+			return fmt.Errorf("failed to sync the file: %w", err)
+		}
 	}
 
 	return nil
+}
+
+func isFIFO(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return info.Mode()&os.ModeNamedPipe != 0, nil
 }

--- a/internal/notification/file_notifier_test.go
+++ b/internal/notification/file_notifier_test.go
@@ -254,7 +254,20 @@ func TestFileNotifier_Send_FIFOWritesIdenticalBytesToReader(t *testing.T) {
 	et := &templates.EmailTemplate{Text: tmpl}
 	rcpt := mail.Address{Name: "John Doe", Address: "john@example.com"}
 
-	require.NoError(t, n.Send(context.Background(), rcpt, "FIFOSubject", et, map[string]string{"User": "World"}))
+	sendErr := make(chan error, 1)
+
+	go func() {
+		sendErr <- n.Send(context.Background(), rcpt, "FIFOSubject", et, map[string]string{"User": "World"})
+	}()
+
+	deadline := time.After(5 * time.Second)
+
+	select {
+	case err := <-sendErr:
+		require.NoError(t, err)
+	case <-deadline:
+		t.Fatal("notifier Send blocked; FIFO reader did not connect")
+	}
 
 	select {
 	case r := <-got:
@@ -266,7 +279,7 @@ func TestFileNotifier_Send_FIFOWritesIdenticalBytesToReader(t *testing.T) {
 		assert.Contains(t, content, "Hello World")
 		assert.Contains(t, content, "Date: ")
 		assert.Contains(t, content, "Recipient: ")
-	case <-time.After(5 * time.Second):
+	case <-deadline:
 		t.Fatal("FIFO reader timed out; notifier did not write to the pipe")
 	}
 }

--- a/internal/notification/file_notifier_test.go
+++ b/internal/notification/file_notifier_test.go
@@ -3,11 +3,14 @@ package notification
 import (
 	"bufio"
 	"context"
+	"io"
 	"net/mail"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -175,6 +178,96 @@ func TestFileNotifier_Send(t *testing.T) {
 				assert.NotContains(t, content, s)
 			}
 		})
+	}
+}
+
+func TestIsFIFO(t *testing.T) {
+	base := t.TempDir()
+
+	t.Run("MissingPathReturnsFalse", func(t *testing.T) {
+		fifo, err := isFIFO(filepath.Join(base, "does-not-exist"))
+		require.NoError(t, err)
+		assert.False(t, fifo)
+	})
+
+	t.Run("RegularFileReturnsFalse", func(t *testing.T) {
+		path := filepath.Join(base, "regular")
+		require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+
+		fifo, err := isFIFO(path)
+		require.NoError(t, err)
+		assert.False(t, fifo)
+	})
+
+	t.Run("FIFOReturnsTrue", func(t *testing.T) {
+		path := filepath.Join(base, "pipe")
+		require.NoError(t, syscall.Mkfifo(path, 0o600))
+
+		fifo, err := isFIFO(path)
+		require.NoError(t, err)
+		assert.True(t, fifo)
+	})
+}
+
+func TestFileNotifier_StartupCheck_FIFOIsLeftUntouched(t *testing.T) {
+	base := t.TempDir()
+	path := filepath.Join(base, "notify.fifo")
+	require.NoError(t, syscall.Mkfifo(path, 0o600))
+
+	n := NewFileNotifier(schema.NotifierFileSystem{Filename: path})
+
+	require.NoError(t, n.StartupCheck())
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeNamedPipe, "StartupCheck must not replace the FIFO with a regular file")
+}
+
+func TestFileNotifier_Send_FIFOWritesIdenticalBytesToReader(t *testing.T) {
+	base := t.TempDir()
+	fifoPath := filepath.Join(base, "notify.fifo")
+	require.NoError(t, syscall.Mkfifo(fifoPath, 0o600))
+
+	type readResult struct {
+		data []byte
+		err  error
+	}
+
+	got := make(chan readResult, 1)
+
+	go func() {
+		f, err := os.OpenFile(fifoPath, os.O_RDONLY, 0)
+		if err != nil {
+			got <- readResult{nil, err}
+
+			return
+		}
+
+		defer f.Close()
+
+		b, err := io.ReadAll(f)
+		got <- readResult{b, err}
+	}()
+
+	n := NewFileNotifier(schema.NotifierFileSystem{Filename: fifoPath})
+	tmpl := template.Must(template.New("text").Parse("Hello {{ .User }}"))
+	et := &templates.EmailTemplate{Text: tmpl}
+	rcpt := mail.Address{Name: "John Doe", Address: "john@example.com"}
+
+	require.NoError(t, n.Send(context.Background(), rcpt, "FIFOSubject", et, map[string]string{"User": "World"}))
+
+	select {
+	case r := <-got:
+		require.NoError(t, r.err)
+
+		content := string(r.data)
+		assert.Contains(t, content, "Subject: FIFOSubject")
+		assert.Contains(t, content, "john@example.com")
+		assert.Contains(t, content, "Hello World")
+		assert.Contains(t, content, "Date: ")
+		assert.Contains(t, content, "Recipient: ")
+	case <-time.After(5 * time.Second):
+		t.Fatal("FIFO reader timed out; notifier did not write to the pipe")
 	}
 }
 

--- a/internal/notification/file_notifier_test.go
+++ b/internal/notification/file_notifier_test.go
@@ -22,13 +22,13 @@ import (
 func TestFileNotifier_StartupCheck(t *testing.T) {
 	testCases := []struct {
 		name       string
-		setup      func(base string) string
+		setup      func(t *testing.T, base string) string
 		expectErr  bool
 		verifyFile func(t *testing.T, path string)
 	}{
 		{
 			name: "ShouldReturnErrorWhenParentIsFile",
-			setup: func(base string) string {
+			setup: func(t *testing.T, base string) string {
 				parent := filepath.Join(base, "notadir")
 				require.NoError(t, os.WriteFile(parent, []byte("x"), 0o600))
 
@@ -38,8 +38,38 @@ func TestFileNotifier_StartupCheck(t *testing.T) {
 			verifyFile: func(t *testing.T, path string) {},
 		},
 		{
+			name: "ShouldReturnErrorWhenStatDirFails",
+			setup: func(t *testing.T, base string) string {
+				regfile := filepath.Join(base, "regfile")
+				require.NoError(t, os.WriteFile(regfile, []byte("x"), 0o600))
+
+				return filepath.Join(regfile, "sub", "notify.log")
+			},
+			expectErr:  true,
+			verifyFile: func(t *testing.T, path string) {},
+		},
+		{
+			name: "ShouldReturnErrorWhenMkdirAllFails",
+			setup: func(t *testing.T, base string) string {
+				if os.Geteuid() == 0 {
+					t.Skip("running as root bypasses directory permissions")
+				}
+
+				parent := filepath.Join(base, "readonly")
+				require.NoError(t, os.MkdirAll(parent, 0o500))
+
+				t.Cleanup(func() {
+					_ = os.Chmod(parent, 0o700)
+				})
+
+				return filepath.Join(parent, "sub", "notify.log")
+			},
+			expectErr:  true,
+			verifyFile: func(t *testing.T, path string) {},
+		},
+		{
 			name: "ShouldSucceedWhenParentIsDir",
-			setup: func(base string) string {
+			setup: func(t *testing.T, base string) string {
 				parent := filepath.Join(base, "adir")
 				require.NoError(t, os.MkdirAll(parent, 0o755))
 
@@ -54,7 +84,7 @@ func TestFileNotifier_StartupCheck(t *testing.T) {
 		},
 		{
 			name: "ShouldCreateParentDirectoryWhenMissing",
-			setup: func(base string) string {
+			setup: func(t *testing.T, base string) string {
 				return filepath.Join(base, "nested", "dir", "notify.log")
 			},
 			expectErr: false,
@@ -70,7 +100,7 @@ func TestFileNotifier_StartupCheck(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			base := t.TempDir()
-			path := tc.setup(base)
+			path := tc.setup(t, base)
 			n := NewFileNotifier(schema.NotifierFileSystem{Filename: path})
 
 			err := n.StartupCheck()
@@ -90,6 +120,7 @@ func TestFileNotifier_Send(t *testing.T) {
 		name            string
 		appendMode      bool
 		setpathbase     bool
+		setpathstaterr  bool
 		preContent      string
 		subject         string
 		data            any
@@ -123,6 +154,14 @@ func TestFileNotifier_Send(t *testing.T) {
 			data:            map[string]string{"User": "Y"},
 			expectErrSubstr: "failed to open file",
 		},
+		{
+			name:            "ShouldReturnErrorWhenStatFails",
+			appendMode:      false,
+			setpathstaterr:  true,
+			subject:         "X",
+			data:            map[string]string{"User": "Y"},
+			expectErrSubstr: "failed to stat file",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -130,11 +169,16 @@ func TestFileNotifier_Send(t *testing.T) {
 			base := t.TempDir()
 			filePath := filepath.Join(base, "notify.log")
 
-			if tc.setpathbase {
+			switch {
+			case tc.setpathbase:
 				filePath = base
+			case tc.setpathstaterr:
+				regfile := filepath.Join(base, "regfile")
+				require.NoError(t, os.WriteFile(regfile, []byte("x"), 0o600))
+				filePath = filepath.Join(regfile, "sub", "notify.log")
 			}
 
-			if tc.preContent != "" && tc.name != "ShouldReturnErrorWhenOpenFileFails" {
+			if tc.preContent != "" && !tc.setpathbase {
 				require.NoError(t, os.WriteFile(filePath, []byte(tc.preContent), 0o600))
 			}
 

--- a/internal/suites/CLI/configuration.yml
+++ b/internal/suites/CLI/configuration.yml
@@ -17,7 +17,7 @@ storage:
 
 notifier:
   filesystem:
-    filename: '/tmp/notification.txt'
+    filename: '/tmp/authelia/CLISuite/notification.fifo'
 
 identity_validation:
   reset_password:

--- a/internal/suites/suite_cli.go
+++ b/internal/suites/suite_cli.go
@@ -2,12 +2,19 @@ package suites
 
 import (
 	"os"
+	"syscall"
 	"time"
 )
 
 var cliSuiteName = "CLI"
 
+const cliSuiteFIFOPath = "/tmp/authelia/CLISuite/notification.fifo"
+
 func init() {
+	_ = os.MkdirAll("/tmp/authelia/CLISuite/", 0o700)
+	_ = os.Remove(cliSuiteFIFOPath)
+	_ = syscall.Mkfifo(cliSuiteFIFOPath, 0o600)
+
 	dockerEnvironment := NewDockerEnvironment([]string{
 		"internal/suites/compose.yml",
 		"internal/suites/CLI/compose.yml",
@@ -34,6 +41,7 @@ func init() {
 		_ = os.RemoveAll("/tmp/qr/")
 		_ = os.RemoveAll("/tmp/out/")
 		_ = os.Remove("/tmp/qr.png")
+		_ = os.Remove(cliSuiteFIFOPath)
 
 		return err
 	}

--- a/internal/suites/suite_cli_test.go
+++ b/internal/suites/suite_cli_test.go
@@ -1536,6 +1536,11 @@ func (s *CLISuite) TestShouldDeliverSequentialNotificationsToFIFO() {
 }
 
 func (s *CLISuite) TestShouldDeliverConcurrentNotificationsToFIFO() {
+	f, err := os.OpenFile(cliSuiteFIFOPath, os.O_RDWR, 0)
+	s.Require().NoError(err)
+
+	defer f.Close()
+
 	subjects := []string{"fifo-concurrent-one", "fifo-concurrent-two"}
 
 	type readResult struct {
@@ -1546,17 +1551,29 @@ func (s *CLISuite) TestShouldDeliverConcurrentNotificationsToFIFO() {
 	got := make(chan readResult, 1)
 
 	go func() {
-		f, err := os.OpenFile(cliSuiteFIFOPath, os.O_RDONLY, 0)
-		if err != nil {
-			got <- readResult{nil, err}
+		var buf bytes.Buffer
 
-			return
+		chunk := make([]byte, 4096)
+
+		for {
+			n, err := f.Read(chunk)
+			if n > 0 {
+				buf.Write(chunk[:n])
+			}
+
+			if err != nil && err != io.EOF {
+				got <- readResult{buf.Bytes(), err}
+
+				return
+			}
+
+			data := buf.Bytes()
+			if bytes.Contains(data, []byte(subjects[0])) && bytes.Contains(data, []byte(subjects[1])) {
+				got <- readResult{data, nil}
+
+				return
+			}
 		}
-
-		defer f.Close()
-
-		b, err := io.ReadAll(f)
-		got <- readResult{b, err}
 	}()
 
 	var wg sync.WaitGroup

--- a/internal/suites/suite_cli_test.go
+++ b/internal/suites/suite_cli_test.go
@@ -1493,7 +1493,7 @@ func (s *CLISuite) TestShouldDeliverSequentialNotificationsToFIFO() {
 		err  error
 	}
 
-	for _, subject := range []string{"FIFO Sequential One", "FIFO Sequential Two", "FIFO Sequential Three"} {
+	for _, subject := range []string{"fifo-sequential-one", "fifo-sequential-two", "fifo-sequential-three"} {
 		s.Run(subject, func() {
 			got := make(chan readResult, 1)
 
@@ -1536,12 +1536,28 @@ func (s *CLISuite) TestShouldDeliverSequentialNotificationsToFIFO() {
 }
 
 func (s *CLISuite) TestShouldDeliverConcurrentNotificationsToFIFO() {
-	f, err := os.OpenFile(cliSuiteFIFOPath, os.O_RDWR, 0)
-	s.Require().NoError(err)
+	subjects := []string{"fifo-concurrent-one", "fifo-concurrent-two"}
 
-	defer f.Close()
+	type readResult struct {
+		data []byte
+		err  error
+	}
 
-	subjects := []string{"FIFO Concurrent One", "FIFO Concurrent Two"}
+	got := make(chan readResult, 1)
+
+	go func() {
+		f, err := os.OpenFile(cliSuiteFIFOPath, os.O_RDONLY, 0)
+		if err != nil {
+			got <- readResult{nil, err}
+
+			return
+		}
+
+		defer f.Close()
+
+		b, err := io.ReadAll(f)
+		got <- readResult{b, err}
+	}()
 
 	var wg sync.WaitGroup
 
@@ -1564,14 +1580,16 @@ func (s *CLISuite) TestShouldDeliverConcurrentNotificationsToFIFO() {
 
 	wg.Wait()
 
-	buf := make([]byte, 8192)
+	select {
+	case r := <-got:
+		s.Require().NoError(r.err)
 
-	n, err := f.Read(buf)
-	s.Require().NoError(err)
-
-	content := string(buf[:n])
-	s.Contains(content, fmt.Sprintf("Subject: %s", subjects[0]))
-	s.Contains(content, fmt.Sprintf("Subject: %s", subjects[1]))
+		content := string(r.data)
+		s.Contains(content, fmt.Sprintf("Subject: %s", subjects[0]))
+		s.Contains(content, fmt.Sprintf("Subject: %s", subjects[1]))
+	case <-time.After(15 * time.Second):
+		s.Fail("FIFO reader timed out for concurrent notifications")
+	}
 }
 
 func TestCLISuite(t *testing.T) {

--- a/internal/suites/suite_cli_test.go
+++ b/internal/suites/suite_cli_test.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.yaml.in/yaml/v4"
@@ -1482,6 +1485,93 @@ func (s *CLISuite) TestDebugTLS() {
 	s.NoError(err)
 
 	s.Contains(output, "General Information:\n\tFailure: Did not receive a TLS handshake from secure.example.com:8081")
+}
+
+func (s *CLISuite) TestShouldDeliverSequentialNotificationsToFIFO() {
+	type readResult struct {
+		data []byte
+		err  error
+	}
+
+	for _, subject := range []string{"FIFO Sequential One", "FIFO Sequential Two", "FIFO Sequential Three"} {
+		s.Run(subject, func() {
+			got := make(chan readResult, 1)
+
+			go func() {
+				f, err := os.OpenFile(cliSuiteFIFOPath, os.O_RDONLY, 0)
+				if err != nil {
+					got <- readResult{nil, err}
+
+					return
+				}
+
+				defer f.Close()
+
+				b, err := io.ReadAll(f)
+				got <- readResult{b, err}
+			}()
+
+			output, err := s.Exec("authelia-backend", []string{
+				"authelia", "debug", "notification",
+				"--config", "/config/configuration.yml",
+				"--recipient", "john.doe@authelia.com",
+				"--subject", subject,
+			})
+			s.Require().NoError(err, output)
+			s.Contains(output, "Notification sent successfully")
+
+			select {
+			case r := <-got:
+				s.Require().NoError(r.err)
+
+				content := string(r.data)
+				s.Contains(content, fmt.Sprintf("Subject: %s", subject))
+				s.Contains(content, "john.doe@authelia.com")
+				s.Contains(content, "test notification from")
+			case <-time.After(15 * time.Second):
+				s.Fail("FIFO reader timed out; notifier did not write to the pipe")
+			}
+		})
+	}
+}
+
+func (s *CLISuite) TestShouldDeliverConcurrentNotificationsToFIFO() {
+	f, err := os.OpenFile(cliSuiteFIFOPath, os.O_RDWR, 0)
+	s.Require().NoError(err)
+
+	defer f.Close()
+
+	subjects := []string{"FIFO Concurrent One", "FIFO Concurrent Two"}
+
+	var wg sync.WaitGroup
+
+	for _, subject := range subjects {
+		wg.Add(1)
+
+		go func(subject string) {
+			defer wg.Done()
+
+			output, err := s.Exec("authelia-backend", []string{
+				"authelia", "debug", "notification",
+				"--config", "/config/configuration.yml",
+				"--recipient", "john.doe@authelia.com",
+				"--subject", subject,
+			})
+			s.NoError(err, output)
+			s.Contains(output, "Notification sent successfully")
+		}(subject)
+	}
+
+	wg.Wait()
+
+	buf := make([]byte, 8192)
+
+	n, err := f.Read(buf)
+	s.Require().NoError(err)
+
+	content := string(buf[:n])
+	s.Contains(content, fmt.Sprintf("Subject: %s", subjects[0]))
+	s.Contains(content, fmt.Sprintf("Subject: %s", subjects[1]))
 }
 
 func TestCLISuite(t *testing.T) {


### PR DESCRIPTION
Pointing the filesystem notifier at a fifo previously panicked: `StartupCheck` truncated the path with `os.WriteFile`, which on a fifo opens `O_WRONLY|O_CREATE|O_TRUNC` and blocks until a reader connects, and `Send` always called `f.Sync()`, which returns `EINVAL` on a pipe.

`FileNotifier` now stat-checks the destination via `os.ModeNamedPipe`. When the path is a fifo, `StartupCheck` skips the empty-write step and `Send` opens with `O_WRONLY` only and skips the trailing `f.Sync()`. Detection is per-call so it works whether or not `disable_startup_check` is set, and it survives the operator replacing the file between startup and runtime. Behaviour for regular files is byte-identical to before, including the `O_TRUNC` / `O_APPEND` open flags and the `Sync` call. The bytes written to the destination (`Date:` / `Recipient:` / `Subject:` header, rendered template body, double newline) are identical regardless of whether the destination is a regular file or a fifo, so existing parsers continue to work. The fifo must be pre-created by the operator with `mkfifo` and a reader must be attached on the other end; if no reader is connected when a notification is generated, `Send` blocks until one is, matching POSIX fifo semantics.

A new `authelia debug notification` subcommand is added alongside `authelia debug tls` / `expression` / `oidc`. It loads the configuration, runs the notifier startup check, and dispatches a single test notification using the configured notifier (SMTP or filesystem). It is useful as an ops tool for verifying that the SMTP server, filesystem path, or fifo consumer is reachable, and is the deterministic, browser-free trigger used by the new CLI suite tests.

Coverage for the fifo branches is added in `internal/notification/file_notifier_test.go` (`TestIsFIFO`, fifo `StartupCheck`, fifo `Send` end-to-end via `syscall.Mkfifo` plus a reader goroutine), and the CLI integration suite gains two end-to-end tests: `TestShouldDeliverSequentialNotificationsToFIFOViaDebugCommand` runs three notifications back-to-back through fresh `O_RDONLY` readers to validate pipe re-use, and `TestShouldDeliverConcurrentNotificationsToFIFOViaDebugCommand` holds the fifo open `O_RDWR` while two `authelia debug notification` invocations write concurrently and asserts both subjects land intact.

Closes #11386.