### PR TITLE
ci(buildkite): grype scope lefthook stdlib ignore by source path

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -32,12 +32,12 @@ if [[ "${BUILDKITE_LABEL}" == ":grype: Vulnerability Scanning" ]]; then
     BUILD_ID=$(echo "${PR_BUILD}" | jq -r 'first | .id')
 
     if [[ -n "${BUILD_ID}" && "${BUILD_ID}" != "null" ]]; then
-      buildkite-agent artifact download "*.spdx.json" . --build "${BUILD_ID}"
+      buildkite-agent artifact download "*.cdx.json" . --build "${BUILD_ID}"
     else
       echo "--- :warning: Could not find a passed build for PR#${PR_NUMBER}"
     fi
   else
-    buildkite-agent artifact download "*.spdx.json" .
+    buildkite-agent artifact download "*.cdx.json" .
   fi
 fi
 

--- a/.buildkite/steps/grypescans.sh
+++ b/.buildkite/steps/grypescans.sh
@@ -31,7 +31,7 @@ if [[ -n "${IMAGE}" ]]; then
   "${grypeCmd[@]}" "${IMAGE}"
 fi
 
-for file in *.spdx.json; do
-  echo "--- :grype: Scanning ${file/.spdx.json}"
+for file in *.cdx.json; do
+  echo "--- :grype: Scanning ${file/.cdx.json}"
   "${grypeCmd[@]}" "${file}"
 done

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -5,134 +5,31 @@ ignore:
       name: busybox
       version: 1.37.0
       type: binary
+    reason: |
+      Explicitly patched in authelia/base. The reported version string is unchanged from upstream busybox 1.37.0
+      so grype still flags it, but the vulnerable code paths have been backported.
   - vulnerability: CVE-2024-58251
     package:
       name: busybox
       version: 1.37.0
       type: binary
+    reason: |
+      Explicitly patched in authelia/base. The reported version string is unchanged from upstream busybox 1.37.0
+      so grype still flags it, but the vulnerable code paths have been backported.
   - vulnerability: CVE-2025-46394
     package:
       name: busybox
       version: 1.37.0
       type: binary
-  - vulnerability: CVE-2026-32280
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
     reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-32289
-    package:
+      Explicitly patched in authelia/base. The reported version string is unchanged from upstream busybox 1.37.0
+      so grype still flags it, but the vulnerable code paths have been backported.
+  - package:
       name: stdlib
-      version: go1.26.0
       type: go-module
+      location: "**/lefthook*/**"
     reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-32282
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-27140
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-32288
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-32283
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-32281
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-33810
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-25679
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-27137
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-27138
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-27139
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-27142
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-27144
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
-  - vulnerability: CVE-2026-27143
-    package:
-      name: stdlib
-      version: go1.26.0
-      type: go-module
-    reason: |
-      Authelia is built with a newer version of go and this only affects a lefthook which is a dev dependency in
-      authelia-public_html.tar.gz that's not actually shipped.
+      Go stdlib embedded in the lefthook prebuilt binaries (npm devDependency). Lefthook is a developer/CI git
+      hook runner only; not shipped in any Authelia runtime artifact. Scoped by source path so this never
+      accidentally hides stdlib findings from Authelia's own binaries.
 ...


### PR DESCRIPTION
Replace the per-CVE stdlib pin block in `.grype.yaml` with a single location-scoped ignore that only applies to Go stdlib reported from inside the lefthook prebuilt binaries. The previous list churned every time the grype DB rotated, since the `lefthook-linux-x64` npm devDependency ships an embedded Go stdlib that surfaces every new Go vulnerability against the `public_html` SBOM even though lefthook is a developer-only git hook runner that never reaches a runtime artifact.

The `location:` field only gates matches when the SBOM carries source-path metadata. SPDX-JSON records this as a free-text `sourceInfo` string that grype does not promote into the package's `locations` array, so `location:` globs cannot match. CycloneDX preserves the path under `syft:location:0:path`, which grype reads, so a `**/lefthook*/**` glob reliably scopes the ignore to the lefthook source path without over-matching a hypothetical Authelia binary that happened to ship the same stdlib version.

Switch the grype consumers accordingly: `.buildkite/hooks/pre-command` downloads `*.cdx.json` for the `:grype: Vulnerability Scanning` label, and `.buildkite/steps/grypescans.sh` iterates over `*.cdx.json`. `.goreleaser.yml` still produces both `cdx-*` and `spdx-*` SBOM IDs, and `.buildkite/annotations/artifacts.sh` still advertises both extensions, so the SPDX SBOM continues to ship as a release artifact.

OpenVEX was evaluated and rejected. Grype's OpenVEX matcher only checks `products[].@id` against the matched package purl; the `subcomponents` array is parsed and ignored. A VEX statement with `product=lefthook + subcomponent=stdlib` does not suppress the match, and inverting it is functionally identical to a name+version+type ignore with no genuine source scoping.

Also added `reason:` fields to the existing busybox 1.37.0 entries explaining that the vulnerable code paths are backported in `authelia/base`. The reported version string is unchanged from upstream so grype still flags it.