### PR TITLE
ci: add zizmor as local github actions workflow linter

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -2,7 +2,7 @@
 name: PR Labels
 
 on:
-  pull_request_target:
+  pull_request_target:  # zizmor: ignore[dangerous-triggers]
     types:
       - opened
       - edited

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
         MISSING=""
         COUNT=0
 
-        for TOOL in goimports-reviser golangci-lint pnpm shellcheck trufflehog typos yamllint; do
+        for TOOL in goimports-reviser golangci-lint pnpm shellcheck trufflehog typos yamllint zizmor; do
           if ! command -v ${TOOL} >/dev/null 2>&1; then
             if [ "$COUNT" -eq 0 ]; then
               MISSING=${TOOL}
@@ -32,7 +32,7 @@ pre-commit:
         parallel: true
         jobs:
           - name: eslint
-            run: pnpm lint && echo "0 issues."
+            run: pnpm -s lint && echo "0 issues."
             root: "web/"
             glob: "*.{js,jsx,ts,tsx}"
             stage_fixed: true
@@ -66,6 +66,10 @@ pre-commit:
           - name: yamllint
             run: yamllint -f parsable . && echo "0 issues."
             glob: "*.{yml,yaml}"
+
+          - name: zizmor
+            run: zizmor {staged_files} && echo "0 issues."
+            glob: ".github/workflows/*.{yml,yaml}"
 
 commit-msg:
   jobs:


### PR DESCRIPTION
Wires `zizmor` into lefthook as a pre-commit linter scoped to `.github/workflows/*.{yml,yaml}` so workflow security issues are caught locally before pushing. The tool is added to the `check tools` availability list so contributors get a clear error if it is not installed.

While here, switch `pnpm lint` to `pnpm -s lint` so the eslint job stops echoing its underlying `$ eslint --format visualstudio ...` script line alongside `0 issues.`.

Suppresses `zizmor`'s high-severity `dangerous-triggers` finding on `.github/workflows/pr-labels.yml` with an inline `# zizmor: ignore[dangerous-triggers]` directive; the workflow uses `pull_request_target` deliberately and only reads `pull_request.title` to apply labels, never checking out untrusted PR code.