### PR TITLE
test(suites): fetch a page again when it loses a response

### DIFF
--- a/.buildkite/steps/e2etests.sh
+++ b/.buildkite/steps/e2etests.sh
@@ -19,12 +19,13 @@ cat << EOF
   - label: ":selenium: ${SUITE_NAME} Suite"
     command: "authelia-scripts --log-level debug suites test ${SUITE_NAME} --failfast --headless"
     artifact_paths:
+      - "screenshots/**/*.access.log"
+      - "screenshots/**/*.containers.log"
+      - "screenshots/**/*.html"
+      - "screenshots/**/*.png"
+      - "screenshots/**/*.resources.json"
       - "test-results-*.json"
       - "test-results-*.xml"
-      - "screenshots/**/*.png"
-      - "screenshots/**/*.html"
-      - "screenshots/**/*.resources.json"
-      - "screenshots/**/*.containers.log"
     timeout_in_minutes: ${TIMEOUT}
     retry:
       automatic:

--- a/internal/suites/action_login.go
+++ b/internal/suites/action_login.go
@@ -59,7 +59,6 @@ func (rs *RodSession) doFillPasswordAndClick(t *testing.T, page *rod.Page, passw
 	rs.ClickElementLocatedByID(t, page, "sign-in-button")
 }
 
-// Login 1FA.
 func (rs *RodSession) doLoginOneFactor(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool, domain, targetURL string) {
 	rs.doVisitLoginPage(t, page, domain, targetURL)
 	rs.doFillLoginPageAndClick(t, page, username, password, keepMeLoggedIn)
@@ -75,7 +74,6 @@ func (rs *RodSession) doLoginPasskey(t *testing.T, page *rod.Page, keepMeLoggedI
 	rs.ClickElementLocatedByID(t, page, "passkey-sign-in-button")
 }
 
-// Login 1FA and 2FA subsequently (must already be registered).
 func (rs *RodSession) doLoginSecondFactorTOTP(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool, targetURL string) {
 	rs.doLoginOneFactor(t, page, username, password, keepMeLoggedIn, BaseDomain, targetURL)
 	rs.verifyIsSecondFactorPage(t, page)
@@ -86,7 +84,6 @@ func (rs *RodSession) doLoginSecondFactorTOTP(t *testing.T, page *rod.Page, user
 	}
 }
 
-// Login 1FA and register 2FA.
 func (rs *RodSession) doLoginAndRegisterTOTP(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool) {
 	rs.doLoginOneFactor(t, page, username, password, keepMeLoggedIn, BaseDomain, "")
 	rs.doOpenSettingsAndRegisterTOTP(t, page, username)
@@ -94,9 +91,7 @@ func (rs *RodSession) doLoginAndRegisterTOTP(t *testing.T, page *rod.Page, usern
 	rs.verifyIsSecondFactorPage(t, page)
 }
 
-// Register a user with TOTP, logout and then authenticate until TOTP-2FA.
 func (rs *RodSession) doRegisterTOTPAndLogin2FA(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool, targetURL string) { //nolint:unparam
-	// Register TOTP secret and logout.
 	rs.doLoginAndRegisterTOTPThenLogout(t, page, username, password)
 	rs.doLoginSecondFactorTOTP(t, page, username, password, keepMeLoggedIn, targetURL)
 }

--- a/internal/suites/action_reset_password.go
+++ b/internal/suites/action_reset_password.go
@@ -13,10 +13,8 @@ func (rs *RodSession) doInitiatePasswordReset(t *testing.T, page *rod.Page, user
 
 	require.NoError(t, page.WaitStable(time.Millisecond*100))
 
-	// Fill in username.
 	err := rs.WaitElementLocatedByID(t, page, "username-textfield").Input(username)
 	require.NoError(t, err)
-	// And click on the reset button.
 	rs.ClickElementLocatedByID(t, page, "reset-button")
 }
 
@@ -60,7 +58,6 @@ func (rs *RodSession) doUnsuccessfulPasswordReset(t *testing.T, page *rod.Page, 
 
 func (rs *RodSession) doResetPassword(t *testing.T, page *rod.Page, username, newPassword1, newPassword2 string, unsuccessful bool) {
 	rs.doInitiatePasswordReset(t, page, username)
-	// then wait for the "email sent notification".
 	rs.verifyMailNotificationDisplayed(t, page)
 
 	if unsuccessful {

--- a/internal/suites/action_visit.go
+++ b/internal/suites/action_visit.go
@@ -8,8 +8,25 @@ import (
 
 	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
+
+// A transport failure in the burst of requests the portal's entry module makes for its chunks leaves the
+// module graph unresolved: the document reaches readyState complete and nothing renders or is fetched
+// again. The lost response is what separates that page from one that is merely slow, and it reports a
+// zero status against a zero body. Pages that are not the portal have no root and count as rendered.
+const pageRenderState = `() => {
+	const root = document.getElementById('root');
+
+	if (root === null || root.innerHTML.length !== 0) {
+		return 'rendered';
+	}
+
+	const lost = performance.getEntriesByType('resource').some((entry) => entry.responseStatus === 0 && entry.encodedBodySize === 0);
+
+	return lost ? 'lost' : 'pending';
+}`
 
 func (s *RodSuite) doSetupTest(url string) {
 	ctx, cancel := context.WithTimeout(context.Background(), setupTestTimeout)
@@ -56,6 +73,44 @@ func (rs *RodSession) doCreateTab(t *testing.T, url string) *rod.Page {
 func (rs *RodSession) doVisit(t *testing.T, page *rod.Page, url string) {
 	require.NoError(t, page.Navigate(url))
 	require.NoError(t, page.WaitLoad())
+
+	rs.doReloadIfRenderWasLost(t, page, url)
+}
+
+func (rs *RodSession) doReloadIfRenderWasLost(t *testing.T, page *rod.Page, url string) {
+	if !rs.renderWasLost(page) {
+		return
+	}
+
+	log.Warnf("The page at '%s' lost a response it needed to render, fetching it again once", url)
+
+	require.NoError(t, page.Reload())
+	require.NoError(t, page.WaitLoad())
+}
+
+func (rs *RodSession) renderWasLost(page *rod.Page) bool {
+	deadline := time.Now().Add(pageRenderTimeout)
+
+	for {
+		value, err := page.Eval(pageRenderState)
+		if err != nil {
+			// The page carries the deadline of the test that owns it, and that test reports its expiry
+			// against the element it was waiting for, which names the failure better than this can.
+			return false
+		}
+
+		state := value.Value.Str()
+
+		if state == "rendered" {
+			return false
+		}
+
+		if time.Now().After(deadline) {
+			return state == "lost"
+		}
+
+		time.Sleep(elementRetryInterval)
+	}
 }
 
 func (rs *RodSession) doVisitAndVerifyOneFactorStep(t *testing.T, page *rod.Page, url string) {

--- a/internal/suites/action_visit_test.go
+++ b/internal/suites/action_visit_test.go
@@ -1,0 +1,150 @@
+package suites
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testVisitIndex = `<!doctype html>
+<html><head><script type="module" src="./static/chunk.js"></script></head>
+<body><div id="root"></div></body></html>`
+
+const testVisitChunk = `document.getElementById('root').textContent = 'rendered';`
+
+// visitFailure is how the server fails a chunk. Dropping the connection leaves the browser with no
+// status to record, which is what a request cut mid-flight looks like, and is the only failure a visit
+// fetches the page again for. Refusing the request leaves the page just as blank but with a status
+// against it, which stands for every other reason a page does not render.
+type visitFailure int
+
+const (
+	visitDropped visitFailure = iota
+	visitRefused
+)
+
+func newVisitServer(t *testing.T, failure visitFailure, failFirstLoad bool) (server *httptest.Server, documents, requests *atomic.Int32) {
+	documents, requests = &atomic.Int32{}, &atomic.Int32{}
+
+	mux := http.NewServeMux()
+
+	// Which document is asking decides whether the chunk fails, rather than a count of failures. How
+	// many times the browser retries a request of its own accord is its business, and a count would let
+	// a change to it serve the chunk within the first load, leaving the test passing without a reload.
+	mux.HandleFunc("/static/chunk.js", func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+
+		switch {
+		case !failFirstLoad || documents.Load() > 1:
+			w.Header().Set("Content-Type", "text/javascript")
+
+			_, err := w.Write([]byte(testVisitChunk))
+			require.NoError(t, err)
+		case failure == visitDropped:
+			connection, _, err := w.(http.Hijacker).Hijack()
+			require.NoError(t, err)
+			require.NoError(t, connection.Close())
+		default:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	})
+
+	// This pattern is the mux's catch-all, so the favicon the browser asks for on its own lands here
+	// too and only a request for the document itself counts as a load.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/" {
+			documents.Add(1)
+		}
+
+		w.Header().Set("Content-Type", "text/html")
+
+		_, err := w.Write([]byte(testVisitIndex))
+		require.NoError(t, err)
+	})
+
+	server = httptest.NewServer(mux)
+
+	t.Cleanup(server.Close)
+
+	return server, documents, requests
+}
+
+func newVisitSession(t *testing.T) *RodSession {
+	path, err := GetBrowserPath()
+	require.NoError(t, err)
+
+	l := launcher.New().Bin(path).Headless(true)
+
+	t.Cleanup(l.Cleanup)
+
+	browser := rod.New().ControlURL(l.MustLaunch()).MustConnect()
+
+	t.Cleanup(func() { _ = browser.Close() })
+
+	return &RodSession{WebDriver: browser}
+}
+
+func (rs *RodSession) mustVisitAndReadRoot(t *testing.T, url string) string {
+	page, err := rs.WebDriver.Page(proto.TargetCreateTarget{URL: "about:blank"})
+	require.NoError(t, err)
+
+	rs.doVisit(t, page, url)
+
+	value, err := page.Eval(`() => document.getElementById('root').textContent`)
+	require.NoError(t, err)
+
+	return value.Value.Str()
+}
+
+// TestVisitShouldFetchAgainAPageThatLostAResponse is the regression guard for the flake where a page
+// whose module graph was cut mid-fetch stayed blank for the rest of the test: no element wait recovers
+// it, because the document has loaded and nothing further is ever fetched.
+func TestVisitShouldFetchAgainAPageThatLostAResponse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping browser test in short mode")
+	}
+
+	server, documents, _ := newVisitServer(t, visitDropped, true)
+	session := newVisitSession(t)
+
+	assert.Equal(t, "rendered", session.mustVisitAndReadRoot(t, server.URL))
+	assert.Equal(t, int32(2), documents.Load(), "the page is fetched again exactly once, after the browser gave up retrying")
+}
+
+// TestVisitShouldNotFetchAgainAPageThatRendered pins the second fetch to pages that need it, so that
+// every other visit does not pay for it.
+func TestVisitShouldNotFetchAgainAPageThatRendered(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping browser test in short mode")
+	}
+
+	server, documents, requests := newVisitServer(t, visitDropped, false)
+	session := newVisitSession(t)
+
+	assert.Equal(t, "rendered", session.mustVisitAndReadRoot(t, server.URL))
+	assert.Equal(t, int32(1), documents.Load(), "the page is fetched once")
+	assert.Equal(t, int32(1), requests.Load(), "the chunk is fetched once")
+}
+
+// TestVisitShouldNotFetchAgainAPageThatWasAnswered keeps a blank page that was answered, rather than cut
+// off, failing the way it always has. Fetching those again would hide real breakage and would spend a
+// second page load out of the budget of the test that is already failing.
+func TestVisitShouldNotFetchAgainAPageThatWasAnswered(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping browser test in short mode")
+	}
+
+	server, documents, requests := newVisitServer(t, visitRefused, true)
+	session := newVisitSession(t)
+
+	assert.Empty(t, session.mustVisitAndReadRoot(t, server.URL))
+	assert.Equal(t, int32(1), documents.Load(), "the page is fetched once")
+	assert.Equal(t, int32(1), requests.Load(), "the chunk is fetched once")
+}

--- a/internal/suites/const.go
+++ b/internal/suites/const.go
@@ -8,7 +8,6 @@ import (
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
 )
 
-// BaseDomain the base domain.
 var (
 	BaseDomain     = "example.com:8080"
 	Example2DotCom = "example2.com:8080"
@@ -95,7 +94,7 @@ const (
 const (
 	agentAddressOctet        = 10
 	composeProjectDefault    = "authelia"
-	containerLogLines        = 200
+	containerLogLines        = 3000
 	containerLogTailLines    = 15
 	envFileProd              = "/web/.env.production"
 	envFileDev               = "/web/.env.development"

--- a/internal/suites/docker.go
+++ b/internal/suites/docker.go
@@ -1,6 +1,7 @@
 package suites
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -52,6 +53,18 @@ func SuiteTmpPath(elem ...string) string {
 	}
 
 	return filepath.Join(append([]string{path}, elem...)...)
+}
+
+func proxyAccessLog() string {
+	return fmt.Sprintf("traefik-access-%s.log", composeProjectName())
+}
+
+func removeProxyAccessLog() {
+	// The proxy appends, and the directory it writes into outlives the containers, so a run would
+	// otherwise collect every run before it.
+	if err := os.Remove(SuiteTmpPath(proxyAccessLog())); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Debugf("Error removing the previous access log: %v", err)
+	}
 }
 
 func agentContainer() string {
@@ -132,6 +145,8 @@ func (de *DockerEnvironment) Pull(images ...string) error {
 
 // Up spawn a docker environment.
 func (de *DockerEnvironment) Up() error {
+	removeProxyAccessLog()
+
 	command := "up --build -d"
 
 	if os.Getenv("CI") == t {

--- a/internal/suites/example/compose/traefik/compose.yml
+++ b/internal/suites/example/compose/traefik/compose.yml
@@ -7,6 +7,7 @@ services:
       - '/var/run/docker.sock:/var/run/docker.sock'
       - './example/compose/traefik/config:/config'
       - './common/pki:/pki'
+      - '${SUITE_TMP:-/tmp}:/tmp'
     labels:
       traefik.enable: 'true'
       traefik.http.routers.api.rule: 'Host(`traefik.example.com`)'
@@ -19,19 +20,21 @@ services:
       traefik.http.middlewares.authelia.forwardAuth.maxResponseBodySize: '8192'
       traefik.http.middlewares.authelia.forwardAuth.authResponseHeaders: 'Authorization,Proxy-Authorization,Remote-User,Remote-Groups,Remote-Email,Remote-Name'  # yamllint disable-line rule:line-length
     command:
+      - '--accesslog=true'
+      - '--accesslog.filepath=/tmp/traefik-access-${COMPOSE_PROJECT_NAME:-authelia}.log'
       - '--api.dashboard=true'
       - '--api.insecure=false'
-      - '--log.level=DEBUG'
-      - '--accesslog=true'
-      - '--global.sendanonymoususage=false'
-      - '--global.checknewversion=false'
       - '--entrypoints.https.address=:8080/tcp'
-      - '--serverstransport.insecureskipverify=true'
-      - '--providers.docker.exposedbydefault=false'
+      - '--global.checknewversion=false'
+      - '--global.sendanonymoususage=false'
+      - '--log.level=DEBUG'
       - '--providers.docker.constraints=Label(`com.docker.compose.project`,`${COMPOSE_PROJECT_NAME:-authelia}`)'
+      - '--providers.docker.exposedbydefault=false'
       - '--providers.docker.network=${COMPOSE_PROJECT_NAME:-authelia}_authelianet'
       - '--providers.file.directory=/config/dynamic/'
       - '--providers.file.watch=true'
+      - '--providers.providersthrottleduration=5s'
+      - '--serverstransport.insecureskipverify=true'
     networks:
       authelianet:
         aliases:

--- a/internal/suites/external_suite_templates_test.go
+++ b/internal/suites/external_suite_templates_test.go
@@ -128,10 +128,10 @@ func (s *TemplatesSuite) previewText(outer *rod.Page, readySelector, selector st
 }
 
 func (s *TemplatesSuite) openPreviewFrame(outer *rod.Page, readySelector string) *rod.Page {
-	// react-email has rendered the element matching readySelector. Callers should prefer previewText,
-	// which additionally recovers from the document being swapped after the descent.
 	s.WaitElementLocatedBySelector(s.T(), outer, "iframe")
 
+	// readySelector is only present once react-email has finished populating the preview iframe, so
+	// waiting on it is what stops a partial or empty srcdoc being captured.
 	outer.MustWait(`(sel) => {
 		const f = document.querySelector('iframe');
 		return !!(f && f.contentDocument && f.contentDocument.querySelector(sel));
@@ -228,9 +228,9 @@ func (s *TemplatesSuite) TestEventRenders() {
 	}
 }
 
-// injectEmbeddedFont rewrites srcdoc to force Liberation Sans via a data-URL @font-face so
-// visual snapshots rasterize from the same outlines on every host.
 func (s *TemplatesSuite) injectEmbeddedFont(repoRoot, srcdoc string) string {
+	// Forcing one font through the document means visual snapshots rasterize from the same outlines
+	// on every host.
 	fontPath := filepath.Join(repoRoot, "internal", "suites", "testdata", "fonts", "LiberationSans-Regular.ttf")
 
 	fontBytes, err := os.ReadFile(fontPath)
@@ -257,10 +257,6 @@ html, body, * {
 	return style + srcdoc
 }
 
-// runTemplateSnapshot renders the template's srcdoc in a clean tab with an embedded font
-// and asserts it against the committed baseline. readySelector identifies an element that
-// is only present once react-email has finished populating the preview iframe — waiting on
-// it prevents capturing a partial or empty srcdoc.
 func (s *TemplatesSuite) runTemplateSnapshot(slug, readySelector, snapshotName string) {
 	outer := s.doCreateTab(s.T(), s.templatesURL("/preview/"+slug))
 	defer outer.MustClose()

--- a/internal/suites/hosts.go
+++ b/internal/suites/hosts.go
@@ -93,7 +93,6 @@ func hostEntriesCookieDomains(ip string) []HostEntry {
 	return entries
 }
 
-// hostAddresses indexes HostEntries by domain.
 func hostAddresses() map[string]string {
 	entries := HostEntries()
 

--- a/internal/suites/scenario_oidc_test.go
+++ b/internal/suites/scenario_oidc_test.go
@@ -92,7 +92,6 @@ func (s *OIDCScenario) TestShouldAuthorizeAccessToOIDCApp() {
 
 	s.waitBodyContains(s.T(), s.Context(ctx), "Not logged yet...")
 
-	// Search for the 'login' link.
 	err := s.Page.MustSearch("Log in").Click("left", 1)
 	assert.NoError(s.T(), err)
 
@@ -169,7 +168,6 @@ func (s *OIDCScenario) TestShouldDenyConsent() {
 
 	s.waitBodyContains(s.T(), s.Context(ctx), "Not logged yet...")
 
-	// Search for the 'login' link.
 	err := s.Page.MustSearch("Log in").Click("left", 1)
 	assert.NoError(s.T(), err)
 

--- a/internal/suites/scenario_passkey_test.go
+++ b/internal/suites/scenario_passkey_test.go
@@ -82,14 +82,11 @@ func (s *PasskeyScenario) TestShouldAuthorizeAfterPasskeyLogin() {
 	s.verifyNotificationDisplayed(s.T(), s.Context(ctx), "Incorrect password")
 	s.doFillPasswordAndClick(s.T(), s.Context(ctx), "password")
 
-	// And check if the user is redirected to the secret.
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 
-	// Leave the secret.
 	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// And try to reload it again to check the session is kept.
 	s.doVisit(s.T(), s.Context(ctx), targetURL)
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 }

--- a/internal/suites/scenario_password_complexity_test.go
+++ b/internal/suites/scenario_password_complexity_test.go
@@ -53,7 +53,6 @@ func (s *PasswordComplexityScenario) TestShouldRejectPasswordReset() {
 	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
-	// Attempt to reset the password to a.
 	s.doResetPassword(s.T(), s.Context(ctx), "john", "a", "a", true)
 }
 

--- a/internal/suites/scenario_reset_password_test.go
+++ b/internal/suites/scenario_reset_password_test.go
@@ -53,20 +53,15 @@ func (s *ResetPasswordScenario) TestShouldResetPassword() {
 	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
-	// Reset the password to abc.
 	s.doResetPassword(s.T(), s.Context(ctx), "john", "abc", "abc", false)
 
-	// Try to login with the old password.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
 	s.verifyNotificationDisplayed(s.T(), s.Context(ctx), "Incorrect username or password")
 
-	// Try to login with the new password.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "abc", false, BaseDomain, "")
 
-	// Logout.
 	s.doLogout(s.T(), s.Context(ctx))
 
-	// Reset the original password.
 	s.doResetPassword(s.T(), s.Context(ctx), "john", "password", "password", false)
 }
 
@@ -81,7 +76,6 @@ func (s *ResetPasswordScenario) TestShouldMakeAttackerThinkPasswordResetIsInitia
 	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
-	// Try to initiate a password reset of an nonexistent user.
 	s.doInitiatePasswordReset(s.T(), s.Context(ctx), "i_dont_exist")
 
 	// Check that the notification make the attacker thinks the process is initiated.

--- a/internal/suites/scenario_signin_email_test.go
+++ b/internal/suites/scenario_signin_email_test.go
@@ -1,7 +1,5 @@
 package suites
 
-// This scenario is used to test sign in using the user email address.
-
 import (
 	"context"
 	"fmt"

--- a/internal/suites/scenario_two_factor_totp_test.go
+++ b/internal/suites/scenario_two_factor_totp_test.go
@@ -102,18 +102,14 @@ func (s *TwoFactorTOTPScenario) TestShouldAuthorizeSecretAfterTwoFactor() {
 	username := testUsername
 	password := testPassword
 
-	// Login and register TOTP, logout and login again with 1FA & 2FA.
 	targetURL := fmt.Sprintf("%s/secret.html", AdminBaseURL)
 	s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), username, password, false, targetURL)
 
-	// And check if the user is redirected to the secret.
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 
-	// Leave the secret.
 	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// And try to reload it again to check the session is kept.
 	s.doVisit(s.T(), s.Context(ctx), targetURL)
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 }

--- a/internal/suites/scenario_two_factor_webauthn_test.go
+++ b/internal/suites/scenario_two_factor_webauthn_test.go
@@ -81,14 +81,11 @@ func (s *TwoFactorWebAuthnScenario) TestShouldAuthorizeSecretAfterTwoFactor() {
 
 	s.doWebAuthnMethodMaybeSelect(s.T(), s.Context(ctx))
 
-	// And check if the user is redirected to the secret.
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 
-	// Leave the secret.
 	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// And try to reload it again to check the session is kept.
 	s.doVisit(s.T(), s.Context(ctx), targetURL)
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 }

--- a/internal/suites/scenario_user_preferences_test.go
+++ b/internal/suites/scenario_user_preferences_test.go
@@ -52,11 +52,9 @@ func (s *UserPreferencesScenario) TestShouldRememberLastUsed2FAMethod() {
 		s.collectScreenshot(ctx.Err(), s.Page)
 	}()
 
-	// Authenticate.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
 	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
 
-	// Then switch to push notification method.
 	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")
 	s.WaitElementLocatedByID(s.T(), s.Context(ctx), "push-notification-method")
 
@@ -64,15 +62,11 @@ func (s *UserPreferencesScenario) TestShouldRememberLastUsed2FAMethod() {
 	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Then go back to portal.
 	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
-	// And check the latest method is still used.
 	s.WaitElementLocatedByID(s.T(), s.Context(ctx), "push-notification-method")
-	// Meaning the authentication is successful.
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Logout the user and see what user 'harry' sees.
 	s.doLogout(s.T(), s.Context(ctx))
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "harry", "password", false, BaseDomain, "")
 	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
@@ -81,7 +75,6 @@ func (s *UserPreferencesScenario) TestShouldRememberLastUsed2FAMethod() {
 	s.doLogout(s.T(), s.Context(ctx))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
-	// Then log back as previous user and verify the push notification is still the default method.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
 	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
 	s.WaitElementLocatedByID(s.T(), s.Context(ctx), "push-notification-method")

--- a/internal/suites/suite_cli_test.go
+++ b/internal/suites/suite_cli_test.go
@@ -505,7 +505,6 @@ func (s *CLISuite) TestShouldGenerateCertificateCAAndSignCertificate() {
 	s.Contains(output, "\tPrivate Key: private.pem")
 	s.Contains(output, "\tCertificate: public.crt")
 
-	// Check the certificates look fine.
 	privateKeyData, err := os.ReadFile(SuiteTmpPath("private.pem"))
 	s.NoError(err)
 

--- a/internal/suites/suite_duo_push_test.go
+++ b/internal/suites/suite_duo_push_test.go
@@ -133,18 +133,14 @@ func (s *DuoPushWebDriverSuite) TestShouldAutoSelectDevice() {
 	ConfigureDuoPreAuth(s.T(), PreAuthAPIResponse)
 	ConfigureDuo(s.T(), Allow)
 
-	// Authenticate.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
 	// Switch Method where single Device should be selected automatically.
 	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Re-Login the user.
 	s.doLogout(s.T(), s.Context(ctx))
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
-	// And check the latest method and device is still used.
 	s.WaitElementLocatedByID(s.T(), s.Context(ctx), "push-notification-method")
-	// Meaning the authentication is successful.
 	s.verifyIsHome(s.T(), s.Context(ctx))
 }
 
@@ -173,24 +169,17 @@ func (s *DuoPushWebDriverSuite) TestShouldSelectDevice() {
 	ConfigureDuoPreAuth(s.T(), PreAuthAPIResponse)
 	ConfigureDuo(s.T(), Allow)
 
-	// Authenticate.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
 	// Switch Method where Device Selection should open automatically.
 	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")
-	// Check for available Device 1.
 	s.WaitElementLocatedByID(s.T(), s.Context(ctx), "device-12345ABCDEFGHIJ67890")
-	// Test Back button.
 	s.doClickButton(s.T(), s.Context(ctx), "device-selection-back")
-	// then select Device 2 for further use and be redirected.
 	s.doChangeDevice(s.T(), s.Context(ctx), "1234567890ABCDEFGHIJ")
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Re-Login the user.
 	s.doLogout(s.T(), s.Context(ctx))
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
-	// And check the latest method and device is still used.
 	s.WaitElementLocatedByID(s.T(), s.Context(ctx), "push-notification-method")
-	// Meaning the authentication is successful.
 	s.verifyIsHome(s.T(), s.Context(ctx))
 }
 

--- a/internal/suites/suite_high_availability_test.go
+++ b/internal/suites/suite_high_availability_test.go
@@ -167,7 +167,6 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrim
 	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
 
-	// Then logout and login again to check we can see the secret.
 	s.doLogout(s.T(), s.Context(ctx))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
@@ -266,7 +265,6 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepSessionAfterAutheliaResta
 	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
 
-	// Then logout and login again to check the secret is still there.
 	s.doLogout(s.T(), s.Context(ctx))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 

--- a/internal/suites/suite_one_factor_only_test.go
+++ b/internal/suites/suite_one_factor_only_test.go
@@ -115,7 +115,6 @@ func (s *OneFactorOnlySuite) TestShouldNotRedirectAlreadyAuthenticatedUserToUnsa
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Visit the login page and wait for redirection to 2FA page with success icon displayed.
 	s.doVisit(s.T(), s.Context(ctx), fmt.Sprintf("%s?rd=https://secure.example.local:8080", GetLoginBaseURL(BaseDomain)))
 	s.verifyNotificationDisplayed(s.T(), s.Context(ctx), "Redirection was determined to be unsafe and aborted ensure the redirection URL is correct")
 }

--- a/internal/suites/suite_standalone_test.go
+++ b/internal/suites/suite_standalone_test.go
@@ -69,7 +69,6 @@ func (s *StandaloneWebDriverSuite) TestShouldLetUserKnowHeIsAlreadyAuthenticated
 	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Visit the login page and wait for redirection to 2FA page with success icon displayed.
 	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsAuthenticatedPage(s.T(), s.Context(ctx))
 }
@@ -86,16 +85,13 @@ func (s *StandaloneWebDriverSuite) TestShouldRedirectAfterOneFactorOnAnotherTab(
 		page2.MustClose()
 	}()
 
-	// Open second tab with secret page.
 	page2.MustWaitStable()
 
-	// Switch to first, visit the login page and wait for redirection to secret page with secret displayed.
 	s.MustActivate()
 	s.verifyIsHome(s.T(), s.Context(ctx))
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, targetURL)
 	s.verifySecretAuthorized(s.T(), s.Page)
 
-	// Switch to second tab and wait for redirection to secret page with secret displayed.
 	page2.MustActivate()
 	s.verifySecretAuthorized(s.T(), page2.Context(ctx))
 }
@@ -114,7 +110,6 @@ func (s *StandaloneWebDriverSuite) TestShouldRedirectAlreadyAuthenticatedUser() 
 	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Visit the login page and wait for redirection to 2FA page with success icon displayed.
 	s.doVisit(s.T(), s.Context(ctx), fmt.Sprintf("%s?rd=https://secure.example.com:8080", GetLoginBaseURL(BaseDomain)))
 
 	_, err := s.ElementR("h1", "Public resource")
@@ -136,7 +131,6 @@ func (s *StandaloneWebDriverSuite) TestShouldNotRedirectAlreadyAuthenticatedUser
 	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
 	s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Visit the login page and wait for redirection to 2FA page with success icon displayed.
 	s.doVisit(s.T(), s.Context(ctx), fmt.Sprintf("%s?rd=https://secure.example.local:8080", GetLoginBaseURL(BaseDomain)))
 	s.verifyNotificationDisplayed(s.T(), s.Context(ctx), "Redirection was determined to be unsafe and aborted ensure the redirection URL is correct")
 }
@@ -158,21 +152,15 @@ func (s *StandaloneWebDriverSuite) TestShouldCheckUserIsAskedToRegisterDevice() 
 
 	require.NoError(s.T(), provider.DeleteTOTPConfiguration(ctx, username))
 
-	// Login one factor.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), username, password, false, BaseDomain, "")
 
-	// Check the user is asked to register a new device.
 	s.WaitElementLocatedByClassName(s.T(), s.Context(ctx), "state-not-registered")
 
-	// Then register the TOTP factor.
 	s.doOpenSettingsAndRegisterTOTP(s.T(), s.Context(ctx), username)
-	// And logout.
 	s.doLogout(s.T(), s.Context(ctx))
 
-	// Login one factor again.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), username, password, false, BaseDomain, "")
 
-	// now the user should be asked to perform 2FA.
 	s.WaitElementLocatedByClassName(s.T(), s.Context(ctx), "state-method")
 }
 

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -272,7 +272,10 @@ func (s *RodSuite) collectScreenshot(err error, page *rod.Page) {
 
 func (rs *RodSession) collectContainerLogs(test *testing.T, base string) {
 	// The OnError hook prints these too, but it runs in a separate process after the test binary has
-	// exited, so nothing it prints can be associated with the test that failed.
+	// exited, so nothing it prints can be associated with the test that failed. The collected tail is deep
+	// because one configuration rebuild on a shared daemon costs a proxy a debug line per container the
+	// daemon holds, which on its own is as many lines as this used to collect in total. Only the artifact
+	// grows with the depth, since the lines reported inline stay at containerLogTailLines.
 	output, _, err := utils.RunCommandAndReturnOutput(
 		fmt.Sprintf("docker ps --filter label=com.docker.compose.project=%s --format '{{.Names}}'", composeProjectName()),
 	)
@@ -304,6 +307,26 @@ func (rs *RodSession) collectContainerLogs(test *testing.T, base string) {
 	path, _ := screenshotPaths(base + ".containers.log")
 
 	if err = os.WriteFile(path, []byte(builder.String()), 0600); err != nil {
+		log.Debugf("Error writing '%s': %v", path, err)
+	}
+}
+
+func (rs *RodSession) collectProxyAccessLog(base string) {
+	source := SuiteTmpPath(proxyAccessLog())
+
+	data, err := os.ReadFile(source)
+	if err != nil {
+		// Suites that do not run behind a proxy have no such file.
+		log.Debugf("Error reading '%s': %v", source, err)
+
+		return
+	}
+
+	path, _ := screenshotPaths(base + ".access.log")
+
+	// Both paths are named by this package from the name of the running test, and neither carries anything
+	// a request could reach.
+	if err = os.WriteFile(path, data, 0600); err != nil { //nolint:gosec
 		log.Debugf("Error writing '%s': %v", path, err)
 	}
 }
@@ -348,6 +371,7 @@ func (rs *RodSession) collectScreenshot(test *testing.T, err error, page *rod.Pa
 	base := strings.NewReplacer("/", "-", " ", "_").Replace(test.Name())
 
 	defer rs.collectContainerLogs(test, base)
+	defer rs.collectProxyAccessLog(base)
 
 	path, reported := screenshotPaths(base + ".png")
 
@@ -452,8 +476,6 @@ func fixCoveragePath(path string, file os.FileInfo, err error) error {
 	return nil
 }
 
-// getDomainEnvInfo gets environments variables for specified cookie domain
-// this func makes a http call to https://login.<domain>/devworkflow and is only useful for suite tests.
 func getDomainEnvInfo(domain string) (info map[string]string, err error) {
 	info = make(map[string]string)
 
@@ -492,7 +514,6 @@ func getDomainEnvInfo(domain string) (info map[string]string, err error) {
 	return info, nil
 }
 
-// generateDevEnvFile generates web/.env.development based on opts.
 func generateDevEnvFile(info map[string]string) (err error) {
 	base, _ := os.Getwd()
 	base = strings.TrimSuffix(base, "/internal/suites")
@@ -513,9 +534,6 @@ func generateDevEnvFile(info map[string]string) (err error) {
 	return nil
 }
 
-// updateDevEnvFileForDomain updates web/.env.development and waits for the
-// Vite dev server to restart after the file change. This function only affects
-// local dev environments.
 func updateDevEnvFileForDomain(domain string, dockerEnvironment *DockerEnvironment) (err error) {
 	if os.Getenv("CI") == t {
 		return nil

--- a/internal/suites/webdriver.go
+++ b/internal/suites/webdriver.go
@@ -24,6 +24,7 @@ const (
 	elementAttemptTimeout = time.Second
 	elementRetryInterval  = time.Millisecond * 50
 	elementStateTimeout   = time.Second * 5
+	pageRenderTimeout     = time.Second * 5
 	setupTestTimeout      = time.Second * 30
 	waitElementsAttempts  = 10
 )
@@ -354,9 +355,6 @@ func (rs *RodSession) waitElementTextIsNot(t *testing.T, page *rod.Page, selecto
 	rs.waitElementText(t, page, selector, unexpected, false)
 }
 
-// waitElementText polls the text rod reports for the element, which is the text as rendered and so the
-// same value the assertions read: the components uppercase their labels through a style, which the text
-// in the document does not account for.
 func (rs *RodSession) waitElementText(t *testing.T, page *rod.Page, selector, value string, equal bool) {
 	ctx, cancel := context.WithTimeout(page.GetContext(), elementActionTimeout)
 
@@ -367,6 +365,8 @@ func (rs *RodSession) waitElementText(t *testing.T, page *rod.Page, selector, va
 
 	for {
 		if element, err := bounded.Element(selector); err == nil {
+			// rod reports the text as rendered, which is the value the assertions read: the components
+			// uppercase their labels through a style the text in the document does not account for.
 			if text, errText := element.Text(); errText == nil {
 				observed = text
 
@@ -392,11 +392,6 @@ func (rs *RodSession) waitElementText(t *testing.T, page *rod.Page, selector, va
 	}
 }
 
-// doElementAction locates the element and performs the action, repeating both while the element is in
-// a state it is expected to leave: replaced by a re-render, animating in, scrolled out of view, covered
-// or disabled. rod gives up on all of those bar the covered one immediately, and retries that one until
-// its context expires, so the attempt is given a deadline of its own. Without one a single element that
-// never becomes actionable consumes the whole test budget and reports nothing but the expiry.
 func (rs *RodSession) doElementAction(t *testing.T, page *rod.Page, selector string, action func(element *rod.Element) error) {
 	ctx, cancel := context.WithTimeout(page.GetContext(), elementActionTimeout)
 
@@ -456,8 +451,6 @@ func retryElementAction(page *rod.Page, selector string, action func(element *ro
 	}
 }
 
-// preferElementError reports the last state the element was seen in rather than the expiry that ended
-// the attempt, which on its own says nothing about why the element could not be acted on.
 func preferElementError(ctx context.Context, err, last error) error {
 	if last != nil && ctx.Err() != nil {
 		return last
@@ -466,9 +459,8 @@ func preferElementError(ctx context.Context, err, last error) error {
 	return err
 }
 
-// describeElement reads the element state through a context of its own so it still reports when the one
-// the action ran under has expired.
 func describeElement(page *rod.Page, selector string) string {
+	// A context of its own, so the state still reports once the one the action ran under has expired.
 	result, err := page.Context(context.Background()).Timeout(elementStateTimeout).Eval(elementState, selector)
 	if err != nil {
 		return fmt.Sprintf("unavailable: %v", err)
@@ -477,8 +469,6 @@ func describeElement(page *rod.Page, selector string) string {
 	return result.Value.Str()
 }
 
-// isTransientElementError reports whether the error describes a state the element is expected to leave
-// on its own.
 func isTransientElementError(err error) bool {
 	var notInteractable *rod.NotInteractableError
 


### PR DESCRIPTION
A `PathPrefix` run failed with the portal never rendering. The document was served, 10 of the 27 chunks the entry module preloads returned `200`, and the other 17 recorded a zero `responseStatus` against a zero `encodedBodySize`, which is what a request that never received a response looks like. The module graph therefore never resolved: `#root` stayed empty, `#first-factor-stage` never appeared, and the test spent its whole budget waiting for an element that could not arrive. No wait recovers that page, because the document has loaded and nothing further is ever fetched, so `doVisit` now fetches it once more when it finds an empty root alongside a response that was lost. A page that is merely slow, or one that was answered and still did not render, is left alone so that no visit is made worse by this.

The proxy the suites run behind was starved at the time. It logged a docker event stamped `22:43:54` at `22:44:11`, 17 seconds late, and the configuration rebuild it was working through enumerated the 199 containers the shared daemon was holding for every other suite on the machine. `--providers.providersthrottleduration` coalesces those events so that work stays off the two cores the container has to proxy the suite with.

Whether any of the 17 requests reached the proxy at all is a question only its access log answers, and that log was not collectable. It shared stdout with the debug log, where one rebuild emits a line per container the daemon holds, so the 200 lines a failing test collected held no access log line at all. Measured against a quiet daemon the same tail also held none of the `Remote error` lines the `forwardAuth` middleware logs and none of the routing configuration, so raising the level to `INFO` would have traded one missing record for another. The access log moves to a file in the suite directory instead, which a failing test collects whole and `Up` discards from the run before, and the tail of stdout carries the debug log alone at a depth one rebuild cannot exhaust.

The suites are swept of the comments that restated the code they sat above. The GoDoc of every unexported function goes, since the name says what the header did, along with the narration in the scenarios, where `// Logout.` sat above `doLogout` and `// Login one factor.` above `doLoginOneFactor`. What a reader cannot get from the code stays, moved to the line it explains: why the previous run's access log is removed, why a missing one is not an error, why `rod` is asked for the text as rendered, and how many failures it takes for the browser to give up on a chunk.