### PR TITLE
ci(buildkite): fix stale grype scans and leftover image tags

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -100,7 +100,7 @@ if [[ ${BUILDKITE_LABEL} =~ :docker:\ Deploy ]]; then
   docker logout ghcr.io
 fi
 
-if [[ ${BUILDKITE_LABEL} == ":grype: Vulnerability Scanning" ]] && [[ ${CI_PRIVATE} == "true" ]]; then
+if [[ ${BUILDKITE_LABEL} == ":grype: Vulnerability Scanning" ]]; then
   docker logout
 fi
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -17,9 +17,7 @@ if [[ "${BUILDKITE_LABEL}" == ":service_dog: Linting" ]]; then
 fi
 
 if [[ "${BUILDKITE_LABEL}" == ":grype: Vulnerability Scanning" ]]; then
-  if [[ "${CI_PRIVATE}" == "true" ]]; then
-    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-  fi
+  echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 
   if [[ "${CI_MERGE_QUEUE}" == "true" ]]; then
     PR_NUMBER=$(echo "${BUILDKITE_BRANCH}" | sed -E 's|^gh-readonly-queue/.*/pr-([0-9]+)-.*|\1|')

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -18,6 +18,10 @@ if [[ ! "${BUILDKITE_COMMAND}" =~ buildkite-agent\ pipeline\ upload ]]; then
     docker network ls -q --filter "label=com.docker.compose.project=${PROJECT}" | xargs -r docker network rm
     docker images --filter "reference=${PROJECT}-*" --format '{{.Repository}}:{{.Tag}}' | xargs -r docker rmi -f > /dev/null 2>&1
     [[ -n "${SUITE_IMAGE}" ]] && docker rmi -f "${SUITE_IMAGE}" > /dev/null 2>&1
+
+    if [[ "${BUILDKITE_LABEL}" == ":grype: Vulnerability Scanning" ]]; then
+      docker images --filter "reference=authelia/authelia:*" --filter "reference=authelia/authelia-cve:*" --format '{{.Repository}}:{{.Tag}}' | xargs -r docker rmi > /dev/null 2>&1
+    fi
   fi
 fi
 

--- a/.buildkite/steps/grypescans.sh
+++ b/.buildkite/steps/grypescans.sh
@@ -26,12 +26,16 @@ if [[ "${CI_MERGE_QUEUE}" != "true" ]]; then
   fi
 fi
 
+STATUS=0
+
 if [[ -n "${IMAGE}" ]]; then
   echo "--- :grype: Scanning ${IMAGE}"
-  "${grypeCmd[@]}" "${IMAGE}"
+  "${grypeCmd[@]}" "registry:${IMAGE}" || STATUS=1
 fi
 
 for file in *.cdx.json; do
   echo "--- :grype: Scanning ${file/.cdx.json}"
-  "${grypeCmd[@]}" "${file}"
+  "${grypeCmd[@]}" "${file}" || STATUS=1
 done
+
+exit "${STATUS}"


### PR DESCRIPTION
Grype resolved the scan target through the Docker daemon, which returns whatever is tagged locally. `authelia-scripts docker push-manifest` builds with buildx and pushes straight to the registry, so the manifest a build has just published is never loaded into the daemon and the scan reads an image left over from an earlier build instead. Builds 57317 and 57344 both failed on Go stdlib advisories against `go1.26.5` while the images they had actually pushed carried `go1.26.6` binaries and scan clean.

`grypescans.sh` now scans `registry:${IMAGE}`. Nothing is written to the image store, so the scan cannot go stale and cannot leave a tag behind. Every run fetches a manifest rather than hitting a warm local tag, so the Docker Hub login in `pre-command` is no longer gated on `CI_PRIVATE` and those fetches are not counted against the anonymous pull rate limit shared by every agent behind the one address; the matching `docker logout` in `post-command` follows it.

Daemon resolution had already left one `authelia/authelia:<branch>` tag behind per branch ever scanned on a host, and those accumulate on a shared daemon that `cleanbuild=false` deliberately never prunes. `pre-exit` drains them after the scan job. The filter names the two repositories exactly so nothing the agents retain is reachable, and the removal is by name without `-f` so an image also reached by another tag, such as the `authelia:dist` a concurrent Build Image job is about to save, is only untagged rather than deleted.

`grypescans.sh` also records failures instead of aborting on the first one. A failing image scan previously skipped the `*.cdx.json` loop entirely, which meant the SBOMs of the binaries the build actually produced went unscanned in exactly the builds where that mattered most.