### PR TITLE
ci(buildkite): cache the pnpm store for the image builds

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -40,10 +40,6 @@ if [[ "${BUILDKITE_LABEL}" == ":grype: Vulnerability Scanning" ]]; then
   fi
 fi
 
-if [[ "${BUILDKITE_LABEL}" == ":docker: Build Image [coverage]" ]]; then
-  cp -R /buildkite/.local .
-fi
-
 if [[ "${BUILDKITE_LABEL}" =~ :selenium: ]]; then
   echo "--- :docker: Extract and load build container"
   mkdir coverage

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -5,13 +5,11 @@ FROM node:26-alpine@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781
 
 WORKDIR /node/src/app
 
-COPY --link .local /root/.local
 COPY --link web ./
 
-# Install the dependencies and build
-RUN \
-	npm install -g pnpm && \
-	pnpm install --frozen-lockfile --ignore-scripts && \
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+	npm install -g pnpm@11 && \
+	pnpm install --frozen-lockfile --ignore-scripts --store-dir /pnpm/store && \
 	pnpm coverage
 
 # =======================================

--- a/Dockerfile.coverage.dockerignore
+++ b/Dockerfile.coverage.dockerignore
@@ -21,4 +21,3 @@ bootstrap.sh
 
 # Overrides
 !.healthcheck.env
-!.local

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,10 +7,9 @@ WORKDIR /node/src/app
 
 COPY --link web ./
 
-# Install the dependencies and build
-RUN \
-	npm install -g pnpm && \
-	pnpm install --frozen-lockfile --ignore-scripts && \
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+	npm install -g pnpm@11 && \
+	pnpm install --frozen-lockfile --ignore-scripts --store-dir /pnpm/store && \
 	pnpm coverage
 
 # =======================================


### PR DESCRIPTION
pnpm resolves its store from the filesystem layout and never says which branch it took: `${HOME}/.local/share/pnpm/store` when the project shares a filesystem with the home directory, `<mountpoint>/.pnpm-store` when it does not. On the agents `/buildkite` is an anonymous volume and `/buildkite/builds` is the host bind mount, so every host side pnpm run lands on `/buildkite/builds/.pnpm-store` and nothing has ever been written to `/buildkite/.local`.

The coverage image copied that empty `/buildkite/.local` into the build context and placed it at `/root/.local`, which is where the container's pnpm does look, since both paths share the overlay there. The copy has been empty since it was introduced, so its layer was permanently cached and the image re-downloaded all 690 packages on every build.

Copying the real store in instead would cost more than it saves: it is several gigabytes of small files that the build context would have to be scanned through on every build. The store becomes a BuildKit cache mount, which stays on the agent between builds and costs nothing to carry, and `--store-dir` is passed explicitly because the guess pnpm makes without it is what hid the original breakage.

`Dockerfile.dev` takes the same mount under the same cache id so the two image builds warm each other, and both pin `pnpm@11` to match `engines.pnpm` in `web/package.json`: a major bump rolls the store version and would silently cold start the cache.