### PR TITLE
feat(authentication): ldap client startup check retry

### DIFF
--- a/internal/authentication/ldap_user_provider_lifecycle.go
+++ b/internal/authentication/ldap_user_provider_lifecycle.go
@@ -3,6 +3,9 @@ package authentication
 import (
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/go-ldap/ldap/v3"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 	"github.com/authelia/authelia/v4/internal/utils"
@@ -20,7 +23,21 @@ func (p *LDAPUserProvider) StartupCheck() (err error) {
 
 	var client LDAPExtendedClient
 
-	if client, err = p.factory.GetClient(); err != nil {
+	for i := 0; i < 19; i++ {
+		if i != 0 {
+			time.Sleep(time.Millisecond * 500)
+		}
+
+		if client, err = p.factory.GetClient(); err == nil {
+			break
+		}
+
+		if !ldap.IsErrorAnyOf(err, ldap.ErrorNetwork) {
+			return err
+		}
+	}
+
+	if err != nil {
 		return err
 	}
 

--- a/internal/storage/sql_provider.go
+++ b/internal/storage/sql_provider.go
@@ -395,11 +395,13 @@ func (p *SQLProvider) StartupCheck() (err error) {
 
 	// TODO: Decide if this is needed, or if it should be configurable.
 	for i := 0; i < 19; i++ {
+		if i != 0 {
+			time.Sleep(time.Millisecond * 500)
+		}
+
 		if err = p.db.Ping(); err == nil {
 			break
 		}
-
-		time.Sleep(time.Millisecond * 500)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Automatically tries to connect to the LDAP client acquisition during the startup check for a limited number of tries specifically when the returned error is a network error. This is effectively the equivalent of the SQL Storage startup check.

Closes #5989