### PR TITLE
test(suites): remove failures the harness was creating itself

### DIFF
--- a/internal/suites/action_login.go
+++ b/internal/suites/action_login.go
@@ -78,9 +78,9 @@ func (rs *RodSession) doLoginSecondFactorTOTP(t *testing.T, page *rod.Page, user
 	rs.doLoginOneFactor(t, page, username, password, keepMeLoggedIn, BaseDomain, targetURL)
 	rs.verifyIsSecondFactorPage(t, page)
 	rs.doValidateTOTP(t, page, username)
-	// timeout when targetURL is not defined to prevent a show stopping redirect when visiting a protected domain.
+	// wait for requests to settle when targetURL is not defined to prevent a show stopping redirect when visiting a protected domain.
 	if targetURL == "" {
-		require.NoError(t, page.WaitStable(time.Second))
+		page.WaitRequestIdle(time.Second, nil, nil, nil)()
 	}
 }
 

--- a/internal/suites/action_reset_password.go
+++ b/internal/suites/action_reset_password.go
@@ -2,19 +2,15 @@ package suites
 
 import (
 	"testing"
-	"time"
 
 	"github.com/go-rod/rod"
-	"github.com/stretchr/testify/require"
 )
 
 func (rs *RodSession) doInitiatePasswordReset(t *testing.T, page *rod.Page, username string) {
 	rs.ClickElementLocatedByID(t, page, "reset-password-button")
 
-	require.NoError(t, page.WaitStable(time.Millisecond*100))
+	rs.TypeElementLocatedByID(t, page, "username-textfield", username)
 
-	err := rs.WaitElementLocatedByID(t, page, "username-textfield").Input(username)
-	require.NoError(t, err)
 	rs.ClickElementLocatedByID(t, page, "reset-button")
 }
 
@@ -22,26 +18,8 @@ func (rs *RodSession) doCompletePasswordReset(t *testing.T, page *rod.Page, newP
 	link := doGetResetPasswordJWTLinkFromLastEmail(t)
 	rs.doVisit(t, page, link)
 
-	password1 := rs.WaitElementLocatedByID(t, page, "password1-textfield")
-	password2 := rs.WaitElementLocatedByID(t, page, "password2-textfield")
-
-password1:
-	err := password1.MustSelectAllText().Input(newPassword1)
-
-	require.NoError(t, err)
-
-	if password1.MustText() != newPassword1 {
-		goto password1
-	}
-
-password2:
-	err = password2.MustSelectAllText().Input(newPassword2)
-
-	require.NoError(t, err)
-
-	if password2.MustText() != newPassword2 {
-		goto password2
-	}
+	rs.TypeElementLocatedByID(t, page, "password1-textfield", newPassword1)
+	rs.TypeElementLocatedByID(t, page, "password2-textfield", newPassword2)
 
 	rs.ClickElementLocatedByID(t, page, "reset-button")
 }

--- a/internal/suites/action_totp.go
+++ b/internal/suites/action_totp.go
@@ -29,10 +29,7 @@ func (rs *RodSession) doMaybeDeleteTOTP(t *testing.T, page *rod.Page, username s
 
 	rs.WaitElementLocatedBySelector(t, page, `#one-time-password-panel[data-loading="false"]`)
 
-	has, _, err := page.Has("#one-time-password-delete")
-	require.NoError(t, err)
-
-	if !has {
+	if !rs.CheckElementExistsLocatedByID(t, page, "one-time-password-delete") {
 		return
 	}
 

--- a/internal/suites/action_verify.go
+++ b/internal/suites/action_verify.go
@@ -15,10 +15,7 @@ func (rs *RodSession) isVerifyIdentityShowing(t *testing.T, page *rod.Page, othe
 
 	require.NoError(t, err)
 
-	has, _, err := page.Has("#dialog-verify-one-time-code")
-	require.NoError(t, err)
-
-	return has
+	return rs.CheckElementExistsLocatedByID(t, page, "dialog-verify-one-time-code")
 }
 
 func (rs *RodSession) doMaybeVerifyIdentity(t *testing.T, page *rod.Page, otherwise string) {

--- a/internal/suites/action_visit.go
+++ b/internal/suites/action_visit.go
@@ -3,6 +3,7 @@ package suites
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,7 +17,17 @@ import (
 // module graph unresolved: the document reaches readyState complete and nothing renders or is fetched
 // again. The lost response is what separates that page from one that is merely slow, and it reports a
 // zero status against a zero body. Pages that are not the portal have no root and count as rendered.
+//
+// A document that has not finished loading has no root either, and the responses this looks at are the
+// ones it is still waiting on, so it has to be told apart from a page that never has a root. Reported
+// separately from a pending render because only the latter is the page taking too long to draw: the
+// caller gives loading whatever time the page context allows, the same as waiting on the load event did,
+// and holds the render budget for the question this is actually asking.
 const pageRenderState = `() => {
+	if (document.readyState !== 'complete') {
+		return 'loading';
+	}
+
 	const root = document.getElementById('root');
 
 	if (root === null || root.innerHTML.length !== 0) {
@@ -35,8 +46,6 @@ func (s *RodSuite) doSetupTest(url string) {
 	s.Page = s.doCreateTab(s.T(), url)
 
 	page := s.Context(ctx)
-
-	require.NoError(s.T(), page.WaitLoad())
 
 	s.doReloadIfRenderWasLost(s.T(), page, url)
 
@@ -73,7 +82,7 @@ func (rs *RodSession) doCreateTab(t *testing.T, url string) *rod.Page {
 			log.Debugf("Error installing the console collector: %v", err)
 		}
 
-		err = page.Navigate(url)
+		err = rs.doNavigate(page, url)
 
 		created <- tab{page: page, err: err}
 	}()
@@ -91,9 +100,22 @@ func (rs *RodSession) doCreateTab(t *testing.T, url string) *rod.Page {
 	}
 }
 
+func (rs *RodSession) doNavigate(page *rod.Page, url string) error {
+	err := page.Navigate(url)
+
+	// Chrome reports this when its certificate verifier is reconfigured while a request is already in
+	// flight, which it only does while it is still starting: both occurrences in CI were the first
+	// navigation a suite made, within half a second of the suite beginning. Sent again rather than
+	// failing a test against a browser that had not finished coming up.
+	if err != nil && strings.Contains(err.Error(), "net::ERR_CERT_VERIFIER_CHANGED") {
+		return page.Navigate(url)
+	}
+
+	return err
+}
+
 func (rs *RodSession) doVisit(t *testing.T, page *rod.Page, url string) {
-	require.NoError(t, page.Navigate(url))
-	require.NoError(t, page.WaitLoad())
+	require.NoError(t, rs.doNavigate(page, url))
 
 	rs.doReloadIfRenderWasLost(t, page, url)
 }
@@ -106,7 +128,6 @@ func (rs *RodSession) doReloadIfRenderWasLost(t *testing.T, page *rod.Page, url 
 	log.Warnf("The page at '%s' lost a response it needed to render, fetching it again once", url)
 
 	require.NoError(t, page.Reload())
-	require.NoError(t, page.WaitLoad())
 }
 
 func (rs *RodSession) renderWasLost(page *rod.Page) bool {
@@ -117,7 +138,20 @@ func (rs *RodSession) renderWasLost(page *rod.Page) bool {
 		if err != nil {
 			// The page carries the deadline of the test that owns it, and that test reports its expiry
 			// against the element it was waiting for, which names the failure better than this can.
-			return false
+			if page.GetContext().Err() != nil {
+				return false
+			}
+
+			// Anything else is the execution context going away underneath the probe, which is what a
+			// navigation committing looks like from here. The next document is the one being asked
+			// about, so wait for it rather than reporting on the one that has just gone.
+			if time.Now().After(deadline) {
+				return false
+			}
+
+			time.Sleep(elementRetryInterval)
+
+			continue
 		}
 
 		state := value.Value.Str()
@@ -126,7 +160,12 @@ func (rs *RodSession) renderWasLost(page *rod.Page) bool {
 			return false
 		}
 
-		if time.Now().After(deadline) {
+		// The budget is for the render, not for the load in front of it, so it only starts once the
+		// responses this reports on have all been settled one way or the other. A document that never
+		// finishes is left to the page context, which the failing element reports against.
+		if state == "loading" {
+			deadline = time.Now().Add(pageRenderTimeout)
+		} else if time.Now().After(deadline) {
 			return state == "lost"
 		}
 

--- a/internal/suites/action_webauthn.go
+++ b/internal/suites/action_webauthn.go
@@ -81,10 +81,7 @@ func (rs *RodSession) doWebAuthnUpdateCredentials(t *testing.T, page *rod.Page) 
 func (rs *RodSession) doWebAuthnMethodMaybeSelect(t *testing.T, page *rod.Page) {
 	_ = rs.WaitElementLocatedByID(t, page, "second-factor-stage")
 
-	has, _, err := page.Has("#one-time-password-method")
-	require.NoError(t, err)
-
-	if !has {
+	if !rs.CheckElementExistsLocatedByID(t, page, "one-time-password-method") {
 		return
 	}
 
@@ -99,10 +96,7 @@ func (rs *RodSession) doWebAuthnMethodMustSelect(t *testing.T, page *rod.Page) {
 func (rs *RodSession) doWebAuthnCredentialMaybeDelete(t *testing.T, page *rod.Page) {
 	rs.WaitElementLocatedBySelector(t, page, `#webauthn-credentials-panel[data-loading="false"]`)
 
-	has, _, err := page.Has("#webauthn-credential-0-delete")
-	require.NoError(t, err)
-
-	if !has {
+	if !rs.CheckElementExistsLocatedByID(t, page, "webauthn-credential-0-delete") {
 		return
 	}
 

--- a/internal/suites/console_test.go
+++ b/internal/suites/console_test.go
@@ -20,7 +20,7 @@ console.warn('a warning');
 console.error('an error');
 Promise.reject(new Error('a rejection'));
 setTimeout(() => { throw new Error('an exception') }, 0);
-</script></body></html>`
+</script><div id="reported"></div></body></html>`
 
 type consoleRecord struct {
 	Installed bool `json:"installed"`
@@ -66,7 +66,8 @@ func TestConsoleCollector(t *testing.T) {
 	t.Run("ShouldReportThatItWasNotInstalled", func(t *testing.T) {
 		page, err := session.WebDriver.Page(proto.TargetCreateTarget{URL: server.URL})
 		require.NoError(t, err)
-		require.NoError(t, page.WaitLoad())
+
+		session.WaitElementLocatedByID(t, page, "reported")
 
 		record := read(t, page)
 
@@ -81,7 +82,8 @@ func TestConsoleCollector(t *testing.T) {
 		session := newVisitSession(t)
 
 		page := session.doCreateTab(t, server.URL)
-		require.NoError(t, page.WaitLoad())
+
+		session.WaitElementLocatedByID(t, page, "reported")
 
 		record := read(t, page)
 
@@ -106,7 +108,8 @@ func TestConsoleCollector(t *testing.T) {
 		// Installed ahead of the navigation rather than on the document in front of it, which is how the
 		// suites install it: the load a test fails on is a later one than the tab was opened at.
 		require.NoError(t, page.Navigate(server.URL))
-		require.NoError(t, page.WaitLoad())
+
+		session.WaitElementLocatedByID(t, page, "reported")
 
 		record := read(t, page)
 

--- a/internal/suites/example/compose/nginx/backend/nginx.conf
+++ b/internal/suites/example/compose/nginx/backend/nginx.conf
@@ -6,6 +6,8 @@ events {
 
 
 http {
+    add_header Cache-Control "no-store" always;
+
     server {
         listen 80;
         root /usr/share/nginx/html/home;

--- a/internal/suites/example/compose/redis/entrypoint.sh
+++ b/internal/suites/example/compose/redis/entrypoint.sh
@@ -3,6 +3,14 @@
 MODE=${1}
 
 sed "s/__SUITE_SUBNET__/${SUITE_SUBNET:-192.168.240}/g" "/templates/${MODE}.conf" > /data/redis.conf
+
+if [ "${MODE}" = "sentinel" ]; then
+  ADDRESS=$(hostname -i | cut -d ' ' -f 1)
+  MYID=$(printf 'authelia-sentinel-%s' "${ADDRESS}" | sha1sum | cut -c 1-40)
+
+  printf 'sentinel myid %s\n' "${MYID}" >> /data/redis.conf
+fi
+
 chown -R redis:redis /data
 
 if [ "${MODE}" = "master" ] || [ "${MODE}" = "slave" ]; then

--- a/internal/suites/external_main_test.go
+++ b/internal/suites/external_main_test.go
@@ -4,6 +4,7 @@
 package suites
 
 import (
+	"flag"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -19,6 +20,10 @@ import (
 var globalDevServer atomic.Pointer[DevServer]
 
 func TestMain(m *testing.M) {
+	flag.Parse()
+
+	startArtifactWatchdog()
+
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 
@@ -32,6 +37,8 @@ func TestMain(m *testing.M) {
 	}()
 
 	code := m.Run()
+
+	discardWatchdogArtifacts()
 
 	closeSharedBrowsers()
 

--- a/internal/suites/external_suite_docs_test.go
+++ b/internal/suites/external_suite_docs_test.go
@@ -126,7 +126,6 @@ func (s *DocsSuite) TestHomepageVisualSnapshot() {
 	page.MustSetViewport(1280, 800, 1, false)
 
 	require.NoError(s.T(), page.Navigate(s.docsURL("/")))
-	require.NoError(s.T(), page.WaitLoad())
 
 	s.WaitElementLocatedByClassName(s.T(), page, "navbar")
 	s.WaitForVisualStable(s.T(), page)

--- a/internal/suites/scenario_inactivity_test.go
+++ b/internal/suites/scenario_inactivity_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const shortTimeoutsCookieExpiration = 10 * time.Second
+
 type InactivityScenario struct {
 	*RodSuite
 }
@@ -93,6 +95,8 @@ func (s *InactivityScenario) TestShouldRequireReauthenticationAfterCookieExpirat
 
 	s.doLoginSecondFactorTOTP(s.T(), s.Context(ctx), "john", "password", false, "")
 
+	loggedInAt := time.Now()
+
 	for i := 0; i < 3; i++ {
 		s.doVisit(s.T(), s.Context(ctx), HomeBaseURL)
 		s.verifyIsHome(s.T(), s.Context(ctx))
@@ -103,7 +107,9 @@ func (s *InactivityScenario) TestShouldRequireReauthenticationAfterCookieExpirat
 		s.verifySecretAuthorized(s.T(), s.Context(ctx))
 	}
 
-	time.Sleep(2 * time.Second)
+	if remaining := shortTimeoutsCookieExpiration + time.Second - time.Since(loggedInAt); remaining > 0 {
+		time.Sleep(remaining)
+	}
 
 	require.NoError(s.T(), s.Context(ctx).Reload())
 	s.verifyIsFirstFactorPage(s.T(), s.Context(ctx))

--- a/internal/suites/suite_caddy.go
+++ b/internal/suites/suite_caddy.go
@@ -57,7 +57,7 @@ func init() {
 		SetUpTimeout:    5 * time.Minute,
 		OnSetupTimeout:  displayAutheliaLogs,
 		OnError:         displayAutheliaLogs,
-		TestTimeout:     2 * time.Minute,
+		TestTimeout:     150 * time.Second,
 		TearDown:        teardown,
 		TearDownTimeout: 2 * time.Minute,
 	})

--- a/internal/suites/suite_cli_test.go
+++ b/internal/suites/suite_cli_test.go
@@ -1307,8 +1307,12 @@ func (s *CLISuite) TestStorage07CacheMDS3() {
 	}
 
 	output, err = s.ExecWithEnv("authelia-backend", append([]string{"authelia", "storage", "cache", "mds3", "update"}, updateArgs...), env)
-	s.NoError(err)
-	s.Regexp(reUpdated, output)
+
+	// Fatal because the version and date are read out of this output below. An update that did not happen,
+	// which is what an expired or rotated signing chain upstream looks like from here, otherwise reaches
+	// that read with nothing captured and panics, taking the rest of the suite with it.
+	s.Require().NoError(err)
+	s.Require().Regexp(reUpdated, output)
 
 	matches := reUpdated.FindStringSubmatch(output)
 

--- a/internal/suites/suite_envoy.go
+++ b/internal/suites/suite_envoy.go
@@ -57,7 +57,7 @@ func init() {
 		SetUpTimeout:    5 * time.Minute,
 		OnSetupTimeout:  displayAutheliaLogs,
 		OnError:         displayAutheliaLogs,
-		TestTimeout:     2 * time.Minute,
+		TestTimeout:     150 * time.Second,
 		TearDown:        teardown,
 		TearDownTimeout: 2 * time.Minute,
 	})

--- a/internal/suites/suite_pathprefix.go
+++ b/internal/suites/suite_pathprefix.go
@@ -63,7 +63,7 @@ func init() {
 		SetUpTimeout:    5 * time.Minute,
 		OnSetupTimeout:  displayAutheliaLogs,
 		OnError:         displayAutheliaLogs,
-		TestTimeout:     2 * time.Minute,
+		TestTimeout:     150 * time.Second,
 		TearDown:        teardown,
 		TearDownTimeout: 2 * time.Minute,
 	})

--- a/internal/suites/suite_standalone_test.go
+++ b/internal/suites/suite_standalone_test.go
@@ -85,7 +85,10 @@ func (s *StandaloneWebDriverSuite) TestShouldRedirectAfterOneFactorOnAnotherTab(
 		page2.MustClose()
 	}()
 
-	page2.MustWaitStable()
+	// The second tab has to have arrived at the portal before the first one logs in, since what this test
+	// asserts is that the login on the first tab redirects it. Waiting for the page it is expected to be
+	// showing says that; waiting for it to stop changing does not distinguish it from one still in flight.
+	s.verifyIsFirstFactorPage(s.T(), page2.Context(ctx))
 
 	s.MustActivate()
 	s.verifyIsHome(s.T(), s.Context(ctx))

--- a/internal/suites/watchdog.go
+++ b/internal/suites/watchdog.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-rod/rod"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -100,15 +99,7 @@ func collectWatchdogArtifacts() {
 		base = "TIMEOUT-" + suite
 	}
 
-	sharedBrowsersMutex.Lock()
-
-	browsers := make([]*rod.Browser, 0, len(sharedBrowsers))
-
-	for _, shared := range sharedBrowsers {
-		browsers = append(browsers, shared.browser)
-	}
-
-	sharedBrowsersMutex.Unlock()
+	browsers := liveBrowsersSnapshot()
 
 	// The helpers below are addressed through a session only because that is where they are defined; none
 	// of them read the session itself.

--- a/internal/suites/watchdog_test.go
+++ b/internal/suites/watchdog_test.go
@@ -4,11 +4,13 @@
 package suites
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/go-rod/rod/lib/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,4 +110,50 @@ func TestDiscardWatchdogArtifacts(t *testing.T) {
 
 		watchdogTimer, watchdogDone = nil, nil
 	})
+}
+
+// The external suites ask for a browser of their own rather than a shared one, which is a different path
+// out of NewRodSession and used to leave that browser out of what the watchdog could reach: a run that
+// expired reported no pages and wrote nothing at all, which is the state the suites it covers were in.
+func TestCollectWatchdogArtifactsCapturesAnUnsharedBrowser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping browser test in short mode")
+	}
+
+	t.Setenv("SUITE", "WatchdogUnit")
+	t.Setenv("CI", "")
+
+	session, err := NewRodSession(RodSessionWithoutDevtools())
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = session.Stop() })
+
+	page, err := session.WebDriver.Page(proto.TargetCreateTarget{
+		URL: "data:text/html," + url.PathEscape(`<html><body><div id="captured">captured</div></body></html>`),
+	})
+	require.NoError(t, err)
+
+	session.WaitElementLocatedByID(t, page, "captured")
+
+	base := "TIMEOUT-WATCHDOGUNIT"
+
+	t.Cleanup(func() {
+		pattern, _ := screenshotPaths(base + "*")
+
+		matches, _ := filepath.Glob(pattern)
+
+		for _, match := range matches {
+			_ = os.Remove(match)
+		}
+
+		watchdogMutex.Lock()
+		watchdogCollected = ""
+		watchdogMutex.Unlock()
+	})
+
+	collectWatchdogArtifacts()
+
+	shot, _ := screenshotPaths(base + "-page-0.png")
+
+	assert.FileExists(t, shot, "a browser that was not shared is captured when the run runs out of time")
 }

--- a/internal/suites/webdriver.go
+++ b/internal/suites/webdriver.go
@@ -66,6 +66,8 @@ type sharedBrowser struct {
 }
 
 var (
+	liveBrowsersMutex   sync.Mutex
+	liveBrowsers        = map[*rod.Browser]struct{}{}
 	sharedBrowsersMutex sync.Mutex
 	sharedBrowsers      = map[string]*sharedBrowser{}
 )
@@ -207,7 +209,36 @@ func newBrowser(opts *RodSessionOpts) (shared *sharedBrowser, err error) {
 
 	browser.MustIgnoreCertErrors(true)
 
+	registerLiveBrowser(browser)
+
 	return &sharedBrowser{launcher: l, browser: browser}, nil
+}
+
+func registerLiveBrowser(browser *rod.Browser) {
+	liveBrowsersMutex.Lock()
+	defer liveBrowsersMutex.Unlock()
+
+	liveBrowsers[browser] = struct{}{}
+}
+
+func forgetLiveBrowser(browser *rod.Browser) {
+	liveBrowsersMutex.Lock()
+	defer liveBrowsersMutex.Unlock()
+
+	delete(liveBrowsers, browser)
+}
+
+func liveBrowsersSnapshot() []*rod.Browser {
+	liveBrowsersMutex.Lock()
+	defer liveBrowsersMutex.Unlock()
+
+	browsers := make([]*rod.Browser, 0, len(liveBrowsers))
+
+	for browser := range liveBrowsers {
+		browsers = append(browsers, browser)
+	}
+
+	return browsers
 }
 
 func closeSharedBrowsers() {
@@ -215,6 +246,8 @@ func closeSharedBrowsers() {
 	defer sharedBrowsersMutex.Unlock()
 
 	for key, shared := range sharedBrowsers {
+		forgetLiveBrowser(shared.browser)
+
 		if err := shared.browser.Close(); err != nil {
 			log.Warnf("Error closing the shared browser: %v", err)
 		}
@@ -243,6 +276,8 @@ func (rs *RodSession) Stop() error {
 	if rs.shared {
 		return nil
 	}
+
+	forgetLiveBrowser(rs.WebDriver)
 
 	if err := rs.WebDriver.Close(); err != nil {
 		return err

--- a/internal/suites/webdriver_wait_test.go
+++ b/internal/suites/webdriver_wait_test.go
@@ -48,7 +48,6 @@ func TestWaitElementLocatedBySelector(t *testing.T) {
 	newPage := func(t *testing.T) *rod.Page {
 		page, err := session.WebDriver.Page(proto.TargetCreateTarget{URL: server.URL})
 		require.NoError(t, err)
-		require.NoError(t, page.WaitLoad())
 
 		return page
 	}


### PR DESCRIPTION
The redis entrypoint rewrote `/data/redis.conf` from the template on every start, so a restarted sentinel returned with a new id. Its peer then either cleared the down flag on reconnect and logged `-sdown sentinel`, or saw the new id first, logged `+sentinel-invalid-addr` and discarded the instance the flag lived on. `doStartAndSettle` waits thirty seconds for `-sdown`, so the second path burnt that budget and failed in teardown after the assertions had passed. Deriving the id from the pinned address removes that path: 19 of 22 cycles passed before, 32 of 32 after.

`TestShouldVerifyAccessControl` walks the same URLs as three users through one browser, and those pages carry only a `Last-Modified`, so the first user filled the cache and the rest were served it without a request reaching the proxy. Only the first passed. The backend now sends `Cache-Control: no-store`.

Pages were being read before they existed or after they were replaced. `pageRenderState` now tells a document still loading apart from one that never has a root, and `renderWasLost` waits through a navigation, which is what `page.WaitLoad` was doing for it; those go in favour of the bounded element waits already following them. Typing goes through `TypeElementLocatedByID`, which re-locates between attempts instead of looping unbounded on a handle React replaced, and `page.Has` through `CheckElementExistsLocatedBySelector`. A login without a target waits for requests to settle rather than for the DOM. A navigation that loses the race with Chrome's certificate verifier is sent again.

`TestShouldRequireReauthenticationAfterCookieExpiration` was reaching the expiration on time the login helper happened to spend rather than time it asked for. The two second gaps in its loop keep the session inside the seven second inactivity period, so the ten second expiration is the only timeout it can trigger, and its own sleeps come to eight. It now holds the wait against the login.

Caddy, Envoy and PathPrefix ran at 87 to 89 percent of their budget, reporting a slowdown as twenty broken tests rather than one slow suite; they get another thirty seconds. The MDS3 assertions are fatal, since the version and date are read from that output and an update that did not happen panicked through the rest of the suite. The external suites arm the artifact watchdog, which now collects from every running browser rather than only the shared ones, which is not the kind either uses.