### PR TITLE
build(cmd): enable auto go toolchain in crossbuild container

### DIFF
--- a/cmd/authelia-scripts/cmd/build.go
+++ b/cmd/authelia-scripts/cmd/build.go
@@ -80,6 +80,7 @@ func buildAutheliaBinaryCI(xflags []string) {
 		"-e", "BUILDKITE_TAG=" + os.Getenv("BUILDKITE_TAG"),
 		"-e", "GOPATH=/tmp/go",
 		"-e", "GOCACHE=/tmp/go-build",
+		"-e", "GOTOOLCHAIN=auto",
 		"-e", "GPG_PASSWORD=" + os.Getenv("GPG_PASSWORD"),
 		"-e", "GPG_KEY_PATH=" + os.Getenv("GPG_KEY_PATH"),
 		"-e", "HOME=/tmp",


### PR DESCRIPTION
The `authelia/crossbuild` image bundles `go1.26.2` (mounted at `/usr/lib/go`), but `go.mod` declares `toolchain go1.26.3`. With Go's default `GOTOOLCHAIN=auto` the bundled `go` honours the directive and re-execs the build with the requested toolchain, fetching it on first use; environments that pin `GOTOOLCHAIN=local` would otherwise silently fall back to the bundled version. Setting the variable explicitly on the `docker run` invocation removes that ambiguity. The downloaded toolchain persists under the existing `/buildkite/.go` (`GOPATH`) mount, so subsequent builds reuse it without re-downloading.