### PR TITLE
fix(session): add startup check for backend connectivity

### DIFF
--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -116,6 +116,7 @@ const (
 	ProviderNameNTP              = "ntp"
 	ProviderNameStorage          = "storage"
 	ProviderNameUser             = "user"
+	ProviderNameSession          = "session"
 	ProviderNameNotification     = "notification"
 	ProviderNameExpressions      = "expressions"
 	ProviderNameWebAuthnMetaData = "webauthn-metadata"

--- a/internal/middlewares/startup.go
+++ b/internal/middlewares/startup.go
@@ -30,6 +30,9 @@ func (p *Providers) StartupChecks(ctx ServiceContext, log bool) (err error) {
 	provider, disable = ctx.GetProviders().StorageProvider, false
 	doStartupCheck(ctx, ProviderNameStorage, provider, nil, disable, log, e.errors)
 
+	provider, disable = ctx.GetProviders().SessionProvider, false
+	doStartupCheck(ctx, ProviderNameSession, provider, nil, disable, log, e.errors)
+
 	provider, disable = ctx.GetProviders().UserProvider, false
 	doStartupCheck(ctx, ProviderNameUser, provider, nil, disable, log, e.errors)
 

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -3,29 +3,32 @@ package session
 import (
 	"crypto/x509"
 	"fmt"
+	"time"
 
 	"github.com/fasthttp/session/v2"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
-	"github.com/authelia/authelia/v4/internal/logging"
 )
 
 // Provider contains a list of domain sessions.
 type Provider struct {
-	sessions map[string]*Session
+	sessions    map[string]*Session
+	backend     session.Provider
+	backendName string
+	errStartup  error
 }
 
 // NewProvider instantiate a session provider given a configuration.
 func NewProvider(config schema.Session, certPool *x509.CertPool) *Provider {
-	log := logging.Logger()
-
 	name, p, s, err := NewSessionProvider(config, certPool)
 	if err != nil {
-		log.Fatal(err)
+		return &Provider{errStartup: fmt.Errorf("error initializing session backend: %w", err)}
 	}
 
 	provider := &Provider{
-		sessions: map[string]*Session{},
+		sessions:    map[string]*Session{},
+		backend:     p,
+		backendName: name,
 	}
 
 	var (
@@ -34,7 +37,9 @@ func NewProvider(config schema.Session, certPool *x509.CertPool) *Provider {
 
 	for _, dconfig := range config.Cookies {
 		if _, holder, err = NewProviderConfigAndSession(dconfig, name, s, p); err != nil {
-			log.Fatal(err)
+			provider.errStartup = fmt.Errorf("error initializing session for domain '%s': %w", dconfig.Domain, err)
+
+			return provider
 		}
 
 		provider.sessions[dconfig.Domain] = &Session{
@@ -44,6 +49,34 @@ func NewProvider(config schema.Session, certPool *x509.CertPool) *Provider {
 	}
 
 	return provider
+}
+
+// StartupCheck implements the provider startup check interface.
+func (p *Provider) StartupCheck() (err error) {
+	if p.errStartup != nil {
+		return p.errStartup
+	}
+
+	id := []byte("authelia-startup-probe")
+	data := []byte("ok")
+
+	for i := 0; i < 19; i++ {
+		if err = p.backend.Save(id, data, time.Second); err == nil {
+			break
+		}
+
+		time.Sleep(time.Millisecond * 500)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error writing startup probe to session backend '%s': %w", p.backendName, err)
+	}
+
+	if err = p.backend.Destroy(id); err != nil {
+		return fmt.Errorf("error destroying startup probe in session backend '%s': %w", p.backendName, err)
+	}
+
+	return nil
 }
 
 // Get returns session information for specified domain.

--- a/internal/session/provider_test.go
+++ b/internal/session/provider_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -334,4 +335,55 @@ func TestShouldDestroySessionAndWipeSessionData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", newUserSession.Username)
 	assert.Equal(t, authentication.NotAuthenticated, newUserSession.AuthenticationLevel(false))
+}
+
+func TestStartupCheckShouldSucceedForMemoryBackend(t *testing.T) {
+	config := schema.Session{}
+	config.Cookies = []schema.SessionCookie{
+		{
+			SessionCookieCommon: schema.SessionCookieCommon{
+				Name:       testName,
+				Expiration: testExpiration,
+			},
+			Domain: testDomain,
+		},
+	}
+
+	provider := NewProvider(config, nil)
+
+	assert.NoError(t, provider.StartupCheck())
+}
+
+func TestStartupCheckShouldSucceedForMemoryBackendWithMultipleDomains(t *testing.T) {
+	config := schema.Session{}
+	config.Cookies = []schema.SessionCookie{
+		{
+			SessionCookieCommon: schema.SessionCookieCommon{
+				Name:       testName,
+				Expiration: testExpiration,
+			},
+			Domain: "first.example.com",
+		},
+		{
+			SessionCookieCommon: schema.SessionCookieCommon{
+				Name:       testName,
+				Expiration: testExpiration,
+			},
+			Domain: "second.example.com",
+		},
+	}
+
+	provider := NewProvider(config, nil)
+
+	assert.NoError(t, provider.StartupCheck())
+	assert.Len(t, provider.sessions, 2)
+}
+
+func TestStartupCheckShouldSurfaceConstructionError(t *testing.T) {
+	construction := fmt.Errorf("backend connection refused")
+
+	provider := &Provider{errStartup: construction}
+
+	err := provider.StartupCheck()
+	assert.ErrorIs(t, err, construction)
 }


### PR DESCRIPTION
Adds a `StartupCheck()` method to the session provider so misconfigured backends, such as Redis with the wrong password or an unreachable address, fail at boot via the existing `ErrProviderStartupCheck` aggregator rather than mid-login on the first `SaveSession` call. Previously the session provider was the only `Providers` field with no entry in `Providers.StartupChecks`, which is how `NOAUTH Authentication required.` responses from Redis could surface only on a user's first successful one-factor attempt instead of being caught at startup.

The check exercises the shared backend with a `Save` and `Destroy` round-trip on a probe key, with a 19 by 500ms retry loop matching the SQL provider's pattern in `internal/storage/sql_provider.go`. Validating the real write path used by login means Redis ACL configurations that permit `PING` but deny `SET` are caught as well. Because the fasthttp `session.Provider` interface is satisfied by both the Redis and in-memory backends, no backend-specific dispatch is required and multi-cookie-domain setups are covered by the single shared backend.

This also replaces two `log.Fatal` calls in `session.NewProvider` with the storage-style `errStartup` pattern from `internal/storage/sql_provider.go`. Construction errors, including per-domain initialisation failures with the offending domain in the wrapped message, are stashed on the provider and surfaced by `StartupCheck()` instead of immediately killing the process.