### PR TITLE
docs(oidc): add userinfo option to nextcloud user_oidc

### DIFF
--- a/docs/content/integration/openid-connect/clients/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/clients/nextcloud/index.md
@@ -252,6 +252,7 @@ To configure [Nextcloud] and the [Nextcloud OpenID Connect user backend app] to 
 ``` php
 'user_oidc' => [
   'default_token_endpoint_auth_method' => 'client_secret_post',
+  'enrich_login_id_token_with_userinfo' => true,
 ]
 ```
 

--- a/docs/content/integration/openid-connect/clients/nextcloud/index.md
+++ b/docs/content/integration/openid-connect/clients/nextcloud/index.md
@@ -238,6 +238,7 @@ To configure [Nextcloud] and the [Nextcloud OpenID Connect user backend app] to 
 ``` php
 'user_oidc' => [
   'default_token_endpoint_auth_method' => 'client_secret_post',
+  'enrich_login_id_token_with_userinfo' => true,
 ]
 ```
 


### PR DESCRIPTION
This indicates that the `user_oidc` plugin isn't fully conformant with the oidc specifications due to the need to enable user info queries to fill in claims not included in the id tokens.