### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/contributing/development/build-and-test.md
+++ b/docs/content/contributing/development/build-and-test.md
@@ -85,7 +85,7 @@ authelia-scripts suites test
 authelia-scripts suites teardown Standalone
 ```
 
-In order to test all suites (approx 30 minutes), you need to make sure there is no currently running sui te and then you
+In order to test all suites (approx 30 minutes), you need to make sure there is no currently running suite and then you
 should run:
 
 ```bash


### PR DESCRIPTION
## Summary

Fix a typo in the contributing build-and-test guide where the word "suite" was split into "sui te".

## Motivation

The sentence instructing contributors to ensure no suite is currently running reads "no currently running sui te", which is a broken spelling of "suite". Every other reference on the page uses "suite" correctly, so this restores consistency and readability for contributors following the guide.
