### PR TITLE
fix(handlers): hoist issuer checks

### DIFF
--- a/internal/handlers/handler_oauth2_authorization.go
+++ b/internal/handlers/handler_oauth2_authorization.go
@@ -29,6 +29,16 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 		err       error
 	)
 
+	if issuer, err = ctx.IssuerURL(); err != nil {
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
+
+		ctx.GetLogger().WithError(err).Errorf("Authorization Request could not be processed: %s", oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, rfc)
+
+		return
+	}
+
 	if requester, err = ctx.Providers.OpenIDConnect.NewAuthorizeRequest(ctx, r); requester == nil {
 		err = oauthelia2.ErrServerError.WithDebug("The requester was nil.")
 
@@ -54,14 +64,6 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 	clientID := requester.GetClient().GetID()
 
 	ctx.GetLogger().Debugf("Authorization Request with id '%s' on client with id '%s' is being processed", requester.GetID(), clientID)
-
-	if issuer, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("Authorization Request with id '%s' on client with id '%s' could not be processed: %s", requester.GetID(), clientID, oidc.ErrTextEffectiveIssuer)
-
-		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrEffectiveIssuer)
-
-		return
-	}
 
 	if client, err = ctx.Providers.OpenIDConnect.GetRegisteredClient(ctx, clientID); err != nil {
 		if errors.Is(err, oauthelia2.ErrNotFound) || errors.Is(err, oauthelia2.ErrInvalidClient) {
@@ -179,7 +181,20 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 func OAuth2AuthorizationPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, r *http.Request) {
 	requester := oauthelia2.NewAuthorizeRequest()
 
-	var err error
+	var (
+		redirectURL *url.URL
+		err         error
+	)
+
+	if redirectURL, err = ctx.IssuerURL(); err != nil {
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
+
+		ctx.GetLogger().WithError(err).Errorf("Authorization Request with id '%s' could not be processed: %s", requester.GetID(), oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, rfc)
+
+		return
+	}
 
 	r.Body = http.MaxBytesReader(rw, r.Body, 10<<20)
 
@@ -193,16 +208,6 @@ func OAuth2AuthorizationPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWrite
 	}
 
 	query := r.Form
-
-	var redirectURL *url.URL
-
-	if redirectURL, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("Authorization Request with id '%s' could not be processed: %s", requester.GetID(), oidc.ErrTextEffectiveIssuer)
-
-		ctx.Providers.OpenIDConnect.WriteAuthorizeError(ctx, rw, requester, oidc.ErrEffectiveIssuer)
-
-		return
-	}
 
 	redirectURL = redirectURL.JoinPath(oidc.EndpointPathAuthorization)
 

--- a/internal/handlers/handler_oauth2_device_authorization.go
+++ b/internal/handlers/handler_oauth2_device_authorization.go
@@ -28,6 +28,17 @@ func OAuth2DeviceAuthorizationPOST(ctx *middlewares.AutheliaCtx, rw http.Respons
 
 		err error
 	)
+
+	if _, err = ctx.IssuerURL(); err != nil {
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
+
+		ctx.GetLogger().WithError(err).Errorf("Device Authorization Request could not be processed: %s", oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		errorsx.WriteJSONError(rw, r, rfc)
+
+		return
+	}
+
 	if requester, err = ctx.Providers.OpenIDConnect.NewRFC862DeviceAuthorizeRequest(ctx, r); err != nil {
 		ctx.GetLogger().
 			WithError(oauthelia2.ErrorToDebugRFC6749Error(err)).
@@ -41,14 +52,6 @@ func OAuth2DeviceAuthorizationPOST(ctx *middlewares.AutheliaCtx, rw http.Respons
 	log := ctx.GetLogger().WithFields(map[string]any{logging.FieldRequestID: requester.GetID(), logging.FieldClientID: requester.GetClient().GetID(), logging.FieldScope: strings.Join(requester.GetRequestedScopes(), " ")})
 
 	log.Debug("Device Authorization Request is processing the Device Authorization Flow")
-
-	if _, err = ctx.IssuerURL(); err != nil {
-		log.WithError(err).Errorf("Device Authorization Request could not be processed: %s", oidc.ErrTextEffectiveIssuer)
-
-		errorsx.WriteJSONError(rw, r, oidc.ErrEffectiveIssuer)
-
-		return
-	}
 
 	if response, err = ctx.Providers.OpenIDConnect.NewRFC862DeviceAuthorizeResponse(ctx, requester, oidc.NewSessionWithRequestedAt(ctx.GetClock().Now())); err != nil {
 		log.WithError(oauthelia2.ErrorToDebugRFC6749Error(err)).Error("Device Authorization Request had an error while trying to create a response during the Device Authorization Flow")
@@ -68,6 +71,7 @@ func OAuth2DeviceAuthorizationPOST(ctx *middlewares.AutheliaCtx, rw http.Respons
 //nolint:gocyclo
 func OAuth2DeviceAuthorizationPUT(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, r *http.Request) {
 	var (
+		issuer    *url.URL
 		requester oauthelia2.DeviceAuthorizeRequester
 		responder oauthelia2.DeviceUserAuthorizeResponder
 		flowID    uuid.UUID
@@ -76,6 +80,17 @@ func OAuth2DeviceAuthorizationPUT(ctx *middlewares.AutheliaCtx, rw http.Response
 
 		err error
 	)
+
+	if issuer, err = ctx.IssuerURL(); err != nil {
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
+
+		ctx.GetLogger().WithError(err).Errorf("Device Authorization Request during the User Authorization Flow could not be processed: %s", oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.Providers.OpenIDConnect.WriteRFC8628UserAuthorizeError(ctx, rw, requester, rfc)
+
+		return
+	}
+
 	if requester, err = ctx.Providers.OpenIDConnect.NewRFC8628UserAuthorizeRequest(ctx, r); err != nil {
 		ctx.GetLogger().
 			WithError(oauthelia2.ErrorToDebugRFC6749Error(err)).
@@ -89,18 +104,6 @@ func OAuth2DeviceAuthorizationPUT(ctx *middlewares.AutheliaCtx, rw http.Response
 	log := ctx.GetLogger().WithFields(map[string]any{logging.FieldRequestID: requester.GetID(), logging.FieldClientID: requester.GetClient().GetID()})
 
 	log.Debug("Device Authorization Request is processing the User Authorization Flow")
-
-	var issuer *url.URL
-
-	if issuer, err = ctx.IssuerURL(); err != nil {
-		log.
-			WithError(err).
-			Errorf("Device Authorization Request could not be processed: %s", oidc.ErrTextEffectiveIssuer)
-
-		ctx.Providers.OpenIDConnect.WriteRFC8628UserAuthorizeError(ctx, rw, requester, oidc.ErrEffectiveIssuer)
-
-		return
-	}
 
 	if flowID, err = uuid.Parse(requester.GetRequestForm().Get(oidc.FormParameterFlowID)); err != nil {
 		log.

--- a/internal/handlers/handler_oauth2_introspection.go
+++ b/internal/handlers/handler_oauth2_introspection.go
@@ -30,9 +30,11 @@ func OAuth2IntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWrite
 	ctx.GetLogger().Debugf("Introspection Request with id '%s' is being processed", requestID)
 
 	if _, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("Introspection Request with id '%s' could not be processed: %s", requestID, oidc.ErrTextEffectiveIssuer)
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
 
-		ctx.Providers.OpenIDConnect.WriteIntrospectionError(ctx, rw, oidc.ErrEffectiveIssuer)
+		ctx.GetLogger().WithError(err).Errorf("Introspection Request with id '%s' could not be processed: %s", requestID, oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.Providers.OpenIDConnect.WriteIntrospectionError(ctx, rw, rfc)
 
 		return
 	}

--- a/internal/handlers/handler_oauth2_introspection.go
+++ b/internal/handlers/handler_oauth2_introspection.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/google/uuid"
 
@@ -16,6 +17,7 @@ import (
 // https://datatracker.ietf.org/doc/html/rfc7662
 func OAuth2IntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, req *http.Request) {
 	var (
+		issuer    *url.URL
 		requestID uuid.UUID
 		responder oauthelia2.IntrospectionResponder
 		err       error
@@ -29,7 +31,7 @@ func OAuth2IntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWrite
 
 	ctx.GetLogger().Debugf("Introspection Request with id '%s' is being processed", requestID)
 
-	if _, err = ctx.IssuerURL(); err != nil {
+	if issuer, err = ctx.IssuerURL(); err != nil {
 		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
 
 		ctx.GetLogger().WithError(err).Errorf("Introspection Request with id '%s' could not be processed: %s", requestID, oauthelia2.ErrorToDebugRFC6749Error(rfc))
@@ -45,6 +47,22 @@ func OAuth2IntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWrite
 		ctx.Providers.OpenIDConnect.WriteIntrospectionError(ctx, rw, err)
 
 		return
+	}
+
+	if requester := responder.GetAccessRequester(); requester != nil {
+		if s := requester.GetSession(); s != nil {
+			if session, ok := s.(*oidc.Session); ok {
+				if !session.ValidIssuer(issuer) {
+					err = oauthelia2.ErrInvalidRequest.WithDebug("The original request and the introspection request occurred at endpoints where the origin or effective issuer did not match.")
+
+					ctx.GetLogger().WithError(oauthelia2.ErrorToDebugRFC6749Error(err)).Errorf("Introspection Request with id '%s' failed with error", requestID)
+
+					ctx.Providers.OpenIDConnect.WriteIntrospectionError(ctx, rw, err)
+
+					return
+				}
+			}
+		}
 	}
 
 	ctx.GetLogger().Tracef("Introspection Request with id '%s' yielded a %s (active: %t) requested at %s created with request id '%s' on client with id '%s'", requestID, responder.GetTokenUse(), responder.IsActive(), responder.GetAccessRequester().GetRequestedAt().String(), responder.GetAccessRequester().GetID(), responder.GetAccessRequester().GetClient().GetID())

--- a/internal/handlers/handler_oauth2_introspection.go
+++ b/internal/handlers/handler_oauth2_introspection.go
@@ -49,7 +49,9 @@ func OAuth2IntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWrite
 		return
 	}
 
-	if requester := responder.GetAccessRequester(); requester != nil {
+	requester := responder.GetAccessRequester()
+
+	if requester != nil {
 		if s := requester.GetSession(); s != nil {
 			if session, ok := s.(*oidc.Session); ok {
 				if !session.ValidIssuer(issuer) {
@@ -63,9 +65,11 @@ func OAuth2IntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWrite
 				}
 			}
 		}
-	}
 
-	ctx.GetLogger().Tracef("Introspection Request with id '%s' yielded a %s (active: %t) requested at %s created with request id '%s' on client with id '%s'", requestID, responder.GetTokenUse(), responder.IsActive(), responder.GetAccessRequester().GetRequestedAt().String(), responder.GetAccessRequester().GetID(), responder.GetAccessRequester().GetClient().GetID())
+		ctx.GetLogger().Tracef("Introspection Request with id '%s' yielded a %s (active: %t) requested at %s created with request id '%s' on client with id '%s'", requestID, responder.GetTokenUse(), responder.IsActive(), requester.GetRequestedAt().String(), requester.GetID(), requester.GetClient().GetID())
+	} else {
+		ctx.GetLogger().Tracef("Introspection Request with id '%s' yielded a %s (active: %t)", requestID, responder.GetTokenUse(), responder.IsActive())
+	}
 
 	ctx.Providers.OpenIDConnect.WriteIntrospectionResponse(ctx, rw, responder)
 }

--- a/internal/handlers/handler_oauth2_jwks.go
+++ b/internal/handlers/handler_oauth2_jwks.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"encoding/json"
 
-	"github.com/valyala/fasthttp"
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/oidc"
@@ -13,9 +13,11 @@ import (
 func OAuth2JSONWebKeySetGET(ctx *middlewares.AutheliaCtx) {
 	var err error
 	if _, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("JSON Web Key Set Request could not be processed: %s", oidc.ErrTextEffectiveIssuer)
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
 
-		ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
+		ctx.GetLogger().WithError(err).Errorf("JSON Web Key Set Request could not be processed: %s", oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.ReplyStatusCode(rfc.StatusCode())
 
 		return
 	}

--- a/internal/handlers/handler_oauth2_oidc_userinfo.go
+++ b/internal/handlers/handler_oauth2_oidc_userinfo.go
@@ -41,9 +41,11 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 	ctx.GetLogger().Debugf("User Info Request with id '%s' is being processed", requestID)
 
 	if _, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("User Info Request with id '%s' could not be processed: %s", requestID, oidc.ErrTextEffectiveIssuer)
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
 
-		errorsx.WriteJSONError(rw, r, oidc.ErrEffectiveIssuer)
+		ctx.GetLogger().WithError(err).Errorf("User Info Request with id '%s' could not be processed: %s", requestID, oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		errorsx.WriteJSONError(rw, r, rfc)
 
 		return
 	}

--- a/internal/handlers/handler_oauth2_oidc_userinfo.go
+++ b/internal/handlers/handler_oauth2_oidc_userinfo.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/uuid"
@@ -25,6 +26,7 @@ import (
 //nolint:gocyclo
 func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, r *http.Request) {
 	var (
+		issuer    *url.URL
 		requestID uuid.UUID
 		tokenType oauthelia2.TokenType
 		requester oauthelia2.AccessRequester
@@ -40,7 +42,7 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 
 	ctx.GetLogger().Debugf("User Info Request with id '%s' is being processed", requestID)
 
-	if _, err = ctx.IssuerURL(); err != nil {
+	if issuer, err = ctx.IssuerURL(); err != nil {
 		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
 
 		ctx.GetLogger().WithError(err).Errorf("User Info Request with id '%s' could not be processed: %s", requestID, oauthelia2.ErrorToDebugRFC6749Error(rfc))
@@ -110,6 +112,16 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 
 	switch session := requester.GetSession().(type) {
 	case *oidc.Session:
+		if !session.ValidIssuer(issuer) {
+			err = oauthelia2.ErrInvalidRequest.WithDebug("The original request and the userinfo request occurred at endpoints where the origin or effective issuer did not match.")
+
+			ctx.GetLogger().Errorf("User Info Request with id '%s' could not be processed: %s", requestID, oauthelia2.ErrorToDebugRFC6749Error(err))
+
+			errorsx.WriteRFC6750Error(rw, err, nil)
+
+			return
+		}
+
 		original = session.IDTokenClaims().ToMap()
 		requests = session.ClaimRequests.GetUserInfoRequests()
 		requested = session.GetRequestedAt()

--- a/internal/handlers/handler_oauth2_oidc_userinfo.go
+++ b/internal/handlers/handler_oauth2_oidc_userinfo.go
@@ -76,6 +76,16 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 		return
 	}
 
+	if session, ok := requester.GetSession().(*oidc.Session); ok && !session.ValidIssuer(issuer) {
+		err = oauthelia2.ErrInvalidRequest.WithDebug("The original request and the userinfo request occurred at endpoints where the origin or effective issuer did not match.")
+
+		ctx.GetLogger().Errorf("User Info Request with id '%s' could not be processed: %s", requestID, oauthelia2.ErrorToDebugRFC6749Error(err))
+
+		errorsx.WriteRFC6750Error(rw, err, nil)
+
+		return
+	}
+
 	if client, err = ctx.Providers.OpenIDConnect.GetRegisteredClient(ctx, requester.GetClient().GetID()); err != nil {
 		ctx.GetLogger().Errorf("User Info Request with id '%s' on client with id '%s' failed to retrieve client configuration with error: %s", requestID, client.GetID(), oauthelia2.ErrorToDebugRFC6749Error(err))
 
@@ -112,16 +122,6 @@ func OpenIDConnectUserinfo(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter,
 
 	switch session := requester.GetSession().(type) {
 	case *oidc.Session:
-		if !session.ValidIssuer(issuer) {
-			err = oauthelia2.ErrInvalidRequest.WithDebug("The original request and the userinfo request occurred at endpoints where the origin or effective issuer did not match.")
-
-			ctx.GetLogger().Errorf("User Info Request with id '%s' could not be processed: %s", requestID, oauthelia2.ErrorToDebugRFC6749Error(err))
-
-			errorsx.WriteRFC6750Error(rw, err, nil)
-
-			return
-		}
-
 		original = session.IDTokenClaims().ToMap()
 		requests = session.ClaimRequests.GetUserInfoRequests()
 		requested = session.GetRequestedAt()

--- a/internal/handlers/handler_oauth2_oidc_wellknown.go
+++ b/internal/handlers/handler_oauth2_oidc_wellknown.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/valyala/fasthttp"
 
+	oauthelia2 "authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
@@ -24,10 +25,13 @@ func WellKnownOpenIDConfigurationGET(ctx *middlewares.AutheliaCtx) {
 		issuer *url.URL
 		err    error
 	)
-	if issuer, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("OpenID Connect 1.0 Discovery Request could not be processed: %s", oidc.ErrTextEffectiveIssuer)
 
-		ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
+	if issuer, err = ctx.IssuerURL(); err != nil {
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
+
+		ctx.GetLogger().WithError(err).Errorf("OpenID Connect 1.0 Discovery Request could not be processed: %s", oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.ReplyStatusCode(rfc.StatusCode())
 
 		return
 	}

--- a/internal/handlers/handler_oauth2_pushed_authorization_request.go
+++ b/internal/handlers/handler_oauth2_pushed_authorization_request.go
@@ -20,6 +20,16 @@ func OAuth2PushedAuthorizationRequest(ctx *middlewares.AutheliaCtx, rw http.Resp
 		err       error
 	)
 
+	if _, err = ctx.IssuerURL(); err != nil {
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
+
+		ctx.GetLogger().WithError(err).Errorf("Pushed Authorization Request could not be processed: %s", oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.Providers.OpenIDConnect.WritePushedAuthorizeError(ctx, rw, requester, rfc)
+
+		return
+	}
+
 	if requester, err = ctx.Providers.OpenIDConnect.NewPushedAuthorizeRequest(ctx, r); err != nil {
 		ctx.GetLogger().Errorf("Pushed Authorization Request failed with error: %s", oauthelia2.ErrorToDebugRFC6749Error(err))
 
@@ -29,14 +39,6 @@ func OAuth2PushedAuthorizationRequest(ctx *middlewares.AutheliaCtx, rw http.Resp
 	}
 
 	ctx.GetLogger().Debugf("Pushed Authorization Request with id '%s' is being processed", requester.GetID())
-
-	if _, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("Pushed Authorization Request with id '%s' could not be processed: %s", requester.GetID(), oidc.ErrTextEffectiveIssuer)
-
-		ctx.Providers.OpenIDConnect.WritePushedAuthorizeError(ctx, rw, requester, oidc.ErrEffectiveIssuer)
-
-		return
-	}
 
 	var client oidc.Client
 

--- a/internal/handlers/handler_oauth2_revocation.go
+++ b/internal/handlers/handler_oauth2_revocation.go
@@ -29,9 +29,11 @@ func OAuth2RevocationPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, 
 	ctx.GetLogger().Debugf("Revocation Request with id '%s' is being processed", requestID)
 
 	if _, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("Revocation Request with id '%s' could not be processed: %s", requestID, oidc.ErrTextEffectiveIssuer)
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
 
-		ctx.Providers.OpenIDConnect.WriteRevocationResponse(ctx, rw, oidc.ErrEffectiveIssuer)
+		ctx.GetLogger().WithError(err).Errorf("Revocation Request with id '%s' could not be processed: %s", requestID, oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.Providers.OpenIDConnect.WriteRevocationResponse(ctx, rw, rfc)
 
 		return
 	}

--- a/internal/handlers/handler_oauth2_token.go
+++ b/internal/handlers/handler_oauth2_token.go
@@ -41,8 +41,8 @@ func OAuth2TokenPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, req *
 		return
 	}
 
-	if session.Claims != nil && session.Claims.Issuer != "" && session.Claims.Issuer != issuer.String() {
-		err = oauthelia2.ErrInvalidRequest.WithDebug("The authorization request and the access request occurred at endpoints where the effective issuer did not match.")
+	if !session.ValidIssuer(issuer) {
+		err = oauthelia2.ErrInvalidRequest.WithDebug("The original request and the access request occurred at endpoints where the effective issuer did not match.")
 
 		ctx.GetLogger().WithError(err).Errorf("Access Request with id '%s' could not be processed: %s", requester.GetID(), oauthelia2.ErrorToDebugRFC6749Error(err))
 

--- a/internal/handlers/handler_oauth2_token.go
+++ b/internal/handlers/handler_oauth2_token.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"net/url"
 
 	oauthelia2 "authelia.com/provider/oauth2"
 
@@ -14,10 +15,21 @@ import (
 // https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
 func OAuth2TokenPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, req *http.Request) {
 	var (
+		issuer    *url.URL
 		requester oauthelia2.AccessRequester
 		responder oauthelia2.AccessResponder
 		err       error
 	)
+
+	if issuer, err = ctx.IssuerURL(); err != nil {
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
+
+		ctx.GetLogger().WithError(err).Errorf("Access Request could not be processed: %s", oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.Providers.OpenIDConnect.WriteAccessError(ctx, rw, requester, rfc)
+
+		return
+	}
 
 	session := oidc.NewSessionWithRequestedAt(ctx.GetClock().Now())
 
@@ -29,15 +41,17 @@ func OAuth2TokenPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter, req *
 		return
 	}
 
-	ctx.GetLogger().Debugf("Access Request with id '%s' is being processed", requester.GetID())
+	if session.Claims != nil && session.Claims.Issuer != "" && session.Claims.Issuer != issuer.String() {
+		err = oauthelia2.ErrInvalidRequest.WithDebug("The authorization request and the access request occurred at endpoints where the effective issuer did not match.")
 
-	if _, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("Access Request with id '%s' could not be processed: %s", requester.GetID(), oidc.ErrTextEffectiveIssuer)
+		ctx.GetLogger().WithError(err).Errorf("Access Request with id '%s' could not be processed: %s", requester.GetID(), oauthelia2.ErrorToDebugRFC6749Error(err))
 
-		ctx.Providers.OpenIDConnect.WriteAccessError(ctx, rw, requester, oidc.ErrEffectiveIssuer)
+		ctx.Providers.OpenIDConnect.WriteAccessError(ctx, rw, requester, err)
 
 		return
 	}
+
+	ctx.GetLogger().Debugf("Access Request with id '%s' is being processed", requester.GetID())
 
 	client, ok := requester.GetClient().(oidc.Client)
 	if !ok {

--- a/internal/handlers/handler_oauth2_wellknown.go
+++ b/internal/handlers/handler_oauth2_wellknown.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/valyala/fasthttp"
 
+	oauthelia2 "authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/middlewares"
@@ -24,10 +25,13 @@ func WellKnownOAuthAuthorizationServerGET(ctx *middlewares.AutheliaCtx) {
 		issuer *url.URL
 		err    error
 	)
-	if issuer, err = ctx.IssuerURL(); err != nil {
-		ctx.GetLogger().WithError(err).Errorf("OAuth 2.0 Discovery Request could not be processed: %s", oidc.ErrTextEffectiveIssuer)
 
-		ctx.ReplyStatusCode(fasthttp.StatusInternalServerError)
+	if issuer, err = ctx.IssuerURL(); err != nil {
+		rfc := oidc.ErrEffectiveIssuer.WithWrap(err)
+
+		ctx.GetLogger().WithError(err).Errorf("OAuth 2.0 Discovery Request could not be processed: %s", oauthelia2.ErrorToDebugRFC6749Error(rfc))
+
+		ctx.ReplyStatusCode(rfc.StatusCode())
 
 		return
 	}

--- a/internal/oidc/const.go
+++ b/internal/oidc/const.go
@@ -435,13 +435,12 @@ const (
 	fieldRFC6750Scope            = valueScope
 )
 
-const ErrTextEffectiveIssuer = "error occurred determining the effective issuer for the given request"
-
 var (
 	ErrEffectiveIssuer = &oauthelia2.RFC6749Error{
-		ErrorField:       "server_error",
-		DescriptionField: "The authorization server encountered an unexpected condition that prevented it from fulfilling the request.",
-		HintField:        "Error occurred determining the effective issuer for this request. Either the server has not been setup to handle these requests, or a failure occurred looking up details for this request.",
-		CodeField:        http.StatusInternalServerError,
+		ErrorField:       "invalid_request",
+		DescriptionField: "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed.",
+		HintField:        "Make sure that the various parameters are correct, be aware of case sensitivity and trim your parameters. Make sure that the client you are using has exactly whitelisted the redirect_uri you specified.",
+		DebugField:       "Error occurred determining the effective issuer for this request. Either the server has not been setup to handle these requests, or a failure occurred looking up details for this request.",
+		CodeField:        http.StatusBadRequest,
 	}
 )

--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -63,6 +63,13 @@ type Session struct {
 	Extra                 map[string]any  `json:"extra"`
 }
 
+// ValidIssuer returns true if the issuer is valid for this session, false otherwise.
+//
+// The issuer is valid if the session has no issuer or if the issuer matches the issuer in the session.
+func (s *Session) ValidIssuer(issuer *url.URL) bool {
+	return s == nil || s.DefaultSession == nil || s.Claims == nil || s.Claims.Issuer == "" || s.Claims.Issuer == issuer.String()
+}
+
 // GetJWTHeader returns the *jwt.Headers for the OAuth 2.0 JWT Profile Access Token.
 func (s *Session) GetJWTHeader() (headers *jwt.Headers) {
 	headers = &jwt.Headers{

--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -67,6 +67,10 @@ type Session struct {
 //
 // The issuer is valid if the session has no issuer or if the issuer matches the issuer in the session.
 func (s *Session) ValidIssuer(issuer *url.URL) bool {
+	if issuer == nil {
+		return false
+	}
+
 	return s == nil || s.DefaultSession == nil || s.Claims == nil || s.Claims.Issuer == "" || s.Claims.Issuer == issuer.String()
 }
 

--- a/internal/oidc/session_test.go
+++ b/internal/oidc/session_test.go
@@ -1,6 +1,7 @@
 package oidc_test
 
 import (
+	"net/url"
 	"testing"
 	"time"
 
@@ -26,6 +27,72 @@ func TestOpenIDSession(t *testing.T) {
 	session = nil
 
 	assert.Nil(t, session.Clone())
+}
+
+func TestSession_ValidIssuer(t *testing.T) {
+	issuer := &url.URL{Scheme: "https", Host: "auth.example.com"}
+
+	testCases := []struct {
+		name     string
+		have     *oidc.Session
+		issuer   *url.URL
+		expected bool
+	}{
+		{
+			"ShouldReturnTrueWhenSessionNil",
+			nil,
+			issuer,
+			true,
+		},
+		{
+			"ShouldReturnTrueWhenDefaultSessionNil",
+			&oidc.Session{},
+			issuer,
+			true,
+		},
+		{
+			"ShouldReturnTrueWhenClaimsNil",
+			&oidc.Session{DefaultSession: &openid.DefaultSession{}},
+			issuer,
+			true,
+		},
+		{
+			"ShouldReturnTrueWhenClaimsIssuerEmpty",
+			&oidc.Session{DefaultSession: &openid.DefaultSession{Claims: &jwt.IDTokenClaims{}}},
+			issuer,
+			true,
+		},
+		{
+			"ShouldReturnTrueWhenClaimsIssuerMatches",
+			&oidc.Session{DefaultSession: &openid.DefaultSession{Claims: &jwt.IDTokenClaims{Issuer: "https://auth.example.com"}}},
+			issuer,
+			true,
+		},
+		{
+			"ShouldReturnFalseWhenClaimsIssuerMismatches",
+			&oidc.Session{DefaultSession: &openid.DefaultSession{Claims: &jwt.IDTokenClaims{Issuer: "https://other.example.com"}}},
+			issuer,
+			false,
+		},
+		{
+			"ShouldReturnFalseWhenClaimsIssuerTrailingSlashDiffers",
+			&oidc.Session{DefaultSession: &openid.DefaultSession{Claims: &jwt.IDTokenClaims{Issuer: "https://auth.example.com/"}}},
+			issuer,
+			false,
+		},
+		{
+			"ShouldReturnFalseWhenClaimsIssuerSchemeDiffers",
+			&oidc.Session{DefaultSession: &openid.DefaultSession{Claims: &jwt.IDTokenClaims{Issuer: "http://auth.example.com"}}},
+			issuer,
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.have.ValidIssuer(tc.issuer))
+		})
+	}
 }
 
 func TestOpenIDSession_GetExtraClaims(t *testing.T) {

--- a/internal/oidc/session_test.go
+++ b/internal/oidc/session_test.go
@@ -86,6 +86,18 @@ func TestSession_ValidIssuer(t *testing.T) {
 			issuer,
 			false,
 		},
+		{
+			"ShouldReturnFalseWhenIssuerNil",
+			&oidc.Session{DefaultSession: &openid.DefaultSession{Claims: &jwt.IDTokenClaims{Issuer: "https://auth.example.com"}}},
+			nil,
+			false,
+		},
+		{
+			"ShouldReturnFalseWhenIssuerNilAndClaimsIssuerEmpty",
+			&oidc.Session{DefaultSession: &openid.DefaultSession{Claims: &jwt.IDTokenClaims{}}},
+			nil,
+			false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This moves the issuer check up higher at every endpoint where applicable. While this probably doesn't make for a meaningful fix it will ensure the most relevant and meaningful error is shown first. In addition it changes the way these messages are communicated. It also add some additional simple hardening.