### PR TITLE
test: remove port from listener

### DIFF
--- a/internal/authentication/ldap_client_dialer_test.go
+++ b/internal/authentication/ldap_client_dialer_test.go
@@ -11,9 +11,10 @@ import (
 )
 
 func TestNewLDAPClientDialerStandard(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:3389")
-
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
+
+	address := "ldap://" + ln.Addr().String()
 
 	testCases := []struct {
 		name    string
@@ -35,7 +36,7 @@ func TestNewLDAPClientDialerStandard(t *testing.T) {
 		},
 		{
 			"ShouldSuccessfullyDial",
-			"ldap://127.0.0.1:3389",
+			address,
 			20 * time.Millisecond,
 			"",
 		},


### PR DESCRIPTION
This adapts the port in one of the tests to use port 0 instead of a potentialy in-use port.

Closes #12154