### PR TITLE
refactor: remove redundant comments and clarify identifier names

### DIFF
--- a/cmd/authelia-scripts/cmd/bootstrap.go
+++ b/cmd/authelia-scripts/cmd/bootstrap.go
@@ -273,7 +273,6 @@ func prepareHostsFile() {
 	}
 }
 
-// ReadHostsFile reads the hosts file.
 func readHostsFile() ([]byte, error) {
 	bs, err := os.ReadFile("/etc/hosts")
 	if err != nil {

--- a/cmd/authelia-scripts/cmd/externalsuites.go
+++ b/cmd/authelia-scripts/cmd/externalsuites.go
@@ -25,8 +25,6 @@ var (
 	externalUpdateSnapshots bool
 )
 
-// externalSuiteTestEntrypoints maps a registered external suite name to its Go test entry
-// function.
 var externalSuiteTestEntrypoints = map[string]string{
 	"docs":      "TestDocsSuite",
 	"templates": "TestTemplatesSuite",

--- a/cmd/authelia-scripts/cmd/slot.go
+++ b/cmd/authelia-scripts/cmd/slot.go
@@ -22,7 +22,6 @@ var (
 	slotRelease bool
 )
 
-// slotEntry is a working tree and the suite slot it owns.
 type slotEntry struct {
 	Slot int    `json:"slot"`
 	Path string `json:"path"`

--- a/cmd/authelia-scripts/cmd/suites.go
+++ b/cmd/authelia-scripts/cmd/suites.go
@@ -154,7 +154,6 @@ func cmdSuitesTestRun(_ *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	// If suite(s) are provided as argument.
 	if len(args) >= 1 {
 		suiteArg := args[0]
 
@@ -360,8 +359,6 @@ func runSuiteTests(suiteName string, withEnv bool) error {
 	cmd.Env = append(cmd.Env, "SUITES_LOG_LEVEL="+log.GetLevel().String())
 
 	testErr := cmd.Run()
-
-	// If the tests failed, run the error hook.
 	if testErr != nil {
 		if err := runOnError(suiteName); err != nil {
 			// Do not return this error to return the test error instead

--- a/cmd/authelia-suites/main.go
+++ b/cmd/authelia-suites/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
-// runningSuiteFile name of the file containing the currently running suite.
 var runningSuiteFile = ".suite"
 
 func init() {
@@ -129,7 +128,6 @@ func setupSuite(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Create the .suite file.
 	if err := createRunningSuiteFile(suiteName); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/authentication/ldap_client_factory.go
+++ b/internal/authentication/ldap_client_factory.go
@@ -175,7 +175,6 @@ func (f *PooledLDAPClientFactory) GetClient(opts ...LDAPClientFactoryOption) (co
 	return f.acquire(context.Background())
 }
 
-// The dial function dials a new LDAPClient and wraps it as a PooledLDAPClient client.
 func (f *PooledLDAPClientFactory) dial() (pooled *PooledLDAPClient, err error) {
 	var client LDAPExtendedClient
 

--- a/internal/authentication/ldap_user_provider.go
+++ b/internal/authentication/ldap_user_provider.go
@@ -437,7 +437,6 @@ func (p *LDAPUserProvider) searchReferrals(request *ldap.SearchRequest, result *
 }
 
 func (p *LDAPUserProvider) getUserProfile(client LDAPExtendedClient, username string) (profile *ldapUserProfile, err error) {
-	// Search for the given username.
 	request := ldap.NewSearchRequest(
 		p.usersBaseDN, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases,
 		1, 0, false, p.resolveUsersFilter(username), p.usersAttributes, nil,
@@ -510,7 +509,6 @@ func (p *LDAPUserProvider) getUserProfileResultToProfile(username string, entry 
 }
 
 func (p *LDAPUserProvider) getUserProfileExtended(client LDAPExtendedClient, username string) (profile *ldapUserProfileExtended, err error) {
-	// Search for the given username.
 	request := ldap.NewSearchRequest(
 		p.usersBaseDN, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases,
 		1, 0, false, p.resolveUsersFilter(username), p.usersAttributesExtended, nil,

--- a/internal/authorization/access_control_rule.go
+++ b/internal/authorization/access_control_rule.go
@@ -81,12 +81,10 @@ func (acr *AccessControlRule) IsMatch(subject Subject, object Object) (match boo
 
 // MatchesDomains returns true if the rule matches the domains.
 func (acr *AccessControlRule) MatchesDomains(subject Subject, object Object) (matches bool) {
-	// If there are no domains in this rule then the domain condition is a match.
 	if len(acr.Domains) == 0 {
 		return true
 	}
 
-	// Iterate over the domains until we find a match (return true) or until we exit the loop (return false).
 	for _, domain := range acr.Domains {
 		if domain.IsMatch(subject, object) {
 			return true
@@ -98,12 +96,10 @@ func (acr *AccessControlRule) MatchesDomains(subject Subject, object Object) (ma
 
 // MatchesResources returns true if the rule matches the resources.
 func (acr *AccessControlRule) MatchesResources(subject Subject, object Object) (matches bool) {
-	// If there are no resources in this rule then the resource condition is a match.
 	if len(acr.Resources) == 0 {
 		return true
 	}
 
-	// Iterate over the resources until we find a match (return true) or until we exit the loop (return false).
 	for _, resource := range acr.Resources {
 		if resource.IsMatch(subject, object) {
 			return true
@@ -115,12 +111,10 @@ func (acr *AccessControlRule) MatchesResources(subject Subject, object Object) (
 
 // MatchesQuery returns true if the rule matches the query arguments.
 func (acr *AccessControlRule) MatchesQuery(object Object) (match bool) {
-	// If there are no query rules in this rule then the query condition is a match.
 	if len(acr.Query) == 0 {
 		return true
 	}
 
-	// Iterate over the queries until we find a match (return true) or until we exit the loop (return false).
 	for _, query := range acr.Query {
 		if query.IsMatch(object) {
 			return true
@@ -132,7 +126,6 @@ func (acr *AccessControlRule) MatchesQuery(object Object) (match bool) {
 
 // MatchesMethods returns true if the rule matches the method.
 func (acr *AccessControlRule) MatchesMethods(object Object) (match bool) {
-	// If there are no methods in this rule then the method condition is a match.
 	if len(acr.Methods) == 0 {
 		return true
 	}
@@ -156,14 +149,12 @@ func (acr *AccessControlRule) MatchesSubjects(subject Subject) (match bool) {
 
 // MatchesSubjectExact returns true if the rule matches the subjects exactly.
 func (acr *AccessControlRule) MatchesSubjectExact(subject Subject) (match bool) {
-	// If there are no subjects in this rule then the subject condition is a match.
 	if len(acr.Subjects) == 0 {
 		return true
 	} else if subject.IsAnonymous() {
 		return false
 	}
 
-	// Iterate over the subjects until we find a match (return true) or until we exit the loop (return false).
 	for _, subjectRule := range acr.Subjects {
 		if subjectRule.IsMatch(subject) {
 			return true

--- a/internal/authorization/util.go
+++ b/internal/authorization/util.go
@@ -20,7 +20,7 @@ func NewLevel(policy string) Level {
 	case deny:
 		return Denied
 	}
-	// By default the deny policy applies.
+
 	return Denied
 }
 

--- a/internal/commands/debug_test.go
+++ b/internal/commands/debug_test.go
@@ -44,7 +44,6 @@ func TestNewDebugCmds(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
-// testUserDatabaseContent is a minimal user database for testing.
 var testUserDatabaseContent = []byte(`
 users:
   john:
@@ -56,8 +55,6 @@ users:
       - dev
 `)
 
-// newTestFileAuthConfig creates a schema.Configuration with a file-based auth backend
-// pointing at a temp user database file.
 func newTestFileAuthConfig(t *testing.T) *schema.Configuration {
 	t.Helper()
 

--- a/internal/commands/storage.go
+++ b/internal/commands/storage.go
@@ -773,7 +773,6 @@ func newStorageSchemaInfoCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 	return cmd
 }
 
-// newStorageMigrateCmd returns a new Migration Cmd.
 func newStorageMigrateCmd(ctx *CmdCtx) (cmd *cobra.Command) {
 	cmd = &cobra.Command{
 		Use:     "migrate",

--- a/internal/configuration/koanf_callbacks.go
+++ b/internal/configuration/koanf_callbacks.go
@@ -11,7 +11,6 @@ import (
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
-// koanfEnvironmentCallback returns a koanf callback to map the environment vars to Configuration keys.
 func koanfEnvironmentCallback(keyMap map[string]string, ignoredKeys []string, prefix, delimiter string) func(key, value string) (finalKey string, finalValue any) {
 	return func(key, value string) (finalKey string, finalValue any) {
 		if k, ok := keyMap[key]; ok {
@@ -33,7 +32,6 @@ func koanfEnvironmentCallback(keyMap map[string]string, ignoredKeys []string, pr
 	}
 }
 
-// koanfEnvironmentSecretsCallback returns a koanf callback to map the environment vars to Configuration keys.
 func koanfEnvironmentSecretsCallback(keyMap map[string]string, validator *schema.StructValidator) func(key, value string) (finalKey string, finalValue any) {
 	return func(key, value string) (finalKey string, finalValue any) {
 		k, ok := keyMap[key]

--- a/internal/configuration/schema/types_address.go
+++ b/internal/configuration/schema/types_address.go
@@ -386,7 +386,7 @@ func (a *Address) SetPort(port uint16) {
 		return
 	}
 
-	a.setport(port)
+	a.setPort(port)
 }
 
 // Path returns the path.
@@ -474,7 +474,7 @@ func (a *Address) Dial() (net.Conn, error) {
 	return net.Dial(a.Network(), a.NetworkAddress())
 }
 
-func (a *Address) setport(port uint16) {
+func (a *Address) setPort(port uint16) {
 	a.port = port
 	a.url.Host = net.JoinHostPort(a.url.Hostname(), strconv.Itoa(int(port)))
 }
@@ -535,15 +535,15 @@ func (a *Address) validateProtocol() (err error) {
 	case "":
 		switch a.url.Scheme {
 		case AddressSchemeLDAP:
-			a.setport(389)
+			a.setPort(389)
 		case AddressSchemeLDAPS:
-			a.setport(636)
+			a.setPort(636)
 		case AddressSchemeSMTP:
-			a.setport(25)
+			a.setPort(25)
 		case AddressSchemeSUBMISSION:
-			a.setport(587)
+			a.setPort(587)
 		case AddressSchemeSUBMISSIONS:
-			a.setport(465)
+			a.setPort(465)
 		}
 	default:
 		var actualPort uint64
@@ -552,7 +552,7 @@ func (a *Address) validateProtocol() (err error) {
 			return fmt.Errorf("failed to parse port: %w", err)
 		}
 
-		a.setport(uint16(actualPort))
+		a.setPort(uint16(actualPort))
 	}
 
 	return nil
@@ -564,7 +564,7 @@ func (a *Address) validateTCPUDP() (err error) {
 	switch port {
 	case "":
 		if a.url.User == nil {
-			a.setport(0)
+			a.setPort(0)
 		}
 	default:
 		var actualPort uint64
@@ -573,7 +573,7 @@ func (a *Address) validateTCPUDP() (err error) {
 			return fmt.Errorf("failed to parse port: %w", err)
 		}
 
-		a.setport(uint16(actualPort))
+		a.setPort(uint16(actualPort))
 	}
 
 	return nil

--- a/internal/configuration/schema/types_test.go
+++ b/internal/configuration/schema/types_test.go
@@ -448,7 +448,7 @@ func TestX509CertificateChain(t *testing.T) {
 	require.NotNil(t, err)
 	assert.Regexp(t, regexp.MustCompile(`^certificate #1 in chain is invalid after 31536000 but the time is \d+$`), err.Error())
 
-	chain = MustParseX509CertificateChain(x509CertificateRSANotBefore + "\n" + x509CACertificateRSAotBefore)
+	chain = MustParseX509CertificateChain(x509CertificateRSANotBefore + "\n" + x509CACertificateRSANotBefore)
 
 	err = chain.Validate()
 	require.NotNil(t, err)
@@ -1275,7 +1275,7 @@ EmiaOgL8c7+PpSWuUggJLb/JXDYnPtvekH3gPao=
 	*/
 
 	// Valid from 2400 to 2401 (years).
-	x509CACertificateRSAotBefore = `-----BEGIN CERTIFICATE-----
+	x509CACertificateRSANotBefore = `-----BEGIN CERTIFICATE-----
 MIIDBzCCAe+gAwIBAgIQeR2/TbyH9gEzyjuTijMGVzANBgkqhkiG9w0BAQsFADAT
 MREwDwYDVQQKEwhBdXRoZWxpYTAiGA8yNDAwMDEwMTAwMDAwMFoYDzI0MDAxMjMx
 MDAwMDAwWjATMREwDwYDVQQKEwhBdXRoZWxpYTCCASIwDQYJKoZIhvcNAQEBBQAD
@@ -1296,7 +1296,7 @@ apA21VwIrpFg54A=
 -----END CERTIFICATE-----`
 
 	/*
-			// Private Key for x509CACertificateRSAotBefore.
+			// Private Key for x509CACertificateRSANotBefore.
 			x509CAPrivateKeyRSANotBefore = `-----BEGIN RSA PRIVATE KEY-----
 		MIIEpAIBAAKCAQEAnu+lFINdW/A4saaNtl2gbbk52xaCaFUBakUJSJ+i2qivP7P5
 		WDA+e9UOnVxOnTvL6YMkr74Y0E4bWlLkbiivpjUcCVPecakTQViGu0MFCaG+pXTq

--- a/internal/configuration/validator/authentication.go
+++ b/internal/configuration/validator/authentication.go
@@ -54,7 +54,6 @@ func ValidateAuthenticationBackend(config *schema.AuthenticationBackend, validat
 	}
 }
 
-// validateFileAuthenticationBackend validates and updates the file authentication backend configuration.
 func validateFileAuthenticationBackend(config *schema.AuthenticationBackendFile, validator *schema.StructValidator) {
 	if config.Path == "" {
 		validator.Push(errors.New(errFmtFileAuthBackendPathNotConfigured))

--- a/internal/configuration/validator/identity_providers_test.go
+++ b/internal/configuration/validator/identity_providers_test.go
@@ -4106,12 +4106,12 @@ func TestValidateOIDCIssuer(t *testing.T) {
 			"ShouldRaiseErrorOnEd25519Keys",
 			&schema.IdentityProvidersOpenIDConnect{
 				JSONWebKeys: []schema.JWK{
-					{Key: keyEd2519, CertificateChain: certEd15519},
+					{Key: keyEd25519, CertificateChain: certEd25519},
 				},
 			},
 			schema.IdentityProvidersOpenIDConnect{
 				JSONWebKeys: []schema.JWK{
-					{Key: keyEd2519, CertificateChain: certEd15519, KeyID: "ca54bd"},
+					{Key: keyEd25519, CertificateChain: certEd25519, KeyID: "ca54bd"},
 				},
 				Discovery: schema.IdentityProvidersOpenIDConnectDiscovery{
 					DefaultSigKeyIDs: map[string]string{},
@@ -5409,7 +5409,7 @@ func MustLoadCertificateChain(alg, op string) schema.X509CertificateChain {
 	}
 }
 
-func MustLoadEd15519PrivateKey(mod string, extra ...string) ed25519.PrivateKey {
+func MustLoadEd25519PrivateKey(mod string, extra ...string) ed25519.PrivateKey {
 	decoded := MustLoadCrypto("ED25519", mod, "pem", extra...)
 
 	key, ok := decoded.(ed25519.PrivateKey)
@@ -5465,9 +5465,9 @@ var (
 	keyECDSAP224, keyECDSAP256, keyECDSAP384, keyECDSAP521     *ecdsa.PrivateKey
 	certECDSAP224, certECDSAP256, certECDSAP384, certECDSAP521 schema.X509CertificateChain
 
-	// Ed15519 key / certificate pair.
-	keyEd2519   ed25519.PrivateKey
-	certEd15519 schema.X509CertificateChain
+	// Ed25519 key / certificate pair.
+	keyEd25519  ed25519.PrivateKey
+	certEd25519 schema.X509CertificateChain
 )
 
 func init() {
@@ -5483,7 +5483,7 @@ func init() {
 	certECDSAP384, keyECDSAP384 = MustLoadECDSACertificatePrivateKeyPair("P384")
 	certECDSAP521, keyECDSAP521 = MustLoadECDSACertificatePrivateKeyPair("P521")
 
-	certEd15519, keyEd2519 = MustLoadCertificateChain("Ed25519", ""), MustLoadEd15519PrivateKey("")
+	certEd25519, keyEd25519 = MustLoadCertificateChain("Ed25519", ""), MustLoadEd25519PrivateKey("")
 
 	keyRSA2048Legacy = MustLoadRSAPrivateKey("2048", "legacy")
 }

--- a/internal/configuration/validator/keys.go
+++ b/internal/configuration/validator/keys.go
@@ -100,7 +100,6 @@ func NewKeyMapPattern(key string) (pattern *regexp.Regexp, err error) {
 		}
 
 		for j, r := range part {
-			// Skip prefixed period.
 			if j == 0 && r == '.' {
 				continue
 			}

--- a/internal/configuration/validator/keys_test.go
+++ b/internal/configuration/validator/keys_test.go
@@ -54,7 +54,6 @@ func TestAllSpecificErrorKeys(t *testing.T) {
 
 	var uniqueValues []string
 
-	// Setup configKeys and uniqueValues expected.
 	for key, value := range specificErrorKeys {
 		configKeys = append(configKeys, key)
 

--- a/internal/configuration/validator/server.go
+++ b/internal/configuration/validator/server.go
@@ -41,7 +41,6 @@ func ValidateServerTLS(config *schema.Configuration, validator *schema.StructVal
 	}
 }
 
-// validateServerTLSFileExists checks whether a file exist.
 func validateServerTLSFileExists(name, path string, validator *schema.StructValidator) {
 	var (
 		info os.FileInfo

--- a/internal/configuration/validator/session.go
+++ b/internal/configuration/validator/session.go
@@ -60,7 +60,7 @@ func validateSession(config *schema.Configuration, validator *schema.StructValid
 	switch {
 	case cookies == 0 && n != 0:
 		validator.PushWarning(errors.New(errFmtSessionDomainLegacy))
-		// Add legacy configuration to the domains list.
+
 		config.Session.Cookies = append(config.Session.Cookies, schema.SessionCookie{
 			SessionCookieCommon: schema.SessionCookieCommon{
 				Name:              config.Session.Name,
@@ -107,7 +107,6 @@ func validateSessionCookieDomains(config *schema.Session, validator *schema.Stru
 	}
 }
 
-// validateSessionDomainName pushes warnings and errors depending on the domain validity.
 func validateSessionDomainName(i int, config *schema.Session, validator *schema.StructValidator) {
 	var d = config.Cookies[i]
 
@@ -159,7 +158,6 @@ func validateSessionExpiration(i int, config *schema.Session) {
 	}
 }
 
-// validateSessionUniqueCookieDomain Check the current domains do not share a root domain with previous domains.
 func validateSessionUniqueCookieDomain(i int, config *schema.Session, domains []string, validator *schema.StructValidator) {
 	var d = config.Cookies[i]
 	if utils.IsStringInSliceF(d.Domain, domains, utils.HasDomainSuffix) {
@@ -171,8 +169,6 @@ func validateSessionUniqueCookieDomain(i int, config *schema.Session, domains []
 	}
 }
 
-// validateSessionCookiesURLs validates the AutheliaURL and DefaultRedirectionURL.
-//
 //nolint:gocyclo
 func validateSessionCookiesURLs(i int, config *schema.Session, validator *schema.StructValidator) {
 	var d = config.Cookies[i]

--- a/internal/handlers/handler_authz_authn.go
+++ b/internal/handlers/handler_authz_authn.go
@@ -596,9 +596,6 @@ func handleVerifyGETAuthorizationBearer(ctx AuthzContext, authn *Authn, object *
 	return handleVerifyGETAuthorizationBearerResolveUser(ctx, username, clientID, ccs, level)
 }
 
-// handleVerifyGETAuthorizationBearerResolveUser turns the result of bearer-token introspection into the final return
-// values for handleVerifyGETAuthorizationBearer. For client-credentials grants (ccs=true) there is no associated user
-// so GetDetails is skipped and the clientID is propagated; for user-bound tokens GetDetails canonicalises the username.
 func handleVerifyGETAuthorizationBearerResolveUser(ctx AuthzContext, username, clientID string, ccs bool, level authentication.Level) (details *authentication.UserDetails, clientIDOut string, ccsOut bool, levelOut authentication.Level, err error) {
 	if ccs {
 		return nil, clientID, ccs, level, nil

--- a/internal/handlers/handler_authz_impl_legacy_test.go
+++ b/internal/handlers/handler_authz_impl_legacy_test.go
@@ -512,7 +512,7 @@ func (s *LegacyAuthzSuite) TestShouldHandleAllMethodsAllowXHR() {
 	}
 }
 
-func (s *LegacyAuthzSuite) TestShouldHandleLegacyBasicAuth() { // TestShouldVerifyAuthBasicArgOk.
+func (s *LegacyAuthzSuite) TestShouldHandleLegacyBasicAuth() {
 	authz := s.BuildWithDelayer()
 
 	mock := mocks.NewMockAutheliaCtx(s.T())
@@ -569,17 +569,17 @@ func (s *LegacyAuthzSuite) TestShouldHandleLegacyBasicAuthFailures() {
 		setup func(mock *mocks.MockAutheliaCtx)
 	}{
 		{
-			"HeaderAbsent", // TestShouldVerifyAuthBasicArgFailingNoHeader.
+			"HeaderAbsent",
 			nil,
 		},
 		{
-			"HeaderEmpty", // TestShouldVerifyAuthBasicArgFailingEmptyHeader.
+			"HeaderEmpty",
 			func(mock *mocks.MockAutheliaCtx) {
 				mock.Ctx.Request.Header.Set(fasthttp.HeaderAuthorization, "")
 			},
 		},
 		{
-			"HeaderIncorrect", // TestShouldVerifyAuthBasicArgFailingWrongHeader.
+			"HeaderIncorrect",
 			func(mock *mocks.MockAutheliaCtx) {
 				mock.Ctx.Request.Header.Set(fasthttp.HeaderProxyAuthorization, "Basic am9objpwYXNzd29yZA==")
 			},
@@ -637,7 +637,7 @@ func (s *LegacyAuthzSuite) TestShouldHandleLegacyBasicAuthFailures() {
 			},
 		},
 		{
-			"IncorrectPassword", // TestShouldVerifyAuthBasicArgFailingWrongPassword.
+			"IncorrectPassword",
 			func(mock *mocks.MockAutheliaCtx) {
 				mock.Ctx.Request.Header.Set(fasthttp.HeaderAuthorization, "Basic am9objpwYXNzd29yZA==")
 
@@ -672,7 +672,7 @@ func (s *LegacyAuthzSuite) TestShouldHandleLegacyBasicAuthFailures() {
 			},
 		},
 		{
-			"NoAccess", // TestShouldVerifyAuthBasicArgFailingWrongPassword.
+			"NoAccess",
 			func(mock *mocks.MockAutheliaCtx) {
 				mock.Ctx.Request.Header.Set(fasthttp.HeaderAuthorization, "Basic am9objpwYXNzd29yZA==")
 				mock.Ctx.Request.Header.Set("X-Original-URL", "https://admin.example.com/")

--- a/internal/handlers/handler_authz_test.go
+++ b/internal/handlers/handler_authz_test.go
@@ -1891,8 +1891,6 @@ func (s *AuthzSuite) TestShouldHandleAuthzWithoutHeaderNoCookie() {
 		s.T().Skip()
 	}
 
-	// Equivalent of TestShouldVerifyAuthBasicArgFailingNoHeader.
-
 	builder := NewAuthzBuilder().WithImplementationLegacy()
 
 	header := NewHeaderAuthorizationAuthnStrategy(time.Duration(0), "basic")
@@ -1927,8 +1925,6 @@ func (s *AuthzSuite) TestShouldHandleAuthzWithEmptyAuthorizationHeader() {
 	if s.setRequest == nil {
 		s.T().Skip()
 	}
-
-	// Equivalent of TestShouldVerifyAuthBasicArgFailingEmptyHeader.
 
 	builder := NewAuthzBuilder().WithImplementationLegacy()
 
@@ -2042,7 +2038,7 @@ func (s *AuthzSuite) TestShouldHandleAuthzWithAuthorizationHeaderInvalidPassword
 	s.Equal([]byte(nil), mock.Ctx.Response.Header.Peek(fasthttp.HeaderProxyAuthenticate))
 }
 
-func (s *AuthzSuite) TestShouldHandleAuthzWithIncorrectAuthHeader() { // TestShouldVerifyAuthBasicArgFailingWrongHeader.
+func (s *AuthzSuite) TestShouldHandleAuthzWithIncorrectAuthHeader() {
 	if s.setRequest == nil {
 		s.T().Skip()
 	}

--- a/internal/handlers/handler_firstfactor_passkey.go
+++ b/internal/handlers/handler_firstfactor_passkey.go
@@ -311,10 +311,8 @@ func FirstFactorPasskeyPOST(ctx *middlewares.AutheliaCtx) {
 		userSession.RefreshTTL = ctx.GetClock().Now().Add(ctx.Configuration.AuthenticationBackend.RefreshInterval.Value())
 	}
 
-	// Check if bodyJSON.KeepMeLoggedIn can be deref'd and derive the value based on the configuration and JSON data.
 	keepMeLoggedIn := !provider.Config.DisableRememberMe && bodyJSON.KeepMeLoggedIn != nil && *bodyJSON.KeepMeLoggedIn
 
-	// Set the cookie to expire if remember me is enabled and the user has asked us to.
 	if keepMeLoggedIn {
 		if err = provider.UpdateExpiration(ctx.RequestCtx, provider.Config.RememberMe); err != nil {
 			ctx.SetStatusCode(fasthttp.StatusForbidden)

--- a/internal/handlers/handler_firstfactor_password.go
+++ b/internal/handlers/handler_firstfactor_password.go
@@ -120,10 +120,8 @@ func FirstFactorPasswordPOST(delayer middlewares.Delayer) middlewares.RequestHan
 			return
 		}
 
-		// Check if bodyJSON.KeepMeLoggedIn can be deref'd and derive the value based on the configuration and JSON data.
 		keepMeLoggedIn := !provider.Config.DisableRememberMe && bodyJSON.KeepMeLoggedIn != nil && *bodyJSON.KeepMeLoggedIn
 
-		// Set the cookie to expire if remember me is enabled and the user has asked us to.
 		if keepMeLoggedIn {
 			err = provider.UpdateExpiration(ctx.RequestCtx, provider.Config.RememberMe)
 			if err != nil {

--- a/internal/handlers/handler_firstfactor_password_test.go
+++ b/internal/handlers/handler_firstfactor_password_test.go
@@ -40,13 +40,11 @@ func (s *FirstFactorSuite) TearDownTest() {
 func (s *FirstFactorSuite) TestShouldFailIfBodyIsNil() {
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// No body.
 	s.mock.AssertLastLogMessage(s.T(), "Failed to parse 1FA request body", "unable to parse body: unexpected end of JSON input")
 	s.mock.Assert401KO(s.T(), "Authentication failed. Check your credentials.")
 }
 
 func (s *FirstFactorSuite) TestShouldFailIfBodyIsInBadFormat() {
-	// Missing password.
 	s.mock.Ctx.Request.SetBodyString(`{
 		"username": "test"
 	}`)
@@ -353,7 +351,6 @@ func (s *FirstFactorSuite) TestShouldAuthenticateUserWithRememberMeChecked() {
 	}`)
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	assert.Equal(s.T(), fasthttp.StatusOK, s.mock.Ctx.Response.StatusCode())
 	assert.Equal(s.T(), []byte("{\"status\":\"OK\"}"), s.mock.Ctx.Response.Body())
 
@@ -403,7 +400,6 @@ func (s *FirstFactorSuite) TestShouldAuthenticateUserWithRememberMeUnchecked() {
 	}`)
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	assert.Equal(s.T(), fasthttp.StatusOK, s.mock.Ctx.Response.StatusCode())
 	assert.Equal(s.T(), []byte("{\"status\":\"OK\"}"), s.mock.Ctx.Response.Body())
 
@@ -457,7 +453,6 @@ func (s *FirstFactorSuite) TestShouldSaveUsernameFromAuthenticationBackendInSess
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	assert.Equal(s.T(), fasthttp.StatusOK, s.mock.Ctx.Response.StatusCode())
 	assert.Equal(s.T(), []byte("{\"status\":\"OK\"}"), s.mock.Ctx.Response.Body())
 
@@ -539,7 +534,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldRedirectToDefaultURLWhenNoTarget
 	}`)
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), &redirectResponse{Redirect: "https://www.example.com"})
 }
 
@@ -571,7 +565,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldRedirectToDefaultURLWhenURLIsUns
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), &redirectResponse{Redirect: "https://www.example.com"})
 }
 
@@ -605,7 +598,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReply200WhenNoTargetURLProvidedA
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), nil)
 }
 
@@ -648,7 +640,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReply200WhenUnsafeTargetURLProvi
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), nil)
 }
 
@@ -685,7 +676,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyWhenBadTargetURL() {
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
 }
 
@@ -724,7 +714,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyTwoFactorOK() {
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), nil)
 }
 
@@ -763,7 +752,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyTwoTwoFactorUnsafe() {
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), nil)
 }
 
@@ -802,7 +790,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyTwoTwoFactorSafe() {
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), &redirectResponse{Redirect: "https://test.example.com"})
 }
 
@@ -842,7 +829,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectCantParseUUID(
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Error occurred parsing the consent session flow id", map[string]any{"error": "invalid UUID length: 55", "flow": "openid_connect", "flow_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaa-9107-4067-8d31-407ca59eb69c", "subflow": ""})
 }
@@ -885,7 +871,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectCantGetConsent
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Error occurred loading the consent session", map[string]any{"error": "failed to obtain", "flow": "openid_connect", "flow_id": "d1ba0ad8-9107-4067-8d31-407ca59eb69c", "subflow": ""})
 }
@@ -928,7 +913,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectConsentSession
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Failed to process consent session as it has already been responded to", map[string]any{"flow": "openid_connect", "flow_id": "d1ba0ad8-9107-4067-8d31-407ca59eb69c", "subflow": ""})
 }
@@ -974,7 +958,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectCantGetClient(
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Error occurred loading the client for the consent session", map[string]any{"error": "invalid_client", "client_id": "abc", "flow": "openid_connect", "flow_id": "d1ba0ad8-9107-4067-8d31-407ca59eb69c", "subflow": ""})
 }
@@ -1036,7 +1019,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectFormRequiresLo
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), &redirectResponse{Redirect: "https://login.example.com:8080/consent/openid/decision?flow=openid_connect&flow_id=d1ba0ad8-9107-4067-8d31-407ca59eb69c"})
 }
 
@@ -1093,7 +1075,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectFormRequiresLo
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Error occurred getting the original form from the consent session", map[string]any{"error": "invalid URL escape \"%1\"", "client_id": "abc", "flow": "openid_connect", "flow_id": "d1ba0ad8-9107-4067-8d31-407ca59eb69c", "subflow": "", "username": "test"})
 }
@@ -1152,7 +1133,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectNeeds2FA() {
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), nil)
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.InfoLevel, "OpenID Connect 1.0 client requires 2FA", map[string]any{"client_id": "abc", "flow": "openid_connect", "flow_id": "d1ba0ad8-9107-4067-8d31-407ca59eb69c", "subflow": ""})
 }
@@ -1211,7 +1191,6 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectNeeds1FA() {
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), &redirectResponse{Redirect: "https://login.example.com:8080/api/oidc/authorization?consent_id=d1ba0ad8-9107-4067-8d31-407ca59eb69c&grant_type=authorization_code"})
 }
 
@@ -1240,13 +1219,11 @@ func (s *FirstFactorReauthenticateSuite) TearDownTest() {
 func (s *FirstFactorReauthenticateSuite) TestShouldFailIfBodyIsNil() {
 	FirstFactorReauthenticatePOST(nil)(s.mock.Ctx)
 
-	// No body.
 	s.mock.AssertLastLogMessage(s.T(), "Failed to parse 1FA request body", "unable to parse body: unexpected end of JSON input")
 	s.mock.Assert401KO(s.T(), "Authentication failed. Check your credentials.")
 }
 
 func (s *FirstFactorReauthenticateSuite) TestShouldFailIfBodyIsInBadFormat() {
-	// Missing password.
 	s.mock.Ctx.Request.SetBodyString(`{
 		"username": "test"
 	}`)
@@ -1346,17 +1323,6 @@ func (s *FirstFactorReauthenticateSuite) TestShouldCheckBannedUser() {
 	}`)
 
 	gomock.InOrder(
-		/*
-			s.mock.StorageMock.EXPECT().
-				LoadAuthenticationLogs(gomock.Eq(s.mock.Ctx), testValue, gomock.Any(), gomock.Any(), gomock.Any()).
-				Return([]model.AuthenticationAttempt{
-					{Successful: false, Time: s.mock.Clock.Now().Add(-time.Second)},
-					{Successful: false, Time: s.mock.Clock.Now().Add(-time.Second)},
-					{Successful: false, Time: s.mock.Clock.Now().Add(-time.Second)},
-					{Successful: false, Time: s.mock.Clock.Now().Add(-time.Second)},
-				}, nil),
-		*/
-
 		s.mock.StorageMock.
 			EXPECT().
 			AppendAuthenticationLog(gomock.Eq(s.mock.Ctx), gomock.Eq(model.AuthenticationAttempt{
@@ -1471,7 +1437,6 @@ func (s *FirstFactorReauthenticateSuite) TestShouldSaveUsernameFromAuthenticatio
 	}`)
 	FirstFactorReauthenticatePOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	assert.Equal(s.T(), fasthttp.StatusOK, s.mock.Ctx.Response.StatusCode())
 	assert.Equal(s.T(), []byte("{\"status\":\"OK\"}"), s.mock.Ctx.Response.Body())
 
@@ -1551,7 +1516,6 @@ func (s *FirstFactorReauthenticateRedirectionSuite) TestShouldRedirectToDefaultU
 	}`)
 	FirstFactorReauthenticatePOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), &redirectResponse{Redirect: "https://www.example.com"})
 }
 
@@ -1572,7 +1536,6 @@ func (s *FirstFactorReauthenticateRedirectionSuite) TestShouldRedirectToDefaultU
 
 	FirstFactorReauthenticatePOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), &redirectResponse{Redirect: "https://www.example.com"})
 }
 
@@ -1595,7 +1558,6 @@ func (s *FirstFactorReauthenticateRedirectionSuite) TestShouldReply200WhenNoTarg
 
 	FirstFactorReauthenticatePOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), nil)
 }
 
@@ -1627,7 +1589,6 @@ func (s *FirstFactorReauthenticateRedirectionSuite) TestShouldReply200WhenUnsafe
 
 	FirstFactorReauthenticatePOST(nil)(s.mock.Ctx)
 
-	// Respond with 200.
 	s.mock.Assert200OK(s.T(), nil)
 }
 

--- a/internal/handlers/handler_reset_password.go
+++ b/internal/handlers/handler_reset_password.go
@@ -179,7 +179,6 @@ func ResetPasswordPOST(ctx *middlewares.AutheliaCtx) {
 
 	ctx.GetLogger().Debugf("Password of user %s has been reset", username)
 
-	// Reset the request.
 	userSession.PasswordResetUsername = nil
 
 	if err = ctx.SaveSession(userSession); err != nil {
@@ -187,7 +186,6 @@ func ResetPasswordPOST(ctx *middlewares.AutheliaCtx) {
 		return
 	}
 
-	// Send Notification.
 	userInfo, err := ctx.Providers.UserProvider.GetDetails(username)
 	if err != nil {
 		ctx.GetLogger().WithError(err).WithFields(map[string]any{"username": username}).Error("Error occurred retrieving user details")

--- a/internal/handlers/types.go
+++ b/internal/handlers/types.go
@@ -19,14 +19,12 @@ import (
 // MethodList is the list of available methods.
 type MethodList = []string
 
-// configurationBody the content returned by the configuration endpoint.
 type configurationBody struct {
 	AvailableMethods       MethodList `json:"available_methods"`
 	PasswordChangeDisabled bool       `json:"password_change_disabled"`
 	PasswordResetDisabled  bool       `json:"password_reset_disabled"`
 }
 
-// bodySignTOTPRequest is the  model of the request body of TOTP 2FA authentication endpoint.
 type bodySignTOTPRequest struct {
 	Token     string `json:"token" valid:"required"`
 	TargetURL string `json:"targetURL"`
@@ -46,7 +44,6 @@ type bodyRegisterFinishTOTP struct {
 	Token string `json:"token" valid:"required"`
 }
 
-// bodySignWebAuthnRequest is the  model of the request body of WebAuthn 2FA authentication endpoint.
 type bodySignWebAuthnRequest struct {
 	TargetURL string `json:"targetURL"`
 	FlowID    string `json:"flowID"`
@@ -57,7 +54,6 @@ type bodySignWebAuthnRequest struct {
 	Response json.RawMessage `json:"response"`
 }
 
-// bodySignPasskeyRequest is the  model of the request body of WebAuthn 2FA authentication endpoint.
 type bodySignPasskeyRequest struct {
 	TargetURL      string `json:"targetURL"`
 	RequestMethod  string `json:"requestMethod"`
@@ -70,7 +66,6 @@ type bodySignPasskeyRequest struct {
 	Response json.RawMessage `json:"response"`
 }
 
-// bodyGETUserSessionElevate is the  model of the request body of the User Session Elevation PUT endpoint.
 type bodyGETUserSessionElevate struct {
 	RequireSecondFactor bool `json:"require_second_factor"`
 	SkipSecondFactor    bool `json:"skip_second_factor"`
@@ -80,12 +75,10 @@ type bodyGETUserSessionElevate struct {
 	Expires             int  `json:"expires"`
 }
 
-// bodyPOSTUserSessionElevate is the  model of the request body of the User Session Elevation PUT endpoint.
 type bodyPOSTUserSessionElevate struct {
 	DeleteID string `json:"delete_id"`
 }
 
-// bodyPUTUserSessionElevate is the  model of the request body of the User Session Elevation PUT endpoint.
 type bodyPUTUserSessionElevate struct {
 	OneTimeCode string `json:"otc"`
 }
@@ -98,7 +91,6 @@ type bodyEditWebAuthnCredentialRequest struct {
 	Description string `json:"description"`
 }
 
-// bodySignDuoRequest is the model of the request body of Duo 2FA authentication endpoint.
 type bodySignDuoRequest struct {
 	TargetURL string `json:"targetURL"`
 	Passcode  string `json:"passcode"`
@@ -108,12 +100,10 @@ type bodySignDuoRequest struct {
 	UserCode  string `json:"userCode"`
 }
 
-// bodyPreferred2FAMethod the selected 2FA method.
 type bodyPreferred2FAMethod struct {
 	Method string `json:"method" valid:"required"`
 }
 
-// bodyFirstFactorRequest represents the JSON body received by the endpoint.
 type bodyFirstFactorRequest struct {
 	Username       string `json:"username" valid:"required"`
 	Password       string `json:"password" valid:"required"`
@@ -126,7 +116,6 @@ type bodyFirstFactorRequest struct {
 	UserCode       string `json:"userCode"`
 }
 
-// bodyFirstFactorRequest represents the JSON body received by the endpoint.
 type bodySecondFactorPasswordRequest struct {
 	Password  string `json:"password" valid:"required"`
 	TargetURL string `json:"targetURL"`
@@ -136,7 +125,6 @@ type bodySecondFactorPasswordRequest struct {
 	UserCode  string `json:"userCode"`
 }
 
-// bodyFirstFactorRequest represents the JSON body received by the endpoint.
 type bodyFirstFactorReauthenticateRequest struct {
 	Password      string `json:"password" valid:"required"`
 	TargetURL     string `json:"targetURL"`
@@ -147,8 +135,6 @@ type bodyFirstFactorReauthenticateRequest struct {
 	UserCode      string `json:"userCode"`
 }
 
-// checkURIWithinDomainRequestBody represents the JSON body received by the endpoint checking if an URI is within
-// the configured domain.
 type checkURIWithinDomainRequestBody struct {
 	URI string `json:"uri"`
 }
@@ -157,8 +143,6 @@ type checkURIWithinDomainResponseBody struct {
 	OK bool `json:"ok"`
 }
 
-// redirectResponse represent the response sent by the first factor endpoint
-// when a redirection URL has been provided.
 type redirectResponse struct {
 	Redirect string `json:"redirect"`
 }
@@ -207,12 +191,10 @@ type StateResponse struct {
 	DefaultRedirectionURL string               `json:"default_redirection_url,omitempty"`
 }
 
-// resetPasswordStep1RequestBody model of the reset password (step1) request body.
 type resetPasswordStep1RequestBody struct {
 	Username string `json:"username"`
 }
 
-// resetPasswordStep2RequestBody model of the reset password (step2) request body.
 type resetPasswordStep2RequestBody struct {
 	Password string `json:"password"`
 }
@@ -221,7 +203,6 @@ type bodyRequestPasswordResetDELETE struct {
 	Token string `json:"token"`
 }
 
-// changePasswordRequestBody model of the change password request body.
 type changePasswordRequestBody struct {
 	Username    string `json:"username"`
 	OldPassword string `json:"old_password"`

--- a/internal/handlers/util.go
+++ b/internal/handlers/util.go
@@ -46,7 +46,6 @@ func ctxLogEvent(ctx *middlewares.AutheliaCtx, username, description string, bod
 
 	ctx.Logger.Debugf("Getting user details for notification")
 
-	// Send Notification.
 	if details, err = ctx.Providers.UserProvider.GetDetails(username); err != nil {
 		ctx.Logger.WithError(err).Errorf("Error occurred looking up user details for user '%s' while attempting to alert them of an important event", username)
 		return

--- a/internal/logging/const.go
+++ b/internal/logging/const.go
@@ -71,5 +71,5 @@ const (
 var (
 	stacktrace       sync.Once
 	reFormatFilePath = regexp.MustCompile(`(%d|\{datetime(:([^}]+))?})`)
-	lf               *File
+	logFile          *File
 )

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -65,9 +65,9 @@ func ConfigureLogger(config schema.Log, log bool) (err error) {
 			writers = append(writers, os.Stdout)
 		}
 
-		lf = NewFile(config.FilePath)
+		logFile = NewFile(config.FilePath)
 
-		if err = lf.Open(); err != nil {
+		if err = logFile.Open(); err != nil {
 			return err
 		}
 
@@ -78,7 +78,7 @@ func ConfigureLogger(config schema.Log, log bool) (err error) {
 			})
 		}
 
-		writers = append(writers, lf)
+		writers = append(writers, logFile)
 	default:
 		writers = []io.Writer{os.Stdout}
 	}
@@ -90,11 +90,11 @@ func ConfigureLogger(config schema.Log, log bool) (err error) {
 
 // Reopen handles safely reopening the log file.
 func Reopen() (err error) {
-	if lf == nil {
+	if logFile == nil {
 		return fmt.Errorf("error reopening log file: file is not configured or open")
 	}
 
-	return lf.Reopen()
+	return logFile.Reopen()
 }
 
 func setLevelStr(level string, log bool) {

--- a/internal/middlewares/http_to_authelia_handler_adaptor.go
+++ b/internal/middlewares/http_to_authelia_handler_adaptor.go
@@ -22,12 +22,12 @@ func NewHTTPToAutheliaHandlerAdaptor(handler AutheliaHandlerFunc) RequestHandler
 		r := &http.Request{
 			Header:        make(http.Header),
 			TLS:           ctx.TLSConnectionState(),
-			Proto:         b2s(ctx.Request.Header.Protocol()),
+			Proto:         bytesToString(ctx.Request.Header.Protocol()),
 			ProtoMinor:    1,
 			ContentLength: int64(len(body)),
-			Method:        b2s(ctx.Method()),
-			Host:          b2s(ctx.Host()),
-			RequestURI:    b2s(ctx.RequestURI()),
+			Method:        bytesToString(ctx.Method()),
+			Host:          bytesToString(ctx.Host()),
+			RequestURI:    bytesToString(ctx.RequestURI()),
 			RemoteAddr:    ctx.RemoteAddr().String(),
 			Body:          io.NopCloser(bytes.NewReader(body)),
 		}
@@ -39,8 +39,8 @@ func NewHTTPToAutheliaHandlerAdaptor(handler AutheliaHandlerFunc) RequestHandler
 		}
 
 		for k, v := range ctx.Request.Header.All() {
-			key := b2s(k)
-			value := b2s(v)
+			key := bytesToString(k)
+			value := bytesToString(v)
 
 			switch key {
 			case fasthttp.HeaderTransferEncoding:
@@ -126,6 +126,6 @@ func (w *netHTTPResponseWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func b2s(b []byte) string {
+func bytesToString(b []byte) string {
 	return unsafe.String(unsafe.SliceData(b), len(b))
 }

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -142,7 +142,7 @@ func (n *SMTPNotifier) Send(ctx context.Context, recipient mail.Address, subject
 		client SMTPClient
 	)
 
-	if msg, err = n.msg(recipient, subject, et, data); err != nil {
+	if msg, err = n.buildMessage(recipient, subject, et, data); err != nil {
 		return fmt.Errorf("notifier: smtp: failed to create envelope: %w", err)
 	}
 
@@ -165,7 +165,7 @@ func (n *SMTPNotifier) Send(ctx context.Context, recipient mail.Address, subject
 	return nil
 }
 
-func (n *SMTPNotifier) msg(recipient mail.Address, subject string, et *templates.EmailTemplate, data any) (msg *gomail.Msg, err error) {
+func (n *SMTPNotifier) buildMessage(recipient mail.Address, subject string, et *templates.EmailTemplate, data any) (msg *gomail.Msg, err error) {
 	msg = gomail.NewMsg(
 		gomail.WithMIMEVersion(gomail.MIME10),
 		gomail.WithBoundary(n.random.StringCustom(30, random.CharSetAlphaNumeric)),

--- a/internal/ntp/util.go
+++ b/internal/ntp/util.go
@@ -6,7 +6,6 @@ import (
 	"time"
 )
 
-// validateResponse strictly validates the mode, stratum, and timestamps.
 func validateResponse(req, resp *packet) (err error) {
 	if mode := resp.LeapVersionMode & maskModeValue; mode != modeServer {
 		return fmt.Errorf("the response has mode '%d' but only the server mode '%d' is considered valid", mode, modeServer)
@@ -50,7 +49,6 @@ func timeToSecondsAndFraction(t time.Time) (seconds, fraction uint32) {
 	return uint32(t.Unix() + epochOffset), uint32((int64(t.Nanosecond()) << 32) / 1e9)
 }
 
-// isOffsetTooLarge return true if there is offset of "offset" between two times.
 func isOffsetTooLarge(maxOffset time.Duration, first, second time.Time) (tooLarge bool) {
 	var offset time.Duration
 

--- a/internal/oidc/client_policy.go
+++ b/internal/oidc/client_policy.go
@@ -81,7 +81,6 @@ func (p *ClientAuthorizationPolicyRule) MatchesSubjects(subject authorization.Su
 		return false
 	}
 
-	// Iterate over the subjects until we find a match (set matchesSubject and break) or until we exit the loop.
 	matchesSubject := false
 
 	for _, rule := range p.Subjects {
@@ -91,7 +90,6 @@ func (p *ClientAuthorizationPolicyRule) MatchesSubjects(subject authorization.Su
 		}
 	}
 
-	// Return false if there is at least one subject defined and none of the subjects match.
 	if len(p.Subjects) != 0 && !matchesSubject {
 		return false
 	}

--- a/internal/oidc/util_blackbox_test.go
+++ b/internal/oidc/util_blackbox_test.go
@@ -841,7 +841,6 @@ func TestIsAccessToken(t *testing.T) {
 		},
 	}
 
-	//
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := oidc.IsAccessToken(tc.ctx, tc.value)

--- a/internal/server/asset.go
+++ b/internal/server/asset.go
@@ -285,25 +285,21 @@ func hfsHandleErr(ctx *fasthttp.RequestCtx, err error) {
 	}
 }
 
-// newLocalesListHandler handles request for obtaining the available locales in backend.
 func newLocalesListHandler() (handler func(ctx *middlewares.AutheliaCtx), err error) {
 	var (
 		data []byte
 	)
 
-	// preload embedded locales.
 	localeInfo, err := utils.GetEmbeddedLanguages(locales)
 	if err != nil {
 		return nil, fmt.Errorf("error occurred initializing the locale list handler: error occurred loading embedded languages: %w", err)
 	}
 
-	// parse embedded locales.
 	data, err = json.Marshal(middlewares.OKResponse{Status: "OK", Data: localeInfo})
 	if err != nil {
 		return nil, fmt.Errorf("error occurred initializing the locale list handler: error occurred marshaling the locale list: %w", err)
 	}
 
-	// generate etag for embedded locales.
 	etag := generateEtag(data)
 
 	return func(ctx *middlewares.AutheliaCtx) {
@@ -329,7 +325,6 @@ func newLocalesListHandler() (handler func(ctx *middlewares.AutheliaCtx), err er
 	}, nil
 }
 
-// generateEtag generates a unique etag for specified payload.
 func generateEtag(payload []byte) []byte {
 	sum := sha1.New() //nolint:gosec // Usage is for collision avoidance not security.
 	sum.Write(payload)

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -305,7 +305,6 @@ func (options *TemplatedFileOptions) CommonData(base, baseURL, domain, nonce, la
 	}
 }
 
-// CommonDataWithRememberMe returns a TemplatedFileCommonData with the dynamic options.
 func (options *TemplatedFileOptions) commonDataWithRememberMe(base, baseURL, domain, nonce, language, logoOverride, rememberMe string) TemplatedFileCommonData {
 	return TemplatedFileCommonData{
 		Base:                   base,

--- a/internal/service/signal_test.go
+++ b/internal/service/signal_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/authelia/authelia/v4/internal/middlewares"
 )
 
-// mockServiceCtx implements ServiceCtx for testing.
 type mockServiceCtx struct {
 	ctx       context.Context
 	config    *schema.Configuration

--- a/internal/session/provider_config.go
+++ b/internal/session/provider_config.go
@@ -34,13 +34,10 @@ func NewProviderConfig(config schema.SessionCookie, providerName string, seriali
 		return bytes
 	}
 
-	// Override the cookie name.
 	c.CookieName = config.Name
 
-	// Set the cookie to the given domain.
 	c.Domain = config.Domain
 
-	// Set the cookie SameSite option.
 	switch config.SameSite {
 	case "strict":
 		c.CookieSameSite = fasthttp.CookieSameSiteStrictMode
@@ -52,7 +49,6 @@ func NewProviderConfig(config schema.SessionCookie, providerName string, seriali
 		c.CookieSameSite = fasthttp.CookieSameSiteLaxMode
 	}
 
-	// Only serve the header over HTTPS.
 	c.Secure = true
 
 	// Ignore the error as it will be handled by validator.
@@ -94,7 +90,6 @@ func NewProviderConfigAndSession(config schema.SessionCookie, providerName strin
 }
 
 func NewSessionProvider(config schema.Session, certPool *x509.CertPool) (name string, provider session.Provider, serializer Serializer, err error) {
-	// If redis configuration is provided, then use the redis provider.
 	switch {
 	case config.Redis != nil:
 		serializer = NewEncryptingSerializer(config.Secret)

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -98,23 +98,18 @@ func loadMigrations(providerName string, prior, target int) (migrations []model.
 func skipMigration(up bool, target, prior int, migration *model.SchemaMigration) (skip bool) {
 	if up {
 		if !migration.Up {
-			// Skip if we wanted an Up migration but it isn't an Up migration.
 			return true
 		}
 
 		if migration.Version > target || migration.Version <= prior {
-			// Skip if the migration version is greater than the target or less than or equal to the previous version.
 			return true
 		}
 	} else {
 		if migration.Up {
-			// Skip if we didn't want an Up migration but it is an Up migration.
 			return true
 		}
 
 		if migration.Version <= target || migration.Version > prior {
-			// Skip the migration if we want to go down and the migration version is less than or equal to the target
-			// or greater than the previous version.
 			return true
 		}
 	}

--- a/internal/storage/sql_provider_backend_mysql.go
+++ b/internal/storage/sql_provider_backend_mysql.go
@@ -32,7 +32,6 @@ func NewMySQLProvider(config *schema.Configuration, caCertPool *x509.CertPool) (
 	// All providers have differing SELECT existing table statements.
 	provider.sqlSelectExistingTables = queryMySQLSelectExistingTables
 
-	// Specific alterations to this provider.
 	provider.sqlFmtRenameTable = queryFmtMySQLRenameTable
 
 	return provider, nil

--- a/internal/storage/sql_provider_backend_postgres.go
+++ b/internal/storage/sql_provider_backend_postgres.go
@@ -38,7 +38,6 @@ func NewPostgreSQLProvider(config *schema.Configuration, caCertPool *x509.CertPo
 	// All providers have differing SELECT existing table statements.
 	provider.sqlSelectExistingTables = queryPostgreSelectExistingTables
 
-	// Specific alterations to this provider.
 	// PostgreSQL doesn't have a UPSERT statement but has an ON CONFLICT operation instead.
 	provider.sqlUpsertDuoDevice = fmt.Sprintf(queryFmtUpsertDuoDevicePostgreSQL, tableDuoDevices)
 	provider.sqlUpsertTOTPConfig = fmt.Sprintf(queryFmtUpsertTOTPConfigurationPostgreSQL, tableTOTPConfigurations)

--- a/internal/storage/sql_provider_schema.go
+++ b/internal/storage/sql_provider_schema.go
@@ -287,7 +287,6 @@ func (p *SQLProvider) schemaMigrateApply(ctx context.Context, conn SQLXConnectio
 		}
 
 		if migration.Version == 1 && migration.Up {
-			// Add the schema encryption value if upgrading to v1.
 			if err = p.setNewEncryptionCheckValue(ctx, conn, p.keys.encryption); err != nil {
 				return err
 			}

--- a/internal/suites/action_login.go
+++ b/internal/suites/action_login.go
@@ -59,7 +59,6 @@ func (rs *RodSession) doFillPasswordAndClick(t *testing.T, page *rod.Page, passw
 	rs.ClickElementLocatedByID(t, page, "sign-in-button")
 }
 
-// Login 1FA.
 func (rs *RodSession) doLoginOneFactor(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool, domain, targetURL string) {
 	rs.doVisitLoginPage(t, page, domain, targetURL)
 	rs.doFillLoginPageAndClick(t, page, username, password, keepMeLoggedIn)
@@ -86,7 +85,6 @@ func (rs *RodSession) doLoginSecondFactorTOTP(t *testing.T, page *rod.Page, user
 	}
 }
 
-// Login 1FA and register 2FA.
 func (rs *RodSession) doLoginAndRegisterTOTP(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool) {
 	rs.doLoginOneFactor(t, page, username, password, keepMeLoggedIn, BaseDomain, "")
 	rs.doOpenSettingsAndRegisterTOTP(t, page, username)
@@ -94,9 +92,7 @@ func (rs *RodSession) doLoginAndRegisterTOTP(t *testing.T, page *rod.Page, usern
 	rs.verifyIsSecondFactorPage(t, page)
 }
 
-// Register a user with TOTP, logout and then authenticate until TOTP-2FA.
 func (rs *RodSession) doRegisterTOTPAndLogin2FA(t *testing.T, page *rod.Page, username, password string, keepMeLoggedIn bool, targetURL string) { //nolint:unparam
-	// Register TOTP secret and logout.
 	rs.doLoginAndRegisterTOTPThenLogout(t, page, username, password)
 	rs.doLoginSecondFactorTOTP(t, page, username, password, keepMeLoggedIn, targetURL)
 }

--- a/internal/suites/action_reset_password.go
+++ b/internal/suites/action_reset_password.go
@@ -13,10 +13,8 @@ func (rs *RodSession) doInitiatePasswordReset(t *testing.T, page *rod.Page, user
 
 	require.NoError(t, page.WaitStable(time.Millisecond*100))
 
-	// Fill in username.
 	err := rs.WaitElementLocatedByID(t, page, "username-textfield").Input(username)
 	require.NoError(t, err)
-	// And click on the reset button.
 	rs.ClickElementLocatedByID(t, page, "reset-button")
 }
 
@@ -60,7 +58,6 @@ func (rs *RodSession) doUnsuccessfulPasswordReset(t *testing.T, page *rod.Page, 
 
 func (rs *RodSession) doResetPassword(t *testing.T, page *rod.Page, username, newPassword1, newPassword2 string, unsuccessful bool) {
 	rs.doInitiatePasswordReset(t, page, username)
-	// then wait for the "email sent notification".
 	rs.verifyMailNotificationDisplayed(t, page)
 
 	if unsuccessful {

--- a/internal/suites/hosts.go
+++ b/internal/suites/hosts.go
@@ -93,7 +93,6 @@ func hostEntriesCookieDomains(ip string) []HostEntry {
 	return entries
 }
 
-// hostAddresses indexes HostEntries by domain.
 func hostAddresses() map[string]string {
 	entries := HostEntries()
 

--- a/internal/suites/scenario_oidc_test.go
+++ b/internal/suites/scenario_oidc_test.go
@@ -92,7 +92,6 @@ func (s *OIDCScenario) TestShouldAuthorizeAccessToOIDCApp() {
 
 	s.waitBodyContains(s.T(), s.Context(ctx), "Not logged yet...")
 
-	// Search for the 'login' link.
 	err := s.Page.MustSearch("Log in").Click("left", 1)
 	assert.NoError(s.T(), err)
 
@@ -169,7 +168,6 @@ func (s *OIDCScenario) TestShouldDenyConsent() {
 
 	s.waitBodyContains(s.T(), s.Context(ctx), "Not logged yet...")
 
-	// Search for the 'login' link.
 	err := s.Page.MustSearch("Log in").Click("left", 1)
 	assert.NoError(s.T(), err)
 

--- a/internal/suites/scenario_passkey_test.go
+++ b/internal/suites/scenario_passkey_test.go
@@ -82,7 +82,6 @@ func (s *PasskeyScenario) TestShouldAuthorizeAfterPasskeyLogin() {
 	s.verifyNotificationDisplayed(s.T(), s.Context(ctx), "Incorrect password")
 	s.doFillPasswordAndClick(s.T(), s.Context(ctx), "password")
 
-	// And check if the user is redirected to the secret.
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 
 	// Leave the secret.

--- a/internal/suites/scenario_password_complexity_test.go
+++ b/internal/suites/scenario_password_complexity_test.go
@@ -53,7 +53,6 @@ func (s *PasswordComplexityScenario) TestShouldRejectPasswordReset() {
 	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
-	// Attempt to reset the password to a.
 	s.doResetPassword(s.T(), s.Context(ctx), "john", "a", "a", true)
 }
 

--- a/internal/suites/scenario_reset_password_test.go
+++ b/internal/suites/scenario_reset_password_test.go
@@ -63,7 +63,6 @@ func (s *ResetPasswordScenario) TestShouldResetPassword() {
 	// Try to login with the new password.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "abc", false, BaseDomain, "")
 
-	// Logout.
 	s.doLogout(s.T(), s.Context(ctx))
 
 	// Reset the original password.

--- a/internal/suites/scenario_two_factor_totp_test.go
+++ b/internal/suites/scenario_two_factor_totp_test.go
@@ -106,7 +106,6 @@ func (s *TwoFactorTOTPScenario) TestShouldAuthorizeSecretAfterTwoFactor() {
 	targetURL := fmt.Sprintf("%s/secret.html", AdminBaseURL)
 	s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), username, password, false, targetURL)
 
-	// And check if the user is redirected to the secret.
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 
 	// Leave the secret.

--- a/internal/suites/scenario_two_factor_webauthn_test.go
+++ b/internal/suites/scenario_two_factor_webauthn_test.go
@@ -81,7 +81,6 @@ func (s *TwoFactorWebAuthnScenario) TestShouldAuthorizeSecretAfterTwoFactor() {
 
 	s.doWebAuthnMethodMaybeSelect(s.T(), s.Context(ctx))
 
-	// And check if the user is redirected to the secret.
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 
 	// Leave the secret.

--- a/internal/suites/suite_duo_push_test.go
+++ b/internal/suites/suite_duo_push_test.go
@@ -133,7 +133,6 @@ func (s *DuoPushWebDriverSuite) TestShouldAutoSelectDevice() {
 	ConfigureDuoPreAuth(s.T(), PreAuthAPIResponse)
 	ConfigureDuo(s.T(), Allow)
 
-	// Authenticate.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
 	// Switch Method where single Device should be selected automatically.
 	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")
@@ -173,7 +172,6 @@ func (s *DuoPushWebDriverSuite) TestShouldSelectDevice() {
 	ConfigureDuoPreAuth(s.T(), PreAuthAPIResponse)
 	ConfigureDuo(s.T(), Allow)
 
-	// Authenticate.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), "john", "password", false, BaseDomain, "")
 	// Switch Method where Device Selection should open automatically.
 	s.doChangeMethod(s.T(), s.Context(ctx), "push-notification")

--- a/internal/suites/suite_standalone_test.go
+++ b/internal/suites/suite_standalone_test.go
@@ -158,18 +158,14 @@ func (s *StandaloneWebDriverSuite) TestShouldCheckUserIsAskedToRegisterDevice() 
 
 	require.NoError(s.T(), provider.DeleteTOTPConfiguration(ctx, username))
 
-	// Login one factor.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), username, password, false, BaseDomain, "")
 
 	// Check the user is asked to register a new device.
 	s.WaitElementLocatedByClassName(s.T(), s.Context(ctx), "state-not-registered")
 
-	// Then register the TOTP factor.
 	s.doOpenSettingsAndRegisterTOTP(s.T(), s.Context(ctx), username)
-	// And logout.
 	s.doLogout(s.T(), s.Context(ctx))
 
-	// Login one factor again.
 	s.doLoginOneFactor(s.T(), s.Context(ctx), username, password, false, BaseDomain, "")
 
 	// now the user should be asked to perform 2FA.

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -492,7 +492,6 @@ func getDomainEnvInfo(domain string) (info map[string]string, err error) {
 	return info, nil
 }
 
-// generateDevEnvFile generates web/.env.development based on opts.
 func generateDevEnvFile(info map[string]string) (err error) {
 	base, _ := os.Getwd()
 	base = strings.TrimSuffix(base, "/internal/suites")

--- a/internal/utils/exec.go
+++ b/internal/utils/exec.go
@@ -124,7 +124,6 @@ func RunCommandUntilCtrlC(cmd *exec.Cmd) {
 
 // RunCommandWithTimeout run a command with timeout.
 func RunCommandWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
-	// Start a process.
 	if err := cmd.Start(); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
A comment carries its weight only when it says something the code does not. An audit of every Go package against that rule found a large body of prose that restates the line beneath it, and a handful of identifiers whose names obscure rather than describe. Both make the surrounding code slower to read and, worse, invite trust in a description that has since drifted from what the code does.

GoDoc now appears only on exported declarations. Fifty-two doc comments sat above unexported ones and named the declaration back to the reader: every request and response body type in `internal/handlers/types.go`, `koanfEnvironmentCallback`, `validateFileAuthenticationBackend`, `validateServerTLSFileExists`, `newStorageMigrateCmd`, `PooledLDAPClientFactory.dial`, `generateEtag`, `hostAddresses` and others. Three of the body types in `internal/handlers/types.go` had been copy-pasted and documented themselves as `bodyFirstFactorRequest`, and two more had outlived a rename: `readHostsFile` was documented as `ReadHostsFile`, `commonDataWithRememberMe` as `CommonDataWithRememberMe`. Doc comments that carry something the signature cannot are kept, such as the locking contract on `IPRateLimitBucket.new` and the sentinel target versions accepted by `loadMigrations`.

The same rule removes a hundred and seven in-code comments. The largest group is twenty-four instances of `// Respond with 200.` sitting directly above an assertion on the status code, several of them above `Assert200KO`, where the comment had become actively wrong. The `// If there are no X …` and `// Iterate over the X …` pairs in `access_control_rule.go` and `client_policy.go` narrate a length check and a range loop; the four `// Skip if …` comments inside `skipMigration` restate the conditions they precede. Nine trailing `// TestShouldVerifyAuthBasicArg*` breadcrumbs point at tests that no longer exist. In `internal/suites` the step labels that duplicate the single helper call beneath them are gone, so `// Logout.` no longer precedes `doLogout`. Comments explaining why something is done, warnings, and the section headers that give large `const` blocks their structure are all untouched.

Six identifiers are renamed. `setport` becomes `setPort`, `lf` becomes `logFile`, `b2s` becomes `bytesToString`, and `SMTPNotifier.msg` becomes `buildMessage`, which also stops the method shadowing its own named return. Two are typos: `keyEd2519` and `certEd15519` name a curve that does not exist, and `x509CACertificateRSAotBefore` is missing a letter.

Also removed is a commented-out `gomock` expectation in `handler_firstfactor_password_test.go`, which is dead code rather than documentation, and an empty `//` in `util_blackbox_test.go`. `internal/session/memory/stdlib.go` is left alone throughout: it is a verbatim copy of the standard library's `sync.Map` and its comments belong to upstream.