### PR TITLE
refactor(middlewares): allow handler to exempt itself from limits

### DIFF
--- a/internal/handlers/handler_oauth2_introspection.go
+++ b/internal/handlers/handler_oauth2_introspection.go
@@ -71,5 +71,9 @@ func OAuth2IntrospectionPOST(ctx *middlewares.AutheliaCtx, rw http.ResponseWrite
 		ctx.GetLogger().Tracef("Introspection Request with id '%s' yielded a %s (active: %t)", requestID, responder.GetTokenUse(), responder.IsActive())
 	}
 
+	if responder.IsActive() {
+		ctx.SetUserValue(middlewares.UserValueRateLimitExempt, true)
+	}
+
 	ctx.Providers.OpenIDConnect.WriteIntrospectionResponse(ctx, rw, responder)
 }

--- a/internal/middlewares/const.go
+++ b/internal/middlewares/const.go
@@ -105,6 +105,7 @@ const (
 	UserValueKeyBaseURL int8 = iota
 	UserValueKeyOpenIDConnectResponseModeFormPost
 	UserValueKeyRawURI
+	UserValueRateLimitExempt
 )
 
 const (

--- a/internal/middlewares/rate_limiting.go
+++ b/internal/middlewares/rate_limiting.go
@@ -172,7 +172,6 @@ func NewRateLimiter(opts ...RateLimiterOption) AutheliaMiddleware {
 
 	handler := options.Handler
 	exemptStatusCodes := options.ExemptStatusCodes
-	disableExemption := len(exemptStatusCodes) == 0
 
 	ctx := options.Ctx
 	if ctx == nil {
@@ -187,7 +186,7 @@ func NewRateLimiter(opts ...RateLimiterOption) AutheliaMiddleware {
 	go runRateLimitGC(ctx, buckets, gcInterval)
 
 	return func(next RequestHandler) RequestHandler {
-		return newRateLimiterHandler(next, buckets, handler, exemptStatusCodes, disableExemption)
+		return newRateLimiterHandler(next, buckets, handler, exemptStatusCodes)
 	}
 }
 
@@ -208,16 +207,13 @@ func runRateLimitGC(ctx context.Context, buckets []RateLimitBucket, interval tim
 	}
 }
 
-func newRateLimiterHandler(next RequestHandler, buckets []RateLimitBucket, handler RateLimitRequestHandler, exemptStatusCodes []int, disableExemption bool) RequestHandler {
-	return func(ctx *AutheliaCtx) {
-		var (
-			retryAfter   time.Duration
-			reservations []*rate.Reservation
-		)
+func newRateLimiterHandler(next RequestHandler, buckets []RateLimitBucket, handler RateLimitRequestHandler, exemptStatusCodes []int) RequestHandler {
+	isRateLimitExempt := newIsRateLimitExempt(exemptStatusCodes)
 
-		if !disableExemption {
-			reservations = make([]*rate.Reservation, 0, len(buckets))
-		}
+	return func(ctx *AutheliaCtx) {
+		var retryAfter time.Duration
+
+		reservations := make([]*rate.Reservation, 0, len(buckets))
 
 		now := time.Now().UTC()
 
@@ -238,9 +234,7 @@ func newRateLimiterHandler(next RequestHandler, buckets []RateLimitBucket, handl
 				continue
 			}
 
-			if !disableExemption {
-				reservations = append(reservations, reservation)
-			}
+			reservations = append(reservations, reservation)
 		}
 
 		if retryAfter > 0 {
@@ -251,15 +245,23 @@ func newRateLimiterHandler(next RequestHandler, buckets []RateLimitBucket, handl
 
 		next(ctx)
 
-		if disableExemption {
-			return
-		}
-
-		if isStatusCodeExempt(ctx.Response.StatusCode(), exemptStatusCodes) {
+		if isRateLimitExempt(ctx) {
 			for _, r := range reservations {
 				r.CancelAt(now)
 			}
 		}
+	}
+}
+
+func newIsRateLimitExempt(exemptStatusCodes []int) func(ctx *AutheliaCtx) bool {
+	return func(ctx *AutheliaCtx) bool {
+		var exempt bool
+
+		if value := ctx.Value(UserValueRateLimitExempt); value != nil {
+			exempt, _ = value.(bool)
+		}
+
+		return exempt || isStatusCodeExempt(ctx.Response.StatusCode(), exemptStatusCodes)
 	}
 }
 

--- a/internal/middlewares/rate_limiting_test.go
+++ b/internal/middlewares/rate_limiting_test.go
@@ -485,6 +485,143 @@ func TestNewRateLimiterExemptStatusCodes(t *testing.T) {
 	}
 }
 
+func TestNewRateLimiterUserValueExempt(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		ExemptStatuses   []int
+		BucketRequests   int
+		ExemptRequests   []bool
+		ExpectedStatuses []int
+	}{
+		{
+			Name:             "ShouldNotConsumeTokensForExemptUserValueWithoutExemptStatusCodes",
+			ExemptStatuses:   nil,
+			BucketRequests:   2,
+			ExemptRequests:   []bool{true, true, true, true},
+			ExpectedStatuses: []int{fasthttp.StatusOK, fasthttp.StatusOK, fasthttp.StatusOK, fasthttp.StatusOK},
+		},
+		{
+			Name:             "ShouldConsumeTokensForNonExemptUserValueWithoutExemptStatusCodes",
+			ExemptStatuses:   nil,
+			BucketRequests:   2,
+			ExemptRequests:   []bool{false, false, false},
+			ExpectedStatuses: []int{fasthttp.StatusOK, fasthttp.StatusOK, fasthttp.StatusTooManyRequests},
+		},
+		{
+			Name:             "ShouldMixExemptAndNonExemptUserValues",
+			ExemptStatuses:   nil,
+			BucketRequests:   2,
+			ExemptRequests:   []bool{true, false, true, false, false},
+			ExpectedStatuses: []int{fasthttp.StatusOK, fasthttp.StatusOK, fasthttp.StatusOK, fasthttp.StatusOK, fasthttp.StatusTooManyRequests},
+		},
+		{
+			Name:             "ShouldEnforceLimitForExemptUserValueWhenBucketAlreadyFull",
+			ExemptStatuses:   nil,
+			BucketRequests:   1,
+			ExemptRequests:   []bool{false, true},
+			ExpectedStatuses: []int{fasthttp.StatusOK, fasthttp.StatusTooManyRequests},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var exempt bool
+
+			middleware := NewRateLimiter(
+				WithRateLimitBuckets(RateLimitBucketConfig{
+					Period:   time.Minute,
+					Requests: tc.BucketRequests,
+				}),
+				WithRateLimitExemptStatusCodes(tc.ExemptStatuses...),
+				WithRateLimitContext(t.Context()),
+			)
+
+			handler := middleware(func(ctx *AutheliaCtx) {
+				ctx.SetStatusCode(fasthttp.StatusOK)
+
+				if exempt {
+					ctx.SetUserValue(UserValueRateLimitExempt, true)
+				}
+			})
+
+			for i, expected := range tc.ExpectedStatuses {
+				exempt = tc.ExemptRequests[i]
+				ctx := newTestAutheliaCtx("10.0.0.1")
+				handler(ctx)
+				assert.Equal(t, expected, ctx.Response.StatusCode(), "request %d", i+1)
+			}
+		})
+	}
+}
+
+func TestNewIsRateLimitExempt(t *testing.T) {
+	testCases := []struct {
+		Name              string
+		ExemptStatusCodes []int
+		UserValue         any
+		StatusCode        int
+		Expected          bool
+	}{
+		{
+			Name:              "ShouldReturnFalseWhenNoUserValueAndStatusNotExempt",
+			ExemptStatusCodes: []int{fasthttp.StatusOK},
+			UserValue:         nil,
+			StatusCode:        fasthttp.StatusUnauthorized,
+			Expected:          false,
+		},
+		{
+			Name:              "ShouldReturnTrueWhenStatusExempt",
+			ExemptStatusCodes: []int{fasthttp.StatusOK},
+			UserValue:         nil,
+			StatusCode:        fasthttp.StatusOK,
+			Expected:          true,
+		},
+		{
+			Name:              "ShouldReturnTrueWhenUserValueTrue",
+			ExemptStatusCodes: nil,
+			UserValue:         true,
+			StatusCode:        fasthttp.StatusUnauthorized,
+			Expected:          true,
+		},
+		{
+			Name:              "ShouldReturnFalseWhenUserValueFalse",
+			ExemptStatusCodes: nil,
+			UserValue:         false,
+			StatusCode:        fasthttp.StatusUnauthorized,
+			Expected:          false,
+		},
+		{
+			Name:              "ShouldIgnoreNonBoolUserValue",
+			ExemptStatusCodes: nil,
+			UserValue:         "true",
+			StatusCode:        fasthttp.StatusUnauthorized,
+			Expected:          false,
+		},
+		{
+			Name:              "ShouldReturnTrueWhenUserValueTrueAndStatusExempt",
+			ExemptStatusCodes: []int{fasthttp.StatusOK},
+			UserValue:         true,
+			StatusCode:        fasthttp.StatusOK,
+			Expected:          true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			isRateLimitExempt := newIsRateLimitExempt(tc.ExemptStatusCodes)
+
+			ctx := newTestAutheliaCtx("10.0.0.1")
+			ctx.Response.SetStatusCode(tc.StatusCode)
+
+			if tc.UserValue != nil {
+				ctx.SetUserValue(UserValueRateLimitExempt, tc.UserValue)
+			}
+
+			assert.Equal(t, tc.Expected, isRateLimitExempt(ctx))
+		})
+	}
+}
+
 func TestHandlerRateLimitAPI(t *testing.T) {
 	ctx := newTestAutheliaCtx("192.168.1.1")
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -501,7 +501,6 @@ func RegisterOpenIDConnectRoutes(ctx context.Context, r *router.Router, config *
 
 	rateLimitIntrospection := middlewares.NewRateLimiter(
 		middlewares.WithRateLimitConfig(config.Server.Endpoints.RateLimits.OpenIDConnectIntrospection),
-		middlewares.WithRateLimitExemptStatusCodes(fasthttp.StatusOK),
 		middlewares.WithRateLimitErrorHandler(middlewares.HandlerRateLimitOpenIDConnect),
 		middlewares.WithRateLimitContext(ctx),
 	)


### PR DESCRIPTION
This allows handlers to set a user value to mark them exempt from rate limits.