### PR TITLE
fix(authentication): incorrect bind mode

### DIFF
--- a/internal/authentication/ldap_client_factory.go
+++ b/internal/authentication/ldap_client_factory.go
@@ -181,7 +181,7 @@ func (f *PooledLDAPClientFactory) dial() (pooled *PooledLDAPClient, err error) {
 
 	f.log.Trace("Dialing new pooled client")
 
-	if client, err = ldapDialBind(f.log, f.config, f.dialer, f.tls, f.opts); err != nil {
+	if client, err = ldapDialBind(f.log, f.config, f.dialer, f.tls, f.opts, WithPermitUnauthenticatedBind(f.config.PermitUnauthenticatedBind)); err != nil {
 		return nil, fmt.Errorf("error occurred establishing new client for the pool: %w", err)
 	}
 

--- a/internal/authentication/ldap_client_factory.go
+++ b/internal/authentication/ldap_client_factory.go
@@ -363,9 +363,8 @@ func ldapDialBind(log *logrus.Entry, config *schema.AuthenticationBackendLDAP, d
 	}
 
 	// TODO: Add additional bind logic here, such as MD5Bind, NTLMBind, NTLMUnauthenticatedBind, etc.
-	//nolint:staticcheck
 	switch {
-	case options.Password == "":
+	case options.Password == "" && options.PermitUnauthenticatedBind:
 		err = client.UnauthenticatedBind(options.Username)
 	default:
 		err = client.Bind(options.Username, options.Password)

--- a/internal/authentication/ldap_client_factory_config.go
+++ b/internal/authentication/ldap_client_factory_config.go
@@ -4,6 +4,8 @@ type LDAPClientFactoryOptions struct {
 	Address  string
 	Username string
 	Password string
+
+	PermitUnauthenticatedBind bool
 }
 
 type LDAPClientFactoryOption func(*LDAPClientFactoryOptions)
@@ -23,5 +25,11 @@ func WithUsername(username string) func(*LDAPClientFactoryOptions) {
 func WithPassword(password string) func(*LDAPClientFactoryOptions) {
 	return func(settings *LDAPClientFactoryOptions) {
 		settings.Password = password
+	}
+}
+
+func WithPermitUnauthenticatedBind(permit bool) func(*LDAPClientFactoryOptions) {
+	return func(settings *LDAPClientFactoryOptions) {
+		settings.PermitUnauthenticatedBind = permit
 	}
 }

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -87,7 +87,7 @@ func (p *LDAPUserProvider) CheckUserPassword(username string, password string) (
 		profile         *ldapUserProfile
 	)
 
-	if client, err = p.factory.GetClient(); err != nil {
+	if client, err = p.factory.GetClient(WithPermitUnauthenticatedBind(p.config.PermitUnauthenticatedBind)); err != nil {
 		return false, err
 	}
 
@@ -121,7 +121,7 @@ func (p *LDAPUserProvider) GetDetails(username string) (details *UserDetails, er
 		profile *ldapUserProfile
 	)
 
-	if client, err = p.factory.GetClient(); err != nil {
+	if client, err = p.factory.GetClient(WithPermitUnauthenticatedBind(p.config.PermitUnauthenticatedBind)); err != nil {
 		return nil, err
 	}
 
@@ -158,7 +158,7 @@ func (p *LDAPUserProvider) GetDetailsExtended(username string) (details *UserDet
 		profile *ldapUserProfileExtended
 	)
 
-	if client, err = p.factory.GetClient(); err != nil {
+	if client, err = p.factory.GetClient(WithPermitUnauthenticatedBind(p.config.PermitUnauthenticatedBind)); err != nil {
 		return nil, err
 	}
 
@@ -247,7 +247,7 @@ func (p *LDAPUserProvider) UpdatePassword(username, password string) (err error)
 		profile *ldapUserProfile
 	)
 
-	if client, err = p.factory.GetClient(); err != nil {
+	if client, err = p.factory.GetClient(WithPermitUnauthenticatedBind(p.config.PermitUnauthenticatedBind)); err != nil {
 		return fmt.Errorf("unable to update password. Cause: %w", err)
 	}
 
@@ -275,7 +275,7 @@ func (p *LDAPUserProvider) ChangePassword(username, oldPassword string, newPassw
 		profile *ldapUserProfile
 	)
 
-	if client, err = p.factory.GetClient(); err != nil {
+	if client, err = p.factory.GetClient(WithPermitUnauthenticatedBind(p.config.PermitUnauthenticatedBind)); err != nil {
 		return fmt.Errorf("unable to update password for user '%s'. Cause: %w", username, err)
 	}
 
@@ -403,7 +403,7 @@ func (p *LDAPUserProvider) searchReferral(referral string, request *ldap.SearchR
 		result *ldap.SearchResult
 	)
 
-	if client, err = p.factory.GetClient(WithAddress(referral)); err != nil {
+	if client, err = p.factory.GetClient(WithAddress(referral), WithPermitUnauthenticatedBind(p.config.PermitUnauthenticatedBind)); err != nil {
 		return fmt.Errorf("error occurred connecting to referred LDAP server '%s': %w", referral, err)
 	}
 
@@ -808,7 +808,7 @@ func (p *LDAPUserProvider) modify(client LDAPExtendedClient, modifyRequest *ldap
 		clientRef LDAPExtendedClient
 		errRef    error
 	)
-	if clientRef, errRef = p.factory.GetClient(WithAddress(result.Referral)); errRef != nil {
+	if clientRef, errRef = p.factory.GetClient(WithAddress(result.Referral), WithPermitUnauthenticatedBind(p.config.PermitUnauthenticatedBind)); errRef != nil {
 		return fmt.Errorf("error occurred connecting to referred LDAP server '%s': %+v. Original Error: %w", result.Referral, errRef, err)
 	}
 
@@ -854,7 +854,7 @@ func (p *LDAPUserProvider) pwdModify(client LDAPExtendedClient, pwdModifyRequest
 		clientRef LDAPExtendedClient
 		errRef    error
 	)
-	if clientRef, errRef = p.factory.GetClient(WithAddress(result.Referral)); errRef != nil {
+	if clientRef, errRef = p.factory.GetClient(WithAddress(result.Referral), WithPermitUnauthenticatedBind(p.config.PermitUnauthenticatedBind)); errRef != nil {
 		return fmt.Errorf("error occurred connecting to referred LDAP server '%s': %+v. Original Error: %w", result.Referral, errRef, err)
 	}
 

--- a/internal/authentication/ldap_user_provider_lifecycle.go
+++ b/internal/authentication/ldap_user_provider_lifecycle.go
@@ -20,7 +20,7 @@ func (p *LDAPUserProvider) StartupCheck() (err error) {
 
 	var client LDAPExtendedClient
 
-	if client, err = p.factory.GetClient(); err != nil {
+	if client, err = p.factory.GetClient(WithPermitUnauthenticatedBind(p.config.PermitUnauthenticatedBind)); err != nil {
 		return err
 	}
 

--- a/internal/authentication/ldap_user_provider_test.go
+++ b/internal/authentication/ldap_user_provider_test.go
@@ -440,16 +440,15 @@ func TestShouldReturnCheckServerSearchErrorPooled(t *testing.T) {
 	gomock.InOrder(
 		mockDialer.EXPECT().DialURL("ldap://127.0.0.1:389", gomock.Any()).Return(mockClient, nil),
 		mockClient.EXPECT().SetTimeout(gomock.Eq(time.Second*0)),
-		NewRootDSESearchRequest(mockClient, nil),
-		clientBind,
-		mockClient.EXPECT().IsClosing().Return(false),
 		searchOIDs,
+		clientBind,
 		mockDialer.EXPECT().DialURL("ldap://127.0.0.1:389", gomock.Any()).Return(mockClientSecond, nil),
 		mockClientSecond.EXPECT().SetTimeout(gomock.Eq(time.Second*0)),
 		mockClientSecond.EXPECT().Search(gomock.Any()).Return(&ldap.SearchResult{}, nil),
 		clientBindSecond,
-		mockClientSecond.EXPECT().IsClosing().Return(false),
 		mockClientSecond.EXPECT().Close().Return(nil),
+		mockClient.EXPECT().IsClosing().Return(false),
+		mockClient.EXPECT().Close().Return(nil),
 	)
 
 	assert.NoError(t, provider.StartupCheck())
@@ -529,30 +528,20 @@ func TestShouldPermitRootDSEFailurePooled(t *testing.T) {
 		Bind(gomock.Eq("cn=admin,dc=example,dc=com"), gomock.Eq("password")).
 		Return(nil)
 
-	search := NewExtendedSearchRequestMatcher("(objectClass=*)", "",
-		ldap.ScopeBaseObject, ldap.NeverDerefAliases, false,
-		[]string{
-			ldapObjectClassAttribute,
-			ldapSupportedLDAPVersionAttribute,
-			ldapSupportedExtensionAttribute,
-			ldapSupportedControlAttribute,
-			ldapSupportedFeaturesAttribute,
-			ldapSupportedSASLMechanismsAttribute,
-			ldapVendorNameAttribute,
-			ldapVendorVersionAttribute,
-			ldapDomainFunctionalityAttribute,
-			ldapForestFunctionalityAttribute,
-		})
+	clientBindSecond := mockClient.EXPECT().
+		Bind(gomock.Eq("cn=admin,dc=example,dc=com"), gomock.Eq("password")).
+		Return(nil)
 
 	gomock.InOrder(
 		mockDialer.EXPECT().DialURL("ldap://127.0.0.1:389", gomock.Any()).Return(mockClient, nil),
 		mockClient.EXPECT().SetTimeout(gomock.Eq(time.Second*0)),
-		NewRootDSESearchRequest(mockClient, nil),
+		NewRootDSESearchRequest(mockClient, fmt.Errorf("failed")),
 		clientBind,
-		mockClient.EXPECT().IsClosing().Return(false),
-		mockClient.EXPECT().
-			Search(search).
-			Return(&ldap.SearchResult{Entries: []*ldap.Entry{{}}}, nil),
+		mockDialer.EXPECT().DialURL("ldap://127.0.0.1:389", gomock.Any()).Return(mockClient, nil),
+		mockClient.EXPECT().SetTimeout(gomock.Eq(time.Second*0)),
+		NewRootDSESearchRequest(mockClient, fmt.Errorf("failed")),
+		clientBindSecond,
+		mockClient.EXPECT().Close().Return(nil),
 		mockClient.EXPECT().IsClosing().Return(false),
 		mockClient.EXPECT().Close().Return(nil),
 	)
@@ -2091,9 +2080,10 @@ func TestShouldUnauthenticatedBind(t *testing.T) {
 	defer ctrl.Finish()
 
 	config := &schema.AuthenticationBackendLDAP{
-		Address:  testLDAPAddress,
-		User:     "cn=admin,dc=example,dc=com",
-		Password: "",
+		Address:                   testLDAPAddress,
+		User:                      "cn=admin,dc=example,dc=com",
+		Password:                  "",
+		PermitUnauthenticatedBind: true,
 		Attributes: schema.AuthenticationBackendLDAPAttributes{
 			Username:    "uid",
 			DisplayName: "displayName",


### PR DESCRIPTION
This fixes an issue where theoretically anonymous bind could be used in situations where it would not work causing an error or could inadvertently introduce future regressions.