### PR TITLE
fix(authorization): case-insensitive domain matching [security]

### DIFF
--- a/internal/authorization/access_control_domain.go
+++ b/internal/authorization/access_control_domain.go
@@ -63,15 +63,15 @@ type AccessControlDomainMatcher struct {
 func (m AccessControlDomainMatcher) IsMatch(domain string, subject Subject) (match bool) {
 	switch {
 	case m.Wildcard:
-		return strings.HasSuffix(domain, m.Name)
+		return utils.StringHasSuffixFold(domain, m.Name)
 	case m.UserWildcard:
-		if subject.IsAnonymous() && strings.HasSuffix(domain, m.Name) {
+		if subject.IsAnonymous() && utils.StringHasSuffixFold(domain, m.Name) {
 			return len(domain) > len(m.Name)
 		}
 
 		return domain == fmt.Sprintf("%s%s", subject.Username, m.Name)
 	case m.GroupWildcard:
-		if subject.IsAnonymous() && strings.HasSuffix(domain, m.Name) {
+		if subject.IsAnonymous() && utils.StringHasSuffixFold(domain, m.Name) {
 			return len(domain) > len(m.Name)
 		}
 

--- a/internal/authorization/access_control_domain_test.go
+++ b/internal/authorization/access_control_domain_test.go
@@ -25,12 +25,32 @@ func TestAccessControlDomain_IsMatch(t *testing.T) {
 			true,
 		},
 		{
+			"ShouldMatchDomainSuffixUserWildcardWithMixedCaseDomain",
+			&AccessControlDomainMatcher{
+				Name:         "-user.domain.com",
+				UserWildcard: true,
+			},
+			"A-User.Domain.COM",
+			Subject{},
+			true,
+		},
+		{
 			"ShouldMatchDomainSuffixGroupWildcard",
 			&AccessControlDomainMatcher{
 				Name:          "-group.domain.com",
 				GroupWildcard: true,
 			},
 			"a-group.domain.com",
+			Subject{},
+			true,
+		},
+		{
+			"ShouldMatchDomainSuffixGroupWildcardWithMixedCaseDomain",
+			&AccessControlDomainMatcher{
+				Name:          "-group.domain.com",
+				GroupWildcard: true,
+			},
+			"A-Group.Domain.COM",
 			Subject{},
 			true,
 		},
@@ -45,6 +65,26 @@ func TestAccessControlDomain_IsMatch(t *testing.T) {
 			false,
 		},
 		{
+			"ShouldNotMatchExactDomainWithUserWildcardWithMixedCaseDomain",
+			&AccessControlDomainMatcher{
+				Name:         "-user.domain.com",
+				UserWildcard: true,
+			},
+			"-User.Domain.COM",
+			Subject{},
+			false,
+		},
+		{
+			"ShouldNotMatchExactDomainWithGroupWildcardWithMixedCaseDomain",
+			&AccessControlDomainMatcher{
+				Name:          "-group.domain.com",
+				GroupWildcard: true,
+			},
+			"-Group.Domain.COM",
+			Subject{},
+			false,
+		},
+		{
 			"ShouldMatchWildcard",
 			&AccessControlDomainMatcher{
 				Name:     "user.domain.com",
@@ -53,6 +93,26 @@ func TestAccessControlDomain_IsMatch(t *testing.T) {
 			"abc.user.domain.com",
 			Subject{},
 			true,
+		},
+		{
+			"ShouldMatchWildcardWithMixedCaseDomain",
+			&AccessControlDomainMatcher{
+				Name:     "user.domain.com",
+				Wildcard: true,
+			},
+			"ABC.User.Domain.COM",
+			Subject{},
+			true,
+		},
+		{
+			"ShouldNotMatchWildcardWithDifferentSuffix",
+			&AccessControlDomainMatcher{
+				Name:     "user.domain.com",
+				Wildcard: true,
+			},
+			"abc.user.example.com",
+			Subject{},
+			false,
 		},
 	}
 

--- a/internal/authorization/authorizer_test.go
+++ b/internal/authorization/authorizer_test.go
@@ -197,6 +197,27 @@ func (s *AuthorizerSuite) TestShouldCheckMultipleDomainRule() {
 	tester.CheckAuthorizations(s.T(), UserWithGroups, "https://private.other.com/", fasthttp.MethodGet, Denied)
 }
 
+func (s *AuthorizerSuite) TestShouldCheckWildcardDomainRulePrecedenceIsCaseInsensitive() {
+	tester := NewAuthorizerBuilder().
+		WithDefaultPolicy(deny).
+		WithRule(schema.AccessControlRule{
+			Domains: []string{"*.admin.example5.com"},
+			Policy:  twoFactor,
+		}).
+		WithRule(schema.AccessControlRule{
+			Domains: []string{"*.example5.com"},
+			Policy:  bypass,
+		}).
+		Build()
+
+	tester.CheckAuthorizations(s.T(), UserWithGroups, "https://secure.admin.example5.com/", fasthttp.MethodGet, TwoFactor)
+	tester.CheckAuthorizations(s.T(), UserWithGroups, "https://secure.ADMIN.example5.com/", fasthttp.MethodGet, TwoFactor)
+	tester.CheckAuthorizations(s.T(), UserWithGroups, "https://secure.Admin.example5.com/", fasthttp.MethodGet, TwoFactor)
+	tester.CheckAuthorizations(s.T(), UserWithGroups, "https://SECURE.ADMIN.EXAMPLE5.COM/", fasthttp.MethodGet, TwoFactor)
+	tester.CheckAuthorizations(s.T(), UserWithGroups, "https://public.example5.com/", fasthttp.MethodGet, Bypass)
+	tester.CheckAuthorizations(s.T(), UserWithGroups, "https://public.EXAMPLE5.com/", fasthttp.MethodGet, Bypass)
+}
+
 func (s *AuthorizerSuite) TestShouldCheckFactorsPolicy() {
 	tester := NewAuthorizerBuilder().
 		WithDefaultPolicy(deny).

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -303,3 +303,7 @@ func StringJoinBuild(sep, sepFinal, quote string, items []string) string {
 
 	return b.String()
 }
+
+func StringHasSuffixFold(s, suffix string) bool {
+	return len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix)
+}


### PR DESCRIPTION
This fixes edge cases where domain matching was case-sensitive. This specifically applies when using wildcard records or user/group segment domains.

Fixes: GHSA-j748-h363-wqj8