### PR TITLE
build(deps): update @docsearch monorepo to v5

### DIFF
--- a/docs/assets/js/docsearch.js
+++ b/docs/assets/js/docsearch.js
@@ -3,7 +3,7 @@ import docsearch from "@docsearch/js";
 docsearch({
   container: "#docsearch",
   appId: "BIQ7DDWR39",
-  indexName: "Production",
+  indices: ["Production"],
   apiKey: "27590c872bf247526427720080358240",
   insights: true
 });

--- a/docs/assets/scss/app.scss
+++ b/docs/assets/scss/app.scss
@@ -96,4 +96,3 @@ body {
 
 // 10. DocSearch
 @import "common/variables-docsearch";
-@import "@docsearch/css/dist/modal";

--- a/docs/config/_default/module.toml
+++ b/docs/config/_default/module.toml
@@ -79,6 +79,10 @@
   target = "assets/svgs/tabler-icons"
 
 [[mounts]]
+  source = "node_modules/@docsearch/css/dist"
+  target = "assets/css/docsearch"
+
+[[mounts]]
   source = "node_modules/@thulite/images/assets"
   target = "assets"
 

--- a/docs/layouts/_partials/head/custom-head.html
+++ b/docs/layouts/_partials/head/custom-head.html
@@ -1,1 +1,9 @@
 <!-- Custom head -->
+{{ if site.Params.add_ons.docSearch -}}
+{{/* @docsearch/css is compiled output, not Sass source, and since v5 it ships Media Queries Level 4
+     range syntax which libsass can't parse. Link the modal bundle through the asset pipeline instead
+     of importing it into scss/app.scss. head/custom-head renders after head/stylesheet, so the
+     cascade order matches the @import this replaced. */}}
+{{ $docsearch := resources.Get "css/docsearch/modal.css" | resources.Fingerprint "sha512" -}}
+<link rel="stylesheet" href="{{ $docsearch.RelPermalink }}" integrity="{{ $docsearch.Data.Integrity }}" crossorigin="anonymous">
+{{ end -}}

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,8 +13,8 @@
     "preview": "vite preview --outDir public"
   },
   "dependencies": {
-    "@docsearch/css": "4.7.0",
-    "@docsearch/js": "4.7.0",
+    "@docsearch/css": "5.0.3",
+    "@docsearch/js": "5.0.3",
     "@tabler/icons": "3.46.0",
     "@thulite/core": "1.5.9",
     "@thulite/doks-core": "1.9.3",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -23,11 +23,11 @@ importers:
   .:
     dependencies:
       '@docsearch/css':
-        specifier: 4.7.0
-        version: 4.7.0
+        specifier: 5.0.3
+        version: 5.0.3
       '@docsearch/js':
-        specifier: 4.7.0
-        version: 4.7.0
+        specifier: 5.0.3
+        version: 5.0.3
       '@tabler/icons':
         specifier: 3.46.0
         version: 3.46.0
@@ -677,11 +677,11 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@docsearch/css@4.7.0':
-    resolution: {integrity: sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==}
+  '@docsearch/css@5.0.3':
+    resolution: {integrity: sha512-0ySbB5MsKdRH6+eipZRFGyOUT/kaxtfaG28B5/CBLH9GF9LltXPhlldzkYZa0d1uDxRP0UZjT63krdbzUzYkKA==}
 
-  '@docsearch/js@4.7.0':
-    resolution: {integrity: sha512-x5lCqu1tetgsJFkjQ6VSocbHldsRkGEgwg5N98Vx21sq/V5wcmj4u226PY9k+TEpIgQ772zlYbPLTPicWyGnpA==}
+  '@docsearch/js@5.0.3':
+    resolution: {integrity: sha512-YimVtMfwXbkfZkT8CYvQATU7vUP0SQPZxtwt/qg4RUT3m9gBYDHRi4Dus3/vlaeMaHU6HiSj0Fh0pM+xRu9CLg==}
 
   '@fullhuman/postcss-purgecss@8.0.0':
     resolution: {integrity: sha512-fSRaBGf6+DYdfQMxedWfnIW8FSYE1LBpgy16jpK1L2vNb1HgeBRRZ+UX4UokNmW7YEAwPdvwkKdYtlkYpH+Aqg==}
@@ -2434,9 +2434,9 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@docsearch/css@4.7.0': {}
+  '@docsearch/css@5.0.3': {}
 
-  '@docsearch/js@4.7.0': {}
+  '@docsearch/js@5.0.3': {}
 
   '@fullhuman/postcss-purgecss@8.0.0(postcss@8.5.26)':
     dependencies:


### PR DESCRIPTION
DocSearch v5 is a breaking release for both `@docsearch/css` and `@docsearch/js`, and each of the Renovate branches fails the `docs` external suite on its own.

`@docsearch/js` v5 replaces the `indexName` option with an `indices` array, so the existing call throws `Must supply at least one indices entry for DocSearch` during init. The modal never mounts and `TestHomepageRendersAndSearch` times out waiting for `#docsearch-input`. Upstream documents `indices` as the replacement, so the call now passes `indices: ["Production"]`.

`@docsearch/css` v5 breaks the Hugo build before the dev server comes up. It ships `dist/modal.scss` alongside `dist/modal.css`, which makes the extensionless `@import "@docsearch/css/dist/modal"` ambiguous, and pinning the extension only surfaces the real problem: the compiled bundle uses Media Queries Level 4 range syntax such as `@media screen and (width>=768px)` which libsass cannot parse.

The `.scss` files are not a way out of this. Upstream is explicit that they are the compiled bundle written to a second extension rather than Sass sources, and the documented modal integration imports plain CSS. Neither can we transpile with Dart Sass. `@thulite/core` hardcodes `"transpiler" "libsass"` in `head/libsass.html`, so Hugo keeps using libsass even when the `sass` binary is on `PATH` and `hugo env` reports it, and the Doks v1.9 upgrade guide states that Dart Sass support arrives in a future release. Forcing `dartsass` fails in the theme's own stylesheets where `@thulite/doks-core` bare `@extend`s Bootstrap 4 classes that Bootstrap 5 removed.

The modal bundle is therefore mounted into `assets` and linked through the asset pipeline instead of being imported into `scss/app.scss`. `head/custom-head` renders after `head/stylesheet`, so `modal.css` still loads after `main.css` and the cascade order matches the `@import` it replaces, which the unprefixed `.DocSearch-Hit-icon` and `.DocSearch-Hits mark` overrides in `_custom.scss` rely on.

Only `modal.css` is linked. v4 bundled the Ask AI styles into it and v5 splits them into `_askai.css`, however `askAi` is not configured so nothing renders them. The root `style.css` is deliberately avoided as its `:root` block would load after `main.css` and override the theming in `_variables-docsearch.scss`.

Closes #12698, Closes #12699.