### PR TITLE
ci: recompute pr milestone on title edits

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -132,11 +132,6 @@ jobs:
               });
             }
 
-            if (context.payload.pull_request.milestone) {
-              core.info(`PR already has milestone "${context.payload.pull_request.milestone.title}"; leaving as-is.`);
-              return;
-            }
-
             let targetTitle = null;
 
             if (type === 'release') {
@@ -174,6 +169,34 @@ jobs:
               } else {
                 targetTitle = `v${major}.${minor}.${patch + 1}`;
               }
+            }
+
+            const currentMilestone = context.payload.pull_request.milestone;
+
+            if (currentMilestone) {
+              if (currentMilestone.title === targetTitle) {
+                core.info(`PR milestone "${currentMilestone.title}" already matches computed target; nothing to do.`);
+                return;
+              }
+
+              const events = await github.paginate(github.rest.issues.listEvents, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+              const lastMilestoned = events
+                .filter((e) => e.event === 'milestoned' && e.milestone && e.milestone.title === currentMilestone.title)
+                .pop();
+              const setter = lastMilestoned && lastMilestoned.actor ? lastMilestoned.actor.login : null;
+              if (setter !== 'github-actions[bot]') {
+                core.info(`PR milestone "${currentMilestone.title}" was set by ${setter || 'unknown'}; leaving as-is.`);
+                return;
+              }
+              core.info(
+                `PR milestone "${currentMilestone.title}" was set by github-actions[bot]; ` +
+                  `recomputing to "${targetTitle}".`,
+              );
             }
 
             const milestones = await github.paginate(github.rest.issues.listMilestones, {


### PR DESCRIPTION
Previously the pr-labels workflow returned early whenever a milestone was already set, so a title edit that flipped the type label (e.g. `feat` to `fix`) updated `type/*` but left the milestone pointing at the version computed from the original title.

Compute the target milestone unconditionally, no-op when it already matches, and otherwise inspect the most recent `milestoned` event for the current milestone: if its actor is `github-actions[bot]` the workflow owns it and gets overwritten with the recomputed target, otherwise a maintainer set it manually and it is left alone.