### PR TITLE
test(suites): increase timeout for ldap

### DIFF
--- a/internal/suites/suite_ldap.go
+++ b/internal/suites/suite_ldap.go
@@ -44,7 +44,7 @@ func init() {
 		SetUp:           setup,
 		SetUpTimeout:    5 * time.Minute,
 		OnSetupTimeout:  displayAutheliaLogs,
-		TestTimeout:     120 * time.Second,
+		TestTimeout:     150 * time.Second,
 		TearDown:        teardown,
 		TearDownTimeout: 2 * time.Minute,
 		OnError:         displayAutheliaLogs,


### PR DESCRIPTION
This adds additional time for the ldap suite which appears to be necessary for reliable completion.