### PR TITLE
fix(logging): incorrect multi writer order

### DIFF
--- a/cmd/authelia-scripts/cmd/suites.go
+++ b/cmd/authelia-scripts/cmd/suites.go
@@ -349,7 +349,7 @@ func runSuiteTests(suiteName string, withEnv bool) error {
 	defer results.Close()
 
 	cmd := utils.CommandWithStdout("bash", "-c", testCmdLine)
-	cmd.Stdout = io.MultiWriter(results, &testOutputWriter{out: os.Stdout})
+	cmd.Stdout = io.MultiWriter(&testOutputWriter{out: os.Stdout}, results)
 	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
 

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -59,6 +59,12 @@ func ConfigureLogger(config schema.Log, log bool) (err error) {
 
 	switch {
 	case config.FilePath != "":
+		writers = []io.Writer{}
+
+		if config.KeepStdout {
+			writers = append(writers, os.Stdout)
+		}
+
 		lf = NewFile(config.FilePath)
 
 		if err = lf.Open(); err != nil {
@@ -72,11 +78,7 @@ func ConfigureLogger(config schema.Log, log bool) (err error) {
 			})
 		}
 
-		writers = []io.Writer{lf}
-
-		if config.KeepStdout {
-			writers = append(writers, os.Stdout)
-		}
+		writers = append(writers, lf)
 	default:
 		writers = []io.Writer{os.Stdout}
 	}


### PR DESCRIPTION
This fixes an issue where the io.MultiWriter wrote to files before os.Stdout. This ensures os.Stdout is always written to regardless of the file status.