### PR TITLE
docs(commands): add reference pages for external suites subcommand

### DIFF
--- a/.trufflehog
+++ b/.trufflehog
@@ -6,6 +6,7 @@
 ^docs\/assets\/js\/docsearch\.js$
 ^docs\/content\/
 ^docs\/public\/
+^graphify-out\/
 ^internal\/configuration\/test_resources\/
 ^internal\/suites\/.*\/configuration\.yml$
 ^internal\/suites\/common\/pki\/.*\.pem$

--- a/cmd/authelia-scripts/cmd/const.go
+++ b/cmd/authelia-scripts/cmd/const.go
@@ -122,7 +122,7 @@ authelia-scripts suites setup Standalone - sets up the Standalone suite (there a
 
 	cmdSuitesListLong = `List available suites.
 
-Suites can be ran with the authelia-scripts suites test [suite] command.`
+Suites can be run with the authelia-scripts suites test [suite] command.`
 
 	cmdSuitesListExample = `authelia-scripts suites list`
 
@@ -162,7 +162,7 @@ External suites drive a project-local dev server and use the go-rod browser harn
 
 	cmdSuitesExternalListLong = `List available external suites.
 
-External suites can be ran with the authelia-scripts suites external test [suite] command.`
+External suites can be run with the authelia-scripts suites external test [suite] command.`
 
 	cmdSuitesExternalListExample = `authelia-scripts suites external list`
 

--- a/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites.md
+++ b/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites.md
@@ -2,7 +2,7 @@
 title: "authelia-scripts suites"
 description: "Reference for the authelia-scripts suites command."
 lead: ""
-date: 2026-04-02T15:48:22+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 925
@@ -48,6 +48,7 @@ authelia-scripts suites
 ### SEE ALSO
 
 * [authelia-scripts](authelia-scripts.md)	 - A utility used in the Authelia development process.
+* [authelia-scripts suites external](authelia-scripts_suites_external.md)	 - Commands related to external suites management
 * [authelia-scripts suites list](authelia-scripts_suites_list.md)	 - List available suites
 * [authelia-scripts suites setup](authelia-scripts_suites_setup.md)	 - Setup a test suite environment
 * [authelia-scripts suites teardown](authelia-scripts_suites_teardown.md)	 - Teardown a test suite environment

--- a/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_external.md
+++ b/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_external.md
@@ -1,0 +1,55 @@
+---
+title: "authelia-scripts suites external"
+description: "Reference for the authelia-scripts suites external command."
+lead: ""
+date: 2026-04-30T17:13:00+10:00
+draft: false
+images: []
+weight: 925
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia-scripts suites external
+
+Commands related to external suites management
+
+### Synopsis
+
+Commands related to external suites management.
+
+External suites drive a project-local dev server and use the go-rod browser harness to assert the rendered output is correct.
+
+```
+authelia-scripts suites external [flags]
+```
+
+### Examples
+
+```
+authelia-scripts suites external
+```
+
+### Options
+
+```
+  -h, --help   help for external
+```
+
+### Options inherited from parent commands
+
+```
+      --buildkite          Set CI flag for Buildkite
+      --log-level string   Set the log level for the command (default "info")
+```
+
+### SEE ALSO
+
+* [authelia-scripts suites](authelia-scripts_suites.md)	 - Commands related to suites management
+* [authelia-scripts suites external list](authelia-scripts_suites_external_list.md)	 - List available external suites
+* [authelia-scripts suites external test](authelia-scripts_suites_external_test.md)	 - Run an external test suite
+

--- a/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_external_list.md
+++ b/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_external_list.md
@@ -1,0 +1,53 @@
+---
+title: "authelia-scripts suites external list"
+description: "Reference for the authelia-scripts suites external list command."
+lead: ""
+date: 2026-04-30T17:13:00+10:00
+draft: false
+images: []
+weight: 925
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia-scripts suites external list
+
+List available external suites
+
+### Synopsis
+
+List available external suites.
+
+External suites can be ran with the authelia-scripts suites external test [suite] command.
+
+```
+authelia-scripts suites external list [flags]
+```
+
+### Examples
+
+```
+authelia-scripts suites external list
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --buildkite          Set CI flag for Buildkite
+      --log-level string   Set the log level for the command (default "info")
+```
+
+### SEE ALSO
+
+* [authelia-scripts suites external](authelia-scripts_suites_external.md)	 - Commands related to external suites management
+

--- a/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_external_list.md
+++ b/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_external_list.md
@@ -2,7 +2,7 @@
 title: "authelia-scripts suites external list"
 description: "Reference for the authelia-scripts suites external list command."
 lead: ""
-date: 2026-04-30T17:13:00+10:00
+date: 2026-04-30T17:16:39+10:00
 draft: false
 images: []
 weight: 925
@@ -22,7 +22,7 @@ List available external suites
 
 List available external suites.
 
-External suites can be ran with the authelia-scripts suites external test [suite] command.
+External suites can be run with the authelia-scripts suites external test [suite] command.
 
 ```
 authelia-scripts suites external list [flags]

--- a/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_external_test.md
+++ b/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_external_test.md
@@ -1,0 +1,56 @@
+---
+title: "authelia-scripts suites external test"
+description: "Reference for the authelia-scripts suites external test command."
+lead: ""
+date: 2026-04-30T17:13:00+10:00
+draft: false
+images: []
+weight: 925
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia-scripts suites external test
+
+Run an external test suite
+
+### Synopsis
+
+Run an external test suite.
+
+External suites can be listed with the authelia-scripts suites external list command.
+
+```
+authelia-scripts suites external test [suite] [flags]
+```
+
+### Examples
+
+```
+authelia-scripts suites external test docs
+```
+
+### Options
+
+```
+      --failfast           Stops tests on first failure
+      --headless           Run tests in headless mode
+  -h, --help               help for test
+      --update-snapshots   Overwrite visual snapshot baselines with the output of the current run
+```
+
+### Options inherited from parent commands
+
+```
+      --buildkite          Set CI flag for Buildkite
+      --log-level string   Set the log level for the command (default "info")
+```
+
+### SEE ALSO
+
+* [authelia-scripts suites external](authelia-scripts_suites_external.md)	 - Commands related to external suites management
+

--- a/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_list.md
+++ b/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_list.md
@@ -2,7 +2,7 @@
 title: "authelia-scripts suites list"
 description: "Reference for the authelia-scripts suites list command."
 lead: ""
-date: 2026-04-02T15:48:22+11:00
+date: 2024-03-14T06:00:14+11:00
 draft: false
 images: []
 weight: 925
@@ -22,7 +22,7 @@ List available suites
 
 List available suites.
 
-Suites can be ran with the authelia-scripts suites test [suite] command.
+Suites can be run with the authelia-scripts suites test [suite] command.
 
 ```
 authelia-scripts suites list [flags]


### PR DESCRIPTION
Regenerate the CLI reference under `docs/content/reference/cli/authelia-scripts/` to cover the new `authelia-scripts suites external` command and its `list` and `test` children. The parent `authelia-scripts suites` page also gains a SEE-ALSO entry for the new sibling.