### PR TITLE
docs: fix missing heading

### DIFF
--- a/docs/content/configuration/miscellaneous/server.md
+++ b/docs/content/configuration/miscellaneous/server.md
@@ -150,6 +150,8 @@ or intermediate certificates. If no item is provided mutual TLS is disabled.
 
 ### headers
 
+#### csp_template
+
 {{< callout context="danger" title="Security Notice" icon="outline/alert-octagon" >}}
 This header is a security critical header which protects you from malicious parties and should almost never be
 configured. This is an advanced option to customize, and at minimum you should do sufficient research about how browsers


### PR DESCRIPTION
In the doc page https://www.authelia.com/configuration/miscellaneous/server/#headers ,  there should be an leaf title `csp_template` under `headers` to match the configuration structure.

This paragraph title was present, but has been (accidentally ?) removed by commit 914b7656f4 which added a warning against modifying this option. In this PR, we just add the missing intermediate title.