### PR TITLE
test(suites): wait for the proxy to route the portal before testing

### DIFF
--- a/internal/suites/environment.go
+++ b/internal/suites/environment.go
@@ -1,6 +1,9 @@
 package suites
 
 import (
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -142,6 +145,37 @@ func waitUntilAutheliaIsReady(dockerEnvironment *DockerEnvironment, suite string
 
 		log.Info("Samba is ready!")
 	}
+
+	return nil
+}
+
+func waitUntilProxyRoutesPortal(baseDomain string) error {
+	// The proxy discovers the portal from the daemon, and `up --wait` returns once the portal's healthcheck
+	// passes, which is before the proxy has enumerated the daemon and published a route to it. Until that
+	// route exists the proxy answers the portal's host itself, and no wait recovers a test that visits the
+	// error page it serves, because the document loads and the portal is never fetched. The path is
+	// deliberately unprefixed: it is the one route the portal serves outside its own base URL, so it answers
+	// for a suite with a path prefix as well as one without.
+	log.Info("Waiting for the proxy to route the portal...")
+
+	client, target := NewHTTPClient(), LoginBaseURLFmt(baseDomain)+"/api/health"
+
+	if err := utils.CheckUntil(time.Second, 30*time.Second, func() (bool, error) {
+		response, err := client.Get(target)
+		if err != nil {
+			return false, nil
+		}
+
+		defer response.Body.Close()
+
+		_, _ = io.Copy(io.Discard, response.Body)
+
+		return response.StatusCode == http.StatusOK, nil
+	}); err != nil {
+		return fmt.Errorf("the proxy did not route '%s' to the portal: %w", target, err)
+	}
+
+	log.Info("The proxy routes the portal!")
 
 	return nil
 }

--- a/internal/suites/example/compose/traefik/compose.yml
+++ b/internal/suites/example/compose/traefik/compose.yml
@@ -33,7 +33,6 @@ services:
       - '--providers.docker.network=${COMPOSE_PROJECT_NAME:-authelia}_authelianet'
       - '--providers.file.directory=/config/dynamic/'
       - '--providers.file.watch=true'
-      - '--providers.providersthrottleduration=5s'
       - '--serverstransport.insecureskipverify=true'
     networks:
       authelianet:

--- a/internal/suites/suite_oidc_traefik.go
+++ b/internal/suites/suite_oidc_traefik.go
@@ -50,6 +50,10 @@ func init() {
 			return err
 		}
 
+		if err = waitUntilProxyRoutesPortal(BaseDomain); err != nil {
+			return err
+		}
+
 		return updateDevEnvFileForDomain(BaseDomain, dockerEnvironment)
 	}
 

--- a/internal/suites/suite_pathprefix.go
+++ b/internal/suites/suite_pathprefix.go
@@ -42,6 +42,10 @@ func init() {
 			return err
 		}
 
+		if err = waitUntilProxyRoutesPortal(BaseDomain); err != nil {
+			return err
+		}
+
 		return updateDevEnvFileForDomain(BaseDomain, dockerEnvironment)
 	}
 

--- a/internal/suites/suite_traefik2.go
+++ b/internal/suites/suite_traefik2.go
@@ -44,6 +44,10 @@ func init() {
 			return err
 		}
 
+		if err = waitUntilProxyRoutesPortal(BaseDomain); err != nil {
+			return err
+		}
+
 		return updateDevEnvFileForDomain(BaseDomain, traefik2DockerEnvironment)
 	}
 

--- a/internal/suites/suite_traefik3.go
+++ b/internal/suites/suite_traefik3.go
@@ -44,6 +44,10 @@ func init() {
 			return err
 		}
 
+		if err = waitUntilProxyRoutesPortal(BaseDomain); err != nil {
+			return err
+		}
+
 		return updateDevEnvFileForDomain(BaseDomain, traefik3DockerEnvironment)
 	}
 


### PR DESCRIPTION
A `Traefik2` run failed with `TestShouldAuthorizeSecretAfterOneFactor` never finding `#first-factor-stage`. The access log `82471ac41` started collecting names the cause: `GET /?rd=https://singlefactor.example.com:8080/secret.html` was answered `404` in `0ms` against a router of `-`, so the proxy had no route for `login.example.com` and served its own error page, which is a document that loads and never renders a portal. The proxy first logged `Adding route for login.example.com` two seconds later. `up --wait` returns once the portal's healthcheck passes, and nothing between that and the first visit establishes that the proxy has enumerated the daemon and published a route to it, so the suites start against a portal the proxy cannot reach yet. `waitUntilProxyRoutesPortal` closes that window for the four suites that run behind the proxy. Its path is deliberately unprefixed: `StripPath` only strips a URI matching the base URL, so `/api/health` reaches the router unstripped and answers for `PathPrefix` as well as for a suite without one.

`--providers.providersthrottleduration` goes. It was added to keep the configuration rebuilds a shared daemon provokes off the two cores the proxy has, and it does not do that. The same log holds 25 docker events against 26 full enumerations of the 115 to 127 containers the daemon was holding, one per event, which is the work that was meant to be avoided and is untouched by the setting because it belongs to the provider rather than to the publish that is throttled. What it did suppress was 26 publishes down to 4, and 3 of those 4 were then logged `Skipping unchanged configuration`, so nearly every publish it prevented was already free. All it bought was a window of up to five seconds between the provider knowing a route and the proxy serving it, and that is the window the portal's route landed in.