### PR TITLE
ci(buildkite): deepen shallow checkouts in the post-checkout hook

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
 set +u
 
-git fetch -q --tags --force
+if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+  if ! git fetch -q --unshallow; then
+    echo "failed to deepen the shallow checkout"
+    exit 1
+  fi
+fi
+
+if ! git fetch -q --tags --force; then
+  echo "failed to fetch tags from origin"
+  exit 1
+fi
+
+if ! git describe --tags --abbrev=0 > /dev/null 2>&1; then
+  echo "no tag reachable from ${BUILDKITE_COMMIT}"
+  exit 1
+fi
 
 if [[ ! "${BUILDKITE_COMMAND}" =~ ^\.buildkite/pipeline.sh ]]; then
   echo "--- :buildkite: Setting up Build environment"

--- a/cmd/authelia-scripts/cmd/helpers.go
+++ b/cmd/authelia-scripts/cmd/helpers.go
@@ -38,16 +38,16 @@ func getBuild(branch, buildNumber, extra string) (b *Build, err error) {
 		gitTagCommit string
 	)
 
-	if gitTagCommit, _, err = utils.RunCommandAndReturnOutput("git rev-list --tags --max-count=1"); err != nil {
-		return nil, fmt.Errorf("error getting tag commit with git rev-list: %w", err)
-	}
-
-	if b.Tag, _, err = utils.RunCommandAndReturnOutput(fmt.Sprintf("git describe --tags --abbrev=0 %s", gitTagCommit)); err != nil {
+	if b.Tag, _, err = utils.RunCommandAndReturnOutput("git describe --tags --abbrev=0"); err != nil {
 		return nil, fmt.Errorf("error getting tag with git describe: %w", err)
 	}
 
 	if b.Commit, _, err = utils.RunCommandAndReturnOutput("git rev-parse HEAD"); err != nil {
 		return nil, fmt.Errorf("error getting commit with git rev-parse: %w", err)
+	}
+
+	if gitTagCommit, _, err = utils.RunCommandAndReturnOutput(fmt.Sprintf("git rev-list -1 %s", b.Tag)); err != nil {
+		return nil, fmt.Errorf("error getting tag commit with git rev-list: %w", err)
 	}
 
 	if gitTagCommit == b.Commit {


### PR DESCRIPTION
An agent whose checkout was created with `git clone --depth` keeps every tag ref but no tagged commit, because each tag points below the graft. `git fetch --tags --force` restores the refs and leaves the truncation in place, so `git describe --tags --abbrev=0` finds nothing to describe `HEAD` with and GoReleaser fails with `git doesn't contain any tags` after the frontend and swagger builds have already run. Two agents were cloned this way, which is why the same commit failed on one and passed when retried on another.

The hook now deepens a shallow checkout, checks the exit status of both fetches, and asserts that a tag is reachable from `BUILDKITE_COMMIT`. A checkout that cannot satisfy that fails the phase the agent retries and wipes the directory for, rather than failing the job several minutes later with an error that points at the wrong thing.

`getBuild` described from `git rev-list --tags --max-count=1`, which finds a tag anywhere in the repository and then describes that commit from itself, so it succeeded on exactly the checkouts GoReleaser rejected. It now describes from `HEAD`, which is the question GoReleaser asks, and takes `Tagged` from the described tag's own commit. Beyond aligning the two, this stops `BuildTag` and the version string being stamped from a tag the commit does not descend from.