### PR TITLE
Fix systemd dependency loop

### DIFF
--- a/authelia.service
+++ b/authelia.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Authelia authentication and authorization server
 Documentation=https://www.authelia.com
-After=multi-user.target
+After=network-online.target
 
 [Service]
 User=authelia

--- a/authelia@.service
+++ b/authelia@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Authelia authentication and authorization server
 Documentation=https://www.authelia.com
-After=multi-user.target
+After=network-online.target
 
 [Service]
 User=authelia


### PR DESCRIPTION
Hi,

I've had issues with Authelia creating a dependency loop when configuring its ordering with other oidc-reliant services (in my case, [Komga](https://github.com/gotson/komga)).

It is reasonable to want apps reliant on Authelia to start after it. In the case of Komga, it is even mandatory (the server will crash if an OIDC backend is configured but not found). Thus my komga service file has the following:

```
[Unit]
After=network-online.target authelia.service
BindsTo=authelia.service

[Install]
WantedBy=multi-user.target
```

This however causes a systemd dependency loop once enabled, due to authelia's curious choice of setting both `After=multi-user.target` and `WantedBy=multi-user.target`.

I do not understand the justification for this choice in https://github.com/authelia/authelia/pull/1883 ; there is to my knowledge no mysql server service bundled with the authelia package on Debian, so I assume this user's personal setup is being awkwardly accomodated. They should probably just override their Authelia service file with something like `After=mysql.service`. I have done this with lldap in my setup and have encountered no issue.

In any case, I think reverting to a more common `After=network-online.target` is for the best. I've confirmed it fixes the dependency loop and works just fine.