### PR TITLE
fix(session): support port-specific authelia urls

### DIFF
--- a/internal/configuration/validator/session.go
+++ b/internal/configuration/validator/session.go
@@ -88,10 +88,8 @@ func validateSessionCookieDomains(config *schema.Session, validator *schema.Stru
 
 	domains := make([]schema.SessionCookie, 0, len(config.Cookies))
 
-	for i, d := range config.Cookies {
+	for i := range config.Cookies {
 		validateSessionDomainName(i, config, validator)
-
-		validateSessionUniqueCookieDomain(i, config, domains, validator)
 
 		validateSessionCookieName(i, config)
 
@@ -103,7 +101,9 @@ func validateSessionCookieDomains(config *schema.Session, validator *schema.Stru
 
 		validateSessionSameSite(i, config, validator)
 
-		domains = append(domains, d)
+		validateSessionUniqueCookieDomain(i, config, domains, validator)
+
+		domains = append(domains, config.Cookies[i])
 	}
 }
 
@@ -164,12 +164,18 @@ func validateSessionUniqueCookieDomain(i int, config *schema.Session, domains []
 	var d = config.Cookies[i]
 
 	for _, domain := range domains {
-		if !utils.HasDomainSuffix(d.Domain, domain.Domain) {
+		if !utils.HasDomainSuffix(d.Domain, domain.Domain) && !utils.HasDomainSuffix(domain.Domain, d.Domain) {
 			continue
 		}
 
 		if strings.EqualFold(d.Domain, domain.Domain) {
 			if sessionCookieAutheliaHost(d) == "" || sessionCookieAutheliaHost(domain) == "" || sessionCookieAutheliaHost(d) == sessionCookieAutheliaHost(domain) {
+				validator.Push(fmt.Errorf(errFmtSessionDomainDuplicate, sessionDomainDescriptor(i, d)))
+
+				return
+			}
+
+			if !sessionCookieSameDomainConfigEqual(d, domain) {
 				validator.Push(fmt.Errorf(errFmtSessionDomainDuplicate, sessionDomainDescriptor(i, d)))
 
 				return
@@ -186,6 +192,16 @@ func validateSessionUniqueCookieDomain(i int, config *schema.Session, domains []
 
 func sessionCookieAutheliaHost(cookie schema.SessionCookie) string {
 	return utils.URLHost(cookie.AutheliaURL)
+}
+
+func sessionCookieSameDomainConfigEqual(first, second schema.SessionCookie) bool {
+	return first.Name == second.Name &&
+		first.SameSite == second.SameSite &&
+		first.Expiration == second.Expiration &&
+		first.Inactivity == second.Inactivity &&
+		first.RememberMe == second.RememberMe &&
+		first.DisableRememberMe == second.DisableRememberMe &&
+		utils.EqualURLs(first.DefaultRedirectionURL, second.DefaultRedirectionURL)
 }
 
 // validateSessionCookiesURLs validates the AutheliaURL and DefaultRedirectionURL.

--- a/internal/configuration/validator/session.go
+++ b/internal/configuration/validator/session.go
@@ -86,7 +86,7 @@ func validateSessionCookieDomains(config *schema.Session, validator *schema.Stru
 		validator.Push(fmt.Errorf(errFmtSessionOptionRequired, "cookies"))
 	}
 
-	domains := make([]string, 0, len(config.Cookies))
+	domains := make([]schema.SessionCookie, 0, len(config.Cookies))
 
 	for i, d := range config.Cookies {
 		validateSessionDomainName(i, config, validator)
@@ -103,7 +103,7 @@ func validateSessionCookieDomains(config *schema.Session, validator *schema.Stru
 
 		validateSessionSameSite(i, config, validator)
 
-		domains = append(domains, d.Domain)
+		domains = append(domains, d)
 	}
 }
 
@@ -160,15 +160,32 @@ func validateSessionExpiration(i int, config *schema.Session) {
 }
 
 // validateSessionUniqueCookieDomain Check the current domains do not share a root domain with previous domains.
-func validateSessionUniqueCookieDomain(i int, config *schema.Session, domains []string, validator *schema.StructValidator) {
+func validateSessionUniqueCookieDomain(i int, config *schema.Session, domains []schema.SessionCookie, validator *schema.StructValidator) {
 	var d = config.Cookies[i]
-	if utils.IsStringInSliceF(d.Domain, domains, utils.HasDomainSuffix) {
-		if utils.IsStringInSlice(d.Domain, domains) {
-			validator.Push(fmt.Errorf(errFmtSessionDomainDuplicate, sessionDomainDescriptor(i, d)))
-		} else {
-			validator.Push(fmt.Errorf(errFmtSessionDomainDuplicateCookieScope, sessionDomainDescriptor(i, d)))
+
+	for _, domain := range domains {
+		if !utils.HasDomainSuffix(d.Domain, domain.Domain) {
+			continue
 		}
+
+		if strings.EqualFold(d.Domain, domain.Domain) {
+			if sessionCookieAutheliaHost(d) == "" || sessionCookieAutheliaHost(domain) == "" || sessionCookieAutheliaHost(d) == sessionCookieAutheliaHost(domain) {
+				validator.Push(fmt.Errorf(errFmtSessionDomainDuplicate, sessionDomainDescriptor(i, d)))
+
+				return
+			}
+
+			continue
+		}
+
+		validator.Push(fmt.Errorf(errFmtSessionDomainDuplicateCookieScope, sessionDomainDescriptor(i, d)))
+
+		return
 	}
+}
+
+func sessionCookieAutheliaHost(cookie schema.SessionCookie) string {
+	return utils.URLHost(cookie.AutheliaURL)
 }
 
 // validateSessionCookiesURLs validates the AutheliaURL and DefaultRedirectionURL.

--- a/internal/configuration/validator/session_test.go
+++ b/internal/configuration/validator/session_test.go
@@ -721,14 +721,40 @@ func TestShouldRaiseErrorWhenHaveDuplicatedDomainName(t *testing.T) {
 	})
 	config.Session.Cookies = append(config.Session.Cookies, schema.SessionCookie{
 		Domain:      exampleDotCom,
-		AutheliaURL: MustParseURL("https://login.example.com"),
+		AutheliaURL: MustParseURL("https://auth.example.com"),
 	})
 
 	ValidateSession(&config, validator)
 	assert.False(t, validator.HasWarnings())
-	require.Len(t, validator.Errors(), 2)
+	require.Len(t, validator.Errors(), 1)
+	assert.EqualError(t, validator.Errors()[0], "session: domain config #3 (domain 'example.com'): option 'domain' is a duplicate value for another configured session domain")
+}
+
+func TestShouldAllowDuplicatedDomainNameWithDifferentAutheliaURLHosts(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+	config.Session.Cookies = append(config.Session.Cookies, schema.SessionCookie{
+		Domain:      exampleDotCom,
+		AutheliaURL: MustParseURL("https://auth.example.com:8443"),
+	})
+
+	ValidateSession(&config, validator)
+	assert.False(t, validator.HasWarnings())
+	assert.False(t, validator.HasErrors())
+}
+
+func TestShouldRaiseErrorWhenDuplicatedDomainNameHasEquivalentDefaultPortAutheliaURL(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+	config.Session.Cookies = append(config.Session.Cookies, schema.SessionCookie{
+		Domain:      exampleDotCom,
+		AutheliaURL: MustParseURL("https://auth.example.com:443"),
+	})
+
+	ValidateSession(&config, validator)
+	assert.False(t, validator.HasWarnings())
+	require.Len(t, validator.Errors(), 1)
 	assert.EqualError(t, validator.Errors()[0], "session: domain config #2 (domain 'example.com'): option 'domain' is a duplicate value for another configured session domain")
-	assert.EqualError(t, validator.Errors()[1], "session: domain config #3 (domain 'example.com'): option 'domain' is a duplicate value for another configured session domain")
 }
 
 func TestShouldRaiseErrorWhenHaveNonAbsAutheliaURL(t *testing.T) {
@@ -831,9 +857,8 @@ func TestShouldRaiseErrorWhenSubdomainConflicts(t *testing.T) {
 
 	ValidateSession(&config, validator)
 	assert.False(t, validator.HasWarnings())
-	require.Len(t, validator.Errors(), 2)
-	assert.EqualError(t, validator.Errors()[0], "session: domain config #2 (domain 'example.com'): option 'domain' is a duplicate value for another configured session domain")
-	assert.EqualError(t, validator.Errors()[1], "session: domain config #3 (domain 'internal.example.com'): option 'domain' shares the same cookie domain scope as another configured session domain")
+	require.Len(t, validator.Errors(), 1)
+	assert.EqualError(t, validator.Errors()[0], "session: domain config #3 (domain 'internal.example.com'): option 'domain' shares the same cookie domain scope as another configured session domain")
 }
 
 func TestShouldRaiseErrorWhenDomainIsInvalid(t *testing.T) {

--- a/internal/configuration/validator/session_test.go
+++ b/internal/configuration/validator/session_test.go
@@ -743,6 +743,40 @@ func TestShouldAllowDuplicatedDomainNameWithDifferentAutheliaURLHosts(t *testing
 	assert.False(t, validator.HasErrors())
 }
 
+func TestShouldRaiseErrorWhenDuplicatedDomainNameWithDifferentAutheliaURLHostsHasDifferentCookieConfig(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+	config.Session.Cookies = append(config.Session.Cookies, schema.SessionCookie{
+		SessionCookieCommon: schema.SessionCookieCommon{
+			Name: "other_session",
+		},
+		Domain:      exampleDotCom,
+		AutheliaURL: MustParseURL("https://auth.example.com:8443"),
+	})
+
+	ValidateSession(&config, validator)
+	assert.False(t, validator.HasWarnings())
+	require.Len(t, validator.Errors(), 1)
+	assert.EqualError(t, validator.Errors()[0], "session: domain config #2 (domain 'example.com'): option 'domain' is a duplicate value for another configured session domain")
+}
+
+func TestShouldRaiseErrorWhenDuplicatedDomainNameWithDifferentAutheliaURLHostsHasCookieNameWithDifferentCase(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+	config.Session.Cookies = append(config.Session.Cookies, schema.SessionCookie{
+		SessionCookieCommon: schema.SessionCookieCommon{
+			Name: "Authelia_Session",
+		},
+		Domain:      exampleDotCom,
+		AutheliaURL: MustParseURL("https://auth.example.com:8443"),
+	})
+
+	ValidateSession(&config, validator)
+	assert.False(t, validator.HasWarnings())
+	require.Len(t, validator.Errors(), 1)
+	assert.EqualError(t, validator.Errors()[0], "session: domain config #2 (domain 'example.com'): option 'domain' is a duplicate value for another configured session domain")
+}
+
 func TestShouldRaiseErrorWhenDuplicatedDomainNameHasEquivalentDefaultPortAutheliaURL(t *testing.T) {
 	validator := schema.NewStructValidator()
 	config := newDefaultSessionConfig()
@@ -843,6 +877,24 @@ func TestShouldRaiseErrorWhenHaveDefaultRedirectionURLEqualAutheliaURL(t *testin
 	assert.EqualError(t, validator.Errors()[0], "session: domain config #1 (domain 'example.com'): option 'default_redirection_url' with value 'https://login.example.com' is effectively equal to option 'authelia_url' with value 'https://login.example.com' which is not permitted")
 }
 
+func TestShouldRaiseErrorWhenHaveDefaultRedirectionURLEqualAutheliaURLWithDefaultPort(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+	config.Session.Domain = "" //nolint:staticcheck
+	config.Session.Cookies = []schema.SessionCookie{
+		{
+			Domain:                exampleDotCom,
+			AutheliaURL:           MustParseURL("https://login.example.com"),
+			DefaultRedirectionURL: MustParseURL("https://login.example.com:443"),
+		},
+	}
+
+	ValidateSession(&config, validator)
+	assert.False(t, validator.HasWarnings())
+	require.Len(t, validator.Errors(), 1)
+	assert.EqualError(t, validator.Errors()[0], "session: domain config #1 (domain 'example.com'): option 'default_redirection_url' with value 'https://login.example.com:443' is effectively equal to option 'authelia_url' with value 'https://login.example.com' which is not permitted")
+}
+
 func TestShouldRaiseErrorWhenSubdomainConflicts(t *testing.T) {
 	validator := schema.NewStructValidator()
 	config := newDefaultSessionConfig()
@@ -859,6 +911,26 @@ func TestShouldRaiseErrorWhenSubdomainConflicts(t *testing.T) {
 	assert.False(t, validator.HasWarnings())
 	require.Len(t, validator.Errors(), 1)
 	assert.EqualError(t, validator.Errors()[0], "session: domain config #3 (domain 'internal.example.com'): option 'domain' shares the same cookie domain scope as another configured session domain")
+}
+
+func TestShouldRaiseErrorWhenSubdomainConflictsInReverseOrder(t *testing.T) {
+	validator := schema.NewStructValidator()
+	config := newDefaultSessionConfig()
+	config.Session.Cookies = []schema.SessionCookie{
+		{
+			Domain:      "internal.example.com",
+			AutheliaURL: MustParseURL("https://login.internal.example.com"),
+		},
+		{
+			Domain:      exampleDotCom,
+			AutheliaURL: MustParseURL("https://login.example.com"),
+		},
+	}
+
+	ValidateSession(&config, validator)
+	assert.False(t, validator.HasWarnings())
+	require.Len(t, validator.Errors(), 1)
+	assert.EqualError(t, validator.Errors()[0], "session: domain config #2 (domain 'example.com'): option 'domain' shares the same cookie domain scope as another configured session domain")
 }
 
 func TestShouldRaiseErrorWhenDomainIsInvalid(t *testing.T) {

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -275,7 +275,7 @@ func (ctx *AutheliaCtx) GetCookieConfigFromAutheliaURL(autheliaURL *url.URL) (co
 			continue
 		}
 
-		if autheliaURL.Host == cookie.AutheliaURL.Host {
+		if utils.URLHost(autheliaURL) == utils.URLHost(cookie.AutheliaURL) {
 			return cookie
 		}
 	}

--- a/internal/middlewares/authelia_context_blackbox_test.go
+++ b/internal/middlewares/authelia_context_blackbox_test.go
@@ -23,6 +23,15 @@ import (
 	"github.com/authelia/authelia/v4/internal/session"
 )
 
+func mustParseURL(rawURL string) *url.URL {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+
+	return parsedURL
+}
+
 func TestNewRequestLogger(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 
@@ -493,6 +502,44 @@ func TestAutheliaCtx_IssuerURL(t *testing.T) {
 				"X-Forwarded-URI":              "/abc",
 			},
 			"https://login.example.com:8080",
+			"",
+		},
+		{
+			"ShouldHandleDuplicateDomainDifferentAutheliaURLPort",
+			&schema.Session{
+				Cookies: []schema.SessionCookie{
+					{
+						Domain:      "example.com",
+						AutheliaURL: mustParseURL("https://login.example.com"),
+					},
+					{
+						Domain:      "example.com",
+						AutheliaURL: mustParseURL("https://login.example.com:8443"),
+					},
+				},
+			},
+			map[string]any{
+				fasthttp.HeaderXForwardedProto: "https",
+				fasthttp.HeaderXForwardedHost:  "login.example.com:8443",
+			},
+			"https://login.example.com:8443",
+			"",
+		},
+		{
+			"ShouldHandleEquivalentDefaultPortAutheliaURL",
+			&schema.Session{
+				Cookies: []schema.SessionCookie{
+					{
+						Domain:      "example.com",
+						AutheliaURL: mustParseURL("https://login.example.com"),
+					},
+				},
+			},
+			map[string]any{
+				fasthttp.HeaderXForwardedProto: "https",
+				fasthttp.HeaderXForwardedHost:  "login.example.com:443",
+			},
+			"https://login.example.com:443",
 			"",
 		},
 		{

--- a/internal/session/provider.go
+++ b/internal/session/provider.go
@@ -36,6 +36,10 @@ func NewProvider(config schema.Session, certPool *x509.CertPool) *Provider {
 	)
 
 	for _, dconfig := range config.Cookies {
+		if _, ok := provider.sessions[dconfig.Domain]; ok {
+			continue
+		}
+
 		if _, holder, err = NewProviderConfigAndSession(dconfig, name, s, p); err != nil {
 			provider.errStartup = fmt.Errorf("error initializing session for domain '%s': %w", dconfig.Domain, err)
 

--- a/internal/session/provider_test.go
+++ b/internal/session/provider_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
@@ -12,6 +13,15 @@ import (
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 )
+
+func mustParseURL(rawURL string) *url.URL {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+
+	return parsedURL
+}
 
 func newTestSession() (*Session, error) {
 	config := schema.Session{}
@@ -377,6 +387,38 @@ func TestStartupCheckShouldSucceedForMemoryBackendWithMultipleDomains(t *testing
 
 	assert.NoError(t, provider.StartupCheck())
 	assert.Len(t, provider.sessions, 2)
+}
+
+func TestStartupCheckShouldShareMemoryBackendWithDuplicateCookieDomains(t *testing.T) {
+	config := schema.Session{}
+	config.Cookies = []schema.SessionCookie{
+		{
+			SessionCookieCommon: schema.SessionCookieCommon{
+				Name:       testName,
+				Expiration: testExpiration,
+			},
+			Domain:      testDomain,
+			AutheliaURL: mustParseURL("https://auth.example.com"),
+		},
+		{
+			SessionCookieCommon: schema.SessionCookieCommon{
+				Name:       testName,
+				Expiration: testExpiration,
+			},
+			Domain:      testDomain,
+			AutheliaURL: mustParseURL("https://auth.example.com:8443"),
+		},
+	}
+
+	provider := NewProvider(config, nil)
+
+	assert.NoError(t, provider.StartupCheck())
+	assert.Len(t, provider.sessions, 1)
+
+	domainSession, err := provider.Get(testDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, testDomain, domainSession.Config.Domain)
+	assert.Equal(t, "auth.example.com", domainSession.Config.AutheliaURL.Host)
 }
 
 func TestStartupCheckShouldSurfaceConstructionError(t *testing.T) {

--- a/internal/utils/url.go
+++ b/internal/utils/url.go
@@ -111,7 +111,7 @@ func EqualURLs(first, second *url.URL) bool {
 		return false
 	}
 
-	if !strings.EqualFold(first.Host, second.Host) {
+	if URLHost(first) != URLHost(second) {
 		return false
 	}
 

--- a/internal/utils/url.go
+++ b/internal/utils/url.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net"
 	"net/url"
 	"path"
 	"strings"
@@ -50,6 +51,34 @@ func IsURISecure(uri *url.URL) bool {
 // suffix prefixed with a period.
 func HasURIDomainSuffix(uri *url.URL, domainSuffix string) bool {
 	return HasDomainSuffix(uri.Hostname(), domainSuffix)
+}
+
+// URLHost returns a normalized host value for comparison. It normalizes host case and treats default scheme ports as
+// equivalent to an omitted port.
+func URLHost(uri *url.URL) string {
+	if uri == nil {
+		return ""
+	}
+
+	hostname := strings.ToLower(uri.Hostname())
+	port := uri.Port()
+
+	switch strings.ToLower(uri.Scheme) {
+	case https, wss:
+		if port == "443" {
+			port = ""
+		}
+	case "http", "ws":
+		if port == "80" {
+			port = ""
+		}
+	}
+
+	if port == "" {
+		return hostname
+	}
+
+	return net.JoinHostPort(hostname, port)
 }
 
 // HasDomainSuffix returns true if the URI hostname is equal to the domain or if it has a suffix of the domain

--- a/internal/utils/url_test.go
+++ b/internal/utils/url_test.go
@@ -66,6 +66,14 @@ func TestHasURIDomainSuffix(t *testing.T) {
 	assert.False(t, HasURIDomainSuffix(&url.URL{Scheme: "https", Host: "auth.xexample.com"}, "example.com"))
 }
 
+func TestURLHost(t *testing.T) {
+	assert.Equal(t, "example.com", URLHost(&url.URL{Scheme: "https", Host: "Example.COM"}))
+	assert.Equal(t, "example.com", URLHost(&url.URL{Scheme: "https", Host: "example.com:443"}))
+	assert.Equal(t, "example.com:8443", URLHost(&url.URL{Scheme: "https", Host: "example.com:8443"}))
+	assert.Equal(t, "[2001:db8::1]:8443", URLHost(&url.URL{Scheme: "https", Host: "[2001:db8::1]:8443"}))
+	assert.Equal(t, "", URLHost(nil))
+}
+
 func TestHasDomainSuffix(t *testing.T) {
 	testCases := []struct {
 		Name         string

--- a/internal/utils/url_test.go
+++ b/internal/utils/url_test.go
@@ -111,6 +111,9 @@ func TestEqualURLs(t *testing.T) {
 
 	assert.True(t, EqualURLs(MustParseURL(url.Parse("https://google.com")), MustParseURL(url.Parse("https://google.com"))))
 	assert.True(t, EqualURLs(MustParseURL(url.Parse("https://google.com")), MustParseURL(url.Parse("https://Google.com"))))
+	assert.True(t, EqualURLs(MustParseURL(url.Parse("https://google.com")), MustParseURL(url.Parse("https://google.com:443"))))
+	assert.True(t, EqualURLs(MustParseURL(url.Parse("http://google.com")), MustParseURL(url.Parse("http://google.com:80"))))
+	assert.False(t, EqualURLs(MustParseURL(url.Parse("https://google.com")), MustParseURL(url.Parse("https://google.com:8443"))))
 	assert.True(t, EqualURLs(MustParseURL(url.Parse("https://google.com/abc")), MustParseURL(url.Parse("https://Google.com/abc"))))
 	assert.False(t, EqualURLs(MustParseURL(url.Parse("https://google.com/abc")), MustParseURL(url.Parse("https://Google.com/ABC"))))
 	assert.False(t, EqualURLs(MustParseURL(url.Parse("https://google.com/abc?abc=1")), MustParseURL(url.Parse("https://Google.com/abc"))))


### PR DESCRIPTION
## Summary
This PR adds core support for Authelia URLs that include explicit non-default ports.
The motivating case is when Authelia is reachable through both a normal HTTPS endpoint and a second endpoint with a custom port, for example:
- `https://auth.example.com`
- `https://auth.example.com:8443`
Before this change, session cookie URL matching and issuer comparison could fail or behave ambiguously when the request URL included an explicit port.

## Context
This is related to the previously closed feature request:
- #12175
I understand that #12175 was closed as not planned, and I’m not trying to push against that decision. I’m opening this PR mainly to provide a concrete implementation with tests, since I’ve now validated the behavior in a real downstream deployment.
If maintainers still prefer not to support this use case, I’m completely fine with closing this PR as well.

## Changes
- Allow session cookie Authelia URLs to differ by explicit port.
- Normalize URL hosts so default ports compare equivalently:
  - `https://auth.example.com`
  - `https://auth.example.com:443`
- Match OIDC issuers using canonical hosts.
- Reject conflicting cookie domain configurations which would otherwise be ambiguous.
- Add tests for the port-specific matching and validation behavior.

## Downstream validation
I validated this in a real deployment where Authelia is reachable via both:
- `https://auth.xcan.cc.cd`
- `https://auth.xcan.cc.cd:2278`
The setup is working with a Helm chart change that renders separate generated `authelia_url` values for the two endpoints while keeping the cookie domain unchanged.