### PR TITLE
fix(authentication): stale user database aliases

### DIFF
--- a/internal/authentication/file_user_provider_database.go
+++ b/internal/authentication/file_user_provider_database.go
@@ -84,6 +84,8 @@ func (m *FileUserDatabase) Load() (err error) {
 
 // LoadAliases performs the loading of alias information from the database.
 func (m *FileUserDatabase) LoadAliases() (err error) {
+	m.Emails, m.Aliases = make(map[string]string, len(m.Users)), make(map[string]string, len(m.Users))
+
 	if m.SearchEmail || m.SearchCI {
 		for k, user := range m.Users {
 			if m.SearchEmail && user.Email != "" {
@@ -166,13 +168,21 @@ func (m *FileUserDatabase) GetUserDetails(username string) (user FileUserDatabas
 
 	if m.SearchEmail {
 		if key, ok := m.Emails[u]; ok {
-			return m.Users[key], nil
+			if user, ok = m.Users[key]; ok {
+				return user, nil
+			}
+
+			return FileUserDatabaseUserDetails{}, ErrUserNotFound
 		}
 	}
 
 	if m.SearchCI {
 		if key, ok := m.Aliases[u]; ok {
-			return m.Users[key], nil
+			if user, ok = m.Users[key]; ok {
+				return user, nil
+			}
+
+			return FileUserDatabaseUserDetails{}, ErrUserNotFound
 		}
 	}
 

--- a/internal/authentication/file_user_provider_database_test.go
+++ b/internal/authentication/file_user_provider_database_test.go
@@ -47,6 +47,176 @@ func TestDatabaseModel_Read(t *testing.T) {
 	assert.EqualError(t, model.Read(f), "could not parse the YAML database: go-yaml load error in scanner (while scanning for the next token) at L2.C1: found character that cannot start any token")
 }
 
+func TestFileUserDatabaseGetUserDetails(t *testing.T) {
+	john := FileUserDatabaseUserDetails{
+		Username:    "john",
+		DisplayName: "John Doe",
+		Email:       "john.doe@authelia.com",
+	}
+
+	users := map[string]FileUserDatabaseUserDetails{"john": john}
+
+	testCases := []struct {
+		name        string
+		users       map[string]FileUserDatabaseUserDetails
+		emails      map[string]string
+		aliases     map[string]string
+		searchEmail bool
+		searchCI    bool
+		have        string
+		expected    FileUserDatabaseUserDetails
+		err         string
+	}{
+		{
+			"ShouldLookupUsername",
+			users,
+			nil,
+			nil,
+			false,
+			false,
+			"john",
+			john,
+			"",
+		},
+		{
+			"ShouldNotLookupUnknownUsername",
+			users,
+			nil,
+			nil,
+			false,
+			false,
+			"harry",
+			FileUserDatabaseUserDetails{},
+			"user not found",
+		},
+		{
+			"ShouldNotLookupUsernameWithMismatchedCase",
+			users,
+			nil,
+			nil,
+			false,
+			false,
+			"JOHN",
+			FileUserDatabaseUserDetails{},
+			"user not found",
+		},
+		{
+			"ShouldLookupEmail",
+			users,
+			map[string]string{"john.doe@authelia.com": "john"},
+			nil,
+			true,
+			false,
+			"JOHN.doe@authelia.com",
+			john,
+			"",
+		},
+		{
+			"ShouldNotLookupEmailWhenSearchEmailDisabled",
+			users,
+			map[string]string{"john.doe@authelia.com": "john"},
+			nil,
+			false,
+			false,
+			"john.doe@authelia.com",
+			FileUserDatabaseUserDetails{},
+			"user not found",
+		},
+		{
+			"ShouldNotLookupEmailAliasForUserWhichNoLongerExists",
+			users,
+			map[string]string{"harry.potter@authelia.com": "harry"},
+			nil,
+			true,
+			false,
+			"harry.potter@authelia.com",
+			FileUserDatabaseUserDetails{},
+			"user not found",
+		},
+		{
+			"ShouldLookupAlias",
+			users,
+			nil,
+			map[string]string{"john": "john"},
+			false,
+			true,
+			"JOHN",
+			john,
+			"",
+		},
+		{
+			"ShouldNotLookupAliasWhenSearchCaseInsensitiveDisabled",
+			users,
+			nil,
+			map[string]string{"john": "john"},
+			false,
+			false,
+			"JOHN",
+			FileUserDatabaseUserDetails{},
+			"user not found",
+		},
+		{
+			"ShouldNotLookupAliasForUserWhichNoLongerExists",
+			users,
+			nil,
+			map[string]string{"harry": "harry"},
+			false,
+			true,
+			"HARRY",
+			FileUserDatabaseUserDetails{},
+			"user not found",
+		},
+		{
+			"ShouldNotFallbackToAliasWhenEmailAliasForUserWhichNoLongerExists",
+			users,
+			map[string]string{"harry.potter@authelia.com": "harry"},
+			map[string]string{"harry.potter@authelia.com": "john"},
+			true,
+			true,
+			"harry.potter@authelia.com",
+			FileUserDatabaseUserDetails{},
+			"user not found",
+		},
+		{
+			"ShouldNotFallbackToUsernameWhenAliasForUserWhichNoLongerExists",
+			users,
+			nil,
+			map[string]string{"john": "harry"},
+			false,
+			true,
+			"john",
+			FileUserDatabaseUserDetails{},
+			"user not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			database := NewFileUserDatabase("", tc.searchEmail, tc.searchCI, nil)
+
+			database.Users = tc.users
+
+			if tc.emails != nil {
+				database.Emails = tc.emails
+			}
+
+			if tc.aliases != nil {
+				database.Aliases = tc.aliases
+			}
+
+			actual, err := database.GetUserDetails(tc.have)
+
+			if tc.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
+			}
+
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func TestFileUserDatabaseShouldNotDeadlockOnSave(t *testing.T) {
 	const (
 		concurrency = 8

--- a/internal/authentication/file_user_provider_test.go
+++ b/internal/authentication/file_user_provider_test.go
@@ -854,6 +854,67 @@ func TestShouldAllowLookupCI(t *testing.T) {
 	})
 }
 
+func TestShouldRegenerateAliasesOnReload(t *testing.T) {
+	testCases := []struct {
+		name            string
+		searchEmail     bool
+		searchCI        bool
+		expectedEmails  map[string]string
+		expectedAliases map[string]string
+	}{
+		{
+			"ShouldRegenerateNothing",
+			false,
+			false,
+			map[string]string{},
+			map[string]string{},
+		},
+		{
+			"ShouldRegenerateEmails",
+			true,
+			false,
+			map[string]string{"john.doe@authelia.com": "john"},
+			map[string]string{},
+		},
+		{
+			"ShouldRegenerateAliases",
+			false,
+			true,
+			map[string]string{},
+			map[string]string{"john": "john"},
+		},
+		{
+			"ShouldRegenerateEmailsAndAliases",
+			true,
+			true,
+			map[string]string{"john.doe@authelia.com": "john"},
+			map[string]string{"john": "john"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			WithDatabase(t, UserDatabaseContent, func(path string) {
+				database := NewFileUserDatabase(path, tc.searchEmail, tc.searchCI, nil)
+
+				require.NoError(t, database.Load())
+
+				require.NoError(t, os.WriteFile(path, UserDatabaseContentSingleUser, fileAuthenticationMode))
+				require.NoError(t, database.Load())
+
+				assert.Equal(t, tc.expectedEmails, database.Emails)
+				assert.Equal(t, tc.expectedAliases, database.Aliases)
+
+				_, err := database.GetUserDetails("harry")
+				assert.EqualError(t, err, "user not found")
+
+				_, err = database.GetUserDetails("harry.potter@authelia.com")
+				assert.EqualError(t, err, "user not found")
+			})
+		})
+	}
+}
+
 func TestNewFileCryptoHashFromConfig(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -1064,6 +1125,17 @@ users:
     password: "$argon2id$v=19$m=65536,t=3,p=2$BpLnfgDsc2WD8F2q$o/vzA4myCqZZ36bUGsDY//8mKUYNZZaR0t4MFFSs+iM"
     disabled: true
     email: disabled@authelia.com
+`)
+
+var UserDatabaseContentSingleUser = []byte(`
+users:
+  john:
+    displayname: "John Doe"
+    password: "{CRYPT}$argon2id$v=19$m=65536,t=3,p=2$BpLnfgDsc2WD8F2q$o/vzA4myCqZZ36bUGsDY//8mKUYNZZaR0t4MFFSs+iM"
+    email: john.doe@authelia.com
+    groups:
+      - admins
+      - dev
 `)
 
 var UserDatabaseContentExtra = []byte(`


### PR DESCRIPTION
The alias based lookups for the user database were never reset on reload. This could result in a lookup not returning a helpful error.