### PR TITLE
fix(storage): incorrect query used for auth code by req id

### DIFF
--- a/internal/oidc/store.go
+++ b/internal/oidc/store.go
@@ -360,7 +360,15 @@ func (s *Store) GetPARSession(ctx context.Context, requestURI string) (request o
 	var par *model.OAuth2PARContext
 
 	if par, err = s.provider.LoadOAuth2PARContext(ctx, requestURI); err != nil {
-		return nil, err
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, oauthelia2.ErrNotFound.WithHint("The requested PAR session was not found, was expired, or was otherwise invalid.")
+		}
+
+		return nil, oauthelia2.ErrServerError.WithWrap(err).WithHintf("Error occurred retrieving the PAR session from storage: %v", err)
+	}
+
+	if par.Revoked {
+		return nil, oauthelia2.ErrNotFound.WithHint("The requested PAR session was not found, was expired, or was otherwise invalid.")
 	}
 
 	return par.ToAuthorizeRequest(ctx, NewSession(), s)

--- a/internal/oidc/store_test.go
+++ b/internal/oidc/store_test.go
@@ -553,6 +553,14 @@ func (s *StoreSuite) TestGetSessions() {
 			EXPECT().
 			LoadOAuth2PARContext(s.ctx, "urn:par").
 			Return(nil, sql.ErrNoRows),
+		s.mock.
+			EXPECT().
+			LoadOAuth2PARContext(s.ctx, "urn:par").
+			Return(nil, fmt.Errorf("connection refused")),
+		s.mock.
+			EXPECT().
+			LoadOAuth2PARContext(s.ctx, "urn:par").
+			Return(&model.OAuth2PARContext{Signature: abc, RequestID: abc, ClientID: "hs256", Session: sessionData, Revoked: true}, nil),
 	)
 
 	var (
@@ -608,7 +616,15 @@ func (s *StoreSuite) TestGetSessions() {
 
 	r, err = s.store.GetPARSession(s.ctx, "urn:par")
 	s.Nil(r)
-	s.EqualError(err, "sql: no rows in result set")
+	s.EqualError(oauthelia2.ErrorToDebugRFC6749Error(err), "Could not find the requested resource(s). The requested PAR session was not found, was expired, or was otherwise invalid.")
+
+	r, err = s.store.GetPARSession(s.ctx, "urn:par")
+	s.Nil(r)
+	s.EqualError(oauthelia2.ErrorToDebugRFC6749Error(err), "The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Error occurred retrieving the PAR session from storage: connection refused")
+
+	r, err = s.store.GetPARSession(s.ctx, "urn:par")
+	s.Nil(r)
+	s.EqualError(oauthelia2.ErrorToDebugRFC6749Error(err), "Could not find the requested resource(s). The requested PAR session was not found, was expired, or was otherwise invalid.")
 }
 
 func (s *StoreSuite) TestIsJWTUsed() {

--- a/internal/storage/sql_provider.go
+++ b/internal/storage/sql_provider.go
@@ -963,7 +963,7 @@ func (p *SQLProvider) SaveIdentityVerification(ctx context.Context, verification
 // ConsumeIdentityVerification marks an identity verification record in the storage provider as consumed.
 func (p *SQLProvider) ConsumeIdentityVerification(ctx context.Context, jti string, ip model.NullIP) (err error) {
 	if _, err = p.db.ExecContext(ctx, p.sqlConsumeIdentityVerification, time.Now(), ip, jti); err != nil {
-		return fmt.Errorf("error updating identity verification: %w", err)
+		return fmt.Errorf("error consuming identity verification with jti '%s': %w", jti, err)
 	}
 
 	return nil
@@ -972,7 +972,7 @@ func (p *SQLProvider) ConsumeIdentityVerification(ctx context.Context, jti strin
 // RevokeIdentityVerification marks an identity verification record in the storage provider as revoked.
 func (p *SQLProvider) RevokeIdentityVerification(ctx context.Context, jti string, ip model.NullIP) (err error) {
 	if _, err = p.db.ExecContext(ctx, p.sqlRevokeIdentityVerification, time.Now(), ip, jti); err != nil {
-		return fmt.Errorf("error updating identity verification: %w", err)
+		return fmt.Errorf("error revoking identity verification with jti '%s': %w", jti, err)
 	}
 
 	return nil
@@ -1039,16 +1039,16 @@ func (p *SQLProvider) ConsumeOneTimeCode(ctx context.Context, code *model.OneTim
 	)
 
 	if result, err = p.db.ExecContext(ctx, p.sqlConsumeOneTimeCode, code.ConsumedAt, code.ConsumedIP, code.Signature); err != nil {
-		return fmt.Errorf("error updating one-time code (consume): %w", err)
+		return fmt.Errorf("error consuming one-time code: %w", err)
 	}
 
 	switch rows, err = result.RowsAffected(); {
 	case err != nil:
-		return fmt.Errorf("error updating one-time code (consume): %w", err)
+		return fmt.Errorf("error consuming one-time code: %w", err)
 	case rows == 0:
-		return fmt.Errorf("error updating one-time code (consume): no rows affected")
+		return fmt.Errorf("error consuming one-time code: no rows affected")
 	case rows > 1:
-		return fmt.Errorf("error updating one-time code (consume): multiple rows affected")
+		return fmt.Errorf("error consuming one-time code: multiple rows affected")
 	default:
 		return nil
 	}
@@ -1062,16 +1062,16 @@ func (p *SQLProvider) RevokeOneTimeCode(ctx context.Context, publicID uuid.UUID,
 	)
 
 	if result, err = p.db.ExecContext(ctx, p.sqlRevokeOneTimeCode, time.Now(), ip, publicID); err != nil {
-		return fmt.Errorf("error updating one-time code (revoke): %w", err)
+		return fmt.Errorf("error revoking one-time code: %w", err)
 	}
 
 	switch rows, err = result.RowsAffected(); {
 	case err != nil:
-		return fmt.Errorf("error updating one-time code (consume): %w", err)
+		return fmt.Errorf("error revoking one-time code: %w", err)
 	case rows == 0:
-		return fmt.Errorf("error updating one-time code (consume): no rows affected")
+		return fmt.Errorf("error revoking one-time code: no rows affected")
 	case rows > 1:
-		return fmt.Errorf("error updating one-time code (consume): multiple rows affected")
+		return fmt.Errorf("error revoking one-time code: multiple rows affected")
 	default:
 		return nil
 	}
@@ -1360,7 +1360,7 @@ func (p *SQLProvider) DeactivateOAuth2SessionByRequestID(ctx context.Context, se
 	case OAuth2SessionTypeAccessToken:
 		query = p.sqlDeactivateOAuth2AccessTokenSessionByRequestID
 	case OAuth2SessionTypeAuthorizeCode:
-		query = p.sqlDeactivateOAuth2AuthorizeCodeSession
+		query = p.sqlDeactivateOAuth2AuthorizeCodeSessionByRequestID
 	case OAuth2SessionTypeOpenIDConnect:
 		query = p.sqlDeactivateOAuth2OpenIDConnectSessionByRequestID
 	case OAuth2SessionTypePKCEChallenge:
@@ -1415,14 +1415,13 @@ func (p *SQLProvider) SaveOAuth2DeviceCodeSession(ctx context.Context, session *
 		return fmt.Errorf("error encrypting oauth2 device code session data for session with signature '%s' for subject '%s' and request id '%s': %w", session.Subject.String, session.Signature, session.RequestID, err)
 	}
 
-	_, err = p.db.ExecContext(ctx, p.sqlInsertOAuth2DeviceCodeSession,
+	if _, err = p.db.ExecContext(ctx, p.sqlInsertOAuth2DeviceCodeSession,
 		session.ChallengeID, session.RequestID, session.ClientID, session.Signature, session.UserCodeSignature,
 		session.Status, session.Subject, session.RequestedAt, session.CheckedAt,
 		session.RequestedScopes, session.GrantedScopes,
 		session.RequestedAudience, session.GrantedAudience,
-		session.Active, session.Revoked, session.Form, session.Session)
-	if err != nil {
-		return fmt.Errorf("error inserting oauth2 device code session with device code signature '%s' and user code signature '%s' for subject '%s' and request id '%s': %w", session.Signature, session.UserCodeSignature, session.Subject.String, session.RequestID, err)
+		session.Active, session.Revoked, session.Form, session.Session); err != nil {
+		return fmt.Errorf("error inserting oauth2 device code session with signature '%s' and user code signature '%s' for subject '%s' and request id '%s': %w", session.Signature, session.UserCodeSignature, session.Subject.String, session.RequestID, err)
 	}
 
 	return nil
@@ -1433,12 +1432,11 @@ func (p *SQLProvider) UpdateOAuth2DeviceCodeSession(ctx context.Context, session
 		return fmt.Errorf("error encrypting oauth2 device code session data for session with signature '%s' for subject '%s' and request id '%s': %w", session.Subject.String, session.Signature, session.RequestID, err)
 	}
 
-	_, err = p.db.ExecContext(ctx, p.sqlUpdateOAuth2DeviceCodeSession,
+	if _, err = p.db.ExecContext(ctx, p.sqlUpdateOAuth2DeviceCodeSession,
 		session.ChallengeID, session.RequestID, session.ClientID, session.Status, session.Subject, session.RequestedAt,
 		session.CheckedAt, session.RequestedScopes, session.RequestedAudience, session.GrantedScopes, session.GrantedAudience,
-		session.Active, session.Revoked, session.Form, session.Session, session.Signature)
-	if err != nil {
-		return fmt.Errorf("error updating oauth2 device code session with device code signature '%s': %w", session.Signature, err)
+		session.Active, session.Revoked, session.Form, session.Session, session.Signature); err != nil {
+		return fmt.Errorf("error updating oauth2 device code session with signature '%s': %w", session.Signature, err)
 	}
 
 	return nil
@@ -1449,21 +1447,19 @@ func (p *SQLProvider) UpdateOAuth2DeviceCodeSessionData(ctx context.Context, ses
 		return fmt.Errorf("error encrypting oauth2 device code session data for session with signature '%s' for subject '%s' and request id '%s': %w", session.Subject.String, session.Signature, session.RequestID, err)
 	}
 
-	_, err = p.db.ExecContext(ctx, p.sqlUpdateOAuth2DeviceCodeSessionData,
+	if _, err = p.db.ExecContext(ctx, p.sqlUpdateOAuth2DeviceCodeSessionData,
 		session.ChallengeID, session.ClientID, session.Status, session.Subject,
 		session.RequestedScopes, session.RequestedAudience, session.GrantedScopes, session.GrantedAudience,
-		session.Form, session.Session, session.Signature)
-	if err != nil {
-		return fmt.Errorf("error updating oauth2 device code session data with device code signature '%s': %w", session.Signature, err)
+		session.Form, session.Session, session.Signature); err != nil {
+		return fmt.Errorf("error updating oauth2 device code session data with signature '%s': %w", session.Signature, err)
 	}
 
 	return nil
 }
 
 func (p *SQLProvider) DeactivateOAuth2DeviceCodeSession(ctx context.Context, signature string) (err error) {
-	_, err = p.db.ExecContext(ctx, p.sqlDeactivateOAuth2DeviceCodeSession, signature)
-	if err != nil {
-		return fmt.Errorf("error deactivating oauth2 device code session with device code signature '%s': %w", signature, err)
+	if _, err = p.db.ExecContext(ctx, p.sqlDeactivateOAuth2DeviceCodeSession, signature); err != nil {
+		return fmt.Errorf("error deactivating oauth2 device code session with signature '%s': %w", signature, err)
 	}
 
 	return nil
@@ -1473,11 +1469,11 @@ func (p *SQLProvider) LoadOAuth2DeviceCodeSession(ctx context.Context, signature
 	session = &model.OAuth2DeviceCodeSession{}
 
 	if err = p.db.GetContext(ctx, session, p.sqlSelectOAuth2DeviceCodeSession, signature); err != nil {
-		return nil, fmt.Errorf("error selecting oauth2 device code session with device code signature '%s': %w", signature, err)
+		return nil, fmt.Errorf("error selecting oauth2 device code session with signature '%s': %w", signature, err)
 	}
 
 	if session.Session, err = p.decrypt(session.Session); err != nil {
-		return nil, fmt.Errorf("error decrypting the oauth2 device code session data with device code signature '%s' for subject '%s' and request id '%s': %w", signature, session.Subject.String, session.RequestID, err)
+		return nil, fmt.Errorf("error decrypting the oauth2 device code session data with signature '%s' for subject '%s' and request id '%s': %w", signature, session.Subject.String, session.RequestID, err)
 	}
 
 	return session, nil
@@ -1530,7 +1526,7 @@ func (p *SQLProvider) LoadOAuth2PARContext(ctx context.Context, signature string
 // RevokeOAuth2PARContext marks an OAuth2.0 PAR context as revoked in the storage provider.
 func (p *SQLProvider) RevokeOAuth2PARContext(ctx context.Context, signature string) (err error) {
 	if _, err = p.db.ExecContext(ctx, p.sqlRevokeOAuth2PARContext, signature); err != nil {
-		return fmt.Errorf("error revoking oauth2 pushed authorization request context with signature '%s': %w", signature, err)
+		return fmt.Errorf("error revoking oauth2 pushed authorization request session with signature '%s': %w", signature, err)
 	}
 
 	return nil
@@ -1657,11 +1653,25 @@ func (p *SQLProvider) LoadBannedUsers(ctx context.Context, limit, page int) (ban
 }
 
 func (p *SQLProvider) RevokeBannedUser(ctx context.Context, id int, expired time.Time) (err error) {
-	if _, err = p.db.ExecContext(ctx, p.sqlRevokeBannedUser, expired, id); err != nil {
+	var (
+		result sql.Result
+		rows   int64
+	)
+
+	if result, err = p.db.ExecContext(ctx, p.sqlRevokeBannedUser, expired, id); err != nil {
 		return fmt.Errorf("error revoking banned user with id '%d': %w", id, err)
 	}
 
-	return nil
+	switch rows, err = result.RowsAffected(); {
+	case err != nil:
+		return fmt.Errorf("error revoking banned user with id '%d': error occurred determining the number of affected rows: %w", id, err)
+	case rows == 0:
+		return fmt.Errorf("error revoking banned user with id '%d': no rows affected", id)
+	case rows > 1:
+		return fmt.Errorf("error revoking banned user with id '%d': multiple rows affected", id)
+	default:
+		return nil
+	}
 }
 
 func (p *SQLProvider) LoadRegulationRecordsByIP(ctx context.Context, ip model.IP, since time.Time, limit int) (records []model.RegulationRecord, err error) {
@@ -1735,11 +1745,25 @@ func (p *SQLProvider) LoadBannedIPs(ctx context.Context, limit, page int) (bans 
 }
 
 func (p *SQLProvider) RevokeBannedIP(ctx context.Context, id int, expired time.Time) (err error) {
-	if _, err = p.db.ExecContext(ctx, p.sqlRevokeBannedIP, expired, id); err != nil {
+	var (
+		result sql.Result
+		rows   int64
+	)
+
+	if result, err = p.db.ExecContext(ctx, p.sqlRevokeBannedIP, expired, id); err != nil {
 		return fmt.Errorf("error revoking banned ip with id '%d': %w", id, err)
 	}
 
-	return nil
+	switch rows, err = result.RowsAffected(); {
+	case err != nil:
+		return fmt.Errorf("error revoking banned ip with id '%d': error occurred determining the number of affected rows: %w", id, err)
+	case rows == 0:
+		return fmt.Errorf("error revoking banned ip with id '%d': no rows affected", id)
+	case rows > 1:
+		return fmt.Errorf("error revoking banned ip with id '%d': multiple rows affected", id)
+	default:
+		return nil
+	}
 }
 
 func (p *SQLProvider) SaveCachedData(ctx context.Context, data model.CachedData) (err error) {

--- a/internal/storage/sql_provider_mock_test.go
+++ b/internal/storage/sql_provider_mock_test.go
@@ -315,7 +315,7 @@ func TestSQLProviderSimpleExecErrors(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.ConsumeIdentityVerification(context.Background(), "jti", model.NullIP{})
 			},
-			expectErr: "error updating identity verification: boom",
+			expectErr: "error consuming identity verification with jti 'jti': boom",
 		},
 		{
 			name: "ShouldReturnErrRevokeIdentityVerification",
@@ -325,7 +325,7 @@ func TestSQLProviderSimpleExecErrors(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.RevokeIdentityVerification(context.Background(), "jti", model.NullIP{})
 			},
-			expectErr: "error updating identity verification: boom",
+			expectErr: "error revoking identity verification with jti 'jti': boom",
 		},
 		{
 			name: "ShouldReturnErrSaveOAuth2ConsentSessionGranted",
@@ -345,7 +345,7 @@ func TestSQLProviderSimpleExecErrors(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.RevokeOAuth2PARContext(context.Background(), "sig")
 			},
-			expectErr: "error revoking oauth2 pushed authorization request context with signature 'sig': boom",
+			expectErr: "error revoking oauth2 pushed authorization request session with signature 'sig': boom",
 		},
 		{
 			name: "ShouldReturnErrSaveOAuth2BlacklistedJTI",
@@ -1225,7 +1225,7 @@ func TestSQLProviderConsumeRevokeOneTimeCodeRowsAffected(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.ConsumeOneTimeCode(context.Background(), &model.OneTimeCode{Signature: "sig"})
 			},
-			expectErr: "error updating one-time code (consume): boom",
+			expectErr: "error consuming one-time code: boom",
 		},
 		{
 			name: "ShouldErrConsumeWhenRowsAffectedErrors",
@@ -1236,7 +1236,7 @@ func TestSQLProviderConsumeRevokeOneTimeCodeRowsAffected(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.ConsumeOneTimeCode(context.Background(), &model.OneTimeCode{Signature: "sig"})
 			},
-			expectErr: "error updating one-time code (consume): ra-err",
+			expectErr: "error consuming one-time code: ra-err",
 		},
 		{
 			name: "ShouldErrConsumeWhenNoRowsAffected",
@@ -1247,7 +1247,7 @@ func TestSQLProviderConsumeRevokeOneTimeCodeRowsAffected(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.ConsumeOneTimeCode(context.Background(), &model.OneTimeCode{Signature: "sig"})
 			},
-			expectErr: "error updating one-time code (consume): no rows affected",
+			expectErr: "error consuming one-time code: no rows affected",
 		},
 		{
 			name: "ShouldErrConsumeWhenMultipleRowsAffected",
@@ -1258,7 +1258,7 @@ func TestSQLProviderConsumeRevokeOneTimeCodeRowsAffected(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.ConsumeOneTimeCode(context.Background(), &model.OneTimeCode{Signature: "sig"})
 			},
-			expectErr: "error updating one-time code (consume): multiple rows affected",
+			expectErr: "error consuming one-time code: multiple rows affected",
 		},
 		{
 			name: "ShouldSucceedConsumeOneTimeCode",
@@ -1278,7 +1278,7 @@ func TestSQLProviderConsumeRevokeOneTimeCodeRowsAffected(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.RevokeOneTimeCode(context.Background(), uuid.Nil, model.NewIP(net.ParseIP("1.2.3.4")))
 			},
-			expectErr: "error updating one-time code (revoke): boom",
+			expectErr: "error revoking one-time code: boom",
 		},
 		{
 			name: "ShouldErrRevokeWhenNoRowsAffected",
@@ -1289,7 +1289,7 @@ func TestSQLProviderConsumeRevokeOneTimeCodeRowsAffected(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.RevokeOneTimeCode(context.Background(), uuid.Nil, model.NewIP(net.ParseIP("1.2.3.4")))
 			},
-			expectErr: "error updating one-time code (consume): no rows affected",
+			expectErr: "error revoking one-time code: no rows affected",
 		},
 		{
 			name: "ShouldErrRevokeWhenMultipleRowsAffected",
@@ -1300,7 +1300,7 @@ func TestSQLProviderConsumeRevokeOneTimeCodeRowsAffected(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.RevokeOneTimeCode(context.Background(), uuid.Nil, model.NewIP(net.ParseIP("1.2.3.4")))
 			},
-			expectErr: "error updating one-time code (consume): multiple rows affected",
+			expectErr: "error revoking one-time code: multiple rows affected",
 		},
 		{
 			name: "ShouldSucceedRevokeOneTimeCode",
@@ -1434,6 +1434,94 @@ func TestSQLProviderOAuth2SessionByType(t *testing.T) {
 	}
 }
 
+func TestSQLProviderExecRowsAffected(t *testing.T) {
+	testCases := []struct {
+		name      string
+		args      []any
+		invoke    func(p *storage.SQLProvider) error
+		rows      int64
+		rowsErr   error
+		expectErr string
+	}{
+		{
+			name:      "ShouldErrRevokeBannedUserWhenRowsAffectedErrors",
+			args:      []any{gomock.Any(), gomock.Any(), gomock.Any(), 3},
+			invoke:    func(p *storage.SQLProvider) error { return p.RevokeBannedUser(context.Background(), 3, time.Now()) },
+			rowsErr:   errors.New("ra-err"),
+			expectErr: "error revoking banned user with id '3': error occurred determining the number of affected rows: ra-err",
+		},
+		{
+			name:      "ShouldErrRevokeBannedUserWhenNoRowsAffected",
+			args:      []any{gomock.Any(), gomock.Any(), gomock.Any(), 3},
+			invoke:    func(p *storage.SQLProvider) error { return p.RevokeBannedUser(context.Background(), 3, time.Now()) },
+			rows:      0,
+			expectErr: "error revoking banned user with id '3': no rows affected",
+		},
+		{
+			name:      "ShouldErrRevokeBannedUserWhenMultipleRowsAffected",
+			args:      []any{gomock.Any(), gomock.Any(), gomock.Any(), 3},
+			invoke:    func(p *storage.SQLProvider) error { return p.RevokeBannedUser(context.Background(), 3, time.Now()) },
+			rows:      2,
+			expectErr: "error revoking banned user with id '3': multiple rows affected",
+		},
+		{
+			name:   "ShouldSucceedRevokeBannedUser",
+			args:   []any{gomock.Any(), gomock.Any(), gomock.Any(), 3},
+			invoke: func(p *storage.SQLProvider) error { return p.RevokeBannedUser(context.Background(), 3, time.Now()) },
+			rows:   1,
+		},
+		{
+			name:      "ShouldErrRevokeBannedIPWhenRowsAffectedErrors",
+			args:      []any{gomock.Any(), gomock.Any(), gomock.Any(), 5},
+			invoke:    func(p *storage.SQLProvider) error { return p.RevokeBannedIP(context.Background(), 5, time.Now()) },
+			rowsErr:   errors.New("ra-err"),
+			expectErr: "error revoking banned ip with id '5': error occurred determining the number of affected rows: ra-err",
+		},
+		{
+			name:      "ShouldErrRevokeBannedIPWhenNoRowsAffected",
+			args:      []any{gomock.Any(), gomock.Any(), gomock.Any(), 5},
+			invoke:    func(p *storage.SQLProvider) error { return p.RevokeBannedIP(context.Background(), 5, time.Now()) },
+			rows:      0,
+			expectErr: "error revoking banned ip with id '5': no rows affected",
+		},
+		{
+			name:      "ShouldErrRevokeBannedIPWhenMultipleRowsAffected",
+			args:      []any{gomock.Any(), gomock.Any(), gomock.Any(), 5},
+			invoke:    func(p *storage.SQLProvider) error { return p.RevokeBannedIP(context.Background(), 5, time.Now()) },
+			rows:      2,
+			expectErr: "error revoking banned ip with id '5': multiple rows affected",
+		},
+		{
+			name:   "ShouldSucceedRevokeBannedIP",
+			args:   []any{gomock.Any(), gomock.Any(), gomock.Any(), 5},
+			invoke: func(p *storage.SQLProvider) error { return p.RevokeBannedIP(context.Background(), 5, time.Now()) },
+			rows:   1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			db := mocks.NewMockSQLXDB(ctrl)
+			result := mocks.NewMockSQLResult(ctrl)
+			p := storage.NewSQLProviderForTesting(db)
+
+			result.EXPECT().RowsAffected().Return(tc.rows, tc.rowsErr)
+			db.EXPECT().ExecContext(tc.args[0], tc.args[1], tc.args[2:]...).Return(result, nil)
+
+			err := tc.invoke(p)
+
+			if tc.expectErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.expectErr)
+			}
+		})
+	}
+}
+
 func TestSQLProviderRemainingExecErrors(t *testing.T) {
 	testCases := []struct {
 		name      string
@@ -1519,7 +1607,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.SaveOAuth2DeviceCodeSession(context.Background(), &model.OAuth2DeviceCodeSession{Signature: "sig", RequestID: "req"})
 			},
-			expectErr: "error inserting oauth2 device code session with device code signature 'sig' and user code signature '' for subject '' and request id 'req': boom",
+			expectErr: "error inserting oauth2 device code session with signature 'sig' and user code signature '' for subject '' and request id 'req': boom",
 		},
 		{
 			name: "ShouldReturnErrUpdateOAuth2DeviceCodeSession",
@@ -1534,7 +1622,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.UpdateOAuth2DeviceCodeSession(context.Background(), &model.OAuth2DeviceCodeSession{Signature: "sig", RequestID: "req"})
 			},
-			expectErr: "error updating oauth2 device code session with device code signature 'sig': boom",
+			expectErr: "error updating oauth2 device code session with signature 'sig': boom",
 		},
 		{
 			name: "ShouldReturnErrUpdateOAuth2DeviceCodeSessionData",
@@ -1549,7 +1637,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.UpdateOAuth2DeviceCodeSessionData(context.Background(), &model.OAuth2DeviceCodeSession{Signature: "sig"})
 			},
-			expectErr: "error updating oauth2 device code session data with device code signature 'sig': boom",
+			expectErr: "error updating oauth2 device code session data with signature 'sig': boom",
 		},
 		{
 			name: "ShouldReturnErrDeactivateOAuth2DeviceCodeSession",
@@ -1559,7 +1647,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 			invoke: func(p *storage.SQLProvider) error {
 				return p.DeactivateOAuth2DeviceCodeSession(context.Background(), "sig")
 			},
-			expectErr: "error deactivating oauth2 device code session with device code signature 'sig': boom",
+			expectErr: "error deactivating oauth2 device code session with signature 'sig': boom",
 		},
 		{
 			name: "ShouldReturnErrLoadOAuth2DeviceCodeSession",
@@ -1570,7 +1658,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 				_, err := p.LoadOAuth2DeviceCodeSession(context.Background(), "sig")
 				return err
 			},
-			expectErr: "error selecting oauth2 device code session with device code signature 'sig': boom",
+			expectErr: "error selecting oauth2 device code session with signature 'sig': boom",
 		},
 		{
 			name: "ShouldReturnErrLoadOAuth2DeviceCodeSessionByUserCode",
@@ -1971,7 +2059,7 @@ func TestSQLProviderRevokeOneTimeCodeRowsAffectedError(t *testing.T) {
 
 		err := p.RevokeOneTimeCode(context.Background(), uuid.Nil, model.NewIP(net.ParseIP("1.2.3.4")))
 
-		assert.EqualError(t, err, "error updating one-time code (consume): ra-err")
+		assert.EqualError(t, err, "error revoking one-time code: ra-err")
 	})
 }
 

--- a/internal/storage/sql_provider_test.go
+++ b/internal/storage/sql_provider_test.go
@@ -669,6 +669,7 @@ func TestSQLProviderOAuth2Session(t *testing.T) {
 		s.Signature = "sig-deact-req"
 		s.RequestID = "req-deact"
 		s.ChallengeID = model.MustNullUUID(model.NewRandomNullUUID())
+		s.Active = true
 
 		require.NoError(t, provider.SaveOAuth2Session(ctx, OAuth2SessionTypeAuthorizeCode, s))
 		require.NoError(t, provider.DeactivateOAuth2SessionByRequestID(ctx, OAuth2SessionTypeAuthorizeCode, "req-deact"))


### PR DESCRIPTION
This fixes an issue where the wrong query was used for the Authorize Code sessions when selecting them by Request ID, and ensures the ban revocation CLI returns errors in more exception situations. In addition this returns more canonical errors when retrieving PAR Sessions.