### PR TITLE
test(suites): gate the backend on the smtp listener

### DIFF
--- a/internal/suites/example/compose/smtp/compose.yml
+++ b/internal/suites/example/compose/smtp/compose.yml
@@ -20,9 +20,17 @@ services:
       traefik.http.routers.mail.tls: 'true'
       traefik.http.services.mail.loadbalancer.server.port: '8025'
     healthcheck:
-      disable: true
+      test: ['CMD-SHELL', 'nc -z 127.0.0.1 1025 && /mailpit readyz || exit 1']
+      interval: '5s'
+      timeout: '10s'
+      retries: 6
+      start_period: '120s'
     networks:
       authelianet:
         aliases:
           - 'mail.example.com'
+  authelia-backend:
+    depends_on:
+      smtp:
+        condition: service_healthy
 ...


### PR DESCRIPTION
The `smtp` service disables the healthcheck the `axllent/mailpit` image ships, so `docker compose up --wait` has nothing to gate on and reports the container ready the moment it is running rather than when it is listening. Nothing orders `authelia-backend` behind it either, because the dependencies declared in #12724 were drawn from the services that had a healthcheck to depend on, so the two start in the same batch and race. The backend dials the notifier once during its startup checks and a failure there is fatal, so losing that race kills it with `failed to dial connection: dial tcp <smtp>:1025: connect: connection refused` and takes the whole environment deployment with it.

The race is not new, it was previously invisible. The backend carries `restart: always` and recovered on the next attempt as soon as mailpit bound the port, and CI did not watch. Gating CI on `--wait` turned that silent recovery into a hard failure: a container in `restarting` reports its health as `unhealthy` no matter how long `start_period` still has to run, so compose aborts on the first crash instead of letting the restart heal it, and the suite never gets as far as a test.

Give the service a healthcheck that probes the SMTP listener and declare the dependency the backend actually has. The check targets port 1025 rather than restoring the image's `readyz` probe because `readyz` only proves the HTTP API on 8025 is up, and 1025 is the port with the fatal startup check behind it. The gate resolves in under two seconds, so it costs the suites nothing measurable.