### PR TITLE
build(deps): update 4 dependencies [security]

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -135,4 +135,92 @@ ignore:
     reason: |
       Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
       authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-39820
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-42499
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-33814
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-33811
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-39836
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-42501
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-39817
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-39826
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-39823
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-39825
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
+  - vulnerability: CVE-2026-39819
+    package:
+      name: stdlib
+      version: go1.26.0
+      type: go-module
+    reason: |
+      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
+      authelia-public_html.tar.gz that's not actually shipped.
 ...

--- a/docs/package.json
+++ b/docs/package.json
@@ -52,12 +52,13 @@
   },
   "pnpm": {
     "overrides": {
+      "@babel/plugin-transform-modules-systemjs": "7.29.4",
       "brace-expansion": "5.0.6",
       "picomatch": "4.0.4",
       "semver": "7.8.0",
+      "vite": "8.0.11",
       "yaml": "2.8.4",
-      "yauzl": "3.3.0",
-      "vite": "8.0.11"
+      "yauzl": "3.3.0"
     },
     "onlyBuiltDependencies": [
       "hugo-extended"

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -401,8 +401,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2230,7 +2230,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -2436,7 +2436,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)

--- a/internal/templates/src/package.json
+++ b/internal/templates/src/package.json
@@ -34,6 +34,7 @@
       "@babel/traverse": "7.29.0",
       "ajv": "8.20.0",
       "brace-expansion": "5.0.6",
+      "fast-uri": "3.1.2",
       "flatted": "3.4.2",
       "glob": "13.0.6",
       "js-yaml": "4.1.1",

--- a/internal/templates/src/pnpm-lock.yaml
+++ b/internal/templates/src/pnpm-lock.yaml
@@ -816,8 +816,8 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -1122,8 +1122,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2174,7 +2174,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@next/env@16.2.3': {}
@@ -2292,7 +2292,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2397,7 +2397,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2669,7 +2669,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -10,9 +10,9 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "7.29.0",
-      "@babel/traverse": "7.29.0",
       "@babel/helpers": "7.29.2",
       "@babel/runtime": "7.29.2",
+      "@babel/traverse": "7.29.0",
       "@typescript-eslint/eslint-plugin": "8.59.2",
       "@typescript-eslint/parser": "8.59.2",
       "@typescript-eslint/typescript-estree": "8.59.2",
@@ -21,6 +21,7 @@
       "brace-expansion": "5.0.6",
       "esbuild": "0.28.0",
       "express": "5.2.1",
+      "fast-uri": "3.1.2",
       "flatted": "3.4.2",
       "follow-redirects": "1.16.0",
       "glob": "13.0.6",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -2403,8 +2403,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.4.4:
     resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
@@ -5669,7 +5669,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6580,7 +6580,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.4.4(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## 🛡️ Security Vulnerability Overrides

Adds `pnpm.overrides` entries to pin transitive deps to their latest published version, then regenerates each affected lockfile.

### Vulnerabilities Addressed

| Severity | Package | Override | Advisory | Manifest |
|----------|---------|----------|----------|----------|
| 🟠 high | `@babel/plugin-transform-modules-systemjs` | `7.29.4` | [GHSA-fv7c-fp4j-7gwp](https://github.com/authelia/authelia/security/dependabot/231) | `docs/pnpm-lock.yaml` |
| 🟠 high | `fast-uri` | `3.1.2` | [GHSA-v39h-62p7-jpjc](https://github.com/authelia/authelia/security/dependabot/230) | `internal/templates/src/pnpm-lock.yaml` |
| 🟠 high | `fast-uri` | `3.1.2` | [GHSA-v39h-62p7-jpjc](https://github.com/authelia/authelia/security/dependabot/229) | `web/pnpm-lock.yaml` |
| 🟡 medium | `postcss` | `8.5.10` | [GHSA-qx2v-qp2m-jg93](https://github.com/authelia/authelia/security/dependabot/226) | `internal/templates/src/pnpm-lock.yaml` |

### Changed Files

- `docs/package.json`
- `docs/pnpm-lock.yaml`
- `internal/templates/src/package.json`
- `internal/templates/src/pnpm-lock.yaml`
- `web/package.json`
- `web/pnpm-lock.yaml`

### Review Checklist

1. Verify overrides in each `package.json`.
2. Confirm each `pnpm-lock.yaml` resolves patched versions.
3. Run CI for regressions.