### PR TITLE
fix(web): quote peer dependency versions in pnpm-workspace

### DIFF
--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ overrides:
   yaml: 2.9.0
 peerDependencyRules:
   allowedVersions:
-    "@types/react": 19
-    eslint: 10
-    react: 19
-    react-dom: 19
+    "@types/react": "19"
+    eslint: "10"
+    react: "19"
+    react-dom: "19"


### PR DESCRIPTION
After the recent pnpm config refactor moved the `pnpm.*` block out of `web/package.json` and into `web/pnpm-workspace.yaml`, the `peerDependencyRules.allowedVersions` entries lost their JSON-string quoting. YAML then parses bare values like `19` and `10` as integers, and `pnpm` iterates those values calling `startsWith` on each one to match selectors against registered specifiers. Integers have no `startsWith`, so any install that exercises peer-dependency resolution against fresh metadata aborts with `ERR_PNPM_INVALID_ALLOWED_VERSION_SELECTOR: bareSpecifier.startsWith is not a function`, and Renovate's `pnpm install` against `web/pnpm-lock.yaml` fails before it can write the lockfile.

Quote the four affected entries (`@types/react`, `eslint`, `react`, `react-dom`) so YAML preserves them as strings. The sibling `overrides:` block is unaffected because every override value (`7.29.0`, `8.59.3`, etc.) contains characters that block YAML's numeric coercion; only the single-integer peer-dependency versions hit the trap. The other two workspaces (`docs/` and `internal/templates/src/`) do not declare `peerDependencyRules` and need no change.

Refs #12032