### PR TITLE
ci(renovate): add pnpm dedupe post update option

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -83,6 +83,7 @@
     }
   ],
   "postUpdateOptions": [
-    "gomodTidy"
+    "gomodTidy",
+    "pnpmDedupe"
   ]
 }


### PR DESCRIPTION
Adds the `pnpmDedupe` post update option so Renovate runs `pnpm dedupe` after it refreshes `pnpm-lock.yaml`. Without it an update that widens a dependency range leaves redundant duplicate entries in the lockfile, which then have to be cleaned up by hand in a follow up commit.