### PR TITLE
perf(server): serve pre-compressed embedded assets

### DIFF
--- a/internal/server/asset.go
+++ b/internal/server/asset.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/authelia/authelia/v4/internal/handlers"
 	"github.com/authelia/authelia/v4/internal/middlewares"
+	"github.com/authelia/authelia/v4/internal/templates"
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
@@ -32,14 +33,34 @@ var (
 )
 
 func newPublicHTMLEmbeddedHandler() fasthttp.RequestHandler {
+	return newEmbeddedHandler(assets, assetsRoot)
+}
+
+func newEmbeddedHandler(embedFS embed.FS, root string) fasthttp.RequestHandler {
 	etags := map[string][]byte{}
 
-	getEmbedETags(assets, assetsRoot, etags)
+	getEmbedETags(embedFS, root, etags)
+
+	encoded := getEmbedCompressed(embedFS, root)
 
 	return func(ctx *fasthttp.RequestCtx) {
-		p := path.Join(assetsRoot, string(ctx.Path()))
+		p := path.Join(root, string(ctx.Path()))
 
-		if etag, ok := etags[p]; ok {
+		var variant *compressedAsset
+
+		if variants, ok := encoded[p]; ok {
+			ctx.Response.Header.SetBytesKV(headerVary, headerValueVaryAcceptEncoding)
+
+			variant = getAcceptedCompressedAsset(ctx, variants)
+		}
+
+		etag, ok := etags[p]
+
+		if variant != nil {
+			etag, ok = variant.etag, true
+		}
+
+		if ok {
 			ctx.Response.Header.SetBytesKV(headerETag, etag)
 			ctx.Response.Header.SetBytesKV(headerCacheControl, headerValueCacheControlETaggedAssets)
 
@@ -54,7 +75,10 @@ func newPublicHTMLEmbeddedHandler() fasthttp.RequestHandler {
 			data []byte
 			err  error
 		)
-		if data, err = assets.ReadFile(p); err != nil {
+
+		if variant != nil {
+			data = variant.data
+		} else if data, err = embedFS.ReadFile(p); err != nil {
 			hfsHandleErr(ctx, err)
 
 			return
@@ -69,6 +93,10 @@ func newPublicHTMLEmbeddedHandler() fasthttp.RequestHandler {
 		}
 
 		ctx.SetContentType(contentType)
+
+		if variant != nil {
+			ctx.Response.Header.SetBytesKV(headerContentEncoding, variant.encoding)
+		}
 
 		switch {
 		case ctx.IsHead():
@@ -114,7 +142,6 @@ func newLocalesPathResolver() (handler func(ctx *middlewares.AutheliaCtx) (suppo
 		}
 	}
 
-	// generate list of macro to micro locale aliases.
 	var languagesInfo *utils.Languages
 
 	if languagesInfo, err = utils.GetEmbeddedLanguages(locales); err != nil {
@@ -274,6 +301,131 @@ func getEmbedETags(embedFS embed.FS, root string, etags map[string][]byte) {
 	}
 }
 
+type compressedAsset struct {
+	encoding []byte
+	etag     []byte
+	data     []byte
+}
+
+func isPreCompressible(p string) bool {
+	return utils.IsStringInSlice(path.Ext(p), extsCompressible) && !utils.IsStringInSlice(p, templates.AssetPathsTemplated)
+}
+
+func getEmbedCompressed(embedFS embed.FS, root string) (encoded map[string][]compressedAsset) {
+	encoded = map[string][]compressedAsset{}
+
+	_ = fs.WalkDir(embedFS, root, func(p string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || !isPreCompressible(p) {
+			return nil
+		}
+
+		var data []byte
+
+		// Files which are unreadable are handled by the request handler, and files which are tiny aren't worth
+		// compressing as the framing overhead outweighs the saving.
+		if data, err = embedFS.ReadFile(p); err != nil || len(data) < compressionMinSize {
+			return nil
+		}
+
+		// Ordered by preference, since the first variant the client accepts is the one served.
+		for _, variant := range []compressedAsset{
+			{encoding: encodingBrotli, data: fasthttp.AppendBrotliBytesLevel(nil, data, compressionLevelBrotli)},
+			{encoding: encodingGzip, data: fasthttp.AppendGzipBytesLevel(nil, data, compressionLevelGzip)},
+		} {
+			if len(variant.data) >= len(data) {
+				continue
+			}
+
+			variant.etag = generateEtag(variant.data)
+
+			encoded[p] = append(encoded[p], variant)
+		}
+
+		return nil
+	})
+
+	return encoded
+}
+
+func getAcceptedCompressedAsset(ctx *fasthttp.RequestCtx, variants []compressedAsset) (variant *compressedAsset) {
+	header := ctx.Request.Header.PeekBytes(headerAcceptEncoding)
+
+	if len(header) == 0 {
+		return nil
+	}
+
+	// A quality of zero is a refusal, so the comparison also excludes the codings the client has explicitly ruled out.
+	// Ties keep the earlier variant since the slice is ordered by our own preference.
+	var quality float64
+
+	for i := range variants {
+		if q := getAcceptEncodingQuality(header, variants[i].encoding); q > quality {
+			variant, quality = &variants[i], q
+		}
+	}
+
+	return variant
+}
+
+func getAcceptEncodingQuality(header, coding []byte) (quality float64) {
+	var element []byte
+
+	for len(header) != 0 {
+		if i := bytes.IndexByte(header, ','); i >= 0 {
+			element, header = header[:i], header[i+1:]
+		} else {
+			element, header = header, nil
+		}
+
+		name, q := element, 1.0
+
+		if i := bytes.IndexByte(element, ';'); i >= 0 {
+			name, q = element[:i], getAcceptEncodingParamsQuality(element[i+1:])
+		}
+
+		switch name = bytes.TrimSpace(name); {
+		case bytes.EqualFold(name, coding):
+			return q
+		case bytes.Equal(name, encodingWildcard):
+			// A coding the header names explicitly takes precedence over the wildcard, so the wildcard is only
+			// remembered as a fallback and the scan continues in case the coding is named later on.
+			quality = q
+		}
+	}
+
+	return quality
+}
+
+func getAcceptEncodingParamsQuality(params []byte) float64 {
+	var param []byte
+
+	for len(params) != 0 {
+		if i := bytes.IndexByte(params, ';'); i >= 0 {
+			param, params = params[:i], params[i+1:]
+		} else {
+			param, params = params, nil
+		}
+
+		i := bytes.IndexByte(param, '=')
+
+		if i < 0 || !bytes.EqualFold(bytes.TrimSpace(param[:i]), paramQuality) {
+			continue
+		}
+
+		// A malformed or out of range quality is treated as a refusal rather than guessed at, which just means the
+		// identity representation is served.
+		quality, err := strconv.ParseFloat(string(bytes.TrimSpace(param[i+1:])), 64)
+
+		if err != nil || quality < 0 || quality > 1 {
+			return 0
+		}
+
+		return quality
+	}
+
+	return 1
+}
+
 func hfsHandleErr(ctx *fasthttp.RequestCtx, err error) {
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
@@ -285,25 +437,21 @@ func hfsHandleErr(ctx *fasthttp.RequestCtx, err error) {
 	}
 }
 
-// newLocalesListHandler handles request for obtaining the available locales in backend.
 func newLocalesListHandler() (handler func(ctx *middlewares.AutheliaCtx), err error) {
 	var (
 		data []byte
 	)
 
-	// preload embedded locales.
 	localeInfo, err := utils.GetEmbeddedLanguages(locales)
 	if err != nil {
 		return nil, fmt.Errorf("error occurred initializing the locale list handler: error occurred loading embedded languages: %w", err)
 	}
 
-	// parse embedded locales.
 	data, err = json.Marshal(middlewares.OKResponse{Status: "OK", Data: localeInfo})
 	if err != nil {
 		return nil, fmt.Errorf("error occurred initializing the locale list handler: error occurred marshaling the locale list: %w", err)
 	}
 
-	// generate etag for embedded locales.
 	etag := generateEtag(data)
 
 	return func(ctx *middlewares.AutheliaCtx) {
@@ -329,10 +477,11 @@ func newLocalesListHandler() (handler func(ctx *middlewares.AutheliaCtx), err er
 	}, nil
 }
 
-// generateEtag generates a unique etag for specified payload.
 func generateEtag(payload []byte) []byte {
 	sum := sha1.New() //nolint:gosec // Usage is for collision avoidance not security.
 	sum.Write(payload)
 
-	return []byte(fmt.Sprintf("%x", sum.Sum(nil)))
+	// The digest is wrapped in double quotes as an ETag is an opaque quoted string, and an unquoted value is liable
+	// to be dropped or rewritten by intermediaries.
+	return []byte(fmt.Sprintf(`"%x"`, sum.Sum(nil)))
 }

--- a/internal/server/asset_test.go
+++ b/internal/server/asset_test.go
@@ -1,9 +1,14 @@
 package server
 
 import (
+	"bytes"
+	"embed"
 	"errors"
 	"io/fs"
+	"mime"
 	"net"
+	"path"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +16,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/v4/internal/mocks"
+	"github.com/authelia/authelia/v4/internal/templates"
 )
 
 func TestGenerateEtag(t *testing.T) {
@@ -45,7 +51,8 @@ func TestGenerateEtag(t *testing.T) {
 				assert.NotEqual(t, etagA, etagB, "etags should differ for different payloads")
 			}
 
-			assert.Len(t, etagA, 40, "etag should be 40 characters (sha1 hex)")
+			assert.Len(t, etagA, 42, "etag should be a quoted 40 character sha1 hex digest")
+			assert.Regexp(t, `^"[0-9a-f]{40}"$`, string(etagA), "etag should be a quoted opaque string")
 		})
 	}
 }
@@ -528,4 +535,283 @@ func TestNewLocalesListHandlerETagCaching(t *testing.T) {
 			assert.Equal(t, tc.expectedStatusCode, mock2.Ctx.Response.StatusCode())
 		})
 	}
+}
+
+func TestGetEmbedCompressed(t *testing.T) {
+	const asset = "locales/en/portal.json"
+
+	identity, err := locales.ReadFile(asset)
+	require.NoError(t, err)
+
+	variants, ok := getEmbedCompressed(locales, "locales")[asset]
+
+	require.True(t, ok)
+	require.Len(t, variants, 2)
+
+	assert.Equal(t, encodingBrotli, variants[0].encoding)
+	assert.Equal(t, encodingGzip, variants[1].encoding)
+	assert.NotEqual(t, variants[0].etag, variants[1].etag)
+
+	for _, variant := range variants {
+		assert.Less(t, len(variant.data), len(identity))
+		assert.Equal(t, identity, decompressAsset(t, variant.encoding, variant.data))
+		assert.Equal(t, generateEtag(variant.data), variant.etag)
+		assert.NotEqual(t, generateEtag(identity), variant.etag)
+	}
+}
+
+func TestGetEmbedCompressedShouldOnlyIncludeCompressibleAssets(t *testing.T) {
+	testCases := []struct {
+		name    string
+		embedFS embed.FS
+		root    string
+	}{
+		{"ShouldOnlyCompressPublicHTML", assets, assetsRoot},
+		{"ShouldOnlyCompressLocales", locales, "locales"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for p, variants := range getEmbedCompressed(tc.embedFS, tc.root) {
+				assert.Contains(t, extsCompressible, path.Ext(p))
+				assert.NotContains(t, templates.AssetPathsTemplated, p)
+
+				identity, err := tc.embedFS.ReadFile(p)
+				require.NoError(t, err)
+
+				assert.GreaterOrEqual(t, len(identity), compressionMinSize)
+
+				for _, variant := range variants {
+					assert.Less(t, len(variant.data), len(identity))
+					assert.Equal(t, identity, decompressAsset(t, variant.encoding, variant.data))
+				}
+			}
+		})
+	}
+}
+
+// The repository holds placeholders for the templated assets which the build replaces: two are empty and the third is
+// under compressionMinSize, so asserting against the embedded tree would pass for a reason that stops holding once they
+// carry the content they ship with.
+func TestIsPreCompressibleShouldExcludeTemplatedAssets(t *testing.T) {
+	require.NotEmpty(t, templates.AssetPathsTemplated)
+
+	for _, asset := range templates.AssetPathsTemplated {
+		t.Run(asset, func(t *testing.T) {
+			assert.False(t, isPreCompressible(asset), "a templated asset is rendered per request, so a representation compressed ahead of time could never be sent")
+		})
+	}
+
+	assert.True(t, isPreCompressible("public_html/static/js/index.js"))
+	assert.False(t, isPreCompressible("public_html/favicon.ico"))
+}
+
+func TestTemplatedAssetsShouldBeEmbedded(t *testing.T) {
+	for _, asset := range templates.AssetPathsTemplated {
+		t.Run(asset, func(t *testing.T) {
+			_, err := assets.ReadFile(asset)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestExtsCompressibleShouldHaveKnownContentTypes(t *testing.T) {
+	for _, ext := range extsCompressible {
+		t.Run(ext, func(t *testing.T) {
+			assert.NotEmpty(t, mime.TypeByExtension(ext), "the content type of a compressed asset can't be detected from its content")
+		})
+	}
+}
+
+func TestGetAcceptedCompressedAsset(t *testing.T) {
+	variants := []compressedAsset{
+		{encoding: encodingBrotli},
+		{encoding: encodingGzip},
+	}
+
+	testCases := []struct {
+		name             string
+		acceptEncoding   string
+		expectedEncoding []byte
+	}{
+		{"ShouldNotMatchWithoutHeader", "", nil},
+		{"ShouldNotMatchIdentity", "identity", nil},
+		{"ShouldNotMatchUnsupported", "zstd, deflate", nil},
+		{"ShouldMatchBrotli", "br", encodingBrotli},
+		{"ShouldMatchGzip", "gzip", encodingGzip},
+		{"ShouldPreferBrotli", "gzip, deflate, br", encodingBrotli},
+		{"ShouldFallbackToGzip", "gzip, deflate", encodingGzip},
+		{"ShouldMatchBrotliWithQuality", "br;q=1", encodingBrotli},
+		{"ShouldMatchCaseInsensitively", "GZIP", encodingGzip},
+		{"ShouldPreferHigherQuality", "br;q=0.5, gzip;q=1", encodingGzip},
+		{"ShouldFallbackToGzipWhenBrotliRefused", "gzip;q=1, br;q=0", encodingGzip},
+		{"ShouldNotMatchWhenAllRefused", "br;q=0, gzip;q=0", nil},
+		{"ShouldMatchWildcard", "*", encodingBrotli},
+		{"ShouldMatchWildcardWithQuality", "identity, *;q=0.5", encodingBrotli},
+		{"ShouldPreferExplicitCodingOverWildcard", "*, br;q=0", encodingGzip},
+		{"ShouldNotMatchRefusedWildcard", "identity, *;q=0", nil},
+		{"ShouldNotMatchMalformedQuality", "br;q=nope, gzip;q=2", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			variant := getAcceptedCompressedAsset(newAssetRequestCtx(fasthttp.MethodGet, "/", tc.acceptEncoding), variants)
+
+			if tc.expectedEncoding == nil {
+				assert.Nil(t, variant)
+
+				return
+			}
+
+			require.NotNil(t, variant)
+			assert.Equal(t, tc.expectedEncoding, variant.encoding)
+		})
+	}
+}
+
+func TestNewEmbeddedHandlerCompression(t *testing.T) {
+	handler := newEmbeddedHandler(locales, "locales")
+
+	identity, err := locales.ReadFile("locales/en/portal.json")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name             string
+		acceptEncoding   string
+		expectedEncoding []byte
+	}{
+		{"ShouldServeIdentityWithoutAcceptEncoding", "", nil},
+		{"ShouldServeIdentityForUnsupportedEncoding", "zstd", nil},
+		{"ShouldServeBrotli", "br", encodingBrotli},
+		{"ShouldServeGzip", "gzip", encodingGzip},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newAssetRequestCtx(fasthttp.MethodGet, "/en/portal.json", tc.acceptEncoding)
+
+			handler(ctx)
+
+			assert.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+			assert.Equal(t, fasthttp.HeaderAcceptEncoding, string(ctx.Response.Header.Peek(fasthttp.HeaderVary)))
+			assert.Contains(t, string(ctx.Response.Header.ContentType()), "application/json")
+
+			encoding := ctx.Response.Header.Peek(fasthttp.HeaderContentEncoding)
+
+			if tc.expectedEncoding == nil {
+				assert.Empty(t, encoding)
+				assert.Equal(t, identity, ctx.Response.Body())
+
+				return
+			}
+
+			assert.Equal(t, tc.expectedEncoding, encoding)
+			assert.Less(t, len(ctx.Response.Body()), len(identity))
+			assert.Equal(t, identity, decompressAsset(t, encoding, ctx.Response.Body()))
+		})
+	}
+}
+
+func TestNewEmbeddedHandlerCompressionHEAD(t *testing.T) {
+	handler := newEmbeddedHandler(locales, "locales")
+
+	identity, err := locales.ReadFile("locales/en/portal.json")
+	require.NoError(t, err)
+
+	ctx := newAssetRequestCtx(fasthttp.MethodHead, "/en/portal.json", "br")
+
+	handler(ctx)
+
+	assert.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+	assert.True(t, ctx.Response.SkipBody)
+	assert.Equal(t, encodingBrotli, ctx.Response.Header.Peek(fasthttp.HeaderContentEncoding))
+
+	contentLength, err := strconv.Atoi(string(ctx.Response.Header.Peek(fasthttp.HeaderContentLength)))
+	require.NoError(t, err)
+
+	assert.Positive(t, contentLength)
+	assert.Less(t, contentLength, len(identity))
+}
+
+func TestNewEmbeddedHandlerCompressionETag(t *testing.T) {
+	handler := newEmbeddedHandler(locales, "locales")
+
+	ctxIdentity := newAssetRequestCtx(fasthttp.MethodGet, "/en/portal.json", "")
+
+	handler(ctxIdentity)
+
+	ctxBrotli := newAssetRequestCtx(fasthttp.MethodGet, "/en/portal.json", "br")
+
+	handler(ctxBrotli)
+
+	etagIdentity := bytes.Clone(ctxIdentity.Response.Header.Peek(fasthttp.HeaderETag))
+	etagBrotli := bytes.Clone(ctxBrotli.Response.Header.Peek(fasthttp.HeaderETag))
+
+	require.NotEmpty(t, etagIdentity)
+	require.NotEmpty(t, etagBrotli)
+
+	assert.Regexp(t, `^"[0-9a-f]{40}"$`, string(etagIdentity))
+	assert.Regexp(t, `^"[0-9a-f]{40}"$`, string(etagBrotli))
+	assert.NotEqual(t, etagIdentity, etagBrotli)
+
+	testCases := []struct {
+		name               string
+		acceptEncoding     string
+		ifNoneMatch        []byte
+		expectedStatusCode int
+	}{
+		{"ShouldReturn304ForMatchingIdentityETag", "", etagIdentity, fasthttp.StatusNotModified},
+		{"ShouldReturn304ForMatchingBrotliETag", "br", etagBrotli, fasthttp.StatusNotModified},
+		{"ShouldReturn200ForBrotliETagWithoutAcceptEncoding", "", etagBrotli, fasthttp.StatusOK},
+		{"ShouldReturn200ForIdentityETagWithAcceptEncoding", "br", etagIdentity, fasthttp.StatusOK},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newAssetRequestCtx(fasthttp.MethodGet, "/en/portal.json", tc.acceptEncoding)
+
+			ctx.Request.Header.SetBytesKV(headerIfNoneMatch, tc.ifNoneMatch)
+
+			handler(ctx)
+
+			assert.Equal(t, tc.expectedStatusCode, ctx.Response.StatusCode())
+			assert.Equal(t, fasthttp.HeaderAcceptEncoding, string(ctx.Response.Header.Peek(fasthttp.HeaderVary)))
+		})
+	}
+}
+
+func newAssetRequestCtx(method, uri, acceptEncoding string) (ctx *fasthttp.RequestCtx) {
+	var req fasthttp.Request
+
+	req.Header.SetMethod(method)
+	req.SetRequestURI(uri)
+
+	if acceptEncoding != "" {
+		req.Header.Set(fasthttp.HeaderAcceptEncoding, acceptEncoding)
+	}
+
+	ctx = &fasthttp.RequestCtx{}
+
+	ctx.Init(&req, &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil)
+
+	return ctx
+}
+
+func decompressAsset(t *testing.T, encoding, data []byte) (decompressed []byte) {
+	t.Helper()
+
+	var err error
+
+	switch {
+	case bytes.Equal(encoding, encodingBrotli):
+		decompressed, err = fasthttp.AppendUnbrotliBytes(nil, data)
+	case bytes.Equal(encoding, encodingGzip):
+		decompressed, err = fasthttp.AppendGunzipBytes(nil, data)
+	default:
+		t.Fatalf("unexpected content encoding '%s'", encoding)
+	}
+
+	require.NoError(t, err)
+
+	return decompressed
 }

--- a/internal/server/const.go
+++ b/internal/server/const.go
@@ -17,12 +17,26 @@ const (
 )
 
 const (
+	// Compression levels used to pre-compress the embedded assets during startup. Neither is the maximum level as the
+	// returns diminish sharply: brotli level 11 takes roughly 32 times as long as level 6 while only producing output
+	// approximately 7% smaller.
+	compressionLevelBrotli = 6
+	compressionLevelGzip   = fasthttp.CompressDefaultCompression
+
+	compressionMinSize = 1024
+)
+
+const (
 	pathAuthz           = "/api/authz"
 	pathAuthzLegacy     = "/api/verify"
 	pathParamAuthzEnvoy = "{extauthz:*}"
 )
 
 var (
+	// Formats which are already compressed such as images and fonts are deliberately excluded as compressing them
+	// again costs CPU and generally increases their size.
+	extsCompressible = []string{".css", ".html", ".js", ".json", ".mjs", ".svg", ".txt", ".xml"}
+
 	filesRoot    = []string{"manifest.json", "robots.txt"}
 	filesSwagger = []string{
 		"favicon-16x16.png",
@@ -52,11 +66,21 @@ const (
 )
 
 var (
-	headerETag         = []byte(fasthttp.HeaderETag)
-	headerIfNoneMatch  = []byte(fasthttp.HeaderIfNoneMatch)
-	headerCacheControl = []byte(fasthttp.HeaderCacheControl)
+	headerETag            = []byte(fasthttp.HeaderETag)
+	headerIfNoneMatch     = []byte(fasthttp.HeaderIfNoneMatch)
+	headerCacheControl    = []byte(fasthttp.HeaderCacheControl)
+	headerAcceptEncoding  = []byte(fasthttp.HeaderAcceptEncoding)
+	headerContentEncoding = []byte(fasthttp.HeaderContentEncoding)
+	headerVary            = []byte(fasthttp.HeaderVary)
 
 	headerValueCacheControlETaggedAssets = []byte("public, max-age=0, must-revalidate")
+	headerValueVaryAcceptEncoding        = []byte(fasthttp.HeaderAcceptEncoding)
+
+	encodingBrotli   = []byte("br")
+	encodingGzip     = []byte("gzip")
+	encodingWildcard = []byte("*")
+
+	paramQuality = []byte("q")
 )
 
 const (

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -29,7 +29,6 @@ import (
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
-// Replacement for the default error handler in fasthttp.
 func handleError(cpath string) func(ctx *fasthttp.RequestCtx, err error) {
 	headerXForwardedFor := []byte(fasthttp.HeaderXForwardedFor)
 
@@ -156,7 +155,6 @@ func handlerMain(ctx context.Context, config *schema.Configuration, providers mi
 
 	r := router.New()
 
-	// Static Assets.
 	r.HEAD("/", bridge(serveIndexHandler))
 	r.GET("/", bridge(serveIndexHandler))
 
@@ -174,7 +172,6 @@ func handlerMain(ctx context.Context, config *schema.Configuration, providers mi
 	r.HEAD("/static/{filepath:*}", handlerPublicHTML)
 	r.GET("/static/{filepath:*}", handlerPublicHTML)
 
-	// Locales.
 	r.GET("/locales", bridge(handlerLocalesList))
 
 	r.HEAD("/locales/{language:[a-z]{1,3}}-{variant:[a-zA-Z0-9-]+}/{namespace:[a-z]+}.json", middlewares.AssetOverride(config.Server.AssetPath, 0, bridge(handlerLocales)))
@@ -183,7 +180,6 @@ func handlerMain(ctx context.Context, config *schema.Configuration, providers mi
 	r.HEAD("/locales/{language:[a-z]{1,3}}/{namespace:[a-z]+}.json", middlewares.AssetOverride(config.Server.AssetPath, 0, bridge(handlerLocales)))
 	r.GET("/locales/{language:[a-z]{1,3}}/{namespace:[a-z]+}.json", middlewares.AssetOverride(config.Server.AssetPath, 0, bridge(handlerLocales)))
 
-	// Swagger.
 	r.HEAD(prefixAPI, bridgeSwagger(serveOpenAPIHandler))
 	r.GET(prefixAPI, bridgeSwagger(serveOpenAPIHandler))
 	r.OPTIONS(prefixAPI, policyCORSPublicGET.HandleOPTIONS)
@@ -259,12 +255,10 @@ func handlerMain(ctx context.Context, config *schema.Configuration, providers mi
 	r.POST("/api/firstfactor/reauthenticate", middleware1FA(handlers.FirstFactorReauthenticatePOST(delayerPassword)))
 	r.POST("/api/logout", middlewareAPI(handlers.LogoutPOST))
 
-	// Only register endpoints if forgot password is not disabled.
 	if !config.AuthenticationBackend.PasswordReset.Disable && config.AuthenticationBackend.PasswordReset.CustomURL.String() == "" {
 		rateLimitResetPasswordStart := middlewares.NewRateLimiter(middlewares.WithRateLimitConfig(config.Server.Endpoints.RateLimits.ResetPasswordStart), middlewares.WithRateLimitContext(ctx))
 		rateLimitResetPasswordFinish := middlewares.NewRateLimiter(middlewares.WithRateLimitConfig(config.Server.Endpoints.RateLimits.ResetPasswordFinish), middlewares.WithRateLimitContext(ctx))
 
-		// Password reset related endpoints.
 		r.POST("/api/reset-password/identity/start", middlewareAPI(rateLimitResetPasswordStart(handlers.ResetPasswordIdentityStart)))
 		r.POST("/api/reset-password/identity/finish", middlewareAPI(rateLimitResetPasswordFinish(handlers.ResetPasswordIdentityFinish)))
 
@@ -276,12 +270,10 @@ func handlerMain(ctx context.Context, config *schema.Configuration, providers mi
 		r.POST("/api/change-password", middlewareElevated1FA(handlers.ChangePasswordPOST))
 	}
 
-	// Information about the user.
 	r.GET("/api/user/info", middleware1FA(handlers.UserInfoGET))
 	r.POST("/api/user/info", middleware1FA(handlers.UserInfoPOST))
 	r.POST("/api/user/info/2fa_method", middleware1FA(handlers.MethodPreferencePOST))
 
-	// User Session Elevation.
 	middlewareElevatePOST := middlewares.NewBridgeBuilder(*config, providers).
 		WithPreMiddlewares(middlewares.SecurityHeadersBase, middlewares.SecurityHeadersNoStore, middlewares.SecurityHeadersCSPNone).
 		WithPostMiddlewares(middlewares.NewRateLimiter(middlewares.WithRateLimitConfig(config.Server.Endpoints.RateLimits.SessionElevationStart), middlewares.WithRateLimitContext(ctx)), middlewares.Require1FA).
@@ -304,7 +296,6 @@ func handlerMain(ctx context.Context, config *schema.Configuration, providers mi
 			WithPostMiddlewares(middlewares.NewRateLimiter(middlewares.WithRateLimitConfig(config.Server.Endpoints.RateLimits.SecondFactorTOTP), middlewares.WithRateLimitContext(ctx)), middlewares.Require1FA).
 			Build()
 
-		// TOTP related endpoints.
 		r.GET("/api/secondfactor/totp", middleware1FA(handlers.TimeBasedOneTimePasswordGET))
 		r.POST("/api/secondfactor/totp", middlewareRateLimitTOTP(handlers.TimeBasedOneTimePasswordPOST))
 		r.DELETE("/api/secondfactor/totp", middlewareElevated1FA(handlers.TOTPConfigurationDELETE))
@@ -325,7 +316,6 @@ func handlerMain(ctx context.Context, config *schema.Configuration, providers mi
 			r.POST("/api/secondfactor/password", middleware1FA(handlers.SecondFactorPasswordPOST(delayerPassword)))
 		}
 
-		// Management of the WebAuthn credentials.
 		r.GET("/api/secondfactor/webauthn/credentials", middleware1FA(handlers.WebAuthnCredentialsGET))
 
 		r.PUT("/api/secondfactor/webauthn/credential/register", middlewareElevated1FA(handlers.WebAuthnRegistrationPUT))
@@ -336,7 +326,6 @@ func handlerMain(ctx context.Context, config *schema.Configuration, providers mi
 		r.DELETE("/api/secondfactor/webauthn/credential/{credentialID}", middlewareElevated1FA(handlers.WebAuthnCredentialDELETE))
 	}
 
-	// Configure DUO api endpoint only if configuration exists.
 	if !config.DuoAPI.Disable {
 		var duoAPI duo.Provider
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -120,7 +120,6 @@ func TestShouldServeOverTLSWhenClientHasProperRootCA(t *testing.T) {
 	c, err := x509.ParseCertificate(block.Bytes)
 	require.NoError(t, err)
 
-	// Create a root CA for the client to properly validate server cert.
 	rootCAs := x509.NewCertPool()
 	rootCAs.AddCert(c)
 
@@ -166,7 +165,6 @@ func TestShouldRaiseWhenMutualTLSIsConfiguredAndClientIsNotAuthenticated(t *test
 	req, err := http.NewRequest(fasthttp.MethodGet, fmt.Sprintf("https://local.example.com:%d/api/notfound", tlsServerContext.Port()), nil)
 	require.NoError(t, err)
 
-	// Create a root CA for the client to properly validate server cert.
 	rootCAs := x509.NewCertPool()
 	rootCAs.AddCert(certificateContext.Certificates[0].Certificate)
 
@@ -207,7 +205,6 @@ func TestShouldServeProperlyWhenMutualTLSIsConfiguredAndClientIsAuthenticated(t 
 	req, err := http.NewRequest(fasthttp.MethodGet, fmt.Sprintf("https://local.example.com:%d/api/notfound", tlsServerContext.Port()), nil)
 	require.NoError(t, err)
 
-	// Create a root CA for the client to properly validate server cert.
 	rootCAs := x509.NewCertPool()
 	rootCAs.AddCert(certificateContext.Certificates[0].Certificate)
 

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"bytes"
-	"crypto/sha1" //nolint:gosec
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path"
@@ -169,7 +167,6 @@ func ServeTemplatedOpenAPI(t templates.Template, opts *TemplatedFileOptions) mid
 func ETagRootURL(next middlewares.RequestHandler) middlewares.RequestHandler {
 	etags := map[string][]byte{}
 
-	h := sha1.New() //nolint:gosec // Usage is for collision avoidance not security.
 	mu := &sync.Mutex{}
 
 	return func(ctx *middlewares.AutheliaCtx) {
@@ -197,15 +194,9 @@ func ETagRootURL(next middlewares.RequestHandler) middlewares.RequestHandler {
 			return
 		}
 
+		etagNew := generateEtag(ctx.Response.Body())
+
 		mu.Lock()
-
-		h.Write(ctx.Response.Body())
-		sum := h.Sum(nil)
-		h.Reset()
-
-		etagNew := make([]byte, hex.EncodedLen(len(sum)))
-
-		hex.Encode(etagNew, sum)
 
 		if !ok || !bytes.Equal(etag, etagNew) {
 			etags[k] = etagNew
@@ -305,7 +296,6 @@ func (options *TemplatedFileOptions) CommonData(base, baseURL, domain, nonce, la
 	}
 }
 
-// CommonDataWithRememberMe returns a TemplatedFileCommonData with the dynamic options.
 func (options *TemplatedFileOptions) commonDataWithRememberMe(base, baseURL, domain, nonce, language, logoOverride, rememberMe string) TemplatedFileCommonData {
 	return TemplatedFileCommonData{
 		Base:                   base,

--- a/internal/server/template_test.go
+++ b/internal/server/template_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"io/fs"
 	"os"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/middlewares"
 	"github.com/authelia/authelia/v4/internal/mocks"
 	"github.com/authelia/authelia/v4/internal/session"
 	"github.com/authelia/authelia/v4/internal/templates"
@@ -184,6 +187,159 @@ func TestServeTemplatedFile(t *testing.T) {
 	}
 }
 
+const tmplTestPortalIndex = `<!doctype html>
+<html lang="{{ .Language }}">
+    <head>
+        <meta property="csp-nonce" content="{{ .CSPNonce }}" />
+    </head>
+    <body data-theme="{{ .Theme }}" data-rememberme="{{ .RememberMe }}">
+        <div id="root"></div>
+    </body>
+</html>`
+
+var reTestCSPNonce = regexp.MustCompile(`'nonce-([a-zA-Z0-9]{32})'`)
+
+// ReadFilePortalIndex substitutes the portal index template so the per request values can be asserted without having
+// built the frontend.
+type ReadFilePortalIndex struct{}
+
+func (lfs *ReadFilePortalIndex) Open(name string) (fs.File, error) {
+	return assets.Open(name)
+}
+
+func (lfs *ReadFilePortalIndex) ReadFile(name string) ([]byte, error) {
+	switch name {
+	case "public_html/index.html":
+		return []byte(tmplTestPortalIndex), nil
+	default:
+		return assets.ReadFile(name)
+	}
+}
+
+func TestServeTemplatedFileShouldServeIdentityWithPerRequestNonce(t *testing.T) {
+	tmpl, err := templates.New(templates.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, tmpl.LoadTemplatedAssets(&ReadFilePortalIndex{}))
+
+	config := &schema.Configuration{Server: schema.DefaultServerConfiguration, Theme: "grey"}
+
+	handler := ServeTemplatedFile(tmpl.GetAssetIndexTemplate(), NewTemplatedFileOptions(config))
+
+	nonces := make([]string, 0, 2)
+
+	for range 2 {
+		mock := mocks.NewMockAutheliaCtx(t)
+
+		mock.Ctx.Configuration.Server = schema.DefaultServerConfiguration
+
+		mock.Ctx.Request.Header.Set(fasthttp.HeaderAcceptEncoding, "br, gzip, deflate")
+		mock.Ctx.Request.Header.Set(fasthttp.HeaderXForwardedProto, "https")
+		mock.Ctx.Request.Header.Set(fasthttp.HeaderXForwardedHost, "auth.example.com")
+
+		handler(mock.Ctx)
+
+		require.Equal(t, fasthttp.StatusOK, mock.Ctx.Response.StatusCode())
+
+		// The index is templated per request so it can't be pre-compressed, and it's small enough that compressing it
+		// on the fly isn't worthwhile.
+		assert.Empty(t, mock.Ctx.Response.Header.Peek(fasthttp.HeaderContentEncoding))
+		assert.Contains(t, string(mock.Ctx.Response.Header.ContentType()), "text/html")
+
+		body := string(mock.Ctx.Response.Body())
+
+		assert.Contains(t, body, `data-theme="grey"`)
+
+		matches := reTestCSPNonce.FindStringSubmatch(string(mock.Ctx.Response.Header.Peek(fasthttp.HeaderContentSecurityPolicy)))
+		require.Len(t, matches, 2)
+
+		assert.Contains(t, body, `<meta property="csp-nonce" content="`+matches[1]+`" />`)
+
+		nonces = append(nonces, matches[1])
+
+		mock.Close()
+	}
+
+	assert.NotEqual(t, nonces[0], nonces[1])
+}
+
+// The direct handler test above can't show that the route which actually serves the portal is the templated one, so
+// this drives the registered "/" route to prove the index reaching a client is neither compressed nor shared between
+// requests.
+func TestHandlerMainShouldServeTemplatedIndexUncompressed(t *testing.T) {
+	provider, err := templates.New(templates.Config{})
+	require.NoError(t, err)
+
+	require.NoError(t, provider.LoadTemplatedAssets(&ReadFilePortalIndex{}))
+
+	providers := middlewares.NewProvidersBasic()
+	providers.Templates = provider
+
+	config := &schema.Configuration{
+		Server: schema.Server{
+			Address:   schema.DefaultServerConfiguration.Address,
+			Endpoints: schema.DefaultServerConfiguration.Endpoints,
+		},
+		Theme: "grey",
+	}
+
+	handler, err := handlerMain(t.Context(), config, providers)
+
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name           string
+		method         string
+		acceptEncoding string
+	}{
+		{"ShouldServeIdentityToBrotliGET", fasthttp.MethodGet, "br"},
+		{"ShouldServeIdentityToGzipGET", fasthttp.MethodGet, "gzip"},
+		{"ShouldServeIdentityToBrotliHEAD", fasthttp.MethodHead, "br"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			nonces := make([]string, 0, 2)
+
+			for range 2 {
+				ctx := newAssetRequestCtx(tc.method, "/", tc.acceptEncoding)
+
+				ctx.Request.Header.Set(fasthttp.HeaderXForwardedProto, "https")
+				ctx.Request.Header.Set(fasthttp.HeaderXForwardedHost, "auth.example.com")
+
+				handler(ctx)
+
+				require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+
+				assert.Empty(t, ctx.Response.Header.Peek(fasthttp.HeaderContentEncoding))
+				assert.Contains(t, string(ctx.Response.Header.ContentType()), "text/html")
+
+				matches := reTestCSPNonce.FindStringSubmatch(string(ctx.Response.Header.Peek(fasthttp.HeaderContentSecurityPolicy)))
+				require.Len(t, matches, 2)
+
+				if tc.method == fasthttp.MethodGet {
+					body := string(ctx.Response.Body())
+
+					assert.Contains(t, body, `data-theme="grey"`)
+					assert.Contains(t, body, `<meta property="csp-nonce" content="`+matches[1]+`" />`)
+				} else {
+					assert.True(t, ctx.Response.SkipBody)
+					assert.Empty(t, ctx.Response.Body())
+
+					contentLength, err := strconv.Atoi(string(ctx.Response.Header.Peek(fasthttp.HeaderContentLength)))
+
+					require.NoError(t, err)
+					assert.Positive(t, contentLength)
+				}
+
+				nonces = append(nonces, matches[1])
+			}
+
+			assert.NotEqual(t, nonces[0], nonces[1])
+		})
+	}
+}
+
 func TestETagRootURL(t *testing.T) {
 	tmpl, err := templates.New(templates.Config{})
 	require.NoError(t, err)
@@ -260,6 +416,7 @@ func TestETagRootURL(t *testing.T) {
 
 			etag := mock.Ctx.Response.Header.Peek("ETag")
 			assert.NotEmpty(t, etag)
+			assert.Regexp(t, `^"[0-9a-f]{40}"$`, string(etag), "etag should be a quoted opaque string")
 		})
 	}
 }

--- a/internal/templates/const.go
+++ b/internal/templates/const.go
@@ -14,6 +14,22 @@ const (
 	TemplateNameOIDCAuthorizeFormPost = "AuthorizeResponseFormPost.html"
 )
 
+// Templated Asset Paths, relative to the root of the embedded asset filesystem.
+const (
+	AssetPathAPIIndex = "public_html/api/index.html"
+	AssetPathAPISpec  = "public_html/api/openapi.yml"
+	AssetPathIndex    = "public_html/index.html"
+
+	assetPathPrefix = "assets/"
+)
+
+// AssetPathsTemplated are the embedded assets rendered per request rather than served as they are embedded.
+var AssetPathsTemplated = []string{
+	AssetPathAPIIndex,
+	AssetPathAPISpec,
+	AssetPathIndex,
+}
+
 // Template Category Names.
 const (
 	TemplateCategoryNotifications = "notification"

--- a/internal/templates/provider.go
+++ b/internal/templates/provider.go
@@ -29,44 +29,33 @@ type Provider struct {
 
 // LoadTemplatedAssets takes an embed.FS and loads each templated asset document into a Template.
 func (p *Provider) LoadTemplatedAssets(fs fs.ReadFileFS) (err error) {
-	var (
-		data []byte
-	)
-
-	if data, err = fs.ReadFile("public_html/index.html"); err != nil {
-		return fmt.Errorf("error occurred loading template 'assets/public_html/index.html': %w", err)
+	if p.templates.asset.index, err = parseTemplatedAsset(fs, AssetPathIndex); err != nil {
+		return err
 	}
 
-	if p.templates.asset.index, err = tt.
-		New("assets/public_html/index.html").
-		Funcs(FuncMap()).
-		Parse(string(data)); err != nil {
-		return fmt.Errorf("error occurred loading template 'assets/public_html/index.html': %w", err)
+	if p.templates.asset.api.index, err = parseTemplatedAsset(fs, AssetPathAPIIndex); err != nil {
+		return err
 	}
 
-	if data, err = fs.ReadFile("public_html/api/index.html"); err != nil {
-		return fmt.Errorf("error occurred loading template 'assets/public_html/api/index.html': %w", err)
-	}
-
-	if p.templates.asset.api.index, err = tt.
-		New("assets/public_html/api/index.html").
-		Funcs(FuncMap()).
-		Parse(string(data)); err != nil {
-		return fmt.Errorf("error occurred loading template 'assets/public_html/api/index.html': %w", err)
-	}
-
-	if data, err = fs.ReadFile("public_html/api/openapi.yml"); err != nil {
-		return fmt.Errorf("error occurred loading template 'assets/public_html/api/openapi.yml': %w", err)
-	}
-
-	if p.templates.asset.api.spec, err = tt.
-		New("assets/public_html/api/openapi.yml").
-		Funcs(FuncMap()).
-		Parse(string(data)); err != nil {
-		return fmt.Errorf("error occurred loading template 'assets/public_html/api/openapi.yml': %w", err)
+	if p.templates.asset.api.spec, err = parseTemplatedAsset(fs, AssetPathAPISpec); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func parseTemplatedAsset(fs fs.ReadFileFS, asset string) (t *tt.Template, err error) {
+	var data []byte
+
+	if data, err = fs.ReadFile(asset); err != nil {
+		return nil, fmt.Errorf("error occurred loading template '%s%s': %w", assetPathPrefix, asset, err)
+	}
+
+	if t, err = tt.New(assetPathPrefix + asset).Funcs(FuncMap()).Parse(string(data)); err != nil {
+		return nil, fmt.Errorf("error occurred loading template '%s%s': %w", assetPathPrefix, asset, err)
+	}
+
+	return t, nil
 }
 
 // GetAssetIndexTemplate returns a Template used to generate the React index document.


### PR DESCRIPTION
The portal is served entirely uncompressed. A first paint issues 28 requests for the entry script and its `modulepreload` graph which currently total 503,058 bytes on the wire, and the largest chunk alone is 821,230 bytes. Bursting that over a single connection is slow everywhere and is enough to stall a loaded reverse proxy mid-flight, leaving the module graph unresolved and the portal unmounted.

Every compressible file in the embedded `public_html` filesystem is now compressed once during handler construction with brotli and gzip, and the resulting representation is selected per request from `Accept-Encoding`. Pre-compressing avoids paying the compression cost on each request, which matters most for exactly the large chunks that cause the problem. Neither level is the maximum as the returns diminish sharply: brotli level 11 takes roughly 32 times as long as level 6 while only producing output approximately 7% smaller. Compressing the whole embedded filesystem at level 6 costs around 69ms of startup time.

The first paint drops from 503,058 to 168,337 bytes with `Accept-Encoding: br`, and the whole static tree from 1,750,748 to 695,593 bytes. Formats which are already compressed such as images and fonts are excluded by extension, files smaller than 1KiB are skipped, and a representation is discarded if it isn't actually smaller than the original. Each representation carries its own `ETag` and responses which have compressible representations set `Vary: Accept-Encoding` so caches and conditional requests can't cross representations.

The templated assets are excluded. `public_html/index.html`, `public_html/api/index.html` and `public_html/api/openapi.yml` are rendered per request to carry the CSP nonce and the configuration of the running instance, so the embedded file is never the body of a response and a representation compressed ahead of time could never be sent. Only the extension decided this before, which left the two documents compressed at startup for nothing and left the specification uncompressed by the accident of `.yml` not being a compressible extension rather than by intent. None is large enough to be worth compressing on the fly.

`internal/templates` now names those paths as `AssetPathsTemplated` and loads them through it, and the server excludes exactly that list rather than a copy of it, so an asset added to the loader later cannot be pre-compressed by omission. The loader keeps the template names and error strings it had, which the existing tests assert verbatim.