### PR TITLE
fix(configuration): jwk type direct not usable

### DIFF
--- a/internal/configuration/validator/util.go
+++ b/internal/configuration/validator/util.go
@@ -182,7 +182,7 @@ func schemaJWKGetPropertiesEnc(jwk schema.JWK) (properties *JWKProperties, err e
 		case 128:
 			return &JWKProperties{oidc.KeyUseEncryption, oidc.EncryptionAlgA128GCMKW, n, nil}, nil
 		default:
-			if n > 32 {
+			if n < 32 {
 				return nil, fmt.Errorf("invalid symmetric key length of %d but the minimum is 32", n)
 			}
 

--- a/internal/configuration/validator/util_test.go
+++ b/internal/configuration/validator/util_test.go
@@ -149,12 +149,12 @@ func TestSchemaJWKGetPropertiesEnc(t *testing.T) {
 			"",
 		},
 		{
-			"ShouldErrForLargeNonStandardSymmetric",
-			func(t *testing.T) any { return make([]byte, 64) },
+			"ShouldErrForNonStandardSymmetricKeyTooShort",
+			func(t *testing.T) any { return make([]byte, 5) },
 			"",
 			"",
 			0,
-			"invalid symmetric key length of 64 but the minimum is 32",
+			"invalid symmetric key length of 5 but the minimum is 32",
 		},
 		{
 			"ShouldReturnEmptyForEd25519PrivateKey",


### PR DESCRIPTION
This fixes an issue where the JWK direct algorithm cannot be used. This is caused by an inverse check of the length which incorrectly validates that it is less than 32 bytes whereas it should be at least 32 bytes.