### PR TITLE
ci(lefthook): exclude nested worktrees from tree wide scanners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .github/_/
 .lefthook-local.yml
 
+# Agent worktrees, which are checkouts of this repository nested inside it
+.claude/worktrees/
+
 # Nodejs modules
 .pnpm-store/
 node_modules/

--- a/.trufflehog
+++ b/.trufflehog
@@ -1,5 +1,6 @@
 ^authelia$
 ^.git\/
+^.claude\/
 ^.github\/workflows\/.*\.yml
 ^.idea\/
 ^.*\/node_modules/.*$

--- a/.typos.toml
+++ b/.typos.toml
@@ -56,6 +56,7 @@ peom = "peom"
 ignore-hidden = false
 extend-exclude = [
     ".git/",
+    ".claude/",
     "*.svg",
     "go.sum",
     "*-lock.yaml",

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -9,6 +9,7 @@ yaml-files:
   - '.yamllint'
 
 ignore: |
+  .claude/
   api/openapi.yml
   dist/public_html/api/openapi.yml
   docs/pnpm-lock.yaml


### PR DESCRIPTION
`typos`, `yamllint` and `trufflehog` are run against the whole tree rather than the staged files, and `ignore-hidden = false` means `typos` descends into dot directories. A worktree created under `.claude/worktrees/` is a checkout of this repository nested inside it, and every exclude these three configure is a path from the root, so none of them match the same file one level down. The nested checkout is therefore scanned as though it had no excludes at all: 22 findings from `typos`, 4275 from `yamllint`, and a private key under `internal/configuration/test_resources/` tripping `trufflehog`, none of which are about the change being committed.

`typos` runs with `-w`, so this is not only noise. It rewrote seven third-party files in a nested checkout, `LDAP_ORGANISATION` to `LDAP_ORGANIZATION` among them, which would have broken the `LDAP` suite in a tree nobody had edited.

Ignoring `.claude/worktrees/` keeps those checkouts out of `git status`, and covers `typos` on its own because it honours the ignore file. `yamllint` and `trufflehog` do not, so both keep an explicit exclude, and `typos` keeps one as well so that all three say the same thing rather than one of them depending on a default. Only the worktrees are ignored, since anything else a project keeps under `.claude/` is worth both committing and linting.

The Go linters need nothing: a nested checkout carries its own `go.mod`, so `./...` never reaches it.