### PR TITLE
refactor(web): replace react-router-dom with react-router v8

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22.13.1",
+    "node": ">=22.22.0",
     "pnpm": "11"
   },
   "dependencies": {
@@ -22,7 +22,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-i18next": "17.0.12",
-    "react-router-dom": "7.18.2",
+    "react-router": "8.3.0",
     "tailwind-merge": "3.6.0",
     "zxcvbn": "4.4.2"
   },

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -9,7 +9,6 @@ overrides:
   js-yaml: 5.3.0
   minimatch: 10.2.6
   picomatch: 4.0.5
-  react-router: 8.3.0
   semver: 7.8.5
   vite: 8.2.2
 
@@ -59,9 +58,9 @@ importers:
       react-i18next:
         specifier: 17.0.12
         version: 17.0.12(i18next@26.4.0(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
-      react-router-dom:
-        specifier: 7.18.2
-        version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router:
+        specifier: 8.3.0
+        version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tailwind-merge:
         specifier: 3.6.0
         version: 3.6.0
@@ -3101,13 +3100,6 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  react-router-dom@7.18.2:
-    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
 
   react-router@8.3.0:
     resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
@@ -6780,12 +6772,6 @@ snapshots:
       typescript: 6.0.3
 
   react-is@17.0.2: {}
-
-  react-router-dom@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-router: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -6,7 +6,6 @@ overrides:
   js-yaml: 5.3.0
   minimatch: 10.2.6
   picomatch: 4.0.5
-  react-router: 8.3.0
   semver: 7.8.5
   vite: 8.2.2
 peerDependencyRules:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { Suspense, lazy } from "react";
 
 import { CSPProvider } from "@base-ui/react/csp-provider";
 import { useTranslation } from "react-i18next";
-import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
+import { Route, BrowserRouter as Router, Routes } from "react-router";
 
 import { TooltipProvider } from "@components/UI/Tooltip";
 import {

--- a/web/src/hooks/Flow.test.ts
+++ b/web/src/hooks/Flow.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from "@testing-library/react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { useFlow, useFlowPresent } from "@hooks/Flow";
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
     useSearchParams: vi.fn(),
 }));
 

--- a/web/src/hooks/Flow.ts
+++ b/web/src/hooks/Flow.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { Flow, FlowID, RedirectionURL, SubFlow } from "@constants/SearchParams";
 

--- a/web/src/hooks/OpenIDConnect.test.ts
+++ b/web/src/hooks/OpenIDConnect.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from "@testing-library/react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { useUserCode } from "@hooks/OpenIDConnect";
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
     useSearchParams: vi.fn(),
 }));
 

--- a/web/src/hooks/OpenIDConnect.ts
+++ b/web/src/hooks/OpenIDConnect.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { UserCode } from "@constants/SearchParams";
 

--- a/web/src/hooks/QueryParam.test.ts
+++ b/web/src/hooks/QueryParam.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from "@testing-library/react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { useQueryParam } from "@hooks/QueryParam";
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
     useSearchParams: vi.fn(),
 }));
 

--- a/web/src/hooks/QueryParam.ts
+++ b/web/src/hooks/QueryParam.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 export function useQueryParam(queryParam: string) {
     const [query] = useSearchParams();

--- a/web/src/hooks/Revoke.test.ts
+++ b/web/src/hooks/Revoke.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from "@testing-library/react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { useID, useToken } from "@hooks/Revoke";
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
     useSearchParams: vi.fn(),
 }));
 

--- a/web/src/hooks/Revoke.ts
+++ b/web/src/hooks/Revoke.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { Identifier, IdentityToken } from "@constants/SearchParams";
 

--- a/web/src/hooks/RouterNavigate.test.ts
+++ b/web/src/hooks/RouterNavigate.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from "@testing-library/react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { useRouterNavigate } from "@hooks/RouterNavigate";
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
     useNavigate: vi.fn(),
     useSearchParams: vi.fn(),
 }));

--- a/web/src/hooks/RouterNavigate.ts
+++ b/web/src/hooks/RouterNavigate.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { Flow, FlowID, RedirectionURL, SubFlow, UserCode } from "@constants/SearchParams";
 

--- a/web/src/hooks/SignOut.test.ts
+++ b/web/src/hooks/SignOut.test.ts
@@ -1,10 +1,10 @@
 import { renderHook } from "@testing-library/react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { useRouterNavigate } from "@hooks/RouterNavigate";
 import { useSignOut } from "@hooks/SignOut";
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
     useSearchParams: vi.fn(),
 }));
 

--- a/web/src/hooks/SignOut.ts
+++ b/web/src/hooks/SignOut.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { LogoutRoute as SignOutRoute } from "@constants/Routes";
 import { RedirectionRestoreURL, RedirectionURL } from "@constants/SearchParams";

--- a/web/src/views/ConsentPortal/CompletionView.test.tsx
+++ b/web/src/views/ConsentPortal/CompletionView.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import CompletionView from "@views/ConsentPortal/CompletionView";
 

--- a/web/src/views/ConsentPortal/CompletionView.tsx
+++ b/web/src/views/ConsentPortal/CompletionView.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 
 import { useTranslation } from "react-i18next";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import HomeButton from "@components/HomeButton";
 import { Card } from "@components/UI/Card";

--- a/web/src/views/ConsentPortal/ConsentPortal.test.tsx
+++ b/web/src/views/ConsentPortal/ConsentPortal.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import ConsentPortal from "@views/ConsentPortal/ConsentPortal";
 

--- a/web/src/views/ConsentPortal/ConsentPortal.tsx
+++ b/web/src/views/ConsentPortal/ConsentPortal.tsx
@@ -1,7 +1,7 @@
 import { FC, Fragment, lazy, useEffect } from "react";
 
 import { useTranslation } from "react-i18next";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router";
 
 import { ConsentCompletionSubRoute, ConsentOpenIDSubRoute } from "@constants/Routes";
 import { useNotifications } from "@contexts/NotificationsContext";

--- a/web/src/views/ConsentPortal/OpenIDConnect/ConsentPortal.test.tsx
+++ b/web/src/views/ConsentPortal/OpenIDConnect/ConsentPortal.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import ConsentPortal from "@views/ConsentPortal/OpenIDConnect/ConsentPortal";
 

--- a/web/src/views/ConsentPortal/OpenIDConnect/ConsentPortal.tsx
+++ b/web/src/views/ConsentPortal/OpenIDConnect/ConsentPortal.tsx
@@ -1,6 +1,6 @@
 import { FC, lazy } from "react";
 
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router";
 
 import { ConsentDecisionSubRoute, ConsentOpenIDDeviceAuthorizationSubRoute } from "@constants/Routes";
 import { UserInfo } from "@models/UserInfo";

--- a/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.test.tsx
+++ b/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.test.tsx
@@ -6,8 +6,8 @@ vi.mock("react-i18next", () => ({
     useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock("react-router-dom", async () => {
-    const actual = await vi.importActual("react-router-dom");
+vi.mock("react-router", async () => {
+    const actual = await vi.importActual("react-router");
     return { ...actual, useNavigate: () => vi.fn() };
 });
 

--- a/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
+++ b/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
@@ -3,7 +3,7 @@ import { KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from
 import { BroadcastChannel } from "broadcast-channel";
 import { Eye, EyeOff } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import { Alert, AlertTitle } from "@components/UI/Alert";
 import { Button } from "@components/UI/Button";

--- a/web/src/views/LoginPortal/LoginPortal.test.tsx
+++ b/web/src/views/LoginPortal/LoginPortal.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import { useLocalStorageMethodContext } from "@contexts/LocalStorageMethodContext";
 import { useNotifications } from "@contexts/NotificationsContext";

--- a/web/src/views/LoginPortal/LoginPortal.tsx
+++ b/web/src/views/LoginPortal/LoginPortal.tsx
@@ -1,7 +1,7 @@
 import { Fragment, ReactNode, lazy, useCallback, useEffect, useState } from "react";
 
 import { useTranslation } from "react-i18next";
-import { Route, Routes, useLocation } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router";
 
 import {
     AuthenticatedRoute,

--- a/web/src/views/LoginPortal/SecondFactor/SecondFactorForm.test.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/SecondFactorForm.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import { SecondFactorMethod } from "@models/Methods";
 import { AuthenticationLevel } from "@services/State";

--- a/web/src/views/LoginPortal/SecondFactor/SecondFactorForm.tsx
+++ b/web/src/views/LoginPortal/SecondFactor/SecondFactorForm.tsx
@@ -2,7 +2,7 @@ import { lazy, useState } from "react";
 
 import { browserSupportsWebAuthn } from "@simplewebauthn/browser";
 import { useTranslation } from "react-i18next";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router";
 
 import LogoutButton from "@components/LogoutButton";
 import SwitchUserButton from "@components/SwitchUserButton";

--- a/web/src/views/LoginPortal/SignOut/SignOut.test.tsx
+++ b/web/src/views/LoginPortal/SignOut/SignOut.test.tsx
@@ -6,7 +6,7 @@ vi.mock("react-i18next", () => ({
     useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
     useSearchParams: () => [new URLSearchParams(), vi.fn()],
 }));
 

--- a/web/src/views/LoginPortal/SignOut/SignOut.tsx
+++ b/web/src/views/LoginPortal/SignOut/SignOut.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import axios from "axios";
 import { useTranslation } from "react-i18next";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 
 import { IndexRoute } from "@constants/Routes";
 import { RedirectionRestoreURL, RedirectionURL } from "@constants/SearchParams";

--- a/web/src/views/ResetPassword/ResetPasswordStep1.test.tsx
+++ b/web/src/views/ResetPassword/ResetPasswordStep1.test.tsx
@@ -8,7 +8,7 @@ vi.mock("react-i18next", () => ({
     useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
     useNavigate: () => mockNavigate,
 }));
 

--- a/web/src/views/ResetPassword/ResetPasswordStep1.tsx
+++ b/web/src/views/ResetPassword/ResetPasswordStep1.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import ComponentWithTooltip from "@components/ComponentWithTooltip";
 import { Button } from "@components/UI/Button";

--- a/web/src/views/ResetPassword/ResetPasswordStep2.test.tsx
+++ b/web/src/views/ResetPassword/ResetPasswordStep2.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import { completeResetPasswordProcess } from "@services/ResetPassword";
 import ResetPasswordStep2 from "@views/ResetPassword/ResetPasswordStep2";

--- a/web/src/views/ResetPassword/ResetPasswordStep2.tsx
+++ b/web/src/views/ResetPassword/ResetPasswordStep2.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Eye, EyeOff } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 import PasswordMeter from "@components/PasswordMeter";
 import { Button } from "@components/UI/Button";

--- a/web/src/views/Settings/SettingsRouter.test.tsx
+++ b/web/src/views/Settings/SettingsRouter.test.tsx
@@ -1,5 +1,5 @@
 import { act, render } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import { useAutheliaState } from "@hooks/State";
 import SettingsRouter from "@views/Settings/SettingsRouter";

--- a/web/src/views/Settings/SettingsRouter.tsx
+++ b/web/src/views/Settings/SettingsRouter.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router";
 
 import { IndexRoute, SecuritySubRoute, SettingsTwoFactorAuthenticationSubRoute } from "@constants/Routes";
 import { useRouterNavigate } from "@hooks/RouterNavigate";


### PR DESCRIPTION
Since v7 the `react-router-dom` package is nothing more than a re-export of `react-router`, and it has no v8 release; the last published version is `7.18.2`. Depending on it means depending on a shim that is no longer maintained alongside the package it wraps, so we now depend on `react-router` directly at `8.3.0` and import from it everywhere.

In practice the router runtime was already v8 before this change. The `overrides` block in `web/pnpm-workspace.yaml` pins `react-router` to `8.3.0`, and `react-router-dom@7.18.2` resolved against that pin, so the only thing this removes is the indirection.

Every symbol the frontend uses (`BrowserRouter`, `MemoryRouter`, `Route`, `Routes`, `useLocation`, `useNavigate`, `useSearchParams`) is still exported from the `react-router` root in v8, so no call sites change. The source diff is limited to the import specifiers and the matching `vi.mock` targets in the tests.

The `engines.node` floor moves from `>=22.13.1` to `>=22.22.0` to match the range `react-router@8.3.0` declares, so the constraint we advertise is not looser than the one our dependencies require.