### PR TITLE
build(git): force LF for *.sh and .shellcheckrc on Windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 * text=auto
 
 *.go text
-*.sh text
+*.sh text eol=lf
 *.html text
 *.js text
 *.jsx text
@@ -29,3 +29,7 @@ LICENSE text
 internal/templates/src/notification/* text eol=crlf
 examples/templates/notifications/*.tmpl text eol=crlf
 examples/templates/notifications/*.html text eol=crlf
+
+# shellcheck rejects literal carriage returns in its config (SC1017).
+# Force LF so Windows checkouts don't break the pre-commit hook.
+.shellcheckrc text eol=lf


### PR DESCRIPTION
### Description

The default `* text=auto` rule in `.gitattributes` converts shell scripts and `.shellcheckrc` to CRLF when checked out on Windows. shellcheck then refuses to parse them, failing the pre-commit hook for every Windows contributor with [SC1017](https://www.shellcheck.net/wiki/SC1017):

```
.shellcheckrc:1:41: error: Literal carriage return. Run script through tr -d '\r' . [SC1017]
.shellcheckrc:2:69: error: Literal carriage return [SC1017]
.buildkite/integration.sh:1:9: error: Literal carriage return [SC1017]
scripts/check-tools.sh:1:10: error: Literal carriage return [SC1017]
...
```

### Fix

Add explicit `eol=lf`:

```diff
-*.sh text
+*.sh text eol=lf

+# shellcheck rejects literal carriage returns in its config (SC1017).
+# Force LF so Windows checkouts don't break the pre-commit hook.
+.shellcheckrc text eol=lf
```

The files in git's index are already LF; this only controls how Windows checkouts materialize them. Linux/macOS contributors are unaffected (they default to LF anyway).

### Verification

On Windows 11 + Git Bash, after applying the patch and re-checking out the affected files:

Before:
```
$ shellcheck .buildkite/integration.sh
.buildkite/integration.sh:1:9: error: Literal carriage return. Run script through tr -d '\r' . [SC1017]
```

After:
```
$ shellcheck .buildkite/integration.sh
(no SC1017 errors)
```

### Notes

- One-line change (plus comment) to `.gitattributes`.
- No content change to any tracked file.
- Pairs well with #12080 (the lefthook check-tools script extraction), which was the other half of getting the pre-commit hook usable on Windows.