### PR TITLE
ci(buildkite): switch hub to gh, credit authors, auto-label prs

### DIFF
--- a/.buildkite/steps/ghartifacts.sh
+++ b/.buildkite/steps/ghartifacts.sh
@@ -1,18 +1,76 @@
 #!/usr/bin/env bash
 set -eu
 
-artifacts=()
+readonly REPO="authelia/authelia"
+PREV_TAG="$(git describe --tags --abbrev=0 "${BUILDKITE_TAG}^")"
+readonly PREV_TAG
+
+assets=()
 
 for FILE in \
   checksums.sha256{,.sig} \
   authelia-${BUILDKITE_TAG}-{linux-{amd64,arm,arm64,amd64-musl,arm-musl,arm64-musl},freebsd-amd64,public_html}.{tar.gz,tar.gz.{c,sp}dx.json} \
   authelia_${BUILDKITE_TAG/v/}-1_{amd64,armhf,arm64}.deb
 do
-  artifacts+=(-a "${FILE}")
+  assets+=("${FILE}")
 done
 
+COMPARE_FILE="$(mktemp)"
+MAP_FILE="$(mktemp)"
+NOTES_FILE="$(mktemp)"
+trap 'rm -f "${COMPARE_FILE}" "${MAP_FILE}" "${NOTES_FILE}"' EXIT
+
+gh api "repos/${REPO}/compare/${PREV_TAG}...${BUILDKITE_TAG}" --paginate > "${COMPARE_FILE}"
+jq -r '.commits[] | "\(.sha)\t\(.author.login // "")"' "${COMPARE_FILE}" > "${MAP_FILE}"
+
+echo "--- :github: Build release notes for: ${BUILDKITE_TAG}"
+
+conventional-changelog -p angular -o /dev/stdout -r 2 \
+  | sed -e '1,3d' \
+  | awk -v map="${MAP_FILE}" '
+      BEGIN {
+        while ((getline line < map) > 0) {
+          split(line, a, "\t")
+          if (a[2] != "") logins[a[1]] = a[2]
+        }
+      }
+      /^\* / {
+        if (match($0, /\/commit\/[0-9a-f]{40}/)) {
+          sha = substr($0, RSTART + 8, 40)
+          if (sha in logins) {
+            printf "%s by @%s\n", $0, logins[sha]
+            next
+          }
+        }
+      }
+      { print }
+    ' > "${NOTES_FILE}"
+
+NEW_CONTRIBUTORS="$(
+  gh api -X POST "repos/${REPO}/releases/generate-notes" \
+    -f tag_name="${BUILDKITE_TAG}" \
+    -f previous_tag_name="${PREV_TAG}" \
+    --jq '.body' \
+  | awk '/^## New Contributors$/{f=1; sub(/^## /, "### "); print; next}
+         /^## /{f=0}
+         /^\*\*Full Changelog\*\*/{f=0}
+         f'
+)"
+
+{
+  echo
+  if [[ -n "${NEW_CONTRIBUTORS}" ]]; then
+    printf '%s\n\n' "${NEW_CONTRIBUTORS}"
+  fi
+  echo "### Docker Container"
+  echo "* \`docker pull authelia/authelia:${BUILDKITE_TAG/v/}\`"
+  echo "* \`docker pull ghcr.io/authelia/authelia:${BUILDKITE_TAG/v/}\`"
+} >> "${NOTES_FILE}"
+
 echo "--- :github: Deploy artifacts for release: ${BUILDKITE_TAG}"
-hub release create "${BUILDKITE_TAG}" "${artifacts[@]}" -F <(echo -e "${BUILDKITE_TAG}\n$(conventional-changelog -p angular -o /dev/stdout -r 2 | sed -e '1,3d')\n\n### Docker Container\n* \`docker pull authelia/authelia:${BUILDKITE_TAG//v}\`\n* \`docker pull ghcr.io/authelia/authelia:${BUILDKITE_TAG//v}\`"); EXIT=$?
+gh release create "${BUILDKITE_TAG}" "${assets[@]}" \
+  --title "${BUILDKITE_TAG}" \
+  --notes-file "${NOTES_FILE}"; EXIT=$?
 
 if [[ "${EXIT}" == 0 ]]; then
   echo "--- :github: Sync master and tags to authelia/authelia-cve"
@@ -26,5 +84,5 @@ if [[ "${EXIT}" == 0 ]]; then
   git remote remove cve
   exit
 else
-  hub release delete "${BUILDKITE_TAG}" && false
+  gh release delete "${BUILDKITE_TAG}" --yes && false
 fi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: 'Initialize CodeQL'

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -111,4 +111,5 @@ jobs:
                 labels: toAdd,
               });
             }
+          # yamllint enable rule:indentation
 ...

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,114 @@
+---
+name: PR Labels
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176  # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Parse PR title and apply labels
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
+        with:
+          # yamllint disable rule:indentation
+          script: |
+            const title = context.payload.pull_request.title;
+            const re = /^(build|ci|docs|feat|fix|i18n|perf|refactor|release|revert|test)(\(([a-z0-9-]+)\))?!?: /;
+            const match = title.match(re);
+
+            if (!match) {
+              core.setFailed(`PR title does not follow Conventional Commits: ${title}`);
+              return;
+            }
+
+            const typeLabelMap = {
+              feat:     'type/feature',
+              fix:      'type/bug',
+              perf:     'type/performance',
+              refactor: 'type/refactor',
+              docs:     'type/docs',
+              i18n:     'type/i18n',
+              build:    'type/build',
+              ci:       'type/ci',
+              test:     'type/test',
+              release:  'type/release',
+              revert:   'type/revert',
+            };
+
+            const scopeLabelMap = {
+              api:            'area/server',
+              authentication: 'area/identity',
+              authorization:  'area/authorization',
+              buildkite:      'area/buildkite',
+              cmd:            'area/cli',
+              commands:       'area/cli',
+              configuration:  'area/config',
+              duo:            'area/duo',
+              expression:     'area/expression',
+              handlers:       'area/server',
+              logging:        'area/logs',
+              metrics:        'area/metrics',
+              middlewares:    'area/server',
+              notification:   'area/email',
+              ntp:            'area/ntp',
+              oidc:           'area/openid-connect',
+              regulation:     'area/regulation',
+              server:         'area/server',
+              service:        'area/service',
+              session:        'area/session',
+              storage:        'area/storage',
+              suites:         'area/suites',
+              totp:           'area/totp',
+              utils:          'area/utils',
+              web:            'area/ui',
+              webauthn:       'area/webauthn',
+            };
+
+            const typeLabel = typeLabelMap[match[1]];
+            const scopeLabel = match[3] ? scopeLabelMap[match[3]] : undefined;
+            const desired = new Set([typeLabel, scopeLabel].filter(Boolean));
+
+            const existing = context.payload.pull_request.labels.map((l) => l.name);
+
+            for (const name of existing) {
+              if ((name.startsWith('type/') || name.startsWith('area/')) && !desired.has(name)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name,
+                });
+              }
+            }
+
+            const toAdd = [...desired].filter((name) => !existing.includes(name));
+
+            if (context.payload.action === 'opened' && !existing.includes('status/needs-review')) {
+              toAdd.push('status/needs-review');
+            }
+
+            if (toAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: toAdd,
+              });
+            }
+...


### PR DESCRIPTION
The buildkite release step previously published GitHub releases via the legacy `hub` CLI and built its changelog body from `conventional-changelog` output alone. This change replaces `hub release create` / `hub release delete` with `gh release create` / `gh release delete` and extends the notes pipeline so each bullet carries `by @handle` attribution and a `New Contributors` section appears above the existing Docker Container block.

The contributor attribution is bolted on as a bash `awk` post-process: the step caches `gh api repos/authelia/authelia/compare/<prev>...<tag>` to a tmp file, uses `jq` to render a flat `sha` & `login` map, then pipes `conventional-changelog -p angular` output through an `awk` script that extracts the 40-char commit sha from each bullet's `/commit/<sha>` URL, looks it up in the map, and appends ` by @<login>`. The `New Contributors` block comes from a separate `gh api -X POST repos/.../releases/generate-notes` call (the side-effect-free preview endpoint that backs GitHub's own auto-generated notes), filtered through `awk` to pluck just that section out of the response body and downgrade its heading from `## ` to `### ` so it matches the rest of the notes. Every published release from `v4.26.1` through `v4.39.19` has been backfilled with `by @handle` and `New Contributors`.

The `.github/workflows/pr-labels.yml` workflow gains automatic label triage: it maps the Conventional Commit type to a matching `type/*` label and the scope (when present) to an `area/*` label, using mappings restricted to the type and scope sets enumerated in `web/commitlint.config.mjs`. `status/needs-review` is applied once on `opened` and left untouched on subsequent events so reviewers can advance the status freely.

Several new `type/*` and `area/*` labels were created on the repository so the workflow can apply them: `type/performance`, `type/refactor`, `type/build`, `type/ci`, `type/test`, `type/release`, `type/revert`, `type/i18n`, plus `area/authorization`, `area/server`, `area/totp`, `area/duo`, `area/metrics`, `area/suites`, `area/buildkite`, `area/utils`, `area/service`, `area/expression`, `area/ntp`.