### PR TITLE
fix(oidc): client credentials at jwt missing sub

### DIFF
--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -92,6 +92,8 @@ func (s *Session) GetJWTHeader() (headers *jwt.Headers) {
 }
 
 // GetJWTClaims returns the jwt.JWTClaimsContainer for the OAuth 2.0 JWT Profile Access Tokens.
+//
+//nolint:gocyclo
 func (s *Session) GetJWTClaims() jwt.JWTClaimsContainer {
 	//nolint:prealloc
 	var (
@@ -141,6 +143,10 @@ func (s *Session) GetJWTClaims() jwt.JWTClaimsContainer {
 
 	if len(s.ClientID) != 0 {
 		claims.Extra[ClaimClientIdentifier] = s.ClientID
+	}
+
+	if s.ClientCredentials && len(claims.Subject) == 0 && len(s.ClientID) != 0 {
+		claims.Subject = s.ClientID
 	}
 
 	return claims

--- a/internal/oidc/session_test.go
+++ b/internal/oidc/session_test.go
@@ -320,6 +320,31 @@ func TestSession_GetJWTClaims(t *testing.T) {
 			},
 			&jwt.JWTClaims{Extra: map[string]any{oidc.ClaimAuthenticationMethodsReference: []string{oidc.AMRMultiFactorAuthentication}, oidc.ClaimClientIdentifier: abc}},
 		},
+
+		{
+			"ShouldSetClientCredentialsSubjectFromClientID",
+			&oidc.Session{DefaultSession: openid.NewDefaultSession(), ClientID: abc, ClientCredentials: true},
+			&jwt.JWTClaims{Subject: abc, Extra: map[string]any{oidc.ClaimClientIdentifier: abc}},
+		},
+		{
+			"ShouldNotOverrideClientCredentialsSubject",
+			&oidc.Session{
+				DefaultSession: &openid.DefaultSession{
+					Subject:     "existing",
+					Claims:      &jwt.IDTokenClaims{Extra: map[string]any{}},
+					Headers:     &jwt.Headers{},
+					RequestedAt: time.Now(),
+				},
+				ClientID:          abc,
+				ClientCredentials: true,
+			},
+			&jwt.JWTClaims{Subject: "existing", Extra: map[string]any{oidc.ClaimClientIdentifier: abc}},
+		},
+		{
+			"ShouldNotSetSubjectFromClientIDWhenNotClientCredentials",
+			&oidc.Session{DefaultSession: openid.NewDefaultSession(), ClientID: abc},
+			&jwt.JWTClaims{Extra: map[string]any{oidc.ClaimClientIdentifier: abc}},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -330,6 +355,7 @@ func TestSession_GetJWTClaims(t *testing.T) {
 
 			require.True(t, ok)
 
+			assert.Equal(t, tc.expected.Subject, actual.Subject)
 			assert.Equal(t, tc.expected.JTI, actual.JTI)
 			assert.Equal(t, tc.expected.Audience, actual.Audience)
 			assert.Equal(t, tc.expected.Issuer, actual.Issuer)


### PR DESCRIPTION
This fixes an issue where using the Client Credentials Flow to produce JWT Profile Access Tokens did not result in a JWT with a sub claim.