### PR TITLE
build(lefthook): fix shell quoting crash in pre-commit check-tools

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -15,7 +15,7 @@ pre-commit:
             elif [ "$COUNT" -eq 1 ]; then
               MISSING="${MISSING} and ${TOOL}"
             else
-              MISSING="$(echo "${MISSING}" | sed 's/ and /, /') and ${TOOL}"
+              MISSING="$(echo "${MISSING}" | sed "s/ and /, /") and ${TOOL}"
             fi
             COUNT=$((COUNT + 1))
           fi


### PR DESCRIPTION
### Description

The `check tools` job in `.lefthook.yml` crashes with a cryptic shell parser error every time the pre-commit hook runs, regardless of whether the listed tools are installed:

```
and: -c: line 1: unexpected EOF while looking for matching `"'

  exit status 2│  linters (skip) broken pipe
```

### Root cause

The job's run-script contains a single-quoted `sed` expression:

```bash
MISSING="$(echo "${MISSING}" | sed 's/ and /, /') and ${TOOL}"
```

When lefthook wraps the script body for shell execution, the embedded single quotes terminate the wrapper prematurely. Bash then tries to parse the remainder as new commands — the literal word `and` after the closing `'/'` becomes the next command name (hence `and: -c: …`), which fails on the unbalanced double quote in `"${TOOL}"`.

### Fix

Replace the outer single quotes around the `sed` pattern with double quotes. The pattern (` and ` → `, `) contains no `$`, backtick, or `"` characters, so substitution is safe.

### Verification

Reproduced the crash on a clean clone with multiple tools missing:

```
$ git commit -m 'test'
🥊 lefthook v2.1.0  hook: pre-commit
and: -c: line 1: unexpected EOF while looking for matching `"'
  exit status 2│  linters (skip) broken pipe
```

After this patch, the same scenario produces the intended message:

```
$ git commit -m 'test'
🥊 lefthook v2.1.0  hook: pre-commit
❌ You must install goimports-reviser, shellcheck, typos and zizmor
```

### Notes

- One-line change in `.lefthook.yml`, no behaviour change when the script succeeds.
- Verified the crash reproduces on `master` and is fixed by this commit.
- No new dependencies or workflow changes.