### PR TITLE
ci(golangci-lint): replace goimports-reviser with gci

### DIFF
--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -61,8 +61,6 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 if [[ $# -eq 0 ]]; then
   FAILED=0
 
-  echo "--- :go::service_dog: Running goimports-reviser"
-  goimports-reviser -rm-unused -format -excludes '*/node_modules,*/*/*/node_modules' -company-prefixes authelia.com,github.com/authelia ./... || FAILED=1
   echo "--- :go::service_dog: Running golangci-lint"
   golangci-lint run || FAILED=1
   echo "--- :yaml::service_dog: Running yamllint"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,9 +82,16 @@ issues:
   max-same-issues: 0
 formatters:
   enable:
+    - gci
     - gofmt
     - goimports
   settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(authelia.com,github.com/authelia)
+        - localmodule
     goimports:
       local-prefixes:
         - github.com/authelia/authelia

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -7,7 +7,7 @@ pre-commit:
       run: |
         COUNT=0
 
-        for TOOL in goimports-reviser golangci-lint pnpm shellcheck trufflehog typos yamllint zizmor; do
+        for TOOL in golangci-lint pnpm shellcheck trufflehog typos yamllint zizmor; do
           if ! command -v ${TOOL} >/dev/null 2>&1; then
             if [ ${COUNT} -eq 0 ]; then
               MISSING=${TOOL}
@@ -34,14 +34,6 @@ pre-commit:
             run: pnpm -s lint && echo "0 issues."
             root: "web/"
             glob: "*.{js,jsx,ts,tsx}"
-            stage_fixed: true
-
-          - name: goimports-reviser
-            run: |
-              goimports-reviser -rm-unused -format \
-              -company-prefixes authelia.com,github.com/authelia {staged_files} 2>/dev/null \
-              && echo "0 issues."
-            glob: "*.go"
             stage_fixed: true
 
           - name: golangci-lint

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -5,15 +5,6 @@ runner:
     format: rdjson
     level: error
 
-  goimports-reviser:
-    cmd: >-
-      goimports-reviser -rm-unused -format
-      -excludes '*/node_modules,*/*/*/node_modules'
-      -company-prefixes authelia.com,github.com/authelia ./...
-      ; git diff --no-prefix -- '*.go'
-    format: diff
-    level: error
-
   golangci:
     cmd: golangci-lint run
     errorformat:

--- a/docs/content/contributing/development/build-and-test.md
+++ b/docs/content/contributing/development/build-and-test.md
@@ -152,4 +152,3 @@ go build -ldflags "-linkmode=external -s -w" -trimpath -buildmode=pie -o autheli
 [Docker]: https://docs.docker.com/get-docker/
 [Docker Compose]: https://docs.docker.com/compose/install/
 [golangci-lint]: https://golangci-lint.run/usage/install/
-[goimports-reviser]: https://github.com/incu6us/goimports-reviser#install

--- a/docs/content/contributing/development/environment.md
+++ b/docs/content/contributing/development/environment.md
@@ -49,7 +49,6 @@ If you wish to use these other tools we will not be able to provide support.
 These additional tools are recommended:
 
 * [golangci-lint]
-* [goimports-reviser]
 * [yamllint]
 * [VSCodium] or [GoLand]
 
@@ -116,7 +115,6 @@ this for you and creates the relevant hosts entries. This is automatically execu
 [Docker]: https://docs.docker.com/get-docker/
 [Docker Compose]: https://docs.docker.com/compose/install/
 [golangci-lint]: https://golangci-lint.run/welcome/install/
-[goimports-reviser]: https://github.com/incu6us/goimports-reviser#install
 [yamllint]: https://yamllint.readthedocs.io/en/stable/quickstart.html
 [VSCodium]: https://vscodium.com/
 [GoLand]: https://www.jetbrains.com/go/

--- a/docs/content/contributing/guidelines/testing.md
+++ b/docs/content/contributing/guidelines/testing.md
@@ -59,7 +59,6 @@ consistency. These linters generally run via [lefthook](https://lefthook.dev/) w
 |                               Tool                                |           Area            |                  Purpose                   |
 |:-----------------------------------------------------------------:|:-------------------------:|:------------------------------------------:|
 |            [golangci-Lint](https://golangci-lint.run/)            |            Go             |  Code Quality and Consistency of Go Code   |
-| [goimports-reviser](https://github.com/incu6us/goimports-reviser) |            Go             |          Import Order Consistency          |
 |                              ESLint                               | JavaScript and TypeScript | Code Quality and Consistency of JS/TS Code |
 |       [ShellCheck](https://github.com/koalaman/shellcheck)        |        Shell Files        |        Code Quality and Consistency        |
 |        [yamllint](https://github.com/adrienverge/yamllint)        |        YAML Files         |         Consistent YAML Formatting         |


### PR DESCRIPTION
The import convention is four groups: the standard library, general third party packages, the company packages under `authelia.com` and `github.com/authelia`, and the project itself. `goimports` cannot express this because `local-prefixes` describes a single trailing group no matter how many prefixes are listed, so it tolerates the existing layout but merges the company group into the third party group whenever it formats a file, which `goimports-reviser` then has to undo.

`gci` is enabled to enforce it as its sections accept an ordered list, with `prefix` covering both company prefixes and `localmodule` resolving the project. It is bundled with `golangci-lint` so it replaces a separately installed binary, and it runs after `goimports` so the two no longer disagree about the result.

Equivalence was established by scrambling the import block of all six hundred and thirteen files which have one and formatting the result with each tool: the output is byte identical, including the twenty six generated files both correctly decline to touch. `goimports-reviser` is therefore removed from the reviewdog runners, the lint step, the git hooks and the contributor documentation.