### PR TITLE
ci: pin slsa-github-generator to commit sha

### DIFF
--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -68,9 +68,11 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    # yamllint disable-line rule:line-length
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a  # v2.1.0
     with:
       base64-subjects: "${{ needs.buildkite.outputs.hashes }}"
       provenance-name: authelia.intoto.jsonl
       upload-assets: true
+      compile-generator: true
 ...

--- a/internal/suites/example/compose/pam/Dockerfile
+++ b/internal/suites/example/compose/pam/Dockerfile
@@ -4,7 +4,7 @@
 #   docker build --build-arg AUTHELIA_PAM_REF=feat-foo \
 #                --build-arg AUTHELIA_PAM_REPO=https://github.com/authelia/pam.git
 
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
 RUN <<EOF
 set -eu

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ overrides:
   yaml: 2.9.0
 peerDependencyRules:
   allowedVersions:
-    "@types/react": "19"
-    eslint: "10"
-    react: "19"
-    react-dom: "19"
+    "@types/react": 19
+    eslint: 10
+    react: 19
+    react-dom: 19


### PR DESCRIPTION
Replace the floating `@v2.1.0` ref on the reusable `generator_generic_slsa3.yml` workflow with the commit sha `f7dd8c54c2067bafc12ca7a55595d5ee9b75204a` (annotated with the version as a trailing comment) so the third-party workflow we consume is immutable and cannot be silently changed under a tag move.

Set `compile-generator: true` on the same job so the SLSA generator binary is built from source at the pinned ref. The prebuilt generator that the workflow downloads by default verifies its release tag against the calling workflow ref, which fails when the ref is a commit sha; compiling from source skips that mismatch while preserving the provenance contents.