### PR TITLE
test(suites): keep what a failing browser test leaves behind

### DIFF
--- a/.buildkite/steps/e2epackages.sh
+++ b/.buildkite/steps/e2epackages.sh
@@ -11,6 +11,7 @@ cat << EOF
       - "screenshots/**/*.png"
       - "screenshots/**/*.html"
       - "screenshots/**/*.resources.json"
+      - "screenshots/**/*.console.json"
       - "screenshots/**/*.containers.log"
       - "internal/suites/testdata/*.actual.png"
     timeout_in_minutes: 20

--- a/.buildkite/steps/e2etests.sh
+++ b/.buildkite/steps/e2etests.sh
@@ -20,6 +20,7 @@ cat << EOF
     command: "authelia-scripts --log-level debug suites test ${SUITE_NAME} --failfast --headless"
     artifact_paths:
       - "screenshots/**/*.access.log"
+      - "screenshots/**/*.console.json"
       - "screenshots/**/*.containers.log"
       - "screenshots/**/*.html"
       - "screenshots/**/*.png"

--- a/internal/suites/action_visit.go
+++ b/internal/suites/action_visit.go
@@ -33,7 +33,14 @@ func (s *RodSuite) doSetupTest(url string) {
 	defer cancel()
 
 	s.Page = s.doCreateTab(s.T(), url)
-	s.verifyIsHome(s.T(), s.Context(ctx))
+
+	page := s.Context(ctx)
+
+	require.NoError(s.T(), page.WaitLoad())
+
+	s.doReloadIfRenderWasLost(s.T(), page, url)
+
+	s.verifyIsHome(s.T(), page)
 }
 
 func (rs *RodSession) doCreateTab(t *testing.T, url string) *rod.Page {
@@ -52,7 +59,21 @@ func (rs *RodSession) doCreateTab(t *testing.T, url string) *rod.Page {
 			return
 		}
 
-		page, err := browser.Page(proto.TargetCreateTarget{URL: url})
+		page, err := browser.Page(proto.TargetCreateTarget{})
+		if err != nil {
+			created <- tab{err: err}
+
+			return
+		}
+
+		// Installed before the tab reaches its target, because a document that has already loaded cannot
+		// be given the recording afterwards, and the first page of a test is the one these failures land
+		// on: a portal that never renders renders nothing to navigate away from.
+		if _, err = page.EvalOnNewDocument(consoleCollector); err != nil {
+			log.Debugf("Error installing the console collector: %v", err)
+		}
+
+		err = page.Navigate(url)
 
 		created <- tab{page: page, err: err}
 	}()

--- a/internal/suites/console_test.go
+++ b/internal/suites/console_test.go
@@ -1,0 +1,125 @@
+//go:build !externalsuites
+// +build !externalsuites
+
+package suites
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testConsoleDocument = `<!doctype html>
+<html><body><script>
+console.warn('a warning');
+console.error('an error');
+Promise.reject(new Error('a rejection'));
+setTimeout(() => { throw new Error('an exception') }, 0);
+</script></body></html>`
+
+type consoleRecord struct {
+	Installed bool `json:"installed"`
+	Entries   []struct {
+		Kind string `json:"kind"`
+		Text string `json:"text"`
+	} `json:"entries"`
+}
+
+func TestConsoleCollector(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping browser test in short mode")
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+
+		_, err := w.Write([]byte(testConsoleDocument))
+		require.NoError(t, err)
+	})
+
+	server := httptest.NewServer(mux)
+
+	t.Cleanup(server.Close)
+
+	session := newVisitSession(t)
+
+	read := func(t *testing.T, page interface {
+		Eval(string, ...any) (*proto.RuntimeRemoteObject, error)
+	}) consoleRecord {
+		value, err := page.Eval(diagnosticsConsole)
+		require.NoError(t, err)
+
+		var record consoleRecord
+
+		require.NoError(t, json.Unmarshal([]byte(value.Value.Str()), &record))
+
+		return record
+	}
+
+	t.Run("ShouldReportThatItWasNotInstalled", func(t *testing.T) {
+		page, err := session.WebDriver.Page(proto.TargetCreateTarget{URL: server.URL})
+		require.NoError(t, err)
+		require.NoError(t, page.WaitLoad())
+
+		record := read(t, page)
+
+		assert.False(t, record.Installed, "an absent recording is reported as absent rather than as an empty one")
+		assert.Empty(t, record.Entries)
+	})
+
+	// The tab is opened at about:blank and navigated, rather than created at its target, so that the
+	// recording covers the first document too. A portal that fails on its very first load leaves no
+	// later navigation to carry the collector.
+	t.Run("ShouldRecordTheFirstDocumentOfATab", func(t *testing.T) {
+		session := newVisitSession(t)
+
+		page := session.doCreateTab(t, server.URL)
+		require.NoError(t, page.WaitLoad())
+
+		record := read(t, page)
+
+		require.True(t, record.Installed, "the first document a tab loads carries the recording")
+
+		kinds := map[string]string{}
+
+		for _, entry := range record.Entries {
+			kinds[entry.Kind] = entry.Text
+		}
+
+		assert.Contains(t, kinds, "error")
+	})
+
+	t.Run("ShouldRecordWhatThePageReported", func(t *testing.T) {
+		page, err := session.WebDriver.Page(proto.TargetCreateTarget{URL: "about:blank"})
+		require.NoError(t, err)
+
+		_, err = page.EvalOnNewDocument(consoleCollector)
+		require.NoError(t, err)
+
+		// Installed ahead of the navigation rather than on the document in front of it, which is how the
+		// suites install it: the load a test fails on is a later one than the tab was opened at.
+		require.NoError(t, page.Navigate(server.URL))
+		require.NoError(t, page.WaitLoad())
+
+		record := read(t, page)
+
+		require.True(t, record.Installed)
+
+		kinds := map[string]string{}
+
+		for _, entry := range record.Entries {
+			kinds[entry.Kind] = entry.Text
+		}
+
+		assert.Contains(t, kinds, "warn")
+		assert.Contains(t, kinds, "error")
+		assert.Contains(t, kinds["error"], "an error")
+	})
+}

--- a/internal/suites/environment.go
+++ b/internal/suites/environment.go
@@ -14,6 +14,9 @@ import (
 	"github.com/authelia/authelia/v4/internal/utils"
 )
 
+// suitesWithTraefikProxy matches suite names that run behind Traefik, which is what writes the access log.
+var suitesWithTraefikProxy = regexp.MustCompile(`^(OIDCTraefik|PathPrefix|Traefik2|Traefik3)$`)
+
 // suitesWithoutFrontend matches suite names that do not include the authelia-frontend service.
 var suitesWithoutFrontend = regexp.MustCompile(`^CLI$`)
 
@@ -70,7 +73,7 @@ func waitUntilAutheliaFrontendIsReady(dockerEnvironment *DockerEnvironment) erro
 		dockerEnvironment,
 		"authelia-frontend",
 		time.Time{},
-		[]string{"dev server running at", "ready in", "server restarted"})
+		[]string{"ready in"})
 }
 
 func waitUntilAutheliaFrontendRestarted(dockerEnvironment *DockerEnvironment, since time.Time) error {
@@ -80,7 +83,7 @@ func waitUntilAutheliaFrontendRestarted(dockerEnvironment *DockerEnvironment, si
 		dockerEnvironment,
 		"authelia-frontend",
 		since,
-		[]string{"Watching for file changes"})
+		[]string{"server restarted"})
 }
 
 func waitUntilK3DIsReady(dockerEnvironment *DockerEnvironment) error {

--- a/internal/suites/example/compose/authelia/compose.frontend.dev.yml
+++ b/internal/suites/example/compose/authelia/compose.frontend.dev.yml
@@ -2,7 +2,6 @@
 services:
   authelia-frontend:
     cpus: 2
-    mem_limit: 4g
     build:
       context: 'example/compose/authelia'
       dockerfile: 'Dockerfile.frontend'

--- a/internal/suites/main_test.go
+++ b/internal/suites/main_test.go
@@ -4,12 +4,19 @@
 package suites
 
 import (
+	"flag"
 	"os"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
+	flag.Parse()
+
+	startArtifactWatchdog()
+
 	code := m.Run()
+
+	discardWatchdogArtifacts()
 
 	closeSharedBrowsers()
 

--- a/internal/suites/suite_high_availability_test.go
+++ b/internal/suites/suite_high_availability_test.go
@@ -112,6 +112,19 @@ func (s *HighAvailabilityWebDriverSuite) redisReplica(sentinel string) string {
 	return ""
 }
 
+func (s *HighAvailabilityWebDriverSuite) doStartAndSettle(service, observer string) {
+	since := time.Now()
+
+	s.Require().NoError(haDockerEnvironment.Start(service))
+
+	// Reported for anything the sentinel had marked down, so it covers a returning node and a returning
+	// sentinel alike.
+	s.Require().NoError(waitUntilServiceLog(haDockerEnvironment, observer, "-sdown", since))
+
+	// Resolving the master confirms the sentinels agree on one and that the node behind it answers as one.
+	s.redisMaster(observer)
+}
+
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActive() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 
@@ -129,8 +142,10 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActive() {
 	// returns fails at the first factor.
 	s.redisMaster("redis-sentinel-0")
 
-	s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), "john", "password", false, "")
-	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+	doWithDisruptedDatastore(func() {
+		s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), "john", "password", false, "")
+		s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+	})
 }
 
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrimaryRedisNodeFailure() {
@@ -154,24 +169,25 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrim
 	s.Require().NoError(err)
 
 	defer func() {
-		err = haDockerEnvironment.Start(master)
-		s.Require().NoError(err)
+		s.doStartAndSettle(master, "redis-sentinel-0")
 	}()
 
 	s.Require().NoError(waitUntilServiceLog(haDockerEnvironment, "redis-sentinel-0", "+switch-master authelia", since))
 
-	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
-	s.verifyIsHome(s.T(), s.Context(ctx))
+	doWithDisruptedDatastore(func() {
+		s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
+		s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Verify the user is still authenticated.
-	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
-	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+		// Verify the user is still authenticated.
+		s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
+		s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
 
-	s.doLogout(s.T(), s.Context(ctx))
-	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
+		s.doLogout(s.T(), s.Context(ctx))
+		s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
-	s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), "john", "password", false, fmt.Sprintf("%s/secret.html", SecureBaseURL))
-	s.verifySecretAuthorized(s.T(), s.Context(ctx))
+		s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), "john", "password", false, fmt.Sprintf("%s/secret.html", SecureBaseURL))
+		s.verifySecretAuthorized(s.T(), s.Context(ctx))
+	})
 }
 
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrimaryRedisSentinelFailureAndSecondaryRedisNodeFailure() {
@@ -195,27 +211,27 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserSessionActiveWithPrim
 	s.Require().NoError(err)
 
 	defer func() {
-		err = haDockerEnvironment.Start("redis-sentinel-0")
-		s.Require().NoError(err)
+		s.doStartAndSettle("redis-sentinel-0", "redis-sentinel-1")
 	}()
 
 	err = haDockerEnvironment.Stop(replica)
 	s.Require().NoError(err)
 
 	defer func() {
-		err = haDockerEnvironment.Start(replica)
-		s.Require().NoError(err)
+		s.doStartAndSettle(replica, "redis-sentinel-1")
 	}()
 
 	s.Require().NoError(waitUntilServiceLog(haDockerEnvironment, "redis-sentinel-1", "+sdown sentinel", since))
 	s.Require().NoError(waitUntilServiceLog(haDockerEnvironment, "redis-sentinel-1", "+sdown slave", since))
 
-	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
-	s.verifyIsHome(s.T(), s.Context(ctx))
+	doWithDisruptedDatastore(func() {
+		s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
+		s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Verify the user is still authenticated.
-	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
-	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+		// Verify the user is still authenticated.
+		s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
+		s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+	})
 }
 
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserDataInDB() {
@@ -235,8 +251,10 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepUserDataInDB() {
 
 	s.Require().NoError(waitUntilServiceLog(haDockerEnvironment, "mariadb", "mariadbd: ready for connections", since))
 
-	s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), "john", "password", false, "")
-	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+	doWithDisruptedDatastore(func() {
+		s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), "john", "password", false, "")
+		s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+	})
 }
 
 func (s *HighAvailabilityWebDriverSuite) TestShouldKeepSessionAfterAutheliaRestart() {
@@ -258,18 +276,20 @@ func (s *HighAvailabilityWebDriverSuite) TestShouldKeepSessionAfterAutheliaResta
 	err = waitUntilAutheliaBackendIsReady(haDockerEnvironment, since)
 	s.Require().NoError(err)
 
-	s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
-	s.verifyIsHome(s.T(), s.Context(ctx))
+	doWithDisruptedDatastore(func() {
+		s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
+		s.verifyIsHome(s.T(), s.Context(ctx))
 
-	// Verify the user is still authenticated.
-	s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
-	s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
+		// Verify the user is still authenticated.
+		s.doVisit(s.T(), s.Context(ctx), GetLoginBaseURL(BaseDomain))
+		s.verifyIsSecondFactorPage(s.T(), s.Context(ctx))
 
-	s.doLogout(s.T(), s.Context(ctx))
-	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
+		s.doLogout(s.T(), s.Context(ctx))
+		s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))
 
-	s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), "john", "password", false, fmt.Sprintf("%s/secret.html", SecureBaseURL))
-	s.verifySecretAuthorized(s.T(), s.Context(ctx))
+		s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), "john", "password", false, fmt.Sprintf("%s/secret.html", SecureBaseURL))
+		s.verifySecretAuthorized(s.T(), s.Context(ctx))
+	})
 }
 
 var UserJohn = "john"

--- a/internal/suites/suite_traefik_test.go
+++ b/internal/suites/suite_traefik_test.go
@@ -18,6 +18,14 @@ func NewTraefikSuite(name string) *TraefikSuite {
 	}
 }
 
+func (s *TraefikSuite) dockerEnvironment() *DockerEnvironment {
+	if s.Name == traefik2SuiteName {
+		return traefik2DockerEnvironment
+	}
+
+	return traefik3DockerEnvironment
+}
+
 func (s *TraefikSuite) Test1FAScenario() {
 	suite.Run(s.T(), New1FAScenario())
 }
@@ -58,9 +66,11 @@ func (s *TraefikSuite) TestShouldKeepSessionAfterRedisRestart() {
 	s.doVisit(s.T(), s.Context(ctx), fmt.Sprintf("%s/secret.html", SecureBaseURL))
 	s.verifySecretAuthorized(s.T(), s.Context(ctx))
 
-	err = traefik3DockerEnvironment.Restart("redis")
+	err = s.dockerEnvironment().Restart("redis")
 	s.Require().NoError(err)
 
-	s.doVisit(s.T(), s.Context(ctx), fmt.Sprintf("%s/secret.html", SecureBaseURL))
-	s.verifySecretAuthorized(s.T(), s.Context(ctx))
+	doWithDisruptedDatastore(func() {
+		s.doVisit(s.T(), s.Context(ctx), fmt.Sprintf("%s/secret.html", SecureBaseURL))
+		s.verifySecretAuthorized(s.T(), s.Context(ctx))
+	})
 }

--- a/internal/suites/suites.go
+++ b/internal/suites/suites.go
@@ -25,6 +25,17 @@ type RodSuite struct {
 	RodSuiteCredentialsProvider
 }
 
+// MustClose closes the page when the suite has one. It shadows the method promoted from the embedded
+// page so that a teardown following a setup which failed before the tab was created closes nothing
+// instead of dereferencing a page that was never assigned.
+func (s *RodSuite) MustClose() {
+	if s.Page == nil {
+		return
+	}
+
+	s.Page.MustClose()
+}
+
 // BaseSuite is the base suite which every suite embeds.
 type BaseSuite struct {
 	suite.Suite

--- a/internal/suites/teardown_test.go
+++ b/internal/suites/teardown_test.go
@@ -1,0 +1,39 @@
+//go:build !externalsuites
+// +build !externalsuites
+
+package suites
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A suite whose setup fails before the tab is opened still has its teardown run, because testify defers
+// it, and the page every teardown reaches for was never assigned. Each of these collected against that
+// page unguarded, so the panic replaced the failure the setup had already reported and took the run's
+// remaining results with it.
+func TestTeardownShouldNotPanicWhenTheSetupLeftNoPage(t *testing.T) {
+	t.Run("ShouldNotCollectCoverage", func(t *testing.T) {
+		session := &RodSession{}
+
+		require.NotPanics(t, func() { session.collectCoverage(nil) })
+	})
+
+	t.Run("ShouldNotCollectPage", func(t *testing.T) {
+		session := &RodSession{}
+
+		var err error
+
+		require.NotPanics(t, func() { err = session.collectPage(nil, "TestTeardown") })
+		assert.ErrorIs(t, err, errPageNotCreated)
+	})
+
+	t.Run("ShouldNotClosePage", func(t *testing.T) {
+		suite := &RodSuite{}
+
+		require.Nil(t, suite.Page)
+		require.NotPanics(t, suite.MustClose)
+	})
+}

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -59,6 +59,39 @@ const diagnosticsResources = `() => JSON.stringify({
 	})),
 }, null, 2)`
 
+const consoleCollector = `(() => {
+	if (window.__diagnostics__) {
+		return;
+	}
+
+	const entries = window.__diagnostics__ = [];
+
+	const record = (kind, text) => {
+		if (entries.length < 200) {
+			entries.push({kind: kind, text: String(text).slice(0, 2000)});
+		}
+	};
+
+	for (const level of ['warn', 'error']) {
+		const original = console[level];
+
+		console[level] = (...args) => {
+			record(level, args.map((arg) => (arg instanceof Error ? (arg.stack || arg.message) : arg)).join(' '));
+			original.apply(console, args);
+		};
+	}
+
+	addEventListener('error', (event) => record('exception', event.error && event.error.stack ? event.error.stack : event.message));
+	addEventListener('unhandledrejection', (event) => record('rejection', event.reason && event.reason.stack ? event.reason.stack : event.reason));
+})()`
+
+const diagnosticsConsole = `() => JSON.stringify({
+	installed: Array.isArray(window.__diagnostics__),
+	entries: window.__diagnostics__ || [],
+}, null, 2)`
+
+var errPageNotCreated = errors.New("the page was not created")
+
 // StringToKeys returns the input.Key values which represent the given string.
 func StringToKeys(value string) []input.Key {
 	n := len(value)
@@ -119,11 +152,17 @@ func GetLoginBaseURLWithFallbackPrefix(baseDomain, fallback string) string {
 }
 
 func (rs *RodSession) collectCoverage(page *rod.Page) {
+	if page == nil {
+		return
+	}
+
 	coverageDir := "../../web/.nyc_output"
 
 	resp, err := page.Eval("() => JSON.stringify(window.__coverage__)")
 	if err != nil {
-		log.Fatal(err)
+		log.Errorf("Error collecting coverage: %v", err)
+
+		return
 	}
 
 	coverageData := fmt.Sprintf("%v", resp.Value)
@@ -131,14 +170,14 @@ func (rs *RodSession) collectCoverage(page *rod.Page) {
 	_ = os.MkdirAll(coverageDir, 0775)
 
 	if coverageData != "<nil>" {
-		err = os.WriteFile(fmt.Sprintf("%s/coverage-%s.json", coverageDir, uuid.New().String()), []byte(coverageData), 0664) //nolint:gosec
-		if err != nil {
-			log.Fatal(err)
+		if err = os.WriteFile(fmt.Sprintf("%s/coverage-%s.json", coverageDir, uuid.New().String()), []byte(coverageData), 0664); err != nil { //nolint:gosec
+			log.Errorf("Error writing coverage: %v", err)
+
+			return
 		}
 
-		err = filepath.Walk("../../web/.nyc_output", fixCoveragePath)
-		if err != nil {
-			log.Fatal(err)
+		if err = filepath.Walk("../../web/.nyc_output", fixCoveragePath); err != nil {
+			log.Errorf("Error rewriting coverage paths: %v", err)
 		}
 	}
 }
@@ -301,7 +340,11 @@ func (rs *RodSession) collectContainerLogs(test *testing.T, base string) {
 
 		fmt.Fprintf(&builder, "===== %s =====\n%s\n", name, logs)
 
-		test.Logf("Last %d log lines of '%s':\n%s", containerLogTailLines, name, tailLines(logs, containerLogTailLines))
+		// The watchdog collects without a test to report against, since the timeout it is racing belongs
+		// to the binary rather than to any one test.
+		if test != nil {
+			test.Logf("Last %d log lines of '%s':\n%s", containerLogTailLines, name, tailLines(logs, containerLogTailLines))
+		}
 	}
 
 	if builder.Len() == 0 {
@@ -315,12 +358,15 @@ func (rs *RodSession) collectContainerLogs(test *testing.T, base string) {
 	}
 }
 
-func (rs *RodSession) collectProxyAccessLog(base string) {
+func (rs *RodSession) collectTraefikProxyAccessLog(base string) {
+	if !suitesWithTraefikProxy.MatchString(os.Getenv("SUITE")) {
+		return
+	}
+
 	source := SuiteTmpPath(proxyAccessLog())
 
 	data, err := os.ReadFile(source)
 	if err != nil {
-		// Suites that do not run behind a proxy have no such file.
 		log.Debugf("Error reading '%s': %v", source, err)
 
 		return
@@ -351,6 +397,7 @@ func (rs *RodSession) collectDiagnostics(page *rod.Page, base string) {
 	for name, expression := range map[string]string{
 		base + ".html":           `() => document.documentElement.outerHTML`,
 		base + ".resources.json": diagnosticsResources,
+		base + ".console.json":   diagnosticsConsole,
 	} {
 		path, _ := screenshotPaths(name)
 
@@ -367,22 +414,19 @@ func (rs *RodSession) collectDiagnostics(page *rod.Page, base string) {
 	}
 }
 
-func (rs *RodSession) collectScreenshot(test *testing.T, err error, page *rod.Page) {
-	if !test.Failed() && !errors.Is(err, context.DeadlineExceeded) {
-		return
+func (rs *RodSession) collectPage(page *rod.Page, base string) (err error) {
+	// A test that failed before its tab was created has nothing to photograph, and the container logs the
+	// caller collects alongside this are the whole of what such a failure leaves behind.
+	if page == nil {
+		return errPageNotCreated
 	}
 
-	base := strings.NewReplacer("/", "-", " ", "_").Replace(test.Name())
-
-	defer rs.collectContainerLogs(test, base)
-	defer rs.collectProxyAccessLog(base)
-
-	path, reported := screenshotPaths(base + ".png")
+	path, _ := screenshotPaths(base + ".png")
 
 	if err = os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		log.Errorf("Error creating screenshot directory '%s': %v", filepath.Dir(path), err)
 
-		return
+		return err
 	}
 
 	rs.collectDiagnostics(page, base)
@@ -391,16 +435,36 @@ func (rs *RodSession) collectScreenshot(test *testing.T, err error, page *rod.Pa
 		log.Debugf("Error labeling the screenshot with the page URL: %v", err)
 	}
 
-	data, err := page.Screenshot(true, nil)
-	if err != nil {
-		log.Errorf("Error capturing screenshot for '%s': %v", test.Name(), err)
+	var data []byte
 
-		return
+	if data, err = page.Screenshot(true, nil); err != nil {
+		log.Errorf("Error capturing screenshot '%s': %v", base, err)
+
+		return err
 	}
 
 	if err = os.WriteFile(path, data, 0600); err != nil {
 		log.Errorf("Error writing screenshot '%s': %v", path, err)
 
+		return err
+	}
+
+	return nil
+}
+
+func (rs *RodSession) collectScreenshot(test *testing.T, err error, page *rod.Page) {
+	if !test.Failed() && !errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+
+	base := strings.NewReplacer("/", "-", " ", "_").Replace(test.Name())
+
+	defer rs.collectContainerLogs(test, base)
+	defer rs.collectTraefikProxyAccessLog(base)
+
+	_, reported := screenshotPaths(base + ".png")
+
+	if err = rs.collectPage(page, base); err != nil {
 		return
 	}
 

--- a/internal/suites/watchdog.go
+++ b/internal/suites/watchdog.go
@@ -1,0 +1,151 @@
+package suites
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-rod/rod"
+	log "github.com/sirupsen/logrus"
+)
+
+const watchdogMargin = 5 * time.Second
+
+var (
+	watchdogMutex     sync.Mutex
+	watchdogTimer     *time.Timer
+	watchdogDone      chan struct{}
+	watchdogCollected string
+)
+
+func startArtifactWatchdog() {
+	f := flag.Lookup("test.timeout")
+	if f == nil {
+		return
+	}
+
+	timeout, err := time.ParseDuration(f.Value.String())
+	if err != nil || timeout <= 0 {
+		return
+	}
+
+	if timeout <= watchdogMargin {
+		log.Debugf("Not arming the artifact watchdog: the timeout of %s leaves no room to collect before it", timeout)
+
+		return
+	}
+
+	watchdogDone = make(chan struct{})
+
+	watchdogTimer = time.AfterFunc(timeout-watchdogMargin, func() {
+		defer close(watchdogDone)
+
+		collectWatchdogArtifacts()
+	})
+}
+
+func discardWatchdogArtifacts() {
+	// Stopped so that no collection can begin once the artifacts are gone. Stop reports false once the
+	// callback has been handed to a goroutine of its own, which is before it has necessarily reached the
+	// lock, so the lock alone would let a discard pass an unstarted collection and leave what it went on
+	// to write. Waiting for the callback to return is what closes that.
+	if watchdogTimer != nil {
+		if !watchdogTimer.Stop() {
+			<-watchdogDone
+		}
+
+		// Cleared because Stop reports false for a timer already stopped as readily as for one that has
+		// fired, so a second discard would otherwise wait on a callback that is never going to run.
+		watchdogTimer = nil
+	}
+
+	watchdogMutex.Lock()
+	defer watchdogMutex.Unlock()
+
+	if watchdogCollected == "" {
+		return
+	}
+
+	pattern, _ := screenshotPaths(watchdogCollected + "*")
+
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return
+	}
+
+	for _, match := range matches {
+		if err = os.Remove(match); err != nil {
+			log.Debugf("Error discarding '%s': %v", match, err)
+		}
+	}
+
+	log.Debugf("Discarded %d watchdog artifact(s): the run finished within its timeout", len(matches))
+
+	watchdogCollected = ""
+}
+
+func collectWatchdogArtifacts() {
+	watchdogMutex.Lock()
+	defer watchdogMutex.Unlock()
+
+	log.Warnf("The test binary is approaching its timeout; collecting diagnostics before it expires")
+
+	base := "TIMEOUT"
+
+	if suite := strings.ToUpper(os.Getenv("SUITE")); suite != "" {
+		base = "TIMEOUT-" + suite
+	}
+
+	sharedBrowsersMutex.Lock()
+
+	browsers := make([]*rod.Browser, 0, len(sharedBrowsers))
+
+	for _, shared := range sharedBrowsers {
+		browsers = append(browsers, shared.browser)
+	}
+
+	sharedBrowsersMutex.Unlock()
+
+	// The helpers below are addressed through a session only because that is where they are defined; none
+	// of them read the session itself.
+	rs := &RodSession{}
+
+	// Only the page capture creates this, and the run with no page to capture is the one whose container
+	// logs are the whole of what it leaves behind: a browser that never started, or a setup that expired
+	// before it could.
+	if dir, _ := screenshotPaths(base); dir != "" {
+		if err := os.MkdirAll(filepath.Dir(dir), 0755); err != nil {
+			log.Debugf("Error creating the diagnostics directory: %v", err)
+		}
+	}
+
+	var collected int
+
+	for _, browser := range browsers {
+		pages, err := browser.Pages()
+		if err != nil {
+			log.Debugf("Error listing the pages of a browser: %v", err)
+
+			continue
+		}
+
+		for _, page := range pages {
+			if err = rs.collectPage(page, fmt.Sprintf("%s-page-%d", base, collected)); err != nil {
+				continue
+			}
+
+			collected++
+		}
+	}
+
+	rs.collectContainerLogs(nil, base)
+	rs.collectTraefikProxyAccessLog(base)
+
+	watchdogCollected = base
+
+	log.Warnf("Collected diagnostics for %d page(s) as '%s'", collected, base)
+}

--- a/internal/suites/watchdog_test.go
+++ b/internal/suites/watchdog_test.go
@@ -1,0 +1,111 @@
+//go:build !externalsuites
+// +build !externalsuites
+
+package suites
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The watchdog collects speculatively, while the tests may still be about to finish, so a run that does
+// finish has to take back what it wrote. Without this a suite that merely ran close to its budget uploads
+// a set of timeout artifacts and is annotated as though it had failed.
+//
+// Run under both path layouts because they are different directories: under CI the artifacts are written
+// where the pipeline collects them from, and a discard that only cleaned the local one would leave
+// exactly the files this exists to remove.
+func TestDiscardWatchdogArtifacts(t *testing.T) {
+	for _, tc := range []struct{ name, ci string }{
+		{"Local", ""},
+		{"CI", "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SUITE", "WatchdogUnit")
+			t.Setenv("CI", tc.ci)
+
+			base := "TIMEOUT-WATCHDOGUNIT"
+
+			written := make([]string, 0, 3)
+
+			for _, suffix := range []string{"-page-0.png", "-page-0.console.json", ".containers.log"} {
+				path, _ := screenshotPaths(base + suffix)
+
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+				require.NoError(t, os.WriteFile(path, []byte("x"), 0600))
+
+				written = append(written, path)
+			}
+
+			t.Cleanup(func() {
+				for _, path := range written {
+					_ = os.Remove(path)
+				}
+			})
+
+			watchdogMutex.Lock()
+			watchdogCollected = base
+			watchdogMutex.Unlock()
+
+			discardWatchdogArtifacts()
+
+			for _, path := range written {
+				assert.NoFileExists(t, path, "a run that finished discards what the watchdog collected")
+			}
+		})
+	}
+
+	t.Run("ShouldDoNothingWhenNothingWasCollected", func(t *testing.T) {
+		require.NotPanics(t, discardWatchdogArtifacts)
+	})
+
+	t.Run("ShouldWaitForACollectionThatHasNotReachedTheLock", func(t *testing.T) {
+		t.Setenv("SUITE", "WatchdogUnit")
+
+		base := "TIMEOUT-WATCHDOGUNIT"
+		path, _ := screenshotPaths(base + "-page-0.png")
+
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+
+		t.Cleanup(func() { _ = os.Remove(path) })
+
+		started := make(chan struct{})
+
+		done := make(chan struct{})
+
+		watchdogDone = done
+		watchdogTimer = time.AfterFunc(time.Millisecond, func() {
+			defer close(done)
+
+			close(started)
+
+			// Stands for the interval between the callback being scheduled and it taking the lock, which
+			// is the window the completion signal exists to cover.
+			time.Sleep(time.Millisecond * 200)
+
+			watchdogMutex.Lock()
+			defer watchdogMutex.Unlock()
+
+			require.NoError(t, os.WriteFile(path, []byte("x"), 0600))
+
+			watchdogCollected = base
+		})
+
+		<-started
+
+		discardWatchdogArtifacts()
+
+		// Waited on so the assertion cannot pass merely by running before the collection wrote anything:
+		// a discard that returned early leaves the file behind, and by here it exists.
+		<-done
+
+		assert.NoFileExists(t, path, "the discard waits for the collection rather than passing it")
+
+		watchdogTimer, watchdogDone = nil, nil
+	})
+}

--- a/internal/suites/webdriver.go
+++ b/internal/suites/webdriver.go
@@ -20,14 +20,34 @@ import (
 )
 
 const (
-	elementActionTimeout  = time.Second * 10
-	elementAttemptTimeout = time.Second
-	elementRetryInterval  = time.Millisecond * 50
-	elementStateTimeout   = time.Second * 5
-	pageRenderTimeout     = time.Second * 5
-	setupTestTimeout      = time.Second * 30
-	waitElementsAttempts  = 10
+	elementActionTimeout          = time.Second * 10
+	elementActionTimeoutDisrupted = time.Second * 30
+	elementAttemptTimeout         = time.Second
+	elementLocateTimeout          = time.Second * 20
+	elementLocateTimeoutDisrupted = time.Second * 45
+	elementRetryInterval          = time.Millisecond * 50
+	elementStateTimeout           = time.Second * 5
+	pageRenderTimeout             = time.Second * 5
+	setupTestTimeout              = time.Second * 30
+	waitElementsAttempts          = 10
 )
+
+var (
+	elementActionBudget = elementActionTimeout
+	elementLocateBudget = elementLocateTimeout
+)
+
+func doWithDisruptedDatastore(fn func()) {
+	previousAction, previousLocate := elementActionBudget, elementLocateBudget
+
+	elementActionBudget, elementLocateBudget = elementActionTimeoutDisrupted, elementLocateTimeoutDisrupted
+
+	defer func() {
+		elementActionBudget, elementLocateBudget = previousAction, previousLocate
+	}()
+
+	fn()
+}
 
 // RodSession binding a chrome session with devtool protocol.
 type RodSession struct {
@@ -249,11 +269,33 @@ func (rs *RodSession) CheckElementExistsLocatedByID(t *testing.T, page *rod.Page
 
 // WaitElementLocatedBySelector waits for an element matching the CSS selector to appear in the DOM.
 func (rs *RodSession) WaitElementLocatedBySelector(t *testing.T, page *rod.Page, selector string) *rod.Element {
-	e, err := page.Element(selector)
-	require.NoError(t, err)
-	require.NotNil(t, e)
+	// Bounded here rather than left to the page's context, which is the whole of what remains of the test.
+	// An element that never appears would otherwise spend the budget every later step still needed and
+	// report only that a deadline passed, naming neither the element nor what it was doing, which is what
+	// a portal that renders nothing looks like from the outside.
+	ctx, cancel := context.WithTimeout(page.GetContext(), elementLocateBudget)
 
-	return e
+	defer cancel()
+
+	found, err := page.Context(ctx).Element(selector)
+	if err != nil {
+		require.FailNowf(t, "Element was not located",
+			"selector '%s' did not appear within %s: %v\nelement state: %s",
+			selector, elementLocateBudget, err, describeElement(page, selector))
+
+		return nil
+	}
+
+	// Rebound onto the page the caller gave, from the object the wait already found. An element carries
+	// the page it was located on and hands it to everything derived from it, so returning it as it stands
+	// would leave a frame descended into afterwards on the context this cancels. Rebinding rather than
+	// looking the element up a second time, because a second lookup can miss one that has since left the
+	// document, which is what a page mid-render does between two states.
+	element, err := page.ElementFromObject(found.Object)
+	require.NoError(t, err)
+	require.NotNil(t, element)
+
+	return element
 }
 
 // WaitElementLocatedByClassName waits for an element located by class name.
@@ -362,7 +404,7 @@ func (rs *RodSession) waitElementTextIsNot(t *testing.T, page *rod.Page, selecto
 }
 
 func (rs *RodSession) waitElementText(t *testing.T, page *rod.Page, selector, value string, equal bool) {
-	ctx, cancel := context.WithTimeout(page.GetContext(), elementActionTimeout)
+	ctx, cancel := context.WithTimeout(page.GetContext(), elementActionBudget)
 
 	defer cancel()
 
@@ -399,7 +441,7 @@ func (rs *RodSession) waitElementText(t *testing.T, page *rod.Page, selector, va
 }
 
 func (rs *RodSession) doElementAction(t *testing.T, page *rod.Page, selector string, action func(element *rod.Element) error) {
-	ctx, cancel := context.WithTimeout(page.GetContext(), elementActionTimeout)
+	ctx, cancel := context.WithTimeout(page.GetContext(), elementActionBudget)
 
 	defer cancel()
 
@@ -410,7 +452,7 @@ func (rs *RodSession) doElementAction(t *testing.T, page *rod.Page, selector str
 
 	require.Failf(t, "Element action did not succeed",
 		"selector '%s' gave up after %s: %v\nelement state: %s",
-		selector, elementActionTimeout, err, describeElement(page, selector))
+		selector, elementActionBudget, err, describeElement(page, selector))
 }
 
 func retryElementAction(page *rod.Page, selector string, action func(element *rod.Element) error) error {

--- a/internal/suites/webdriver_wait_test.go
+++ b/internal/suites/webdriver_wait_test.go
@@ -1,0 +1,139 @@
+//go:build !externalsuites
+// +build !externalsuites
+
+package suites
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testWaitDocument = `<!doctype html>
+<html><body><div id="present">here</div>
+<iframe srcdoc="<html><body><strong id='inner'>framed</strong></body></html>"></iframe></body></html>`
+
+func newWaitServer(t *testing.T) *httptest.Server {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+
+		_, err := w.Write([]byte(testWaitDocument))
+		require.NoError(t, err)
+	})
+
+	server := httptest.NewServer(mux)
+
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func TestWaitElementLocatedBySelector(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping browser test in short mode")
+	}
+
+	server := newWaitServer(t)
+	session := newVisitSession(t)
+
+	newPage := func(t *testing.T) *rod.Page {
+		page, err := session.WebDriver.Page(proto.TargetCreateTarget{URL: server.URL})
+		require.NoError(t, err)
+		require.NoError(t, page.WaitLoad())
+
+		return page
+	}
+
+	t.Run("ShouldReturnAnElementThatOutlivesTheWait", func(t *testing.T) {
+		page := newPage(t)
+
+		element := session.WaitElementLocatedByID(t, page, "present")
+		require.NotNil(t, element)
+
+		// The wait bounds itself with a context it cancels on the way out, so an element still bound to it
+		// would be unusable by the time the caller received it.
+		text, err := element.Text()
+		require.NoError(t, err)
+		assert.Equal(t, "here", text)
+	})
+
+	// The element carries the page it was found on and hands it to everything derived from it, so an
+	// element rebound to the caller's context while still holding the page the wait bounded descends into
+	// a frame that is already cancelled. This is what the templates suite hit.
+	t.Run("ShouldReturnAnElementWhosePageOutlivesTheWait", func(t *testing.T) {
+		page := newPage(t)
+
+		element := session.WaitElementLocatedBySelector(t, page, "iframe")
+		require.NotNil(t, element)
+
+		frame, err := element.Frame()
+		require.NoError(t, err, "the frame is descended into on the caller's context, not the wait's")
+
+		inner, err := frame.Element("#inner")
+		require.NoError(t, err)
+
+		text, err := inner.Text()
+		require.NoError(t, err)
+		assert.Equal(t, "framed", text)
+	})
+
+	t.Run("ShouldGiveUpOnTheBudgetRatherThanThePageContext", func(t *testing.T) {
+		page := newPage(t)
+
+		// A page context far longer than the budget, so whichever of the two ends the wait is unambiguous.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+
+		defer cancel()
+
+		previous := elementLocateBudget
+		elementLocateBudget = 2 * time.Second
+
+		defer func() { elementLocateBudget = previous }()
+
+		reported := &testing.T{}
+		started := time.Now()
+
+		// Runs on its own goroutine because the failure is reported with FailNow, which ends the goroutine
+		// it happens on rather than returning.
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			session.WaitElementLocatedByID(reported, page.Context(ctx), "absent")
+		}()
+
+		<-done
+
+		elapsed := time.Since(started)
+
+		// The ceiling is the budget the wait was given plus the state it gathers to report with the
+		// failure, so that raising either constant does not leave this asserting against a stale number.
+		ceiling := elementLocateBudget + elementStateTimeout + time.Second*5
+
+		assert.True(t, reported.Failed(), "the wait reports a failure when the element never appears")
+		assert.Less(t, elapsed, ceiling, "the wait ends on its own budget rather than the page context")
+		assert.GreaterOrEqual(t, elapsed, elementLocateBudget, "the wait spends its budget before giving up")
+	})
+
+	t.Run("ShouldRaiseTheBudgetsWhileTheDatastoreIsDisrupted", func(t *testing.T) {
+		require.Equal(t, elementLocateTimeout, elementLocateBudget)
+
+		doWithDisruptedDatastore(func() {
+			assert.Equal(t, elementLocateTimeoutDisrupted, elementLocateBudget)
+			assert.Equal(t, elementActionTimeoutDisrupted, elementActionBudget)
+		})
+
+		assert.Equal(t, elementLocateTimeout, elementLocateBudget, "the budget is restored for whatever runs next")
+		assert.Equal(t, elementActionTimeout, elementActionBudget, "the budget is restored for whatever runs next")
+	})
+}


### PR DESCRIPTION
Six tests were reported flaky on master over seven days. Reading the artifacts of every failing execution showed that most of what made them hard to attribute was the harness discarding its own evidence.

Teardown runs after a setup that failed before its tab existed, so guard the page it reaches for, and log a failed coverage collection rather than calling `log.Fatal`, which ended the process and took the results of the run with it. A run that exhausts `go test -timeout` panics from a goroutine of its own, so no deferred capture runs and nothing is uploaded at all: collect shortly before the deadline instead, and discard it when the run finishes, since only a run that times out should keep it.

Record what the page reports about itself, installed before the first navigation because a document already loaded cannot be given the recording afterwards, and name it in `artifact_paths`, which lists each extension it uploads.

Bound element waits and report the state of the element with the failure, rather than spending the rest of the test on one that never appears. Raise the budgets while a test interrupts the datastore, and settle the cluster before such a test returns, so the next test is not measured against one still reconciling. Return the element on the page the caller gave, since it hands that page to everything derived from it.

`TestShouldKeepSessionAfterRedisRestart` named the Traefik3 environment although the suite it belongs to also runs as Traefik2.

Locally, wait on the log line the frontend actually emits when it restarts, and drop the memory limit on that container: setup could not otherwise get past its budget, and the dev server was being killed inside the limit.