### PR TITLE
build(deps): update module github.com/cilium/ebpf to v0.22.0

### DIFF
--- a/internal/suites/example/compose/authelia/resources/go.mod
+++ b/internal/suites/example/compose/authelia/resources/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/cilium/ebpf v0.21.0 // indirect
+	github.com/cilium/ebpf v0.22.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cosiner/argv v0.1.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect

--- a/internal/suites/example/compose/authelia/resources/go.sum
+++ b/internal/suites/example/compose/authelia/resources/go.sum
@@ -1,7 +1,7 @@
 github.com/cespare/reflex v0.3.2 h1:SBN/trM94Ifs/ozz77cR3KxKm4dNE22zfG+0+54y5bQ=
 github.com/cespare/reflex v0.3.2/go.mod h1:3hfHPnuDWHtNWk0aLKwwP6pomRkS3r2nM127108jY/4=
-github.com/cilium/ebpf v0.21.0 h1:4dpx1J/B/1apeTmWBH5BkVLayHTkFrMovVPnHEk+l3k=
-github.com/cilium/ebpf v0.21.0/go.mod h1:1kHKv6Kvh5a6TePP5vvvoMa1bclRyzUXELSs272fmIQ=
+github.com/cilium/ebpf v0.22.0 h1:v2ktp0roffpMOj2MMf3idtCQZOsAoC4BJbAJN+ke2bY=
+github.com/cilium/ebpf v0.22.0/go.mod h1:CDzZbe2hC5JjlDC+CY3KFCzlYwN4gbxppYM+Z10bQt4=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cosiner/argv v0.1.0 h1:BVDiEL32lwHukgJKP87btEPenzrrHUjajs/8yzaqcXg=
@@ -50,8 +50,8 @@ github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
 github.com/ogier/pflag v0.0.1 h1:RW6JSWSu/RkSatfcLtogGfFgpim5p7ARQ10ECk5O750=
 github.com/ogier/pflag v0.0.1/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFPE+g=
-github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
-github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=


### PR DESCRIPTION
`github.com/cilium/ebpf` prior to `v0.22.0` has an integer overflow in its BTF parser, reported as GO-2026-6238 and CVE-2026-10722, which OpenSSF Scorecard flags against this repository. The module reaches us through `internal/suites/example/compose/authelia/resources/go.mod`, the development only tools module the integration suite backend container uses to install `reflex` and `dlv`, so the exposure is limited to the hot reload image and never reaches a release artifact. `github.com/go-delve/delve` `v1.27.1` is the latest release and still requires `v0.21.0`, so the indirect requirement is raised directly. Tidying the module also moves `github.com/rogpeppe/go-internal` from `v1.12.0` to `v1.14.1` in `go.sum`.

Raising the `require` is sufficient here rather than adding a `replace`. The tools `main.go` runs a version-less `go install` with `/resources` as the working directory, which resolves against this `go.mod`, so minimal version selection takes the higher of the two requirements and the built `dlv` links `v0.22.0`. A `replace` would also work today, but it bypasses selection permanently and would hold the module back once `delve` requires a version beyond `v0.22.0`. The existing `replace` on `golang.org/x/net` is not a precedent for this: that module is pruned out of the requirement graph entirely, so a `require` line for it does not survive `go mod tidy`, whereas `github.com/cilium/ebpf` is reached from the packages `dlv` builds and is retained.