### PR TITLE
ci(build): use lf line endings for windows compatability 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 * text=auto
 
 *.go text
-*.sh text
+*.sh text eol=lf
 *.html text
 *.js text
 *.jsx text
@@ -29,3 +29,7 @@ LICENSE text
 internal/templates/src/notification/* text eol=crlf
 examples/templates/notifications/*.tmpl text eol=crlf
 examples/templates/notifications/*.html text eol=crlf
+
+# shellcheck rejects literal carriage returns in its config (SC1017).
+# Force LF so Windows checkouts don't break the pre-commit hook.
+.shellcheckrc text eol=lf

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -3,11 +3,7 @@ pre-commit:
   piped: true
   jobs:
     - name: check tools
-      # Script lives in scripts/check-tools.sh — see the script header
-      # for why it's not inline here (lefthook on Windows wraps inline
-      # `run:` blocks in "..." for sh.exe, breaking scripts that use
-      # double quotes).
-      run: scripts/check-tools.sh
+      run: ./check-tools.sh
 
     - name: linters
       group:

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -3,29 +3,11 @@ pre-commit:
   piped: true
   jobs:
     - name: check tools
-      # yamllint disable rule:indentation
-      run: |
-        MISSING=""
-        COUNT=0
-
-        for TOOL in goimports-reviser golangci-lint pnpm shellcheck trufflehog typos yamllint zizmor; do
-          if ! command -v ${TOOL} >/dev/null 2>&1; then
-            if [ "$COUNT" -eq 0 ]; then
-              MISSING=${TOOL}
-            elif [ "$COUNT" -eq 1 ]; then
-              MISSING="${MISSING} and ${TOOL}"
-            else
-              MISSING="$(echo "${MISSING}" | sed 's/ and /, /') and ${TOOL}"
-            fi
-            COUNT=$((COUNT + 1))
-          fi
-        done
-
-        if [ ${COUNT} -gt 0 ]; then
-          echo "❌ You must install ${MISSING}"
-          exit 1
-        fi
-      # yamllint enable rule:indentation
+      # Script lives in scripts/check-tools.sh — see the script header
+      # for why it's not inline here (lefthook on Windows wraps inline
+      # `run:` blocks in "..." for sh.exe, breaking scripts that use
+      # double quotes).
+      run: scripts/check-tools.sh
 
     - name: linters
       group:

--- a/.trufflehog
+++ b/.trufflehog
@@ -11,3 +11,4 @@
 ^internal\/suites\/.*\/configuration\.yml$
 ^internal\/suites\/common\/pki\/.*\.pem$
 ^.*_test\.go$
+^web\/pnpm-lock\.yaml$

--- a/check-tools.sh
+++ b/check-tools.sh
@@ -1,10 +1,4 @@
 #!/bin/sh
-# Verify all tools the pre-commit linters need are installed.
-# Extracted from .lefthook.yml because lefthook's Windows invocation
-# wraps inline scripts in "..." for sh.exe, which collides with the
-# script's own "..." quoting and produces a cryptic
-# "unexpected EOF while looking for matching `"'" parser error.
-# Calling a script file sidesteps the wrapping entirely.
 set -e
 
 MISSING=""
@@ -12,9 +6,9 @@ COUNT=0
 
 for TOOL in goimports-reviser golangci-lint pnpm shellcheck trufflehog typos yamllint zizmor; do
   if ! command -v "${TOOL}" >/dev/null 2>&1; then
-    if [ "$COUNT" -eq 0 ]; then
+    if [ "${COUNT}" -eq 0 ]; then
       MISSING=${TOOL}
-    elif [ "$COUNT" -eq 1 ]; then
+    elif [ "${COUNT}" -eq 1 ]; then
       MISSING="${MISSING} and ${TOOL}"
     else
       MISSING="$(echo "${MISSING}" | sed 's/ and /, /') and ${TOOL}"

--- a/scripts/check-tools.sh
+++ b/scripts/check-tools.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Verify all tools the pre-commit linters need are installed.
+# Extracted from .lefthook.yml because lefthook's Windows invocation
+# wraps inline scripts in "..." for sh.exe, which collides with the
+# script's own "..." quoting and produces a cryptic
+# "unexpected EOF while looking for matching `"'" parser error.
+# Calling a script file sidesteps the wrapping entirely.
+set -e
+
+MISSING=""
+COUNT=0
+
+for TOOL in goimports-reviser golangci-lint pnpm shellcheck trufflehog typos yamllint zizmor; do
+  if ! command -v "${TOOL}" >/dev/null 2>&1; then
+    if [ "$COUNT" -eq 0 ]; then
+      MISSING=${TOOL}
+    elif [ "$COUNT" -eq 1 ]; then
+      MISSING="${MISSING} and ${TOOL}"
+    else
+      MISSING="$(echo "${MISSING}" | sed 's/ and /, /') and ${TOOL}"
+    fi
+    COUNT=$((COUNT + 1))
+  fi
+done
+
+if [ "${COUNT}" -gt 0 ]; then
+  echo "❌ You must install ${MISSING}"
+  exit 1
+fi


### PR DESCRIPTION
Improves unofficial support for developing on windows.

Closes #12080, Closes #12081