### PR TITLE
fix(web): pass actual remember-me checkbox state to passkey login

### DIFF
--- a/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.test.tsx
+++ b/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.test.tsx
@@ -51,7 +51,7 @@ vi.mock("@services/Password", () => ({
 }));
 
 vi.mock("@views/LoginPortal/FirstFactor/PasskeyForm", () => ({
-    default: () => <div data-testid="passkey-form" />,
+    default: (props: any) => <div data-testid="passkey-form" data-remember-me={String(props.rememberMe)} />,
 }));
 
 const defaultProps = {
@@ -86,6 +86,15 @@ it("does not render remember me checkbox when disabled", () => {
 it("renders passkey form when passkey login is enabled", () => {
     render(<FirstFactorForm {...defaultProps} passkeyLogin={true} />);
     expect(screen.getByTestId("passkey-form")).toBeInTheDocument();
+});
+
+it("passes the actual remember-me checkbox state to the passkey form, not the feature flag", () => {
+    // rememberMe on the props is only the flag for whether the checkbox is
+    // shown at all. The checkbox itself starts unchecked, so the passkey
+    // form should be told rememberMe is false even though the feature is
+    // enabled here.
+    render(<FirstFactorForm {...defaultProps} passkeyLogin={true} rememberMe={true} />);
+    expect(screen.getByTestId("passkey-form")).toHaveAttribute("data-remember-me", "false");
 });
 
 it("renders reset password link when enabled", () => {

--- a/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
+++ b/web/src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx
@@ -346,7 +346,7 @@ const FirstFactorForm = function (props: Props) {
                     {props.passkeyLogin ? (
                         <PasskeyForm
                             disabled={disabled || loading}
-                            rememberMe={props.rememberMe}
+                            rememberMe={rememberMe}
                             onAuthenticationError={(err) => createErrorNotification(err.message)}
                             onAuthenticationStart={() => {
                                 setUsername("");


### PR DESCRIPTION
Fixes #12653.

PasskeyForm was given `props.rememberMe`, which is only the flag for whether the remember-me checkbox is shown at all. The password form correctly uses the local `rememberMe` state (the actual checked value) when calling `postFirstFactor`, but PasskeyForm never got that state, it got the flag instead.

Result: whenever the remember-me feature is enabled in config, every passkey login is sent as remembered regardless of whether the checkbox exists or is checked (the passkey button has no checkbox of its own). That overrides the session's configured inactivity timeout for anyone signing in with a passkey.

Fix is a one-line prop swap. Added a test that mocks PasskeyForm to capture the rememberMe value it receives and checks it reflects the (unchecked, default) local state rather than the feature flag. Confirmed it fails on the current code and passes with the fix.