### PR TITLE
build(deps): update dependency ws to v8.20.1 [security]

### DIFF
--- a/internal/templates/src/pnpm-lock.yaml
+++ b/internal/templates/src/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   rollup: 4.60.4
   socket.io-parser: 4.2.6
   vite: 8.0.13
+  ws: 8.20.1
 
 importers:
 
@@ -1602,8 +1603,8 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2265,7 +2266,7 @@ snapshots:
       cors: 2.8.5
       debug: 4.3.7
       engine.io-parser: 5.2.3
-      ws: 8.17.1
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -2785,7 +2786,7 @@ snapshots:
   socket.io-adapter@2.5.5:
     dependencies:
       debug: 4.3.7
-      ws: 8.17.1
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -2932,7 +2933,7 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  ws@8.17.1: {}
+  ws@8.20.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/internal/templates/src/pnpm-workspace.yaml
+++ b/internal/templates/src/pnpm-workspace.yaml
@@ -23,3 +23,4 @@ overrides:
   rollup: 4.60.4
   socket.io-parser: 4.2.6
   vite: 8.0.13
+  ws: 8.20.1


### PR DESCRIPTION
## 🛡️ Security Vulnerability Overrides

Adds `pnpm.overrides` entries to pin transitive deps to their latest published version, then regenerates each affected lockfile.

### Vulnerabilities Addressed

| Severity | Package | Override | Advisory | Manifest |
|----------|---------|----------|----------|----------|
| 🟡 medium | `ws` | `8.20.1` | [GHSA-58qx-3vcg-4xpx](https://github.com/authelia/authelia/security/dependabot/245) | `internal/templates/src/pnpm-lock.yaml` |

### Changed Files

- `internal/templates/src/pnpm-lock.yaml`
- `internal/templates/src/pnpm-workspace.yaml`

### Review Checklist

1. Verify overrides in each `pnpm-workspace.yaml`.
2. Confirm each `pnpm-lock.yaml` resolves patched versions.
3. Run CI for regressions.