### PR TITLE
build(deps): update dependency esbuild to v0.28.1 [security]

### DIFF
--- a/internal/templates/src/package.json
+++ b/internal/templates/src/package.json
@@ -26,5 +26,10 @@
     "eslint": "10.5.0",
     "tsx": "4.22.4",
     "vitest": "4.1.9"
+  },
+  "pnpm": {
+    "overrides": {
+      "esbuild": "0.28.1"
+    }
   }
 }


### PR DESCRIPTION
## 🛡️ Security Vulnerability Overrides

Adds `pnpm.overrides` entries to pin transitive deps to their
latest published version, then regenerates each affected lockfile.

### Vulnerabilities Addressed

| Severity | Package | Override | Advisory | Manifest |
|----------|---------|----------|----------|----------|
| 🟢 low | `esbuild` | `0.28.1` | [GHSA-g7r4-m6w7-qqqr](https://github.com/authelia/authelia/security/dependabot/247) | `internal/templates/src/pnpm-lock.yaml` |

### Changed Files

- `internal/templates/src/package.json`

### Review Checklist

1. Verify overrides in each `package.json`.
2. Confirm each `pnpm-lock.yaml` resolves patched versions.
3. Run CI for regressions.