### PR TITLE
build(deps): update dependency next to v16.2.5 [security]

### DIFF
--- a/internal/templates/src/package.json
+++ b/internal/templates/src/package.json
@@ -40,6 +40,7 @@
       "js-yaml": "4.1.1",
       "minimatch": "10.2.5",
       "nanoid": "5.1.11",
+      "next": "16.2.6",
       "picomatch": "4.0.4",
       "postcss": "8.5.14",
       "prismjs": "1.30.0",


### PR DESCRIPTION
## 🛡️ Security Vulnerability Overrides

Adds `pnpm.overrides` entries to pin transitive deps to their latest published version, then regenerates each affected lockfile.

### Vulnerabilities Addressed

| Severity | Package | Override | Advisory | Manifest |
|----------|---------|----------|----------|----------|
| 🟠 high | `next` | `16.2.5` | [GHSA-8h8q-6873-q5fj](https://github.com/authelia/authelia/security/dependabot/232) | `internal/templates/src/pnpm-lock.yaml` |

### Changed Files

- `internal/templates/src/package.json`

### Review Checklist

1. Verify overrides in each `package.json`.
2. Confirm each `pnpm-lock.yaml` resolves patched versions.
3. Run CI for regressions.