### PR TITLE
fix(authorization): panic on single-label domain in group wildcard acl

### DIFF
--- a/internal/authorization/access_control_domain.go
+++ b/internal/authorization/access_control_domain.go
@@ -76,6 +76,9 @@ func (m AccessControlDomainMatcher) IsMatch(domain string, subject Subject) (mat
 		}
 
 		i := strings.Index(domain, ".")
+		if i < 0 {
+			return false
+		}
 
 		return domain[i:] == m.Name && utils.IsStringInSliceFold(domain[:i], subject.Groups)
 	default:

--- a/internal/authorization/access_control_domain_test.go
+++ b/internal/authorization/access_control_domain_test.go
@@ -114,6 +114,26 @@ func TestAccessControlDomain_IsMatch(t *testing.T) {
 			Subject{},
 			false,
 		},
+		{
+			"ShouldNotMatchSingleLabelDomainWithGroupWildcard",
+			&AccessControlDomainMatcher{
+				Name:          "-group.domain.com",
+				GroupWildcard: true,
+			},
+			"localhost",
+			Subject{Username: "john", Groups: []string{"a-group"}},
+			false,
+		},
+		{
+			"ShouldNotMatchSingleLabelDomainWithGroupWildcardAnonymous",
+			&AccessControlDomainMatcher{
+				Name:          "-group.domain.com",
+				GroupWildcard: true,
+			},
+			"localhost",
+			Subject{},
+			false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
```
TL;DR: fix a glitch that will cause 5xx. Not DOS-able, nothing too serious
```

## Description

The `{group}` domain matcher slices the domain around the first `.` without checking that one exists:

```go
case m.GroupWildcard:
	if subject.IsAnonymous() && utils.StringHasSuffixFold(domain, m.Name) {
		return len(domain) > len(m.Name)
	}

	i := strings.Index(domain, ".")

	return domain[i:] == m.Name && utils.IsStringInSliceFold(domain[:i], subject.Groups)
```

For a single-label (dotless) domain such as `localhost`, `strings.Index(domain, ".")` returns `-1`, so `domain[-1:]` panics with `slice bounds out of range [-1:]`. The anonymous branch above only returns early when the domain suffix-matches `m.Name`, so a dotless domain falls through to the slice for both anonymous and authenticated subjects.

### Reachability

The matched domain comes from the request: `object.Domain = targetURL.Hostname()` (`internal/authorization/types.go`). The ForwardAuth and nginx `auth_request` handlers construct that URL from the `X-Forwarded-Host` / `X-Original-URL` headers and only validate that the host is non-empty, so a dotless value is client-controllable and reaches the matcher **unauthenticated** — whenever a deployment has an access control rule using a `{group}` domain. Authelia's global `RecoverPanic` middleware converts the panic into a fail-closed `500` (access is denied, not granted), so this is not a crash or an auth bypass, but it is still an unintended panic and a log-spam / wasted-work vector on the authorization hot path.

## Fix

Guard the missing separator. If the domain contains no `.`, it cannot match a `{group}.<suffix>` pattern, so return `false`:

```go
	i := strings.Index(domain, ".")
	if i < 0 {
		return false
	}
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Added two table-driven regression cases to `TestAccessControlDomain_IsMatch` covering a single-label domain (`localhost`) against a `{group}` matcher, for both an anonymous subject and a subject with groups. Verified that without the guard both cases panic with `slice bounds out of range [-1:]`, and with the guard `go test ./internal/authorization/` passes cleanly.