### PR TITLE
build(deps): update 4 dependencies [security]

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -52,12 +52,13 @@
   },
   "pnpm": {
     "overrides": {
+      "@babel/plugin-transform-modules-systemjs": "7.29.4",
       "brace-expansion": "5.0.6",
       "picomatch": "4.0.4",
       "semver": "7.8.0",
+      "vite": "8.0.11",
       "yaml": "2.8.4",
-      "yauzl": "3.3.0",
-      "vite": "8.0.11"
+      "yauzl": "3.3.0"
     },
     "onlyBuiltDependencies": [
       "hugo-extended"

--- a/internal/templates/src/package.json
+++ b/internal/templates/src/package.json
@@ -34,6 +34,7 @@
       "@babel/traverse": "7.29.0",
       "ajv": "8.20.0",
       "brace-expansion": "5.0.6",
+      "fast-uri": "3.1.2",
       "flatted": "3.4.2",
       "glob": "13.0.6",
       "js-yaml": "4.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -10,9 +10,9 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "7.29.0",
-      "@babel/traverse": "7.29.0",
       "@babel/helpers": "7.29.2",
       "@babel/runtime": "7.29.2",
+      "@babel/traverse": "7.29.0",
       "@typescript-eslint/eslint-plugin": "8.59.2",
       "@typescript-eslint/parser": "8.59.2",
       "@typescript-eslint/typescript-estree": "8.59.2",
@@ -21,6 +21,7 @@
       "brace-expansion": "5.0.6",
       "esbuild": "0.28.0",
       "express": "5.2.1",
+      "fast-uri": "3.1.2",
       "flatted": "3.4.2",
       "follow-redirects": "1.16.0",
       "glob": "13.0.6",


### PR DESCRIPTION
## 🛡️ Security Vulnerability Overrides

Adds `pnpm.overrides` entries to pin transitive deps to their latest published version, then regenerates each affected lockfile.

### Vulnerabilities Addressed

| Severity | Package | Override | Advisory | Manifest |
|----------|---------|----------|----------|----------|
| 🟠 high | `@babel/plugin-transform-modules-systemjs` | `7.29.4` | [GHSA-fv7c-fp4j-7gwp](https://github.com/authelia/authelia/security/dependabot/231) | `docs/pnpm-lock.yaml` |
| 🟠 high | `fast-uri` | `3.1.2` | [GHSA-v39h-62p7-jpjc](https://github.com/authelia/authelia/security/dependabot/230) | `internal/templates/src/pnpm-lock.yaml` |
| 🟠 high | `fast-uri` | `3.1.2` | [GHSA-v39h-62p7-jpjc](https://github.com/authelia/authelia/security/dependabot/229) | `web/pnpm-lock.yaml` |
| 🟡 medium | `postcss` | `8.5.10` | [GHSA-qx2v-qp2m-jg93](https://github.com/authelia/authelia/security/dependabot/226) | `internal/templates/src/pnpm-lock.yaml` |

### Changed Files

- `docs/package.json`
- `internal/templates/src/package.json`
- `web/package.json`

### Review Checklist

1. Verify overrides in each `package.json`.
2. Confirm each `pnpm-lock.yaml` resolves patched versions.
3. Run CI for regressions.