### PR TITLE
build(lefthook): extract check-tools to a script file (Windows fix)

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -3,29 +3,11 @@ pre-commit:
   piped: true
   jobs:
     - name: check tools
-      # yamllint disable rule:indentation
-      run: |
-        MISSING=""
-        COUNT=0
-
-        for TOOL in goimports-reviser golangci-lint pnpm shellcheck trufflehog typos yamllint zizmor; do
-          if ! command -v ${TOOL} >/dev/null 2>&1; then
-            if [ "$COUNT" -eq 0 ]; then
-              MISSING=${TOOL}
-            elif [ "$COUNT" -eq 1 ]; then
-              MISSING="${MISSING} and ${TOOL}"
-            else
-              MISSING="$(echo "${MISSING}" | sed 's/ and /, /') and ${TOOL}"
-            fi
-            COUNT=$((COUNT + 1))
-          fi
-        done
-
-        if [ ${COUNT} -gt 0 ]; then
-          echo "❌ You must install ${MISSING}"
-          exit 1
-        fi
-      # yamllint enable rule:indentation
+      # Script lives in scripts/check-tools.sh — see the script header
+      # for why it's not inline here (lefthook on Windows wraps inline
+      # `run:` blocks in "..." for sh.exe, breaking scripts that use
+      # double quotes).
+      run: scripts/check-tools.sh
 
     - name: linters
       group:

--- a/scripts/check-tools.sh
+++ b/scripts/check-tools.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Verify all tools the pre-commit linters need are installed.
+# Extracted from .lefthook.yml because lefthook's Windows invocation
+# wraps inline scripts in "..." for sh.exe, which collides with the
+# script's own "..." quoting and produces a cryptic
+# "unexpected EOF while looking for matching `"'" parser error.
+# Calling a script file sidesteps the wrapping entirely.
+set -e
+
+MISSING=""
+COUNT=0
+
+for TOOL in goimports-reviser golangci-lint pnpm shellcheck trufflehog typos yamllint zizmor; do
+  if ! command -v "${TOOL}" >/dev/null 2>&1; then
+    if [ "$COUNT" -eq 0 ]; then
+      MISSING=${TOOL}
+    elif [ "$COUNT" -eq 1 ]; then
+      MISSING="${MISSING} and ${TOOL}"
+    else
+      MISSING="$(echo "${MISSING}" | sed 's/ and /, /') and ${TOOL}"
+    fi
+    COUNT=$((COUNT + 1))
+  fi
+done
+
+if [ "${COUNT}" -gt 0 ]; then
+  echo "❌ You must install ${MISSING}"
+  exit 1
+fi


### PR DESCRIPTION
### Description

Fixes the cryptic shell parser error from the `check tools` pre-commit hook on Windows:

```
and: -c: line 1: unexpected EOF while looking for matching `"'
exit status 2│  linters (skip) broken pipe
```

This affects every Windows contributor running the pre-commit hook, regardless of whether the listed tools are installed (the script never gets to the existence check).

### Root cause

Visible only with `LEFTHOOK_VERBOSE=1`:

```
"C:\Program Files\Git\bin\sh.exe" -c "MISSING=""
COUNT=0
for TOOL in ...
```

Lefthook on Windows wraps inline `run:` blocks in `"..."` when invoking `sh.exe`. The script's very first statement, `MISSING=""`, immediately closes that wrapper — everything after is parsed as separate commands. The `and:` prefix in the error is `sh` interpreting the literal word `and` (from `… and ${TOOL}`) as the next command name, which then chokes on the unbalanced `"` in `"${TOOL}"`.

Linux is unaffected — lefthook uses argv arrays there, no shell-string wrapping involved.

### Fix

Move the script content to `scripts/check-tools.sh` (executable) and have the lefthook job invoke the file. Calling a file sidesteps the inline wrapping entirely. Script logic is unchanged.

### Verification

Reproduced on Windows 11 + Git Bash + lefthook v2.1.0:

Before:
```
$ git commit -m 'test'
🥊 lefthook v2.1.0  hook: pre-commit
and: -c: line 1: unexpected EOF while looking for matching `"'
  exit status 2│  linters (skip) broken pipe
```

After:
```
$ LEFTHOOK_VERBOSE=1 lefthook run pre-commit
✔️ check tools (0.12 seconds)
🥊 linters (24.46 seconds)
```

Or, with tools missing, the intended message instead of the crash:
```
❌ You must install goimports-reviser, shellcheck, typos and zizmor
```

### Notes

- Replaces #12079, which I closed — that PR addressed the embedded `sed 's/...'` quoting which turned out to be a non-issue.
- One new file (`scripts/check-tools.sh`, executable), one .lefthook.yml block shrunk from a multi-line `run: |` literal to a single `run:` line.
- No behaviour change on Linux/macOS.