### PR TITLE
ci: broaden lefthook grype ignore to all embedded packages

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -25,11 +25,10 @@ ignore:
       Explicitly patched in authelia/base. The reported version string is unchanged from upstream busybox 1.37.0
       so grype still flags it, but the vulnerable code paths have been backported.
   - package:
-      name: stdlib
-      type: go-module
       location: "**/lefthook*/**"
     reason: |
-      Go stdlib embedded in the lefthook prebuilt binaries (npm devDependency). Lefthook is a developer/CI git
-      hook runner only; not shipped in any Authelia runtime artifact. Scoped by source path so this never
-      accidentally hides stdlib findings from Authelia's own binaries.
+      Any dependency (Go stdlib, golang.org/x/* modules, etc.) statically embedded in the lefthook prebuilt
+      binaries (npm devDependency). Lefthook is a developer/CI git hook runner only; not shipped in any Authelia
+      runtime artifact. Scoped by source path so this never accidentally hides findings from Authelia's own
+      binaries.
 ...


### PR DESCRIPTION
The grype ignore rule for the lefthook prebuilt binaries was scoped to `stdlib` go-module findings only, so each new transitive dependency statically linked into the binary (e.g. `golang.org/x/sys` flagged by `GO-2026-5024`) surfaced as a fresh failure and had to be added by hand.

Drop the `name` and `type` constraints and match purely on the `**/lefthook*/**` source path. Any package embedded in the lefthook binary (stdlib, `golang.org/x/*` modules, and future transitive deps) is now suppressed, while the path scoping still ensures the same packages remain visible when they appear in Authelia's own runtime binaries. Lefthook is a developer/CI git hook runner only and is never shipped in a runtime artifact.