### PR TITLE
Custom Redis key prefix

### DIFF
--- a/internal/configuration/schema/keys.go
+++ b/internal/configuration/schema/keys.go
@@ -405,6 +405,7 @@ var Keys = []string{
 	"session.redis.high_availability.sentinel_password",
 	"session.redis.high_availability.sentinel_username",
 	"session.redis.host",
+	"session.redis.key_prefix",
 	"session.redis.max_retries",
 	"session.redis.maximum_active_connections",
 	"session.redis.minimum_idle_connections",

--- a/internal/configuration/schema/session.go
+++ b/internal/configuration/schema/session.go
@@ -53,6 +53,7 @@ type SessionRedis struct {
 	MaximumActiveConnections int           `koanf:"maximum_active_connections" yaml:"maximum_active_connections" toml:"maximum_active_connections" json:"maximum_active_connections" jsonschema:"default=8,title=Maximum Active Connections" jsonschema_description:"The maximum connections that can be made to redis at one time."`
 	MinimumIdleConnections   int           `koanf:"minimum_idle_connections" yaml:"minimum_idle_connections" toml:"minimum_idle_connections" json:"minimum_idle_connections" jsonschema:"title=Minimum Idle Connections" jsonschema_description:"The minimum idle connections that should be open to redis."`
 	TLS                      *TLS          `koanf:"tls" yaml:"tls,omitempty" toml:"tls,omitempty" json:"tls,omitempty" jsonschema:"title=TLS" jsonschema_description:"The TLS configuration for the redis server."`
+	KeyPrefix                string        `koanf:"key_prefix" yaml:"key_prefix,omitempty" toml:"key_prefix,omitempty" json:"key_prefix,omitempty" jsonschema:"default=authelia-session,title=Key Prefix" jsonschema_description:"The prefix for the keys stored in redis."`
 
 	HighAvailability *SessionRedisHighAvailability `koanf:"high_availability" yaml:"high_availability,omitempty" toml:"high_availability,omitempty" json:"high_availability,omitempty" jsonschema:"title=High Availability" jsonschema_description:"The redis high availability configuration."`
 }
@@ -91,6 +92,7 @@ var DefaultRedisConfiguration = SessionRedis{
 	Timeout:                  time.Second * 5,
 	MaxRetries:               0,
 	MaximumActiveConnections: 8,
+	KeyPrefix:                "authelia-session",
 	TLS: &TLS{
 		MinimumVersion: TLSVersion{Value: tls.VersionTLS12},
 	},
@@ -102,6 +104,7 @@ var DefaultRedisHighAvailabilityConfiguration = SessionRedis{
 	Timeout:                  time.Second * 5,
 	MaxRetries:               0,
 	MaximumActiveConnections: 8,
+	KeyPrefix:                "authelia-session",
 	TLS: &TLS{
 		MinimumVersion: TLSVersion{Value: tls.VersionTLS12},
 	},

--- a/internal/configuration/validator/session.go
+++ b/internal/configuration/validator/session.go
@@ -247,6 +247,10 @@ func sessionDomainDescriptor(position int, domain schema.SessionCookie) string {
 }
 
 func validateRedisCommon(config *schema.Session, validator *schema.StructValidator) {
+	if config.Redis.KeyPrefix == "" {
+		config.Redis.KeyPrefix = schema.DefaultRedisConfiguration.KeyPrefix
+	}
+
 	if config.Secret == "" {
 		validator.Push(fmt.Errorf(errFmtSessionSecretRequired, "redis"))
 	}

--- a/internal/configuration/validator/session_test.go
+++ b/internal/configuration/validator/session_test.go
@@ -42,6 +42,35 @@ func TestShouldSetDefaultSessionValues(t *testing.T) {
 	assert.Equal(t, schema.DefaultSessionConfiguration.SameSite, config.Session.SameSite)
 }
 
+func TestShouldSetDefaultRedisKeyPrefix(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+	config.Session.Redis = &schema.SessionRedis{
+		Host: "redis.localhost",
+	}
+
+	ValidateSession(&config, validator)
+
+	assert.Len(t, validator.Warnings(), 0)
+	assert.Len(t, validator.Errors(), 0)
+	assert.Equal(t, "authelia-session", config.Session.Redis.KeyPrefix)
+}
+
+func TestShouldUseConfiguredRedisKeyPrefix(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+	config.Session.Redis = &schema.SessionRedis{
+		Host:      "redis.localhost",
+		KeyPrefix: "custom-prefix",
+	}
+
+	ValidateSession(&config, validator)
+
+	assert.Len(t, validator.Warnings(), 0)
+	assert.Len(t, validator.Errors(), 0)
+	assert.Equal(t, "custom-prefix", config.Session.Redis.KeyPrefix)
+}
+
 func TestShouldSetDefaultSessionDomainsValues(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/internal/session/provider_config.go
+++ b/internal/session/provider_config.go
@@ -138,7 +138,7 @@ func NewSessionProvider(config schema.Session, certPool *x509.CertPool) (name st
 				MinIdleConns:     config.Redis.MinimumIdleConnections,
 				ConnMaxIdleTime:  300,
 				TLSConfig:        tlsConfig,
-				KeyPrefix:        "authelia-session",
+				KeyPrefix:        config.Redis.KeyPrefix,
 			})
 		} else {
 			name = "redis"
@@ -166,7 +166,7 @@ func NewSessionProvider(config schema.Session, certPool *x509.CertPool) (name st
 				MinIdleConns:    config.Redis.MinimumIdleConnections,
 				ConnMaxIdleTime: 300,
 				TLSConfig:       tlsConfig,
-				KeyPrefix:       "authelia-session",
+				KeyPrefix:       config.Redis.KeyPrefix,
 			})
 		}
 	default:


### PR DESCRIPTION
Simple change to add a `key_prefix` key to the Redis config to allow changing the key prefix for deployments that might need it (defaults to the current value `authelia-session`)

Reasons this change is desired:
- Multiple installs that may use the same backend Redis server(s) (Gamma/staging environments/deployments, multi-tenant environments, etc)
- Enabling using a Redis/Valkey cluster behind a cluster proxy (for example, Shotover) to force consistent hashing to support some key operations used by Authelia.

This change also does not change the default settings, so those who don't need it, are not impacted.

I personally needed (and use) this in my own environment in order to make use of my Valkey cluster (with Shotover transparent proxy), as some of the key operations Authelia performs that do not work across partitions.