### PR TITLE
ci(renovate): align npm release age with pnpm default

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -78,7 +78,8 @@
       ],
       "addLabels": [
         "javascript"
-      ]
+      ],
+      "minimumReleaseAge": "1 day"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
pnpm 11 enforces a `minimumReleaseAge` default of 1440 minutes (24 hours), rejecting any lockfile entry whose npm publish timestamp is more recent than the cutoff. Renovate had no equivalent delay on the npm datasource, so it could open a PR for a package the moment it was published; the bump would pass author-machine `pnpm install` (cache hit, no re-verification) but the next CI install would fail the supply-chain pass on `internal/templates/src`. This is what happened with the `react-email` 6.3.3 bump in #12164, which was reverted in #12171 hours later.

Extend the existing npm-scoped `packageRules` entry with `minimumReleaseAge: "1 day"` so Renovate holds dependency PRs back until they have aged past pnpm's threshold. The constraint is gated by `matchDatasources: ["npm"]`, so `gomod`, `docker`, `github-actions`, and `kubernetes` updates continue to flow without any added delay.