### PR TITLE
fix(middlewares): include the error a session was not retrieved with

### DIFF
--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -380,7 +380,7 @@ func (ctx *AutheliaCtx) GetSession() (userSession session.UserSession, err error
 	}
 
 	if userSession, err = provider.GetSession(ctx.RequestCtx); err != nil {
-		ctx.Logger.Error("Unable to retrieve user session")
+		ctx.Logger.WithError(err).Error("Unable to retrieve user session")
 		return provider.NewDefaultUserSession(), nil
 	}
 


### PR DESCRIPTION
Every neighbouring path in `GetSession` reports what went wrong with `WithError`, but the one that runs when the session provider fails logs only that the session could not be retrieved. A store that is briefly unreachable is therefore indistinguishable in the log from one that answered, and the failure that follows names neither the provider nor the error it returned.

This is the whole of what a flaky `HighAvailability` suite failure left behind: the session read failed while redis was converging, the user was returned to the sign in page, and nothing recorded why.