### PR TITLE
ci(buildkite): sign and verify apt deploy commit

### DIFF
--- a/.buildkite/steps/aptdeploy.sh
+++ b/.buildkite/steps/aptdeploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 APT_CONF_ROOT="./apt/conf"
 APT_DB_ROOT="./apt/db"
@@ -35,8 +36,10 @@ for DIST in "${APT_DISTS[@]}"; do
   gpg --batch --pinentry-mode loopback -u security@authelia.com --passphrase "${GPG_PASSWORD}" --clearsign -o "${APT_REPO_ROOT}/dists/${DIST}/InRelease" "${APT_REPO_ROOT}/dists/${DIST}/Release"
 done
 
-cd apt || exit
+cd apt || exit 1
 git add -A
-GIT_AUTHOR_NAME="autheliabot" GIT_AUTHOR_EMAIL="autheliabot@users.noreply.github.com" GIT_COMMITTER_NAME="autheliabot" GIT_COMMITTER_EMAIL="autheliabot@users.noreply.github.com" \
-git commit -m "release: authelia ${BUILDKITE_TAG}"
+GIT_AUTHOR_NAME="autheliabot" GIT_AUTHOR_EMAIL="autheliabot@users.noreply.github.com" \
+GIT_COMMITTER_NAME="autheliabot" GIT_COMMITTER_EMAIL="autheliabot@users.noreply.github.com" \
+  git -c user.signingkey=security@authelia.com commit -S -m "release: authelia ${BUILDKITE_TAG}"
+git verify-commit HEAD
 git push


### PR DESCRIPTION
The git commit that publishes the apt repository update was previously unsigned, even though the `Release.gpg` and `InRelease` files it contains are GPG-signed with `security@authelia.com`. Sign the commit with the same key so the deploy is verifiable end-to-end.

The apt `Release` signing on the preceding lines populates `gpg-agent`'s passphrase cache for `security@authelia.com` via `--pinentry-mode loopback --passphrase`, so `git commit -S` a few lines later hits the cache and signs non-interactively without a wrapper, temp file, or duplicated passphrase plumbing. Add `git verify-commit HEAD` as a gate before `git push` so a bad signature aborts the deploy rather than publishing an unverifiable commit.

Validated on Buildkite nodes with the production key: `git verify-commit` exits zero, `%G?` returns `G` (good signature), `%GS` resolves to the `security@authelia.com` UID, and the author/committer remain `autheliabot`.