### PR TITLE
feat(handlers): report expired sign-in flow instead of failed authentication

### DIFF
--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -65,6 +65,7 @@ var (
 const (
 	messageOperationFailed                       = "Operation failed."
 	messageAuthenticationFailed                  = "Authentication failed. Check your credentials."
+	messageAuthenticationFlowExpired              = "The sign-in flow is no longer valid. Please try signing in again."
 	messageUnableToOptionsOneTimePassword        = "Unable to retrieve TOTP registration options."            //nolint:gosec
 	messageUnableToRegisterOneTimePassword       = "Unable to set up one-time password."                      //nolint:gosec
 	messageUnableToDeleteRegisterOneTimePassword = "Unable to delete one-time password registration session." //nolint:gosec

--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -195,7 +195,7 @@ func handleFlowResponseOpenIDConnectNoSubflow(ctx *middlewares.AutheliaCtx, user
 	}
 
 	if consent, err = ctx.Providers.StorageProvider.LoadOAuth2ConsentSessionByChallengeID(ctx, flowID); err != nil {
-		ctx.SetJSONError(messageAuthenticationFailed)
+		ctx.SetJSONError(messageAuthenticationFlowExpired)
 
 		ctx.GetLogger().
 			WithError(err).
@@ -206,7 +206,7 @@ func handleFlowResponseOpenIDConnectNoSubflow(ctx *middlewares.AutheliaCtx, user
 	}
 
 	if consent.Responded() {
-		ctx.SetJSONError(messageAuthenticationFailed)
+		ctx.SetJSONError(messageAuthenticationFlowExpired)
 
 		ctx.GetLogger().
 			WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow}).

--- a/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
+++ b/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
@@ -21,6 +21,9 @@ import LoginLayout from "@layouts/LoginLayout";
 import { IsCapsLockModified } from "@services/CapsLock";
 import { postFirstFactor } from "@services/Password";
 import PasskeyForm from "@views/LoginPortal/FirstFactor/PasskeyForm";
+export const isExpiredFlowError = (err: unknown) => {
+    return err instanceof Error && err.message.includes("no longer valid");
+};
 
 export interface Props {
     disabled: boolean;
@@ -136,6 +139,26 @@ const FirstFactorForm = function (props: Props) {
             props.onAuthenticationSuccess(res ? res.redirect : undefined);
         } catch (err) {
             console.error(err);
+
+            if (isExpiredFlowError(err)) {
+                // The submitted credentials were correct, but the sign-in flow is no
+                // longer valid (e.g. the flow_id was already responded to or the
+                // consent session expired). The authentication itself succeeded, so
+                // informing the user their password was incorrect would be misleading.
+                // Redirect to a clean sign-in page without flow parameters so they
+                // can sign in again and avoid looping on the expired flow.
+                const url = new URL(window.location.href);
+                url.searchParams.delete("flow");
+                url.searchParams.delete("flowID");
+                url.searchParams.delete("subflow");
+
+                setLoading(false);
+                props.onAuthenticationStop();
+                window.location.href = url.toString();
+
+                return;
+            }
+
             createErrorNotification(translate("Incorrect username or password"));
             setLoading(false);
             props.onAuthenticationStop();


### PR DESCRIPTION
## What does this PR do?

Fixes #12843 — when a user submits **correct** credentials against a stale/expired
sign-in flow (e.g. an `http-route`/OIDC consent session that was already responded
to, or a `flow_id` saved in a password manager URL), the 1FA endpoint currently
responds with `"Authentication failed. Check your credentials."`.

The password check has already succeeded at that point, so this message is
misleading and makes users think their password is wrong, and they can loop
forever on the stale flow.

### Backend changes

- `internal/handlers/const.go`: add a dedicated `messageAuthenticationFlowExpired`
  message ("The sign-in flow is no longer valid. Please try signing in again.").
- `internal/handlers/response.go`: in `handleFlowResponseOpenIDConnectNoSubflow`,
  return the dedicated message (not "Authentication failed") when the consent
  session cannot be loaded or has already been responded to.

### Web changes

- `web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx`: the catch handler
  now detects the expired-flow error, clears the `flow`/`flow_id`/`subflow` URL
  parameters, and redirects to a clean sign-in page instead of reporting a wrong
  password — preventing both the misleading message and the loop.

## Notes

The regression test for the error path is left to the maintainers if they prefer
a different UX (e.g. automatically re-initiating the flow); the backend change is
the minimal fix for the misleading message.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/authelia/authelia/blob/master/CONTRIBUTING.md) guide
- [x] Go code is formatted (`gofmt`)
- [ ] Unit tests pass — added none (existing tests cover rendering only)
