### PR TITLE
test(suites): support concurrent runs across git worktrees

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,24 +30,43 @@ else
   export SUITE_PULL_POLICY=always
 fi
 
-# Agents that share a Docker daemon are each given a slot so their suites cannot collide on the compose project, the
-# network subnet or the debug ports. Everything falls back to the historical values when the slot is unset.
-if [[ -n "${SUITE_SLOT}" ]]; then
-  export COMPOSE_PROJECT_NAME="authelia-${SUITE_SLOT}"
-  export SUITE_SUBNET="10.240.${SUITE_SLOT}"
-  export LDAP_ADMIN_PORT="$((9090 + SUITE_SLOT))"
-  export ENVOY_ADMIN_PORT="$((9901 + SUITE_SLOT))"
-fi
-
-if [[ -n "${SUITE_TMP}" ]]; then
-  mkdir -p "${SUITE_TMP}"
-fi
-
 echo "[BOOTSTRAP] Checking if Go is installed..."
 if [[ ! -x "$(command -v go)" ]];
 then
   echo "[ERROR] You must install Go on your machine." >&2
   return
+fi
+
+# Working trees that share a Docker daemon are each given a slot so their suites cannot collide on the compose project,
+# the network subnet, the debug ports or the temporary directory. CI supplies the slot per agent; locally every working
+# tree is handed one of its own so several of them can run suites at the same time. Set SUITE_SLOT_AUTO=false to opt
+# out. Everything falls back to the historical values when the slot is unset.
+if [[ -z "${SUITE_SLOT}" && "${CI}" != "true" && "${SUITE_SLOT_AUTO}" != "false" ]]; then
+  if SUITE_SLOT="$(authelia-scripts suites slot)"; then
+    export SUITE_SLOT
+    echo "[BOOTSTRAP] Using suite slot ${SUITE_SLOT} for ${PWD}"
+  else
+    unset SUITE_SLOT
+    echo "[BOOTSTRAP] Could not allocate a suite slot, falling back to the shared defaults" >&2
+  fi
+fi
+
+if [[ -n "${SUITE_SLOT}" ]]; then
+  export COMPOSE_PROJECT_NAME="authelia-${SUITE_SLOT}"
+  export SUITE_SUBNET="10.240.${SUITE_SLOT}"
+  export LDAP_ADMIN_PORT="$((9090 + SUITE_SLOT))"
+  export ENVOY_ADMIN_PORT="$((9901 + SUITE_SLOT))"
+
+  # The agent container remaps SUITE_TMP onto its own /tmp, so only a local shell has to move the path it reads and
+  # writes through as well.
+  if [[ "${CI}" != "true" ]]; then
+    export SUITE_TMP="${SUITE_TMP:-/tmp/authelia-suite-${SUITE_SLOT}}"
+    export SUITE_TMP_PATH="${SUITE_TMP_PATH:-${SUITE_TMP}}"
+  fi
+fi
+
+if [[ -n "${SUITE_TMP}" ]]; then
+  mkdir -p "${SUITE_TMP}"
 fi
 
 authelia-scripts bootstrap

--- a/cmd/authelia-scripts/cmd/bootstrap.go
+++ b/cmd/authelia-scripts/cmd/bootstrap.go
@@ -61,88 +61,19 @@ func cmdBootstrapRun(_ *cobra.Command, _ []string) {
 		pnpmInstall()
 	}
 
-	bootstrapPrintln("Preparing /etc/hosts to serve subdomains of example.com...")
-	prepareHostsFile()
+	// /etc/hosts is machine wide but the addresses behind those names are per slot, so a slotted shell must not claim
+	// it: the tests resolve the suite domains themselves through suites.HostResolverRules and suites.DialContext, and
+	// leaving the file alone is what keeps an unslotted working tree browsable while a slotted one runs.
+	if slot := os.Getenv("SUITE_SLOT"); slot != "" {
+		bootstrapPrintln("Leaving /etc/hosts alone because this shell holds suite slot " + slot)
+	} else {
+		bootstrapPrintln("Preparing /etc/hosts to serve subdomains of example.com...")
+		prepareHostsFile()
+	}
 
 	fmt.Println()
 	bootstrapPrintln("Run 'authelia-scripts suites setup Standalone' to start Authelia and visit https://home.example.com:8080.")
 	bootstrapPrintln("More details at https://www.authelia.com/contributing/development/build-and-test/")
-}
-
-func hostEntries() []HostEntry {
-	backend := suites.SuiteAddress(50)
-	portal := suites.SuiteAddress(100)
-	ssh := suites.SuiteAddress(130)
-
-	entries := []HostEntry{
-		// For unit tests.
-		{Domain: "local.example.com", IP: "127.0.0.1"},
-
-		// For authelia backend.
-		{Domain: "authelia.example.com", IP: backend},
-
-		// For common tests.
-		{Domain: "login.example.com", IP: portal},
-		{Domain: "admin.example.com", IP: portal},
-		{Domain: "singlefactor.example.com", IP: portal},
-		{Domain: "deny.example.com", IP: portal},
-		{Domain: "dev.example.com", IP: portal},
-		{Domain: "home.example.com", IP: portal},
-		{Domain: "mx1.mail.example.com", IP: portal},
-		{Domain: "mx2.mail.example.com", IP: portal},
-		{Domain: "public.example.com", IP: portal},
-		{Domain: "secure.example.com", IP: portal},
-		{Domain: "mail.example.com", IP: portal},
-		{Domain: "duo.example.com", IP: portal},
-
-		// For HAProxy suite.
-		{Domain: "haproxy.example.com", IP: portal},
-
-		// Kubernetes dashboard.
-		{Domain: "kubernetes.example.com", IP: portal},
-
-		// OIDC tester app.
-		{Domain: "oidc.example.com", IP: portal},
-		{Domain: "oidc-public.example.com", IP: portal},
-
-		// For Traefik suite.
-		{Domain: "traefik.example.com", IP: portal},
-
-		// For testing network ACLs.
-		{Domain: "proxy-client1.example.com", IP: suites.SuiteAddress(201)},
-		{Domain: "proxy-client2.example.com", IP: suites.SuiteAddress(202)},
-		{Domain: "proxy-client3.example.com", IP: suites.SuiteAddress(203)},
-
-		// Redis Replicas.
-		{Domain: "redis-node-0.example.com", IP: suites.SuiteAddress(110)},
-		{Domain: "redis-node-1.example.com", IP: suites.SuiteAddress(111)},
-		{Domain: "redis-node-2.example.com", IP: suites.SuiteAddress(112)},
-
-		// Redis Sentinel Replicas.
-		{Domain: "redis-sentinel-0.example.com", IP: suites.SuiteAddress(120)},
-		{Domain: "redis-sentinel-1.example.com", IP: suites.SuiteAddress(121)},
-		{Domain: "redis-sentinel-2.example.com", IP: suites.SuiteAddress(122)},
-
-		// For PAM suite.
-		{Domain: "ssh.example.com", IP: ssh},
-	}
-
-	return slices.Concat(entries, hostEntriesCookieDomains(portal))
-}
-
-func hostEntriesCookieDomains(ip string) []HostEntry {
-	domains := []string{"example2.com", "example3.com"}
-	subdomains := []string{"login", "admin", "singlefactor", "dev", "home", "mx1.mail", "mx2.mail", "public", "secure", "mail", "duo"}
-
-	entries := make([]HostEntry, 0, len(domains)*len(subdomains))
-
-	for _, domain := range domains {
-		for _, subdomain := range subdomains {
-			entries = append(entries, HostEntry{Domain: subdomain + "." + domain, IP: ip})
-		}
-	}
-
-	return entries
 }
 
 func runCommand(cmd string, args ...string) {
@@ -171,7 +102,7 @@ func checkCommandExist(cmd string, resolutionHint string) {
 }
 
 func createTemporaryDirectory() {
-	err := os.MkdirAll("/tmp/authelia", 0755)
+	err := os.MkdirAll(suites.SuiteTmpPath("authelia"), 0755)
 	if err != nil {
 		panic(err)
 	}
@@ -272,7 +203,7 @@ func prepareHostsFile() {
 	toBeAddedLine := make([]string, 0)
 	modified := false
 
-	entries := hostEntries()
+	entries := suites.HostEntries()
 
 	addresses := make(map[string]string, len(entries))
 
@@ -321,7 +252,7 @@ func prepareHostsFile() {
 		modified = true
 	}
 
-	fd, err := os.CreateTemp("/tmp/authelia/", "hosts")
+	fd, err := os.CreateTemp(suites.SuiteTmpPath("authelia"), "hosts")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/authelia-scripts/cmd/const.go
+++ b/cmd/authelia-scripts/cmd/const.go
@@ -152,6 +152,17 @@ Suites can be listed with the authelia-scripts suites list command.`
 
 	cmdSuitesTeardownExample = `authelia-scripts suites setup Standalone`
 
+	cmdSuitesSlotShort = "Show the suite slot allocated to this working tree"
+
+	cmdSuitesSlotLong = `Show the suite slot allocated to this working tree, allocating one if it does not have it yet.
+
+The slot is the number bootstrap.sh derives the compose project, the network subnet, the debug ports and the temporary
+directory from, so that several working trees on one machine can run suites at the same time without colliding.`
+
+	cmdSuitesSlotExample = `authelia-scripts suites slot
+authelia-scripts suites slot --list
+authelia-scripts suites slot --release`
+
 	cmdSuitesExternalShort = "Commands related to external suites management"
 
 	cmdSuitesExternalLong = `Commands related to external suites management.

--- a/cmd/authelia-scripts/cmd/slot.go
+++ b/cmd/authelia-scripts/cmd/slot.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/authelia/authelia/v4/internal/utils"
+)
+
+var (
+	slotList    bool
+	slotRelease bool
+)
+
+// slotEntry is a working tree and the suite slot it owns.
+type slotEntry struct {
+	Slot int
+	Path string
+}
+
+func newSuitesSlotCmd() (cmd *cobra.Command) {
+	cmd = &cobra.Command{
+		Use:     "slot",
+		Short:   cmdSuitesSlotShort,
+		Long:    cmdSuitesSlotLong,
+		Example: cmdSuitesSlotExample,
+		Run:     cmdSuitesSlotRun,
+		Args:    cobra.NoArgs,
+
+		DisableAutoGenTag: true,
+	}
+
+	cmd.Flags().BoolVar(&slotList, "list", false, "Lists every allocated slot instead of allocating one")
+	cmd.Flags().BoolVar(&slotRelease, "release", false, "Releases the slot allocated to this working tree")
+
+	return cmd
+}
+
+func cmdSuitesSlotRun(_ *cobra.Command, _ []string) {
+	if slotList && slotRelease {
+		log.Fatal(errors.New("only one of --list and --release may be given"))
+	}
+
+	tree, err := workingTree()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	switch {
+	case slotList:
+		entries, err := slotEntries()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, entry := range entries {
+			fmt.Printf("%d\t%s\n", entry.Slot, entry.Path)
+		}
+	case slotRelease:
+		if err = releaseSlot(tree); err != nil {
+			log.Fatal(err)
+		}
+	default:
+		slot, err := allocateSlot(tree)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// The number alone, so that bootstrap.sh can capture it.
+		fmt.Println(slot)
+	}
+}
+
+// workingTree returns the root of the working tree this command runs in, resolved through any symlink. Allocation and
+// release key the registry on it rather than on the current directory so that a worktree holds one slot however deep in
+// it the command is run from.
+func workingTree() (tree string, err error) {
+	output, err := utils.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err == nil {
+		if tree = strings.TrimSpace(string(output)); tree != "" {
+			return resolveSymlinks(tree), nil
+		}
+	}
+
+	if tree, err = os.Getwd(); err != nil {
+		return "", err
+	}
+
+	return resolveSymlinks(tree), nil
+}
+
+func resolveSymlinks(tree string) string {
+	resolved, err := filepath.EvalSymlinks(tree)
+	if err != nil {
+		return tree
+	}
+
+	return resolved
+}
+
+// slotRegistryPath is the file recording which working tree owns which slot. It lives outside any working tree because
+// the whole point is to keep separate working trees on one machine from picking the same number.
+func slotRegistryPath() (path string, err error) {
+	state := os.Getenv("XDG_STATE_HOME")
+
+	if state == "" {
+		var home string
+
+		if home, err = os.UserHomeDir(); err != nil {
+			return "", err
+		}
+
+		state = filepath.Join(home, ".local", "state")
+	}
+
+	dir := filepath.Join(state, "authelia")
+
+	if err = os.MkdirAll(dir, 0755); err != nil { //nolint:gosec // The directory is derived from XDG_STATE_HOME, not from user input.
+		return "", err
+	}
+
+	return filepath.Join(dir, "suite-slots"), nil
+}
+
+// withSlotRegistry runs f against the registry entries under an exclusive lock, writing back whatever f returns. Every
+// mutation goes through here so two shells sourcing bootstrap.sh at once cannot be handed the same slot.
+func withSlotRegistry(f func(entries []slotEntry) ([]slotEntry, error)) (err error) {
+	var path string
+
+	if path, err = slotRegistryPath(); err != nil {
+		return err
+	}
+
+	var fd *os.File
+
+	if fd, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600); err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = fd.Close()
+	}()
+
+	if err = syscall.Flock(int(fd.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("error locking slot registry '%s': %w", path, err)
+	}
+
+	defer func() {
+		_ = syscall.Flock(int(fd.Fd()), syscall.LOCK_UN)
+	}()
+
+	var entries []slotEntry
+
+	if entries, err = readSlotEntries(fd); err != nil {
+		return err
+	}
+
+	if entries, err = f(entries); err != nil {
+		return err
+	}
+
+	if entries == nil {
+		return nil
+	}
+
+	return writeSlotEntries(fd, entries)
+}
+
+// readSlotEntries parses the registry, dropping entries whose working tree no longer exists so a deleted tree gives its
+// slot back without anyone having to remember to release it.
+func readSlotEntries(fd *os.File) (entries []slotEntry, err error) {
+	if _, err = fd.Seek(0, 0); err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(fd)
+
+	for scanner.Scan() {
+		fields := strings.SplitN(scanner.Text(), "\t", 2)
+		if len(fields) != 2 {
+			continue
+		}
+
+		slot, errSlot := strconv.Atoi(fields[0])
+		if errSlot != nil {
+			continue
+		}
+
+		if _, errStat := os.Stat(fields[1]); errStat != nil {
+			continue
+		}
+
+		entries = append(entries, slotEntry{Slot: slot, Path: fields[1]})
+	}
+
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(entries, func(a, b slotEntry) int { return a.Slot - b.Slot })
+
+	return entries, nil
+}
+
+func writeSlotEntries(fd *os.File, entries []slotEntry) (err error) {
+	builder := &strings.Builder{}
+
+	for _, entry := range entries {
+		fmt.Fprintf(builder, "%d\t%s\n", entry.Slot, entry.Path)
+	}
+
+	if err = fd.Truncate(0); err != nil {
+		return err
+	}
+
+	if _, err = fd.Seek(0, 0); err != nil {
+		return err
+	}
+
+	_, err = fd.WriteString(builder.String())
+
+	return err
+}
+
+func slotEntries() (entries []slotEntry, err error) {
+	err = withSlotRegistry(func(current []slotEntry) ([]slotEntry, error) {
+		entries = current
+
+		// Written back so the pruning of deleted working trees is persisted.
+		return current, nil
+	})
+
+	return entries, err
+}
+
+// allocateSlot returns the slot this working tree owns, giving it the lowest unused number if it has none.
+func allocateSlot(tree string) (slot int, err error) {
+	err = withSlotRegistry(func(entries []slotEntry) ([]slotEntry, error) {
+		for _, entry := range entries {
+			if entry.Path == tree {
+				slot = entry.Slot
+
+				return entries, nil
+			}
+		}
+
+		slot = 1
+
+		for _, entry := range entries {
+			if entry.Slot == slot {
+				slot++
+			}
+		}
+
+		return append(entries, slotEntry{Slot: slot, Path: tree}), nil
+	})
+
+	return slot, err
+}
+
+func releaseSlot(tree string) (err error) {
+	return withSlotRegistry(func(entries []slotEntry) ([]slotEntry, error) {
+		return slices.DeleteFunc(entries, func(entry slotEntry) bool { return entry.Path == tree }), nil
+	})
+}

--- a/cmd/authelia-scripts/cmd/slot.go
+++ b/cmd/authelia-scripts/cmd/slot.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"bufio"
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -24,8 +24,8 @@ var (
 
 // slotEntry is a working tree and the suite slot it owns.
 type slotEntry struct {
-	Slot int
-	Path string
+	Slot int    `json:"slot"`
+	Path string `json:"path"`
 }
 
 func newSuitesSlotCmd() (cmd *cobra.Command) {
@@ -64,7 +64,7 @@ func cmdSuitesSlotRun(_ *cobra.Command, _ []string) {
 		}
 
 		for _, entry := range entries {
-			fmt.Printf("%d\t%s\n", entry.Slot, entry.Path)
+			fmt.Printf("%d\t%q\n", entry.Slot, entry.Path)
 		}
 	case slotRelease:
 		if err = releaseSlot(tree); err != nil {
@@ -87,7 +87,7 @@ func cmdSuitesSlotRun(_ *cobra.Command, _ []string) {
 func workingTree() (tree string, err error) {
 	output, err := utils.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err == nil {
-		if tree = strings.TrimSpace(string(output)); tree != "" {
+		if tree = strings.TrimSuffix(string(output), "\n"); tree != "" {
 			return resolveSymlinks(tree), nil
 		}
 	}
@@ -141,27 +141,17 @@ func withSlotRegistry(f func(entries []slotEntry) ([]slotEntry, error)) (err err
 		return err
 	}
 
-	var fd *os.File
+	var unlock func()
 
-	if fd, err = os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600); err != nil {
+	if unlock, err = lockSlotRegistry(path); err != nil {
 		return err
 	}
 
-	defer func() {
-		_ = fd.Close()
-	}()
-
-	if err = syscall.Flock(int(fd.Fd()), syscall.LOCK_EX); err != nil {
-		return fmt.Errorf("error locking slot registry '%s': %w", path, err)
-	}
-
-	defer func() {
-		_ = syscall.Flock(int(fd.Fd()), syscall.LOCK_UN)
-	}()
+	defer unlock()
 
 	var entries []slotEntry
 
-	if entries, err = readSlotEntries(fd); err != nil {
+	if entries, err = readSlotEntries(path); err != nil {
 		return err
 	}
 
@@ -173,38 +163,81 @@ func withSlotRegistry(f func(entries []slotEntry) ([]slotEntry, error)) (err err
 		return nil
 	}
 
-	return writeSlotEntries(fd, entries)
+	return writeSlotEntries(path, entries)
+}
+
+// lockSlotRegistry takes the exclusive lock guarding the registry. The lock lives in a file of its own because the
+// registry is replaced by a rename, and a lock held on a file that has been replaced no longer excludes anybody: the
+// next process opens the new inode and locks that instead.
+func lockSlotRegistry(path string) (unlock func(), err error) {
+	var fd *os.File
+
+	if fd, err = os.OpenFile(path+".lock", os.O_RDWR|os.O_CREATE, 0600); err != nil {
+		return nil, err
+	}
+
+	if err = syscall.Flock(int(fd.Fd()), syscall.LOCK_EX); err != nil {
+		_ = fd.Close()
+
+		return nil, fmt.Errorf("error locking slot registry '%s': %w", path, err)
+	}
+
+	return func() {
+		_ = syscall.Flock(int(fd.Fd()), syscall.LOCK_UN)
+		_ = fd.Close()
+	}, nil
 }
 
 // readSlotEntries parses the registry, dropping entries whose working tree no longer exists so a deleted tree gives its
-// slot back without anyone having to remember to release it.
-func readSlotEntries(fd *os.File) (entries []slotEntry, err error) {
-	if _, err = fd.Seek(0, 0); err != nil {
+// slot back without anyone having to remember to release it. A registry that cannot be read is an error rather than an
+// empty one: treating it as empty would hand out numbers that other working trees are still using.
+func readSlotEntries(path string) (entries []slotEntry, err error) {
+	var data []byte
+
+	if data, err = os.ReadFile(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+
 		return nil, err
 	}
 
-	scanner := bufio.NewScanner(fd)
-
-	for scanner.Scan() {
-		fields := strings.SplitN(scanner.Text(), "\t", 2)
-		if len(fields) != 2 {
-			continue
-		}
-
-		slot, errSlot := strconv.Atoi(fields[0])
-		if errSlot != nil {
-			continue
-		}
-
-		if _, errStat := os.Stat(fields[1]); errStat != nil {
-			continue
-		}
-
-		entries = append(entries, slotEntry{Slot: slot, Path: fields[1]})
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil, nil
 	}
 
-	if err = scanner.Err(); err != nil {
-		return nil, err
+	var stored []slotEntry
+
+	if err = json.Unmarshal(data, &stored); err != nil {
+		return nil, fmt.Errorf("error parsing slot registry '%s': %w", path, err)
+	}
+
+	slots, paths := make(map[int]bool, len(stored)), make(map[string]bool, len(stored))
+
+	for _, entry := range stored {
+		if entry.Slot < 1 || entry.Path == "" {
+			return nil, fmt.Errorf("error parsing slot registry '%s': the entry for slot %d has no usable working tree", path, entry.Slot)
+		}
+
+		if _, errStat := os.Stat(entry.Path); errStat != nil {
+			if errors.Is(errStat, os.ErrNotExist) {
+				continue
+			}
+
+			log.Warnf("Keeping suite slot %d for '%s' because it could not be checked: %v", entry.Slot, entry.Path, errStat)
+		}
+
+		if slots[entry.Slot] {
+			return nil, fmt.Errorf("error parsing slot registry '%s': slot %d is held by more than one working tree", path, entry.Slot)
+		}
+
+		if paths[entry.Path] {
+			return nil, fmt.Errorf("error parsing slot registry '%s': the working tree '%s' holds more than one slot", path, entry.Path)
+		}
+
+		slots[entry.Slot], paths[entry.Path] = true, true
+
+		entries = append(entries, entry)
 	}
 
 	slices.SortFunc(entries, func(a, b slotEntry) int { return a.Slot - b.Slot })
@@ -212,31 +245,78 @@ func readSlotEntries(fd *os.File) (entries []slotEntry, err error) {
 	return entries, nil
 }
 
-func writeSlotEntries(fd *os.File, entries []slotEntry) (err error) {
-	builder := &strings.Builder{}
+// writeSlotEntries replaces the registry by renaming a complete copy over it, so a process that dies mid-write leaves
+// the previous registry rather than a truncated one. Losing it would free every slot at once.
+func writeSlotEntries(path string, entries []slotEntry) (err error) {
+	var data []byte
 
-	for _, entry := range entries {
-		fmt.Fprintf(builder, "%d\t%s\n", entry.Slot, entry.Path)
-	}
-
-	if err = fd.Truncate(0); err != nil {
+	if data, err = json.Marshal(entries); err != nil {
 		return err
 	}
 
-	if _, err = fd.Seek(0, 0); err != nil {
+	dir := filepath.Dir(path)
+
+	var tmp *os.File
+
+	if tmp, err = os.CreateTemp(dir, "suite-slots"); err != nil {
 		return err
 	}
 
-	_, err = fd.WriteString(builder.String())
+	name := tmp.Name()
 
-	return err
+	defer func() {
+		if err != nil {
+			_ = os.Remove(name)
+		}
+	}()
+
+	if _, err = tmp.Write(append(data, '\n')); err != nil {
+		_ = tmp.Close()
+
+		return err
+	}
+
+	if err = tmp.Sync(); err != nil {
+		_ = tmp.Close()
+
+		return err
+	}
+
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+
+	if err = os.Rename(name, path); err != nil {
+		return err
+	}
+
+	if errSync := syncDirectory(dir); errSync != nil {
+		log.Warnf("Could not flush the slot registry directory '%s': %v", dir, errSync)
+	}
+
+	return nil
+}
+
+// syncDirectory flushes the directory entry, so the rename itself survives a crash rather than only the contents of the
+// file it points at.
+func syncDirectory(dir string) (err error) {
+	var fd *os.File
+
+	if fd, err = os.Open(dir); err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = fd.Close()
+	}()
+
+	return fd.Sync()
 }
 
 func slotEntries() (entries []slotEntry, err error) {
 	err = withSlotRegistry(func(current []slotEntry) ([]slotEntry, error) {
 		entries = current
 
-		// Written back so the pruning of deleted working trees is persisted.
 		return current, nil
 	})
 

--- a/cmd/authelia-scripts/cmd/slot_test.go
+++ b/cmd/authelia-scripts/cmd/slot_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlotShouldAllocateTheLowestFreeNumberPerWorkingTree(t *testing.T) {
+	trees := newSlotRegistry(t, 3)
+
+	first, err := allocateSlot(trees[0])
+	require.NoError(t, err)
+	assert.Equal(t, 1, first)
+
+	second, err := allocateSlot(trees[1])
+	require.NoError(t, err)
+	assert.Equal(t, 2, second)
+
+	third, err := allocateSlot(trees[2])
+	require.NoError(t, err)
+	assert.Equal(t, 3, third)
+}
+
+func TestSlotShouldReturnTheSameNumberForAWorkingTreeThatAlreadyHasOne(t *testing.T) {
+	trees := newSlotRegistry(t, 1)
+
+	first, err := allocateSlot(trees[0])
+	require.NoError(t, err)
+
+	second, err := allocateSlot(trees[0])
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+}
+
+func TestSlotShouldReuseTheNumberOfAReleasedWorkingTree(t *testing.T) {
+	trees := newSlotRegistry(t, 3)
+
+	for _, tree := range trees[:2] {
+		_, err := allocateSlot(tree)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, releaseSlot(trees[0]))
+
+	slot, err := allocateSlot(trees[2])
+	require.NoError(t, err)
+	assert.Equal(t, 1, slot)
+}
+
+func TestSlotShouldPruneWorkingTreesThatNoLongerExist(t *testing.T) {
+	trees := newSlotRegistry(t, 3)
+
+	for _, tree := range trees[:2] {
+		_, err := allocateSlot(tree)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, os.Remove(trees[0]))
+
+	entries, err := slotEntries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, trees[1], entries[0].Path)
+
+	slot, err := allocateSlot(trees[2])
+	require.NoError(t, err)
+	assert.Equal(t, 1, slot)
+}
+
+// newSlotRegistry points the registry at a temporary directory and returns n working tree paths that exist on disk.
+func newSlotRegistry(t *testing.T, n int) (trees []string) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	root := t.TempDir()
+
+	trees = make([]string, n)
+
+	for i := range trees {
+		trees[i] = filepath.Join(root, string(rune('a'+i)))
+
+		require.NoError(t, os.Mkdir(trees[i], 0755))
+	}
+
+	return trees
+}

--- a/cmd/authelia-scripts/cmd/slot_test.go
+++ b/cmd/authelia-scripts/cmd/slot_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,6 +72,163 @@ func TestSlotShouldPruneWorkingTreesThatNoLongerExist(t *testing.T) {
 	slot, err := allocateSlot(trees[2])
 	require.NoError(t, err)
 	assert.Equal(t, 1, slot)
+}
+
+func TestSlotShouldKeepTheSlotOfAWorkingTreeItCannotCheck(t *testing.T) {
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	path, err := slotRegistryPath()
+	require.NoError(t, err)
+
+	unreachable := "/" + strings.Repeat("a", 300)
+	require.NoError(t, os.WriteFile(path, []byte(`[{"slot":1,"path":"`+unreachable+`"}]`), 0600))
+
+	tree := filepath.Join(t.TempDir(), "tree")
+	require.NoError(t, os.Mkdir(tree, 0755))
+
+	slot, err := allocateSlot(tree)
+	require.NoError(t, err)
+	assert.Equal(t, 2, slot)
+
+	entries, err := slotEntries()
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, unreachable, entries[0].Path)
+}
+
+func TestSlotShouldKeepAWorkingTreePathThatEndsInANewline(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required to resolve the working tree root")
+	}
+
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	tree := filepath.Join(t.TempDir(), "working-tree\n")
+	require.NoError(t, os.Mkdir(tree, 0755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(tree, "go.mod"), []byte("module github.com/authelia/authelia/v4\n"), 0600))
+	require.NoError(t, exec.Command("git", "-C", tree, "init", "-q").Run())
+
+	t.Chdir(tree)
+
+	resolved, err := workingTree()
+	require.NoError(t, err)
+
+	expected, err := filepath.EvalSymlinks(tree)
+	require.NoError(t, err)
+	require.Equal(t, expected, resolved)
+
+	slot, err := allocateSlot(resolved)
+	require.NoError(t, err)
+	assert.Equal(t, 1, slot)
+
+	again, err := allocateSlot(resolved)
+	require.NoError(t, err)
+	assert.Equal(t, slot, again)
+
+	require.NoError(t, releaseSlot(resolved))
+
+	entries, err := slotEntries()
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestSlotShouldKeepWorkingTreePathsThatContainNewlines(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	root := t.TempDir()
+
+	odd := filepath.Join(root, "working\ntree")
+	require.NoError(t, os.Mkdir(odd, 0755))
+
+	plain := filepath.Join(root, "plain")
+	require.NoError(t, os.Mkdir(plain, 0755))
+
+	first, err := allocateSlot(odd)
+	require.NoError(t, err)
+	assert.Equal(t, 1, first)
+
+	second, err := allocateSlot(plain)
+	require.NoError(t, err)
+	assert.Equal(t, 2, second)
+
+	again, err := allocateSlot(odd)
+	require.NoError(t, err)
+	assert.Equal(t, first, again)
+
+	entries, err := slotEntries()
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, odd, entries[0].Path)
+}
+
+func TestSlotShouldRefuseARegistryThatContradictsItself(t *testing.T) {
+	testCases := []struct {
+		name     string
+		registry func(first, second string) string
+	}{
+		{
+			"ShouldRefuseASlotHeldTwice",
+			func(first, second string) string {
+				return `[{"slot":1,"path":"` + first + `"},{"slot":1,"path":"` + second + `"}]`
+			},
+		},
+		{
+			"ShouldRefuseAWorkingTreeHoldingTwoSlots",
+			func(first, _ string) string {
+				return `[{"slot":1,"path":"` + first + `"},{"slot":2,"path":"` + first + `"}]`
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+			root := t.TempDir()
+
+			first, second := filepath.Join(root, "first"), filepath.Join(root, "second")
+			require.NoError(t, os.Mkdir(first, 0755))
+			require.NoError(t, os.Mkdir(second, 0755))
+
+			path, err := slotRegistryPath()
+			require.NoError(t, err)
+
+			require.NoError(t, os.WriteFile(path, []byte(tc.registry(first, second)), 0600))
+
+			_, err = slotEntries()
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestSlotShouldRefuseARegistryItCannotRead(t *testing.T) {
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+
+	tree := t.TempDir()
+
+	path, err := slotRegistryPath()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name    string
+		content string
+	}{
+		{"ShouldRefuseContentItCannotParse", "not json at all"},
+		{"ShouldRefuseAnEntryWithoutAWorkingTree", `[{"slot":1,"path":""}]`},
+		{"ShouldRefuseAnEntryWithoutASlot", `[{"slot":0,"path":"/tmp"}]`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0600))
+
+			_, err = allocateSlot(tree)
+			assert.Error(t, err)
+		})
+	}
 }
 
 // newSlotRegistry points the registry at a temporary directory and returns n working tree paths that exist on disk.

--- a/cmd/authelia-scripts/cmd/suites.go
+++ b/cmd/authelia-scripts/cmd/suites.go
@@ -36,7 +36,7 @@ func newSuitesCmd() (cmd *cobra.Command) {
 		DisableAutoGenTag: true,
 	}
 
-	cmd.AddCommand(newSuitesListCmd(), newSuitesSetupCmd(), newSuitesTestCmd(), newSuitesTeardownCmd(), newSuitesExternalCmd())
+	cmd.AddCommand(newSuitesListCmd(), newSuitesSetupCmd(), newSuitesTestCmd(), newSuitesTeardownCmd(), newSuitesSlotCmd(), newSuitesExternalCmd())
 
 	return cmd
 }

--- a/cmd/authelia-scripts/cmd/types.go
+++ b/cmd/authelia-scripts/cmd/types.go
@@ -9,12 +9,6 @@ import (
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
-// HostEntry represents an entry in /etc/hosts.
-type HostEntry struct {
-	Domain string
-	IP     string
-}
-
 // DockerImages represents some of the data from the docker images API.
 type DockerImages []DockerImage
 

--- a/cmd/authelia-suites/main.go
+++ b/cmd/authelia-suites/main.go
@@ -14,8 +14,6 @@ import (
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
-var tmpDirectory = "/tmp/authelia/suites/"
-
 // runningSuiteFile name of the file containing the currently running suite.
 var runningSuiteFile = ".suite"
 
@@ -117,7 +115,7 @@ func setupSuite(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	suiteTmpDirectory := tmpDirectory + suiteName
+	suiteTmpDirectory := suites.SuiteTmpPath("authelia", "suites", suiteName)
 
 	if exist {
 		err := copy.Copy(suiteResourcePath, suiteTmpDirectory)
@@ -185,7 +183,7 @@ func teardownSuite(cmd *cobra.Command, args []string) {
 
 	s := suites.GlobalRegistry.Get(args[0])
 
-	suiteTmpDirectory := tmpDirectory + args[0]
+	suiteTmpDirectory := suites.SuiteTmpPath("authelia", "suites", args[0])
 	if err := s.TearDown(suiteTmpDirectory); err != nil {
 		log.Fatal(err)
 	}

--- a/docs/content/contributing/development/integration-suites.md
+++ b/docs/content/contributing/development/integration-suites.md
@@ -51,16 +51,18 @@ The development suite has a standardized setup which makes it easy to interact w
 The backend is the Authelia binary running in a docker container, the frontend is the webserver which hosts all of the
 web frontends for each application.
 
-These are the defaults and are what you get for local development. CI agents that share a single Docker daemon set
-`SUITE_SLOT` so that each agent gets its own compose project and subnet, which changes the first three octets of every
-address on this page. See [Environment Variables](#environment-variables) below.
+These are the defaults and are what you get for local development. Anything that shares a single Docker daemon with
+another suite run sets `SUITE_SLOT` so that it gets its own compose project and subnet, which changes the first three
+octets of every address on this page. That is every CI agent, and every working tree beyond the first on a development
+machine. See [Running Suites Concurrently](#running-suites-concurrently) and
+[Environment Variables](#environment-variables) below.
 
 ### Sites and Applications
 
 All sites are hosted on the address `${SUITE_SUBNET}.100:8080`, which is `192.168.240.100:8080` for local development.
 This list is not comprehensive and may change over time. You can see a full list of the configured host entries by
 looking at
-[bootstrap.go](https://github.com/authelia/authelia/blob/master/cmd/authelia-scripts/cmd/bootstrap.go). For an idea
+[hosts.go](https://github.com/authelia/authelia/blob/master/internal/suites/hosts.go). For an idea
 of the applications setup in a suite take a look at the `dockerEnvironment` var for the given suite. The file that
 contains the `dockerEnvironment` var for a given suite is located in the
 [internal/suites](https://github.com/authelia/authelia/tree/master/internal/suites) directory and has the name format
@@ -85,23 +87,61 @@ contains the `dockerEnvironment` var for a given suite is located in the
 
 ## Environment Variables
 
-The suites run several concurrent copies of themselves when the Docker daemon is shared between CI agents. Every
-variable below is optional and falls back to the value used for local development, so leaving them all unset gives the
-behavior described above.
+The suites run several concurrent copies of themselves when the Docker daemon is shared. Every variable below is
+optional and falls back to the value used for a single local run, so leaving them all unset gives the behavior
+described above.
 
 | Variable               | Default         | Purpose                                                                                                                                                                                                                                                                                                                                                                                                  |
 |:-----------------------|:----------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `SUITE_SLOT`           | *unset*         | Agent slot number. When set, `bootstrap.sh` derives `COMPOSE_PROJECT_NAME`, `SUITE_SUBNET`, `LDAP_ADMIN_PORT` and `ENVOY_ADMIN_PORT` from it.                                                                                                                                                                                                                                                            |
+| `SUITE_SLOT`           | *unset*         | Slot number owned by this agent or working tree. When set, `bootstrap.sh` derives `COMPOSE_PROJECT_NAME`, `SUITE_SUBNET`, `LDAP_ADMIN_PORT`, `ENVOY_ADMIN_PORT` and, outside CI, `SUITE_TMP` and `SUITE_TMP_PATH` from it. A slotted shell also leaves `/etc/hosts` alone.                                                                                                                              |
+| `SUITE_SLOT_AUTO`      | *unset*         | Set to `false` to stop `bootstrap.sh` allocating a slot for this working tree. Has no effect in CI, where the slot is supplied by the agent.                                                                                                                                                                                                                                                            |
 | `COMPOSE_PROJECT_NAME` | `authelia`      | Compose project name. Also scopes the Traefik Docker provider so it only discovers its own containers.                                                                                                                                                                                                                                                                                                   |
 | `SUITE_SUBNET`         | `192.168.240`   | First three octets of the suite network.                                                                                                                                                                                                                                                                                                                                                                 |
-| `SUITE_TMP`            | `/tmp`          | Directory the agent and the containers exchange files through. It must resolve to the same directory on the host, at `/tmp` inside the agent, and at `/tmp` inside the suite containers, so that a single path is valid on both sides of every exchange. Give each agent its own directory, because everything at its top level apart from the agent's own working files is removed when a job finishes. |
+| `SUITE_TMP`            | `/tmp`          | Host directory bound into the suite containers, which always see it at `/tmp`. Give each agent or working tree its own directory, because everything at its top level apart from the agent's own working files is removed when a job finishes.                                                                                                                                                          |
+| `SUITE_TMP_PATH`       | `/tmp`          | Path the test process itself reads and writes that same content through. In CI this stays `/tmp` because `SUITE_TMP` is bound there inside the agent; locally it is set to `SUITE_TMP`, since the test process runs on the host.                                                                                                                                                                        |
 | `SUITE_IMAGE`          | `authelia:dist` | Image the backend runs.                                                                                                                                                                                                                                                                                                                                                                                  |
 | `AGENT_CONTAINER`      | *unset*         | Name of the container the tests run in. When set, that container is attached to the suite network on setup and detached on teardown, so Chrome can reach the portal.                                                                                                                                                                                                                                     |
+
+## Running Suites Concurrently
+
+Several suites can run at once on one machine, one per git working tree. Sourcing `bootstrap.sh` in a working tree
+allocates it a slot and derives everything that would otherwise collide from that number:
+
+```bash
+source bootstrap.sh
+```
+
+```console
+[BOOTSTRAP] Using suite slot 2 for /home/user/authelia-feature
+```
+
+The slot is remembered per working tree, so it is the same on every subsequent source, and it is freed automatically
+when the working tree is deleted. To inspect or manage the allocations:
+
+```bash
+authelia-scripts suites slot --list
+authelia-scripts suites slot --release
+```
+
+A slotted shell deliberately does **not** touch `/etc/hosts`. The names in that file are machine wide but the addresses
+behind them belong to one network, so only one working tree can own it. The tests do not need it: Chrome resolves the
+suite domains from `--host-resolver-rules` and the Go clients resolve them when they dial, both from the same table in
+[hosts.go](https://github.com/authelia/authelia/blob/master/internal/suites/hosts.go). This leaves `/etc/hosts`
+pointing at the default `192.168.240.0/24` network, so an unslotted working tree stays browsable at the addresses
+listed above while slotted ones run alongside it. To reach a slotted suite from your own browser, use its address
+directly, for example `https://10.240.2.100:8080`.
+
+Two things are still shared between concurrent runs and are worth knowing about:
+
+- The pnpm store at `~/.local/share/pnpm/store` and the Go module and build caches at `${GOPATH}` are bound into the
+  dev containers of every suite. They are safe for concurrent use but they do contend.
+- Each suite in dev mode reserves roughly six CPUs and six gigabytes of memory across its backend, frontend and proxy
+  containers, plus a Chrome process for the tests. Size the number of concurrent suites accordingly.
 
 ## Remote Debugging
 
 The Authelia Suites run via [delve] and can be remotely debugged. You can connect to the debugger on the address
-`192.168.240.50:2345`.
+`${SUITE_SUBNET}.50:2345`, which is `192.168.240.50:2345` for an unslotted working tree.
 
 Example connect command:
 

--- a/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites.md
+++ b/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites.md
@@ -51,6 +51,7 @@ authelia-scripts suites
 * [authelia-scripts suites external](authelia-scripts_suites_external.md)	 - Commands related to external suites management
 * [authelia-scripts suites list](authelia-scripts_suites_list.md)	 - List available suites
 * [authelia-scripts suites setup](authelia-scripts_suites_setup.md)	 - Setup a test suite environment
+* [authelia-scripts suites slot](authelia-scripts_suites_slot.md)	 - Show the suite slot allocated to this working tree
 * [authelia-scripts suites teardown](authelia-scripts_suites_teardown.md)	 - Teardown a test suite environment
 * [authelia-scripts suites test](authelia-scripts_suites_test.md)	 - Run a test suite
 

--- a/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_slot.md
+++ b/docs/content/reference/cli/authelia-scripts/authelia-scripts_suites_slot.md
@@ -1,0 +1,58 @@
+---
+title: "authelia-scripts suites slot"
+description: "Reference for the authelia-scripts suites slot command."
+lead: ""
+date: 2026-08-20T08:52:40+10:00
+draft: false
+images: []
+weight: 925
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+## authelia-scripts suites slot
+
+Show the suite slot allocated to this working tree
+
+### Synopsis
+
+Show the suite slot allocated to this working tree, allocating one if it does not have it yet.
+
+The slot is the number bootstrap.sh derives the compose project, the network subnet, the debug ports and the temporary
+directory from, so that several working trees on one machine can run suites at the same time without colliding.
+
+```
+authelia-scripts suites slot [flags]
+```
+
+### Examples
+
+```
+authelia-scripts suites slot
+authelia-scripts suites slot --list
+authelia-scripts suites slot --release
+```
+
+### Options
+
+```
+  -h, --help      help for slot
+      --list      Lists every allocated slot instead of allocating one
+      --release   Releases the slot allocated to this working tree
+```
+
+### Options inherited from parent commands
+
+```
+      --buildkite          Set CI flag for Buildkite
+      --log-level string   Set the log level for the command (default "info")
+```
+
+### SEE ALSO
+
+* [authelia-scripts suites](authelia-scripts_suites.md)	 - Commands related to suites management
+

--- a/internal/suites/const.go
+++ b/internal/suites/const.go
@@ -107,6 +107,7 @@ const (
 	notificationPollInterval = time.Millisecond * 50
 	redisMasterTimeout       = time.Second * 60
 	suiteSubnetDefault       = "192.168.240"
+	suiteTmpPathDefault      = "/tmp"
 )
 
 var (
@@ -118,7 +119,7 @@ var (
 		Storage: schema.Storage{
 			EncryptionKey: "a_not_so_secure_encryption_key",
 			Local: &schema.StorageLocal{
-				Path: "/tmp/db.sqlite3",
+				Path: SuiteTmpPath("db.sqlite3"),
 			},
 		},
 	}

--- a/internal/suites/docker.go
+++ b/internal/suites/docker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -38,6 +39,19 @@ func SuiteSubnet() string {
 // SuiteAddress returns the address of the given host octet on the suite network.
 func SuiteAddress(octet int) string {
 	return fmt.Sprintf("%s.%d", SuiteSubnet(), octet)
+}
+
+// SuiteTmpPath joins elem onto the directory this process exchanges files with the suite containers through, matching
+// the SUITE_TMP_PATH variable. The containers always see that directory at /tmp; SUITE_TMP is the host directory bound
+// there, and SUITE_TMP_PATH is where this process finds the same content. The three coincide by default and in CI, and
+// differ locally so that concurrent runs on one machine do not write over each other.
+func SuiteTmpPath(elem ...string) string {
+	path := os.Getenv("SUITE_TMP_PATH")
+	if path == "" {
+		path = suiteTmpPathDefault
+	}
+
+	return filepath.Join(append([]string{path}, elem...)...)
 }
 
 func agentContainer() string {

--- a/internal/suites/hosts.go
+++ b/internal/suites/hosts.go
@@ -1,0 +1,147 @@
+package suites
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"time"
+)
+
+// HostEntry represents an entry in /etc/hosts.
+type HostEntry struct {
+	Domain string
+	IP     string
+}
+
+// HostEntries returns every domain the suites use and the address it has on the suite network. The addresses follow
+// SuiteSubnet, so a slotted shell and an unslotted one describe different networks with the same names.
+func HostEntries() []HostEntry {
+	backend := SuiteAddress(50)
+	portal := SuiteAddress(100)
+	ssh := SuiteAddress(130)
+
+	entries := []HostEntry{
+		// For unit tests.
+		{Domain: "local.example.com", IP: "127.0.0.1"},
+
+		// For authelia backend.
+		{Domain: "authelia.example.com", IP: backend},
+
+		// For common tests.
+		{Domain: "login.example.com", IP: portal},
+		{Domain: "admin.example.com", IP: portal},
+		{Domain: "singlefactor.example.com", IP: portal},
+		{Domain: "deny.example.com", IP: portal},
+		{Domain: "dev.example.com", IP: portal},
+		{Domain: "home.example.com", IP: portal},
+		{Domain: "mx1.mail.example.com", IP: portal},
+		{Domain: "mx2.mail.example.com", IP: portal},
+		{Domain: "public.example.com", IP: portal},
+		{Domain: "secure.example.com", IP: portal},
+		{Domain: "mail.example.com", IP: portal},
+		{Domain: "duo.example.com", IP: portal},
+
+		// For HAProxy suite.
+		{Domain: "haproxy.example.com", IP: portal},
+
+		// Kubernetes dashboard.
+		{Domain: "kubernetes.example.com", IP: portal},
+
+		// OIDC tester app.
+		{Domain: "oidc.example.com", IP: portal},
+		{Domain: "oidc-public.example.com", IP: portal},
+
+		// For Traefik suite.
+		{Domain: "traefik.example.com", IP: portal},
+
+		// For testing network ACLs.
+		{Domain: "proxy-client1.example.com", IP: SuiteAddress(201)},
+		{Domain: "proxy-client2.example.com", IP: SuiteAddress(202)},
+		{Domain: "proxy-client3.example.com", IP: SuiteAddress(203)},
+
+		// Redis Replicas.
+		{Domain: "redis-node-0.example.com", IP: SuiteAddress(110)},
+		{Domain: "redis-node-1.example.com", IP: SuiteAddress(111)},
+		{Domain: "redis-node-2.example.com", IP: SuiteAddress(112)},
+
+		// Redis Sentinel Replicas.
+		{Domain: "redis-sentinel-0.example.com", IP: SuiteAddress(120)},
+		{Domain: "redis-sentinel-1.example.com", IP: SuiteAddress(121)},
+		{Domain: "redis-sentinel-2.example.com", IP: SuiteAddress(122)},
+
+		// For PAM suite.
+		{Domain: "ssh.example.com", IP: ssh},
+	}
+
+	return slices.Concat(entries, hostEntriesCookieDomains(portal))
+}
+
+func hostEntriesCookieDomains(ip string) []HostEntry {
+	domains := []string{"example2.com", "example3.com"}
+	subdomains := []string{"login", "admin", "singlefactor", "dev", "home", "mx1.mail", "mx2.mail", "public", "secure", "mail", "duo"}
+
+	entries := make([]HostEntry, 0, len(domains)*len(subdomains))
+
+	for _, domain := range domains {
+		for _, subdomain := range subdomains {
+			entries = append(entries, HostEntry{Domain: subdomain + "." + domain, IP: ip})
+		}
+	}
+
+	return entries
+}
+
+// hostAddresses indexes HostEntries by domain.
+func hostAddresses() map[string]string {
+	entries := HostEntries()
+
+	addresses := make(map[string]string, len(entries))
+
+	for _, entry := range entries {
+		addresses[entry.Domain] = entry.IP
+	}
+
+	return addresses
+}
+
+// HostResolverRules renders HostEntries as the value of Chrome's --host-resolver-rules. Chrome resolves the suite
+// domains from this rather than from /etc/hosts, which is what lets concurrent runs on one machine each reach their
+// own network while a single /etc/hosts describes only one of them.
+func HostResolverRules() string {
+	entries := HostEntries()
+
+	rules := make([]string, len(entries))
+
+	for i, entry := range entries {
+		rules[i] = fmt.Sprintf("MAP %s %s", entry.Domain, entry.IP)
+	}
+
+	return strings.Join(rules, ",")
+}
+
+// ResolveAddr returns addr with the suite address substituted for its host when that host is a suite domain, which is
+// the same resolution Chrome performs through HostResolverRules. Anything else is returned unchanged.
+func ResolveAddr(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+
+	ip, ok := hostAddresses()[host]
+	if !ok {
+		return addr
+	}
+
+	return net.JoinHostPort(ip, port)
+}
+
+// DialContext dials addr through ResolveAddr. Resolving at the dial layer rather than through /etc/hosts is what lets
+// concurrent runs on one machine each reach their own network, and it leaves the SNI name, the Host header and the
+// cookie domain as the name the caller asked for.
+func DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+
+	return dialer.DialContext(ctx, network, ResolveAddr(addr))
+}

--- a/internal/suites/hosts_test.go
+++ b/internal/suites/hosts_test.go
@@ -1,0 +1,74 @@
+//go:build !externalsuites
+// +build !externalsuites
+
+package suites
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostEntriesShouldFollowTheSuiteSubnet(t *testing.T) {
+	testCases := []struct {
+		name    string
+		subnet  string
+		portal  string
+		backend string
+	}{
+		{"ShouldUseTheDefaultSubnetWhenUnset", "", "192.168.240.100", "192.168.240.50"},
+		{"ShouldUseTheSlottedSubnetWhenSet", "10.240.2", "10.240.2.100", "10.240.2.50"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SUITE_SUBNET", tc.subnet)
+
+			addresses := hostAddresses()
+
+			assert.Equal(t, tc.portal, addresses["login.example.com"])
+			assert.Equal(t, tc.portal, addresses["login.example2.com"])
+			assert.Equal(t, tc.backend, addresses["authelia.example.com"])
+			assert.Equal(t, "127.0.0.1", addresses["local.example.com"])
+		})
+	}
+}
+
+func TestHostResolverRulesShouldMapEveryEntry(t *testing.T) {
+	t.Setenv("SUITE_SUBNET", "10.240.2")
+
+	rules := HostResolverRules()
+
+	assert.Contains(t, rules, "MAP login.example.com 10.240.2.100")
+	assert.Contains(t, rules, "MAP proxy-client1.example.com 10.240.2.201")
+	assert.Contains(t, rules, "MAP ssh.example.com 10.240.2.130")
+	assert.Contains(t, rules, "MAP local.example.com 127.0.0.1")
+
+	// One rule per entry, so no ordering rule of Chrome's has to be relied on.
+	require.Len(t, strings.Split(rules, ","), len(HostEntries()))
+}
+
+func TestResolveAddrShouldSubstituteSuiteDomainsOnly(t *testing.T) {
+	t.Setenv("SUITE_SUBNET", "10.240.2")
+
+	testCases := []struct {
+		name     string
+		have     string
+		expected string
+	}{
+		{"ShouldResolveThePortal", "login.example.com:8080", "10.240.2.100:8080"},
+		{"ShouldResolveTheBackend", "authelia.example.com:9091", "10.240.2.50:9091"},
+		{"ShouldResolveTheSSHHost", "ssh.example.com:22", "10.240.2.130:22"},
+		{"ShouldLeaveUnknownDomainsAlone", "example.org:443", "example.org:443"},
+		{"ShouldLeaveAddressesWithoutAPortAlone", "login.example.com", "login.example.com"},
+		{"ShouldLeaveLiteralAddressesAlone", "10.240.2.100:8080", "10.240.2.100:8080"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ResolveAddr(tc.have))
+		})
+	}
+}

--- a/internal/suites/http.go
+++ b/internal/suites/http.go
@@ -6,16 +6,20 @@ import (
 	"time"
 )
 
-// NewHTTPClient create a new client skipping TLS verification and not redirecting.
-func NewHTTPClient() *http.Client {
-	tr := &http.Transport{
+// NewHTTPTransport create a new transport skipping TLS verification and resolving the suite domains itself.
+func NewHTTPTransport() *http.Transport {
+	return &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true, //nolint:gosec // Needs to be enabled in suites. Not used in production.
 		},
+		DialContext: DialContext,
 	}
+}
 
+// NewHTTPClient create a new client skipping TLS verification and not redirecting.
+func NewHTTPClient() *http.Client {
 	return &http.Client{
-		Transport: tr,
+		Transport: NewHTTPTransport(),
 		Timeout:   5 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/internal/suites/scenario_backend_protection_test.go
+++ b/internal/suites/scenario_backend_protection_test.go
@@ -1,7 +1,6 @@
 package suites
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,12 +23,8 @@ func NewBackendProtectionScenario() *BackendProtectionScenario {
 }
 
 func (s *BackendProtectionScenario) SetupSuite() {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // Needs to be enabled in suites. Not used in production.
-	}
-
 	s.client = &http.Client{
-		Transport: tr,
+		Transport: NewHTTPTransport(),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/internal/suites/scenario_request_method_test.go
+++ b/internal/suites/scenario_request_method_test.go
@@ -1,7 +1,6 @@
 package suites
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,12 +22,8 @@ type RequestMethodScenario struct {
 }
 
 func (s *RequestMethodScenario) SetupSuite() {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // Needs to be enabled in suites. Not used in production.
-	}
-
 	s.client = &http.Client{
-		Transport: tr,
+		Transport: NewHTTPTransport(),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/internal/suites/suite_cli.go
+++ b/internal/suites/suite_cli.go
@@ -29,11 +29,11 @@ func init() {
 
 	teardown := func(suitePath string) error {
 		err := dockerEnvironment.Down()
-		_ = os.Remove("/tmp/db.sqlite3")
-		_ = os.Remove("/tmp/db.sqlite")
-		_ = os.RemoveAll("/tmp/qr")
-		_ = os.RemoveAll("/tmp/out")
-		_ = os.Remove("/tmp/qr.png")
+		_ = os.Remove(SuiteTmpPath("db.sqlite3"))
+		_ = os.Remove(SuiteTmpPath("db.sqlite"))
+		_ = os.RemoveAll(SuiteTmpPath("qr"))
+		_ = os.RemoveAll(SuiteTmpPath("out"))
+		_ = os.Remove(SuiteTmpPath("qr.png"))
 
 		return err
 	}

--- a/internal/suites/suite_cli_test.go
+++ b/internal/suites/suite_cli_test.go
@@ -506,16 +506,16 @@ func (s *CLISuite) TestShouldGenerateCertificateCAAndSignCertificate() {
 	s.Contains(output, "\tCertificate: public.crt")
 
 	// Check the certificates look fine.
-	privateKeyData, err := os.ReadFile("/tmp/private.pem")
+	privateKeyData, err := os.ReadFile(SuiteTmpPath("private.pem"))
 	s.NoError(err)
 
-	certificateData, err := os.ReadFile("/tmp/public.crt")
+	certificateData, err := os.ReadFile(SuiteTmpPath("public.crt"))
 	s.NoError(err)
 
-	privateKeyCAData, err := os.ReadFile("/tmp/ca.private.pem")
+	privateKeyCAData, err := os.ReadFile(SuiteTmpPath("ca.private.pem"))
 	s.NoError(err)
 
-	certificateCAData, err := os.ReadFile("/tmp/ca.public.crt")
+	certificateCAData, err := os.ReadFile(SuiteTmpPath("ca.public.crt"))
 	s.NoError(err)
 
 	s.False(bytes.Equal(privateKeyData, privateKeyCAData))
@@ -796,8 +796,8 @@ func (s *CLISuite) TestShouldNotGenerateRSAWithBadCAFileContent() {
 	_, err = s.Exec("authelia-backend", []string{"authelia", "crypto", "certificate", "rsa", "generate", "--common-name='Authelia Standalone Root Certificate Authority'", "--ca", "--directory=/tmp/"})
 	s.NoError(err)
 
-	s.Require().NoError(os.WriteFile("/tmp/ca.private.bad.pem", []byte("INVALID"), 0600)) //nolint:gosec
-	s.Require().NoError(os.WriteFile("/tmp/ca.public.bad.crt", []byte("INVALID"), 0600))  //nolint:gosec
+	s.Require().NoError(os.WriteFile(SuiteTmpPath("ca.private.bad.pem"), []byte("INVALID"), 0600))
+	s.Require().NoError(os.WriteFile(SuiteTmpPath("ca.public.bad.crt"), []byte("INVALID"), 0600))
 
 	output, err = s.Exec("authelia-backend", []string{"authelia", "crypto", "certificate", "rsa", "generate", "--path.ca=/tmp/", "--file.ca-private-key=ca.private.bad.pem", "--directory=/tmp/"})
 	s.NotNil(err)
@@ -809,7 +809,7 @@ func (s *CLISuite) TestShouldNotGenerateRSAWithBadCAFileContent() {
 }
 
 func (s *CLISuite) TestStorage00ShouldShowCorrectPreInitInformation() {
-	_ = os.Remove("/tmp/db.sqlite3")
+	_ = os.Remove(SuiteTmpPath("db.sqlite3"))
 
 	output, err := s.Exec("authelia-backend", []string{"authelia", "storage", "schema-info", "--config=/config/configuration.storage.yml"})
 	s.NoError(err)
@@ -993,15 +993,16 @@ func (s *CLISuite) TestStorage03ShouldExportTOTP() {
 		fileInfo os.FileInfo
 	)
 
-	dir := s.T().TempDir()
+	dir := SuiteTempDir(s.T(), "totp")
 
 	qr := filepath.Join(dir, "qr.png")
+	qrContainer := SuiteTmpContainerPath(qr)
 
 	for _, testCase := range testCases {
 		if testCase.png {
-			output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "totp", "generate", testCase.config.Username, "--period", strconv.FormatUint(uint64(testCase.config.Period), 10), "--algorithm", testCase.config.Algorithm, "--digits", strconv.Itoa(int(testCase.config.Digits)), "--path", qr, "--config=/config/configuration.storage.yml"})
+			output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "totp", "generate", testCase.config.Username, "--period", strconv.FormatUint(uint64(testCase.config.Period), 10), "--algorithm", testCase.config.Algorithm, "--digits", strconv.Itoa(int(testCase.config.Digits)), "--path", qrContainer, "--config=/config/configuration.storage.yml"})
 			s.NoError(err)
-			s.Contains(output, fmt.Sprintf(" and saved it as a PNG image at the path '%s'", qr))
+			s.Contains(output, fmt.Sprintf(" and saved it as a PNG image at the path '%s'", qrContainer))
 
 			fileInfo, err = os.Stat(qr)
 			s.NoError(err)
@@ -1022,7 +1023,7 @@ func (s *CLISuite) TestStorage03ShouldExportTOTP() {
 		expectedLines = append(expectedLines, config.URI())
 	}
 
-	yml := filepath.Join(dir, "authelia.export.totp.yml")
+	yml := SuiteTmpContainerPath(filepath.Join(dir, "authelia.export.totp.yml"))
 	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "totp", "export", "--file", yml, "--config=/config/configuration.storage.yml"})
 	s.NoError(err)
 	s.Contains(output, fmt.Sprintf("Successfully exported %d TOTP configurations as YAML to the '%s' file\n", len(expectedLines), yml))
@@ -1035,9 +1036,10 @@ func (s *CLISuite) TestStorage03ShouldExportTOTP() {
 	}
 
 	csv := filepath.Join(dir, "authelia.export.totp.csv")
-	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "totp", "export", "csv", "--file", csv, "--config=/config/configuration.storage.yml"})
+	csvContainer := SuiteTmpContainerPath(csv)
+	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "totp", "export", "csv", "--file", csvContainer, "--config=/config/configuration.storage.yml"})
 	s.NoError(err)
-	s.Contains(output, fmt.Sprintf("Successfully exported %d TOTP configurations as CSV to the '%s' file\n", len(expectedLines), csv))
+	s.Contains(output, fmt.Sprintf("Successfully exported %d TOTP configurations as CSV to the '%s' file\n", len(expectedLines), csvContainer))
 
 	var data []byte
 
@@ -1050,10 +1052,11 @@ func (s *CLISuite) TestStorage03ShouldExportTOTP() {
 	}
 
 	pngs := filepath.Join(dir, "png-qr-codes")
+	pngsContainer := SuiteTmpContainerPath(pngs)
 
-	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "totp", "export", "png", "--directory", pngs, "--config=/config/configuration.storage.yml"})
+	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "totp", "export", "png", "--directory", pngsContainer, "--config=/config/configuration.storage.yml"})
 	s.NoError(err)
-	s.Contains(output, fmt.Sprintf("Successfully exported %d TOTP configuration as QR codes in PNG format to the '%s' directory\n", len(expectedLines), pngs))
+	s.Contains(output, fmt.Sprintf("Successfully exported %d TOTP configuration as QR codes in PNG format to the '%s' directory\n", len(expectedLines), pngsContainer))
 
 	for _, testCase := range testCases {
 		fileInfo, err = os.Stat(filepath.Join(pngs, fmt.Sprintf("%s.png", testCase.config.Username)))
@@ -1065,13 +1068,13 @@ func (s *CLISuite) TestStorage03ShouldExportTOTP() {
 		s.Greater(fileInfo.Size(), int64(1000))
 	}
 
-	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "totp", "generate", "test", "--period=30", "--algorithm=SHA1", "--digits=6", "--path", qr, "--config=/config/configuration.storage.yml"})
+	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "totp", "generate", "test", "--period=30", "--algorithm=SHA1", "--digits=6", "--path", qrContainer, "--config=/config/configuration.storage.yml"})
 	s.EqualError(err, "exit status 1")
 	s.Contains(output, "Error: image output filepath already exists")
 }
 
 func (s *CLISuite) TestStorage04ShouldManageUniqueID() {
-	dir := s.T().TempDir()
+	dir := SuiteTempDir(s.T(), "identifiers")
 
 	output, err := s.Exec("authelia-backend", []string{"authelia", "storage", "user", "identifiers", "export", "--file=out.yml", "--config=/config/configuration.storage.yml"})
 	s.EqualError(err, "exit status 1")
@@ -1094,13 +1097,14 @@ func (s *CLISuite) TestStorage04ShouldManageUniqueID() {
 	s.Contains(output, "Error: error occurred writing to file 'out.yml': open out.yml: permission denied")
 
 	out1 := filepath.Join(dir, "1.yml")
-	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "identifiers", "export", "--file", out1, "--config=/config/configuration.storage.yml"})
+	out1Container := SuiteTmpContainerPath(out1)
+	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "identifiers", "export", "--file", out1Container, "--config=/config/configuration.storage.yml"})
 	s.NoError(err)
-	s.Contains(output, fmt.Sprintf("Successfully exported %d User Opaque Identifiers as YAML to the '%s' file\n", 1, out1))
+	s.Contains(output, fmt.Sprintf("Successfully exported %d User Opaque Identifiers as YAML to the '%s' file\n", 1, out1Container))
 
-	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "identifiers", "export", "--file", out1, "--config=/config/configuration.storage.yml"})
+	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "identifiers", "export", "--file", out1Container, "--config=/config/configuration.storage.yml"})
 	s.EqualError(err, "exit status 1")
-	s.Contains(output, fmt.Sprintf("Error: must specify a file that doesn't exist but '%s' exists", out1))
+	s.Contains(output, fmt.Sprintf("Error: must specify a file that doesn't exist but '%s' exists", out1Container))
 
 	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "identifiers", "add", "john", "--service=openid", "--sector=''", "--identifier=1097c8f8-83f2-4506-8138-5f40e83a1285", "--config=/config/configuration.storage.yml"})
 	s.EqualError(err, "exit status 1")
@@ -1141,9 +1145,10 @@ func (s *CLISuite) TestStorage04ShouldManageUniqueID() {
 	s.Equal("openid", export.Identifiers[0].Service)
 
 	out2 := filepath.Join(dir, "2.yml")
-	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "identifiers", "export", "--file", out2, "--config=/config/configuration.storage.yml"})
+	out2Container := SuiteTmpContainerPath(out2)
+	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "user", "identifiers", "export", "--file", out2Container, "--config=/config/configuration.storage.yml"})
 	s.NoError(err)
-	s.Contains(output, fmt.Sprintf("Successfully exported %d User Opaque Identifiers as YAML to the '%s' file\n", 2, out2))
+	s.Contains(output, fmt.Sprintf("Successfully exported %d User Opaque Identifiers as YAML to the '%s' file\n", 2, out2Container))
 
 	export = model.UserOpaqueIdentifiersExport{}
 
@@ -1250,7 +1255,7 @@ func (s *CLISuite) TestStorage07CacheMDS3() {
 		err    error
 	)
 
-	dir := s.T().TempDir()
+	dir := SuiteTmpContainerPath(SuiteTempDir(s.T(), "mds3"))
 
 	output, err = s.Exec("authelia-backend", []string{"authelia", "storage", "cache", "mds3", "--help"})
 	s.NoError(err)

--- a/internal/suites/suite_duo_push.go
+++ b/internal/suites/suite_duo_push.go
@@ -36,7 +36,7 @@ func init() {
 
 	teardown := func(suitePath string) error {
 		err := dockerEnvironment.Down()
-		_ = os.Remove("/tmp/db.sqlite3")
+		_ = os.Remove(SuiteTmpPath("db.sqlite3"))
 
 		return err
 	}

--- a/internal/suites/suite_pam.go
+++ b/internal/suites/suite_pam.go
@@ -37,7 +37,7 @@ func init() {
 
 	teardown := func(suitePath string) error {
 		err := pamDockerEnvironment.Down()
-		_ = os.Remove("/tmp/db.sqlite3")
+		_ = os.Remove(SuiteTmpPath("db.sqlite3"))
 
 		return err
 	}

--- a/internal/suites/suite_pam_test.go
+++ b/internal/suites/suite_pam_test.go
@@ -379,7 +379,7 @@ func contextDialTimeout(ctx context.Context, fallback time.Duration) time.Durati
 func dialSSHContext(ctx context.Context, addr string, cfg *ssh.ClientConfig) (*ssh.Client, error) {
 	d := &net.Dialer{Timeout: cfg.Timeout}
 
-	conn, err := d.DialContext(ctx, "tcp", addr)
+	conn, err := d.DialContext(ctx, "tcp", ResolveAddr(addr))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/suites/suite_standalone.go
+++ b/internal/suites/suite_standalone.go
@@ -8,9 +8,9 @@ import (
 var standaloneSuiteName = "Standalone"
 
 func init() {
-	_ = os.MkdirAll("/tmp/authelia/StandaloneSuite", 0700)
-	_ = os.WriteFile("/tmp/authelia/StandaloneSuite/jwt", []byte("very_important_secret"), 0600)       //nolint:gosec
-	_ = os.WriteFile("/tmp/authelia/StandaloneSuite/session", []byte("unsecure_session_secret"), 0600) //nolint:gosec
+	_ = os.MkdirAll(SuiteTmpPath("authelia/StandaloneSuite"), 0700)
+	_ = os.WriteFile(SuiteTmpPath("authelia/StandaloneSuite/jwt"), []byte("very_important_secret"), 0600)
+	_ = os.WriteFile(SuiteTmpPath("authelia/StandaloneSuite/session"), []byte("unsecure_session_secret"), 0600)
 
 	dockerEnvironment := NewDockerEnvironment([]string{
 		"internal/suites/compose.yml",
@@ -40,7 +40,7 @@ func init() {
 
 	teardown := func(suitePath string) error {
 		err := dockerEnvironment.Down()
-		_ = os.Remove("/tmp/db.sqlite3")
+		_ = os.Remove(SuiteTmpPath("db.sqlite3"))
 
 		return err
 	}

--- a/internal/suites/suite_two_factor.go
+++ b/internal/suites/suite_two_factor.go
@@ -8,9 +8,9 @@ import (
 var twoFactorSuiteName = "TwoFactor"
 
 func init() {
-	_ = os.MkdirAll("/tmp/authelia/TwoFactorSuite", 0700)
-	_ = os.WriteFile("/tmp/authelia/TwoFactorSuite/jwt", []byte("very_important_secret"), 0600)       //nolint:gosec
-	_ = os.WriteFile("/tmp/authelia/TwoFactorSuite/session", []byte("unsecure_session_secret"), 0600) //nolint:gosec
+	_ = os.MkdirAll(SuiteTmpPath("authelia/TwoFactorSuite"), 0700)
+	_ = os.WriteFile(SuiteTmpPath("authelia/TwoFactorSuite/jwt"), []byte("very_important_secret"), 0600)
+	_ = os.WriteFile(SuiteTmpPath("authelia/TwoFactorSuite/session"), []byte("unsecure_session_secret"), 0600)
 
 	dockerEnvironment := NewDockerEnvironment([]string{
 		"internal/suites/compose.yml",
@@ -41,7 +41,7 @@ func init() {
 
 	teardown := func(suitePath string) error {
 		err := dockerEnvironment.Down()
-		_ = os.Remove("/tmp/db.sqlite3")
+		_ = os.Remove(SuiteTmpPath("db.sqlite3"))
 
 		return err
 	}

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -3,7 +3,6 @@ package suites
 import (
 	"bufio"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -224,6 +223,32 @@ func (s *BaseSuite) SetupEnvironment() {
 	s.T().Setenv("SUITE_SETUP_ENVIRONMENT", t)
 }
 
+// SuiteTempDir creates a directory inside the directory this process shares with the suite containers, and returns the
+// path this process reaches it at. Pass the result through SuiteTmpContainerPath before handing it to a container.
+// t.TempDir() cannot be used because it honors TMPDIR, which the containers do not share.
+func SuiteTempDir(t *testing.T, pattern string) (dir string) {
+	dir, err := os.MkdirTemp(SuiteTmpPath(), pattern)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+
+	return dir
+}
+
+// SuiteTmpContainerPath returns the path a container sees for a file this process reaches at dir, which has to be
+// inside SuiteTmpPath. The containers always see that directory at /tmp while this process may reach it elsewhere, so
+// a path that crosses the boundary has to be translated rather than shared verbatim.
+func SuiteTmpContainerPath(dir string) string {
+	relative, err := filepath.Rel(SuiteTmpPath(), dir)
+	if err != nil {
+		return dir
+	}
+
+	return filepath.Join(suiteTmpPathDefault, relative)
+}
+
 func screenshotPaths(name string) (path, reported string) {
 	suite := strings.ToLower(os.Getenv("SUITE"))
 
@@ -235,7 +260,8 @@ func screenshotPaths(name string) (path, reported string) {
 		return filepath.Join("../..", reported), reported
 	}
 
-	path = filepath.Join(os.TempDir(), "authelia-suites-screenshots", suite, name)
+	// Scoped by compose project so concurrent runs of the same suite on one machine keep their own screenshots.
+	path = filepath.Join(os.TempDir(), "authelia-suites-screenshots", composeProjectName(), suite, name)
 
 	return path, path
 }
@@ -432,11 +458,7 @@ func getDomainEnvInfo(domain string) (info map[string]string, err error) {
 	info = make(map[string]string)
 
 	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, //nolint:gosec
-			},
-		},
+		Transport: NewHTTPTransport(),
 	}
 
 	var (

--- a/internal/suites/webdriver.go
+++ b/internal/suites/webdriver.go
@@ -158,6 +158,11 @@ func newBrowser(opts *RodSessionOpts) (shared *sharedBrowser, err error) {
 		Headless(headless).
 		Devtools(!headless && !opts.disableDevtools)
 
+	// Chrome resolves the suite domains from these rules rather than from /etc/hosts, so a browser launched by one
+	// suite reaches that suite's network even while another suite on this machine owns the names in /etc/hosts. The
+	// proxy hostnames the NetworkACL suite dials are resolved the same way.
+	l.Set("host-resolver-rules", HostResolverRules())
+
 	if opts.disableDevtools {
 		l.Set("font-render-hinting", "none")
 		l.Set("disable-lcd-text")


### PR DESCRIPTION
Sharing a Docker daemon between suite runs was made safe by #12726, but only for CI, where each job runs the tests and Chrome inside its own agent container. That container is what supplies the two resources the suites still assume they own alone: its own `/etc/hosts` and its own `/tmp`. A development machine has no agent container, so several worktrees on it collide on both and only one can run a suite at a time.

The `hostEntries` table moves from `cmd/authelia-scripts/cmd/bootstrap.go` to `internal/suites/hosts.go`, so `/etc/hosts`, Chrome and the Go clients all describe the network from one source. Chrome resolves the suite domains from `--host-resolver-rules` and the Go clients resolve them in `DialContext`, which `NewHTTPTransport` and `dialSSHContext` now dial through. Resolving at the dial layer rather than by name leaves the SNI name, the `Host` header and the cookie domain as the name the caller asked for, and it means a slotted shell no longer has to write `/etc/hosts` at all. Leaving that file on the default subnet is what keeps an unslotted worktree browsable while slotted ones run beside it.

`SUITE_TMP` moved the host side of the `/tmp` mounts but no Go code read it, so the test process still named the containers' path. `SUITE_TMP_PATH` now names where that process finds the shared directory while the containers keep seeing it at `/tmp`, and the host side of every exchange goes through `SuiteTmpPath`. `t.TempDir()` was the one place a single path crossed the boundary, being written by a container and then read back here, and it also honors `TMPDIR`, which the containers do not share; `SuiteTempDir` and `SuiteTmpContainerPath` replace it so each side is named explicitly.

CI supplies `SUITE_SLOT` per agent and nothing supplied it locally. `authelia-scripts suites slot` hands each worktree the lowest free number under an `flock` on a registry keyed by worktree path, and drops entries whose directory is gone so a deleted worktree frees its slot without anyone remembering to. `bootstrap.sh` asks for one when a shell is unslotted outside CI, and derives `SUITE_TMP` and `SUITE_TMP_PATH` from it there, since only a local shell has to move the path it reads through as well.

Every variable still falls back to the value a single local run has always used, so leaving them unset is byte for byte the existing behaviour.