### PR TITLE
fix(authorization): oauth2 client credentials considered anonymous

### DIFF
--- a/internal/authorization/authorizer_test.go
+++ b/internal/authorization/authorizer_test.go
@@ -84,6 +84,11 @@ var OAuth2UserClientAClient = Subject{
 	IP:       net.ParseIP("127.0.0.1"),
 }
 
+var OAuth2UserClientBClient = Subject{
+	ClientID: "b_client",
+	IP:       net.ParseIP("127.0.0.1"),
+}
+
 var UserWithGroups = Subject{
 	Username: "john",
 	Groups:   []string{"dev", "admins"},
@@ -356,6 +361,11 @@ func (s *AuthorizerSuite) TestShouldCheckRulePrecedence() {
 			Subjects: [][]string{{"oauth2:client:a_client"}},
 		}).
 		WithRule(schema.AccessControlRule{
+			Domains:  []string{"oauth.example2.com"},
+			Policy:   oneFactor,
+			Subjects: [][]string{{"oauth2:client:a_client"}},
+		}).
+		WithRule(schema.AccessControlRule{
 			Domains: []string{"*.example.com"},
 			Policy:  twoFactor,
 		}).
@@ -367,7 +377,9 @@ func (s *AuthorizerSuite) TestShouldCheckRulePrecedence() {
 	tester.CheckAuthorizations(s.T(), Bob, "https://public.example.com/", fasthttp.MethodGet, Bypass)
 	tester.CheckAuthorizations(s.T(), AnonymousUser, "https://public.example.com/", fasthttp.MethodGet, Bypass)
 	tester.CheckAuthorizations(s.T(), OAuth2UserClientAClient, "https://public.example.com/", fasthttp.MethodGet, Bypass)
-	tester.CheckAuthorizations(s.T(), OAuth2UserClientAClient, "https://protected.example.com/", fasthttp.MethodGet, OneFactor)
+	tester.CheckAuthorizations(s.T(), OAuth2UserClientBClient, "https://protected.example.com/", fasthttp.MethodGet, TwoFactor)
+	tester.CheckAuthorizations(s.T(), OAuth2UserClientAClient, "https://oauth.example2.com/", fasthttp.MethodGet, OneFactor)
+	tester.CheckAuthorizations(s.T(), OAuth2UserClientBClient, "https://oauth.example2.com/", fasthttp.MethodGet, Denied)
 }
 
 func (s *AuthorizerSuite) TestShouldCheckDomainMatching() {

--- a/internal/authorization/types.go
+++ b/internal/authorization/types.go
@@ -60,7 +60,7 @@ func (s Subject) String() string {
 
 // IsAnonymous returns true if the Subject username and groups are empty.
 func (s Subject) IsAnonymous() bool {
-	return s.Username == "" && len(s.Groups) == 0
+	return s.Username == "" && len(s.Groups) == 0 && s.ClientID == ""
 }
 
 // Object represents a protected object for the purposes of ACL matching.


### PR DESCRIPTION
This fixes an issue where using an OAuth 2.0 Bearer Token which was generated using the Client Credentials Flow is considered an anonymous user. This could theoretically cause an unintended regression.