### PR TITLE
build(deps): move duo-api pnpm overrides to workspace config [security]

### DIFF
--- a/internal/suites/example/compose/duo-api/package.json
+++ b/internal/suites/example/compose/duo-api/package.json
@@ -10,10 +10,5 @@
   "license": "Apache-2.0",
   "dependencies": {
     "express": "5.2.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "path-to-regexp": "8.4.2"
-    }
   }
 }

--- a/internal/suites/example/compose/duo-api/pnpm-lock.yaml
+++ b/internal/suites/example/compose/duo-api/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   path-to-regexp: 8.4.2
+  qs: 6.15.2
 
 importers:
 
@@ -202,8 +203,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -286,7 +287,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -362,7 +363,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -469,7 +470,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.14.2:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/internal/suites/example/compose/duo-api/pnpm-workspace.yaml
+++ b/internal/suites/example/compose/duo-api/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+overrides:
+  path-to-regexp: 8.4.2
+  qs: 6.15.2


### PR DESCRIPTION
pnpm now expects dependency overrides in `pnpm-workspace.yaml` rather than the `pnpm.overrides` block in `package.json`. Move the existing `path-to-regexp` pin into a new sibling `pnpm-workspace.yaml` alongside `package.json`, and add a `qs@6.15.2` override so the duo-api suite image resolves the latest release transitively under `express`.