### PR TITLE
fix(oidc): resource indicators grant

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -3833,6 +3833,11 @@ components:
               type: array
               items:
                 type: string
+            resource:
+              description: The list of the requested resource indicators for the user to provide consent for.
+              type: array
+              items:
+                type: string
             pre_configuration:
               description: Indicates if this client supports pre-configuration.
               type: boolean

--- a/docs/content/configuration/storage/migrations.md
+++ b/docs/content/configuration/storage/migrations.md
@@ -58,6 +58,7 @@ this instance if you wanted to downgrade to pre1 you would need to use an Authel
 |       25       |     4.39.21      |    Adjusted storage encryption implementation to include HKDF for key derivation and column-specific AADs    |
 |       26       |     4.39.21      | Adjusted storage encryption AADs to be specific to the individual column and row rather than just the column |
 |       27       |     4.39.21      |                    Included Access Token Session Signature in Refresh Token Session Table                    |
-|       28       |     4.39.21      |           Fix the Access Token Session Signature column length in the Refresh Token Session Table            |
+|       28       |     4.39.22      |           Fix the Access Token Session Signature column length in the Refresh Token Session Table            |
+|       29       |     4.39.23      |                       OAuth 2.0 Resource Indicators recorded separately from Audience                        |
 
 [RFC9068]: https://datatracker.ietf.org/doc/html/rfc9068

--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -118,7 +118,7 @@ const (
 	logFmtDbgConsentAuthenticationSufficiency = logFmtConsentPrefix + "authentication level '%s' is %s for client level '%s'"
 	logFmtDbgConsentRedirect                  = logFmtConsentPrefix + "is being redirected to '%s'"
 	logFmtDbgConsentPreConfSuccessfulLookup   = logFmtConsentPrefix + "successfully looked up pre-configured consent with signature of client id '%s' and subject '%s' and scopes '%s' with id '%d'"
-	logFmtDbgConsentPreConfUnsuccessfulLookup = logFmtConsentPrefix + "unsuccessfully looked up pre-configured consent with signature of client id '%s' and subject '%s' and scopes '%s' and audience '%s'"
+	logFmtDbgConsentPreConfUnsuccessfulLookup = logFmtConsentPrefix + "unsuccessfully looked up pre-configured consent with signature of client id '%s' and subject '%s' and scopes '%s' and audience '%s' and resource '%s'"
 	logFmtDbgConsentPreConfTryingLookup       = logFmtConsentPrefix + "attempting to discover pre-configurations with signature of client id '%s' and subject '%s' and scopes '%s'"
 
 	logFmtErrConsentWithIDCouldNotBeProcessed = logFmtConsentPrefix + "could not be processed: error occurred performing consent for consent session with id '%s': "

--- a/internal/handlers/handler_authz_authn.go
+++ b/internal/handlers/handler_authz_authn.go
@@ -635,7 +635,7 @@ func handleVerifyGETAuthorizationBearerIntrospection(ctx context.Context, provid
 	audience := []string{object.URL.String()}
 	strategy := provider.GetAudienceStrategy(ctx)
 
-	if err = strategy(requester.GetGrantedAudience(), audience); err != nil {
+	if err = strategy(oauthelia2.JoinGrantedAudienceAndResource(requester.GetGrantedAudience(), requester.GetGrantedResource()), audience); err != nil {
 		return "", "", false, authentication.NotAuthenticated, fmt.Errorf("token does not contain a valid audience for the url '%s' with the error: %w", audience[0], err)
 	}
 

--- a/internal/handlers/handler_oauth2_authorization.go
+++ b/internal/handlers/handler_oauth2_authorization.go
@@ -149,13 +149,13 @@ func OAuth2AuthorizationGET(ctx *middlewares.AutheliaCtx, rw http.ResponseWriter
 	session := oidc.NewSessionWithRequester(ctx, issuer, ctx.Providers.OpenIDConnect.Issuer.GetKeyID(ctx, client.GetIDTokenSignedResponseKeyID(), client.GetIDTokenSignedResponseAlg()), details.Username, userSession.AuthenticationMethodRefs.MarshalRFC8176(), extra, userSession.LastAuthenticatedTime(), consent, requester, requests)
 
 	if client.GetClaimsStrategy().MergeAccessTokenAudienceWithIDTokenAudience() {
-		session.Claims.Audience = append([]string{clientID}, requester.GetGrantedAudience()...)
+		session.Claims.Audience = append([]string{clientID}, oauthelia2.JoinGrantedAudienceAndResource(requester.GetGrantedAudience(), requester.GetGrantedResource())...)
 	}
 
 	ctx.GetLogger().Tracef("Authorization Request with id '%s' on client with id '%s' using policy '%s' creating session for Authorization Response for subject '%s' with username '%s' with groups: %+v and claims: %+v",
 		requester.GetID(), session.ClientID, policy.Name, session.Subject, session.Username, userSession.Groups, session.Claims)
 
-	ctx.GetLogger().WithFields(map[string]any{"id": requester.GetID(), "response_type": requester.GetResponseTypes(), "response_mode": requester.GetResponseMode(), "scope": requester.GetRequestedScopes(), "aud": requester.GetRequestedAudience(), "redirect_uri": requester.GetRedirectURI(), "state": requester.GetState()}).Tracef("Authorization Request is using the following request parameters")
+	ctx.GetLogger().WithFields(map[string]any{"id": requester.GetID(), "response_type": requester.GetResponseTypes(), "response_mode": requester.GetResponseMode(), "scope": requester.GetRequestedScopes(), "aud": requester.GetRequestedAudience(), "resource": requester.GetRequestedResource(), "redirect_uri": requester.GetRedirectURI(), "state": requester.GetState()}).Tracef("Authorization Request is using the following request parameters")
 
 	if responder, err = ctx.Providers.OpenIDConnect.NewAuthorizeResponse(ctx, requester, session); err != nil {
 		ctx.GetLogger().Errorf("Authorization Response for Request with id '%s' on client with id '%s' using policy '%s' could not be created: %s", requester.GetID(), clientID, policy.Name, oauthelia2.ErrorToDebugRFC6749Error(err))

--- a/internal/handlers/handler_oauth2_authorization_consent_preconfigured.go
+++ b/internal/handlers/handler_oauth2_authorization_consent_preconfigured.go
@@ -253,9 +253,9 @@ func handleOAuth2AuthorizationConsentModePreConfiguredGetPreConfig(ctx *middlewa
 		}
 	}
 
-	scopes, audience := requester.GetRequestedScopes(), requester.GetRequestedAudience()
+	scopes, audience, resource := requester.GetRequestedScopes(), requester.GetRequestedAudience(), requester.GetRequestedResource()
 
-	log := ctx.GetLogger().WithFields(map[string]any{"scopes": scopes, "claims": serialized, "audience": audience, "client_id": client.GetID()})
+	log := ctx.GetLogger().WithFields(map[string]any{"scopes": scopes, "claims": serialized, "audience": audience, "resource": resource, "client_id": client.GetID()})
 
 	for rows.Next() {
 		if config, err = rows.Get(); err != nil {
@@ -268,8 +268,8 @@ func handleOAuth2AuthorizationConsentModePreConfiguredGetPreConfig(ctx *middlewa
 			continue
 		}
 
-		if !config.HasExactGrants(scopes, audience) {
-			log.Debugf("Authorization Request with id '%s' on client with id '%s' using consent mode '%s' found a matching pre-configuration with id '%d' but the configuration has scopes '%s' and audience '%s' which does not match the request", requester.GetID(), client.GetID(), client.GetConsentPolicy(), config.ID, strings.Join(config.Scopes, " "), strings.Join(config.Audience, " "))
+		if !config.HasExactGrants(scopes, audience, resource) {
+			log.Debugf("Authorization Request with id '%s' on client with id '%s' using consent mode '%s' found a matching pre-configuration with id '%d' but the configuration has scopes '%s', audience '%s', and resource '%s' which does not match the request", requester.GetID(), client.GetID(), client.GetConsentPolicy(), config.ID, strings.Join(config.Scopes, " "), strings.Join(config.Audience, " "), strings.Join(config.Resource, " "))
 
 			continue
 		}
@@ -285,7 +285,7 @@ func handleOAuth2AuthorizationConsentModePreConfiguredGetPreConfig(ctx *middlewa
 		return config, nil
 	}
 
-	ctx.GetLogger().Debugf(logFmtDbgConsentPreConfUnsuccessfulLookup, requester.GetID(), client.GetID(), client.GetConsentPolicy(), client.GetID(), subject, strings.Join(scopes, " "), strings.Join(audience, " "))
+	ctx.GetLogger().Debugf(logFmtDbgConsentPreConfUnsuccessfulLookup, requester.GetID(), client.GetID(), client.GetConsentPolicy(), client.GetID(), subject, strings.Join(scopes, " "), strings.Join(audience, " "), strings.Join(resource, " "))
 
 	return nil, nil
 }

--- a/internal/handlers/handler_oauth2_consent.go
+++ b/internal/handlers/handler_oauth2_consent.go
@@ -363,6 +363,7 @@ func handleSavePreConfiguredConsent(ctx *middlewares.AutheliaCtx, userSession se
 		ExpiresAt: sql.NullTime{Time: ctx.GetClock().Now().Add(client.GetConsentPolicy().Duration), Valid: true},
 		Scopes:    consent.GrantedScopes,
 		Audience:  consent.GrantedAudience,
+		Resource:  consent.GrantedResource,
 	}
 
 	var (

--- a/internal/handlers/handler_oauth2_device_authorization.go
+++ b/internal/handlers/handler_oauth2_device_authorization.go
@@ -217,7 +217,7 @@ func OAuth2DeviceAuthorizationPUT(ctx *middlewares.AutheliaCtx, rw http.Response
 	session := oidc.NewSessionWithRequester(ctx, issuer, ctx.Providers.OpenIDConnect.Issuer.GetKeyID(ctx, client.GetIDTokenSignedResponseKeyID(), client.GetIDTokenSignedResponseAlg()), details.Username, userSession.AuthenticationMethodRefs.MarshalRFC8176(), extra, userSession.LastAuthenticatedTime(), consent, requester, requests)
 
 	if client.GetClaimsStrategy().MergeAccessTokenAudienceWithIDTokenAudience() {
-		session.Claims.Audience = append([]string{client.GetID()}, requester.GetGrantedAudience()...)
+		session.Claims.Audience = append([]string{client.GetID()}, oauthelia2.JoinGrantedAudienceAndResource(requester.GetGrantedAudience(), requester.GetGrantedResource())...)
 	}
 
 	requester.SetStatus(oauthelia2.DeviceAuthorizeStatusApproved)

--- a/internal/model/oidc.go
+++ b/internal/model/oidc.go
@@ -32,8 +32,10 @@ func NewOAuth2ConsentSessionWithForm(expires time.Time, subject uuid.UUID, r oau
 		ExpiresAt:         expires,
 		RequestedScopes:   StringSlicePipeDelimited(r.GetRequestedScopes()),
 		RequestedAudience: StringSlicePipeDelimited(r.GetRequestedAudience()),
+		RequestedResource: StringSlicePipeDelimited(r.GetRequestedResource()),
 		GrantedScopes:     StringSlicePipeDelimited(r.GetGrantedScopes()),
 		GrantedAudience:   StringSlicePipeDelimited(r.GetGrantedAudience()),
+		GrantedResource:   StringSlicePipeDelimited(r.GetGrantedResource()),
 	}
 
 	if consent.ChallengeID, err = uuid.NewRandom(); err != nil {
@@ -97,7 +99,9 @@ func NewOAuth2SessionFromRequest(signature string, r oauthelia2.Requester) (sess
 		RequestedScopes:   StringSlicePipeDelimited(requested),
 		GrantedScopes:     StringSlicePipeDelimited(granted),
 		RequestedAudience: StringSlicePipeDelimited(r.GetRequestedAudience()),
+		RequestedResource: StringSlicePipeDelimited(r.GetRequestedResource()),
 		GrantedAudience:   StringSlicePipeDelimited(r.GetGrantedAudience()),
+		GrantedResource:   StringSlicePipeDelimited(r.GetGrantedResource()),
 		Active:            true,
 		Revoked:           false,
 		Form:              r.GetRequestForm().Encode(),
@@ -154,7 +158,9 @@ func NewOAuth2DeviceCodeSessionFromRequest(r oauthelia2.DeviceAuthorizeRequester
 		RequestedScopes:   StringSlicePipeDelimited(requested),
 		GrantedScopes:     StringSlicePipeDelimited(granted),
 		RequestedAudience: StringSlicePipeDelimited(r.GetRequestedAudience()),
+		RequestedResource: StringSlicePipeDelimited(r.GetRequestedResource()),
 		GrantedAudience:   StringSlicePipeDelimited(r.GetGrantedAudience()),
+		GrantedResource:   StringSlicePipeDelimited(r.GetGrantedResource()),
 		Active:            true,
 		Revoked:           false,
 		Form:              r.GetRequestForm().Encode(),
@@ -192,6 +198,7 @@ func NewOAuth2PushedAuthorizationSession(contextID string, r oauthelia2.Authoriz
 		RequestedAt:          r.GetRequestedAt(),
 		Scopes:               StringSlicePipeDelimited(r.GetRequestedScopes()),
 		Audience:             StringSlicePipeDelimited(r.GetRequestedAudience()),
+		Resource:             StringSlicePipeDelimited(r.GetRequestedResource()),
 		HandledResponseTypes: handled,
 		ResponseMode:         string(r.GetResponseMode()),
 		DefaultResponseMode:  string(r.GetDefaultResponseMode()),
@@ -214,21 +221,28 @@ type OAuth2ConsentPreConfig struct {
 
 	Scopes   StringSlicePipeDelimited `db:"scopes"`
 	Audience StringSlicePipeDelimited `db:"audience"`
+	Resource StringSlicePipeDelimited `db:"resource"`
 
 	RequestedClaims sql.NullString           `db:"requested_claims"`
 	SignatureClaims sql.NullString           `db:"signature_claims"`
 	GrantedClaims   StringSlicePipeDelimited `db:"granted_claims"`
 }
 
-// HasExactGrants returns true if the granted audience and scopes of this consent pre-configuration matches exactly with
-// another audience and set of scopes.
-func (s *OAuth2ConsentPreConfig) HasExactGrants(scopes, audience []string) (has bool) {
-	return s.HasExactGrantedScopes(scopes) && s.HasExactGrantedAudience(audience)
+// HasExactGrants returns true if the granted audience, resource and scopes of this consent
+// pre-configuration matches exactly with another audience, resource and set of scopes.
+func (s *OAuth2ConsentPreConfig) HasExactGrants(scopes, audience, resource []string) (has bool) {
+	return s.HasExactGrantedScopes(scopes) && s.HasExactGrantedAudience(audience) && s.HasExactGrantedResource(resource)
 }
 
 // HasExactGrantedAudience returns true if the granted audience of this consent matches exactly with another audience.
 func (s *OAuth2ConsentPreConfig) HasExactGrantedAudience(audience []string) (has bool) {
 	return !utils.IsStringSlicesDifferent(s.Audience, audience)
+}
+
+// HasExactGrantedResource returns true if the granted resource indicators of this consent matches
+// exactly with another set of resource indicators.
+func (s *OAuth2ConsentPreConfig) HasExactGrantedResource(resource []string) (has bool) {
+	return !utils.IsStringSlicesDifferent(s.Resource, resource)
 }
 
 // HasExactGrantedScopes returns true if the granted scopes of this consent matches exactly with another set of scopes.
@@ -271,6 +285,8 @@ type OAuth2ConsentSession struct {
 	GrantedScopes     StringSlicePipeDelimited `db:"granted_scopes"`
 	RequestedAudience StringSlicePipeDelimited `db:"requested_audience"`
 	GrantedAudience   StringSlicePipeDelimited `db:"granted_audience"`
+	RequestedResource StringSlicePipeDelimited `db:"requested_resource"`
+	GrantedResource   StringSlicePipeDelimited `db:"granted_resource"`
 	GrantedClaims     StringSlicePipeDelimited `db:"granted_claims"`
 
 	PreConfiguration sql.NullInt64 `db:"preconfiguration"`
@@ -319,15 +335,26 @@ func (s *OAuth2ConsentSession) GrantAudience() {
 	s.GrantedAudience = s.RequestedAudience
 }
 
-// HasExactGrants returns true if the granted audience and scopes of this consent matches exactly with another
-// audience and set of scopes.
-func (s *OAuth2ConsentSession) HasExactGrants(scopes, audience []string) (has bool) {
-	return s.HasExactGrantedScopes(scopes) && s.HasExactGrantedAudience(audience)
+// GrantResource grants all of the requested resource indicators.
+func (s *OAuth2ConsentSession) GrantResource() {
+	s.GrantedResource = s.RequestedResource
+}
+
+// HasExactGrants returns true if the granted audience, resource and scopes of this consent matches
+// exactly with another audience, resource and set of scopes.
+func (s *OAuth2ConsentSession) HasExactGrants(scopes, audience, resource []string) (has bool) {
+	return s.HasExactGrantedScopes(scopes) && s.HasExactGrantedAudience(audience) && s.HasExactGrantedResource(resource)
 }
 
 // HasExactGrantedAudience returns true if the granted audience of this consent matches exactly with another audience.
 func (s *OAuth2ConsentSession) HasExactGrantedAudience(audience []string) (has bool) {
 	return !utils.IsStringSlicesDifferent(s.GrantedAudience, audience)
+}
+
+// HasExactGrantedResource returns true if the granted resource indicators of this consent matches
+// exactly with another set of resource indicators.
+func (s *OAuth2ConsentSession) HasExactGrantedResource(resource []string) (has bool) {
+	return !utils.IsStringSlicesDifferent(s.GrantedResource, resource)
 }
 
 // HasExactGrantedScopes returns true if the granted scopes of this consent matches exactly with another set of scopes.
@@ -381,6 +408,16 @@ func (s *OAuth2ConsentSession) GetGrantedAudience() []string {
 	return s.GrantedAudience
 }
 
+// GetRequestedResource returns the requested resource.
+func (s *OAuth2ConsentSession) GetRequestedResource() []string {
+	return s.RequestedResource
+}
+
+// GetGrantedResource returns the granted resource.
+func (s *OAuth2ConsentSession) GetGrantedResource() []string {
+	return s.GrantedResource
+}
+
 // MatchesRequester returns an error if the requester is not a technical match for this OAuth2ConsentSession. The
 // prefixPAR value must be the Pushed Authorization Request URI prefix as consent sessions generated for a Pushed
 // Authorization Request only record the 'request_uri' and 'client_id' parameters, so only those parameters are
@@ -396,6 +433,10 @@ func (s *OAuth2ConsentSession) MatchesRequester(requester oauthelia2.Requester, 
 
 	if !oauthelia2.Arguments(s.RequestedAudience).Matches(requester.GetRequestedAudience()...) {
 		return oauthelia2.ErrInvalidRequest.WithDebugf("The requested audience '%s' does not match the requested audience '%s' from the consent session.", strings.Join(requester.GetRequestedAudience(), " "), strings.Join(s.RequestedAudience, " "))
+	}
+
+	if !oauthelia2.Arguments(s.RequestedResource).Matches(requester.GetRequestedResource()...) {
+		return oauthelia2.ErrInvalidRequest.WithDebugf("The requested resource '%s' does not match the requested resource '%s' from the consent session.", strings.Join(requester.GetRequestedResource(), " "), strings.Join(s.RequestedResource, " "))
 	}
 
 	var form url.Values
@@ -444,6 +485,8 @@ type OAuth2Session struct {
 	GrantedScopes     StringSlicePipeDelimited `db:"granted_scopes"`
 	RequestedAudience StringSlicePipeDelimited `db:"requested_audience"`
 	GrantedAudience   StringSlicePipeDelimited `db:"granted_audience"`
+	RequestedResource StringSlicePipeDelimited `db:"requested_resource"`
+	GrantedResource   StringSlicePipeDelimited `db:"granted_resource"`
 	Active            bool                     `db:"active"`
 	Revoked           bool                     `db:"revoked"`
 	Form              string                   `db:"form_data"`
@@ -487,6 +530,8 @@ func (s *OAuth2Session) ToRequest(ctx context.Context, session oauthelia2.Sessio
 		GrantedScope:      oauthelia2.Arguments(s.GrantedScopes),
 		RequestedAudience: oauthelia2.Arguments(s.RequestedAudience),
 		GrantedAudience:   oauthelia2.Arguments(s.GrantedAudience),
+		RequestedResource: oauthelia2.Arguments(s.RequestedResource),
+		GrantedResource:   oauthelia2.Arguments(s.GrantedResource),
 		Form:              values,
 		Session:           session,
 	}, nil
@@ -508,6 +553,8 @@ type OAuth2DeviceCodeSession struct {
 	GrantedScopes     StringSlicePipeDelimited `db:"granted_scopes"`
 	RequestedAudience StringSlicePipeDelimited `db:"requested_audience"`
 	GrantedAudience   StringSlicePipeDelimited `db:"granted_audience"`
+	RequestedResource StringSlicePipeDelimited `db:"requested_resource"`
+	GrantedResource   StringSlicePipeDelimited `db:"granted_resource"`
 	Active            bool                     `db:"active"`
 	Revoked           bool                     `db:"revoked"`
 	Form              string                   `db:"form_data"`
@@ -544,6 +591,16 @@ func (s *OAuth2DeviceCodeSession) GetGrantedAudience() []string {
 	return s.GrantedAudience
 }
 
+// GetRequestedResource returns the requested resource.
+func (s *OAuth2DeviceCodeSession) GetRequestedResource() []string {
+	return s.RequestedResource
+}
+
+// GetGrantedResource returns the granted resource.
+func (s *OAuth2DeviceCodeSession) GetGrantedResource() []string {
+	return s.GrantedResource
+}
+
 // ToRequest converts an OAuth2Session into a oauthelia2.Request given an oauthelia2.Session and oauthelia2.Storage.
 func (s *OAuth2DeviceCodeSession) ToRequest(ctx context.Context, session oauthelia2.Session, store oauthelia2.Storage) (request *oauthelia2.DeviceAuthorizeRequest, err error) {
 	sessionData := s.Session
@@ -573,6 +630,8 @@ func (s *OAuth2DeviceCodeSession) ToRequest(ctx context.Context, session oauthel
 			GrantedScope:      oauthelia2.Arguments(s.GrantedScopes),
 			RequestedAudience: oauthelia2.Arguments(s.RequestedAudience),
 			GrantedAudience:   oauthelia2.Arguments(s.GrantedAudience),
+			RequestedResource: oauthelia2.Arguments(s.RequestedResource),
+			GrantedResource:   oauthelia2.Arguments(s.GrantedResource),
 			Form:              values,
 			Session:           session,
 		},
@@ -594,6 +653,7 @@ type OAuth2PushedAuthorizationSession struct {
 	RequestedAt          time.Time                `db:"requested_at"`
 	Scopes               StringSlicePipeDelimited `db:"scopes"`
 	Audience             StringSlicePipeDelimited `db:"audience"`
+	Resource             StringSlicePipeDelimited `db:"resource"`
 	HandledResponseTypes StringSlicePipeDelimited `db:"handled_response_types"`
 	ResponseMode         string                   `db:"response_mode"`
 	DefaultResponseMode  string                   `db:"response_mode_default"`
@@ -631,6 +691,7 @@ func (par *OAuth2PushedAuthorizationSession) ToAuthorizeRequest(ctx context.Cont
 		Client:            client,
 		RequestedScope:    oauthelia2.Arguments(par.Scopes),
 		RequestedAudience: oauthelia2.Arguments(par.Audience),
+		RequestedResource: oauthelia2.Arguments(par.Resource),
 		Form:              form,
 		Session:           session,
 	}

--- a/internal/model/oidc_test.go
+++ b/internal/model/oidc_test.go
@@ -605,6 +605,8 @@ func TestNewOAuth2DeviceCodeSessionFromRequest(t *testing.T) {
 				assert.Equal(t, tc.expected.RequestedScopes, model.StringSlicePipeDelimited(actual.GetRequestedScopes()))
 				assert.Equal(t, tc.expected.GrantedAudience, model.StringSlicePipeDelimited(actual.GetGrantedAudience()))
 				assert.Equal(t, tc.expected.RequestedAudience, model.StringSlicePipeDelimited(actual.GetRequestedAudience()))
+				assert.Equal(t, tc.expected.GrantedResource, model.StringSlicePipeDelimited(actual.GetGrantedResource()))
+				assert.Equal(t, tc.expected.RequestedResource, model.StringSlicePipeDelimited(actual.GetRequestedResource()))
 
 				form, err := actual.GetForm()
 				assert.NoError(t, err)
@@ -809,17 +811,75 @@ func TestOAuth2ConsentPreConfig(t *testing.T) {
 
 	assert.False(t, config.CanConsent())
 
-	assert.False(t, config.HasExactGrants([]string{oidc.ScopeProfile}, []string{"abc"}))
+	assert.False(t, config.HasExactGrants([]string{oidc.ScopeProfile}, []string{"abc"}, nil))
 
 	config.Scopes = []string{oidc.ScopeProfile}
 
-	assert.False(t, config.HasExactGrants([]string{oidc.ScopeProfile}, []string{"abc"}))
+	assert.False(t, config.HasExactGrants([]string{oidc.ScopeProfile}, []string{"abc"}, nil))
 
 	config.Audience = []string{"abc"}
 
-	assert.True(t, config.HasExactGrants([]string{oidc.ScopeProfile}, []string{"abc"}))
+	assert.True(t, config.HasExactGrants([]string{oidc.ScopeProfile}, []string{"abc"}, nil))
 
 	assert.False(t, config.HasClaimsSignature("abc"))
+}
+
+func TestOAuth2ConsentPreConfigHasExactGrants(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Config   model.OAuth2ConsentPreConfig
+		Scopes   []string
+		Audience []string
+		Resource []string
+		Expected bool
+	}{
+		{
+			Name:     "ShouldMatchWhenResourceMatches",
+			Config:   model.OAuth2ConsentPreConfig{Scopes: model.StringSlicePipeDelimited{"openid"}, Audience: model.StringSlicePipeDelimited{"aud-a"}, Resource: model.StringSlicePipeDelimited{"https://a.example.com"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: []string{"https://a.example.com"},
+			Expected: true,
+		},
+		{
+			Name:     "ShouldNotMatchADifferentResource",
+			Config:   model.OAuth2ConsentPreConfig{Scopes: model.StringSlicePipeDelimited{"openid"}, Audience: model.StringSlicePipeDelimited{"aud-a"}, Resource: model.StringSlicePipeDelimited{"https://a.example.com"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: []string{"https://b.example.com"},
+			Expected: false,
+		},
+		{
+			Name:     "ShouldNotMatchAStoredEmptyResourceAgainstARequestedOne",
+			Config:   model.OAuth2ConsentPreConfig{Scopes: model.StringSlicePipeDelimited{"openid"}, Audience: model.StringSlicePipeDelimited{"aud-a"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: []string{"https://a.example.com"},
+			Expected: false,
+		},
+		{
+			Name:     "ShouldMatchAStoredEmptyResourceAgainstNoRequestedResource",
+			Config:   model.OAuth2ConsentPreConfig{Scopes: model.StringSlicePipeDelimited{"openid"}, Audience: model.StringSlicePipeDelimited{"aud-a"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: nil,
+			Expected: true,
+		},
+		{
+			Name:     "ShouldNotMatchWhenOnlyTheResourceDiffers",
+			Config:   model.OAuth2ConsentPreConfig{Scopes: model.StringSlicePipeDelimited{"openid"}, Audience: model.StringSlicePipeDelimited{"aud-a"}, Resource: model.StringSlicePipeDelimited{"https://a.example.com"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: []string{"https://a.example.com", "https://b.example.com"},
+			Expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert.Equal(t, tc.Expected, tc.Config.HasExactGrants(tc.Scopes, tc.Audience, tc.Resource))
+		})
+	}
 }
 
 func TestOAuth2ConsentSessionMatchesRequester(t *testing.T) {
@@ -1015,6 +1075,32 @@ func TestOAuth2ConsentSessionMatchesRequester(t *testing.T) {
 			},
 			Err:   "invalid_request",
 			Debug: "The requested audience 'b' does not match the requested audience 'a' from the consent session.",
+		},
+		{
+			Name:   "ShouldMatchWhenRequestedResourceIsEqual",
+			Have:   &model.OAuth2ConsentSession{ClientID: "test", RequestedResource: []string{"https://rs.example.com"}},
+			Prefix: prefixPAR,
+			Requester: &oauthelia2.Request{
+				Client:            &oidc.RegisteredClient{ID: "test"},
+				RequestedResource: []string{"https://rs.example.com"},
+			},
+		},
+		{
+			Name:      "ShouldMatchWhenRequestedResourceIsEmpty",
+			Have:      &model.OAuth2ConsentSession{ClientID: "test"},
+			Prefix:    prefixPAR,
+			Requester: &oauthelia2.Request{Client: &oidc.RegisteredClient{ID: "test"}},
+		},
+		{
+			Name:   "ShouldNotMatchDifferentRequestedResource",
+			Have:   &model.OAuth2ConsentSession{ClientID: "test", RequestedResource: []string{"https://rs.example.com"}},
+			Prefix: prefixPAR,
+			Requester: &oauthelia2.Request{
+				Client:            &oidc.RegisteredClient{ID: "test"},
+				RequestedResource: []string{"https://other.example.com"},
+			},
+			Err:   "invalid_request",
+			Debug: "The requested resource 'https://other.example.com' does not match the requested resource 'https://rs.example.com' from the consent session.",
 		},
 		{
 			Name:   "ShouldNotMatchDifferentNonce",
@@ -1282,16 +1368,25 @@ func TestOAuth2ConsentSession(t *testing.T) {
 	assert.Equal(t, []string(nil), session.GetRequestedScopes())
 	assert.Equal(t, []string(nil), session.GetGrantedAudience())
 	assert.Equal(t, []string(nil), session.GetRequestedAudience())
+	assert.Equal(t, []string(nil), session.GetGrantedResource())
+	assert.Equal(t, []string(nil), session.GetRequestedResource())
 
 	session.GrantedScopes = []string{"abc1"}
 	session.RequestedScopes = []string{"abc2"}
 	session.GrantedAudience = []string{"abc3"}
 	session.RequestedAudience = []string{"abc4"}
+	session.GrantedResource = []string{"abc5"}
+	session.RequestedResource = []string{"abc6"}
 
 	assert.Equal(t, []string{"abc1"}, session.GetGrantedScopes())
 	assert.Equal(t, []string{"abc2"}, session.GetRequestedScopes())
 	assert.Equal(t, []string{"abc3"}, session.GetGrantedAudience())
 	assert.Equal(t, []string{"abc4"}, session.GetRequestedAudience())
+	assert.Equal(t, []string{"abc5"}, session.GetGrantedResource())
+	assert.Equal(t, []string{"abc6"}, session.GetRequestedResource())
+
+	session.GrantedResource = nil
+	session.RequestedResource = nil
 
 	session.GrantScope("abc")
 	assert.Equal(t, []string{"abc1", "abc"}, session.GetGrantedScopes())
@@ -1318,15 +1413,15 @@ func TestOAuth2ConsentSession(t *testing.T) {
 
 	assert.False(t, session.CanGrant(before))
 
-	assert.False(t, session.HasExactGrants([]string{oidc.ScopeOpenID}, []string{"abc"}))
+	assert.False(t, session.HasExactGrants([]string{oidc.ScopeOpenID}, []string{"abc"}, nil))
 
 	session.GrantedScopes = model.StringSlicePipeDelimited{oidc.ScopeOpenID}
 
-	assert.False(t, session.HasExactGrants([]string{oidc.ScopeOpenID}, []string{"abc"}))
+	assert.False(t, session.HasExactGrants([]string{oidc.ScopeOpenID}, []string{"abc"}, nil))
 
 	session.GrantedAudience = model.StringSlicePipeDelimited{"abc"}
 
-	assert.True(t, session.HasExactGrants([]string{oidc.ScopeOpenID}, []string{"abc"}))
+	assert.True(t, session.HasExactGrants([]string{oidc.ScopeOpenID}, []string{"abc"}, nil))
 
 	session.GrantedScopes = nil
 	session.GrantedAudience = nil
@@ -1376,6 +1471,64 @@ func TestOAuth2ConsentSession(t *testing.T) {
 	assert.Equal(t, sql.NullTime{Time: now, Valid: true}, session.RespondedAt)
 }
 
+func TestOAuth2ConsentSessionHasExactGrants(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Session  model.OAuth2ConsentSession
+		Scopes   []string
+		Audience []string
+		Resource []string
+		Expected bool
+	}{
+		{
+			Name:     "ShouldMatchWhenResourceMatches",
+			Session:  model.OAuth2ConsentSession{GrantedScopes: model.StringSlicePipeDelimited{"openid"}, GrantedAudience: model.StringSlicePipeDelimited{"aud-a"}, GrantedResource: model.StringSlicePipeDelimited{"https://a.example.com"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: []string{"https://a.example.com"},
+			Expected: true,
+		},
+		{
+			Name:     "ShouldNotMatchADifferentResource",
+			Session:  model.OAuth2ConsentSession{GrantedScopes: model.StringSlicePipeDelimited{"openid"}, GrantedAudience: model.StringSlicePipeDelimited{"aud-a"}, GrantedResource: model.StringSlicePipeDelimited{"https://a.example.com"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: []string{"https://b.example.com"},
+			Expected: false,
+		},
+		{
+			Name:     "ShouldNotMatchAStoredEmptyResourceAgainstARequestedOne",
+			Session:  model.OAuth2ConsentSession{GrantedScopes: model.StringSlicePipeDelimited{"openid"}, GrantedAudience: model.StringSlicePipeDelimited{"aud-a"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: []string{"https://a.example.com"},
+			Expected: false,
+		},
+		{
+			Name:     "ShouldMatchAStoredEmptyResourceAgainstNoRequestedResource",
+			Session:  model.OAuth2ConsentSession{GrantedScopes: model.StringSlicePipeDelimited{"openid"}, GrantedAudience: model.StringSlicePipeDelimited{"aud-a"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: nil,
+			Expected: true,
+		},
+		{
+			Name:     "ShouldNotMatchWhenOnlyTheResourceDiffers",
+			Session:  model.OAuth2ConsentSession{GrantedScopes: model.StringSlicePipeDelimited{"openid"}, GrantedAudience: model.StringSlicePipeDelimited{"aud-a"}, GrantedResource: model.StringSlicePipeDelimited{"https://a.example.com"}},
+			Scopes:   []string{"openid"},
+			Audience: []string{"aud-a"},
+			Resource: []string{"https://a.example.com", "https://b.example.com"},
+			Expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert.Equal(t, tc.Expected, tc.Session.HasExactGrants(tc.Scopes, tc.Audience, tc.Resource))
+		})
+	}
+}
+
 func TestMisc(t *testing.T) {
 	jti := model.NewOAuth2BlacklistedJTI("abc", time.Unix(10000, 0).UTC())
 
@@ -1388,6 +1541,196 @@ func TestMisc(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, session)
+}
+
+func TestOAuth2ResourceSurvivesRehydration(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Resource model.StringSlicePipeDelimited
+		Expected oauthelia2.Arguments
+	}{
+		{
+			Name:     "ShouldRestoreASingleResource",
+			Resource: model.StringSlicePipeDelimited{"https://api.example.com"},
+			Expected: oauthelia2.Arguments{"https://api.example.com"},
+		},
+		{
+			Name:     "ShouldRestoreMultipleResources",
+			Resource: model.StringSlicePipeDelimited{"https://a.example.com", "https://b.example.com"},
+			Expected: oauthelia2.Arguments{"https://a.example.com", "https://b.example.com"},
+		},
+		{
+			Name:     "ShouldRestoreAnEmptyResource",
+			Resource: nil,
+			Expected: oauthelia2.Arguments(nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			defer ctrl.Finish()
+
+			store := mocks.NewMockOAuth2Storage(ctrl)
+
+			store.EXPECT().GetClient(context.TODO(), "test-client").Return(&oidc.RegisteredClient{ID: "test-client"}, nil)
+
+			session := &model.OAuth2Session{
+				RequestID:         "req-1",
+				ClientID:          "test-client",
+				RequestedScopes:   model.StringSlicePipeDelimited{"openid"},
+				GrantedScopes:     model.StringSlicePipeDelimited{"openid"},
+				RequestedAudience: model.StringSlicePipeDelimited{"aud-a"},
+				GrantedAudience:   model.StringSlicePipeDelimited{"aud-a"},
+				RequestedResource: tc.Resource,
+				GrantedResource:   tc.Resource,
+				Session:           []byte("{}"),
+			}
+
+			request, err := session.ToRequest(context.TODO(), oidc.NewSession(), store)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.Expected, request.GetRequestedResource())
+			assert.Equal(t, tc.Expected, request.GetGrantedResource())
+			assert.Equal(t, oauthelia2.Arguments{"aud-a"}, request.GetRequestedAudience())
+		})
+	}
+}
+
+func TestOAuth2DeviceCodeResourceSurvivesRehydration(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Resource model.StringSlicePipeDelimited
+		Expected oauthelia2.Arguments
+	}{
+		{
+			Name:     "ShouldRestoreASingleResource",
+			Resource: model.StringSlicePipeDelimited{"https://api.example.com"},
+			Expected: oauthelia2.Arguments{"https://api.example.com"},
+		},
+		{
+			Name:     "ShouldRestoreMultipleResources",
+			Resource: model.StringSlicePipeDelimited{"https://a.example.com", "https://b.example.com"},
+			Expected: oauthelia2.Arguments{"https://a.example.com", "https://b.example.com"},
+		},
+		{
+			Name:     "ShouldRestoreAnEmptyResource",
+			Resource: nil,
+			Expected: oauthelia2.Arguments(nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			defer ctrl.Finish()
+
+			store := mocks.NewMockOAuth2Storage(ctrl)
+
+			store.EXPECT().GetClient(context.TODO(), "test-client").Return(&oidc.RegisteredClient{ID: "test-client"}, nil)
+
+			session := &model.OAuth2DeviceCodeSession{
+				RequestID:         "req-1",
+				ClientID:          "test-client",
+				RequestedScopes:   model.StringSlicePipeDelimited{"openid"},
+				GrantedScopes:     model.StringSlicePipeDelimited{"openid"},
+				RequestedAudience: model.StringSlicePipeDelimited{"aud-a"},
+				GrantedAudience:   model.StringSlicePipeDelimited{"aud-a"},
+				RequestedResource: tc.Resource,
+				GrantedResource:   tc.Resource,
+				Session:           []byte("{}"),
+			}
+
+			request, err := session.ToRequest(context.TODO(), oidc.NewSession(), store)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.Expected, request.GetRequestedResource())
+			assert.Equal(t, tc.Expected, request.GetGrantedResource())
+			assert.Equal(t, oauthelia2.Arguments{"aud-a"}, request.GetRequestedAudience())
+		})
+	}
+}
+
+func TestOAuth2PARResourceSurvivesRehydration(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Resource model.StringSlicePipeDelimited
+		Expected oauthelia2.Arguments
+	}{
+		{
+			Name:     "ShouldRestoreASingleResource",
+			Resource: model.StringSlicePipeDelimited{"https://api.example.com"},
+			Expected: oauthelia2.Arguments{"https://api.example.com"},
+		},
+		{
+			Name:     "ShouldRestoreMultipleResources",
+			Resource: model.StringSlicePipeDelimited{"https://a.example.com", "https://b.example.com"},
+			Expected: oauthelia2.Arguments{"https://a.example.com", "https://b.example.com"},
+		},
+		{
+			Name:     "ShouldRestoreAnEmptyResource",
+			Resource: nil,
+			Expected: oauthelia2.Arguments(nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			defer ctrl.Finish()
+
+			store := mocks.NewMockOAuth2Storage(ctrl)
+
+			store.EXPECT().GetClient(context.TODO(), "test-client").Return(&oidc.RegisteredClient{ID: "test-client"}, nil)
+
+			par := &model.OAuth2PushedAuthorizationSession{
+				RequestID: "req-1",
+				ClientID:  "test-client",
+				Scopes:    model.StringSlicePipeDelimited{"openid"},
+				Audience:  model.StringSlicePipeDelimited{"aud-a"},
+				Resource:  tc.Resource,
+				Session:   []byte("{}"),
+			}
+
+			request, err := par.ToAuthorizeRequest(context.TODO(), oidc.NewSession(), store)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.Expected, request.GetRequestedResource())
+			assert.Equal(t, oauthelia2.Arguments{"aud-a"}, request.GetRequestedAudience())
+		})
+	}
+}
+
+func TestOAuth2ConsentSessionGrantResource(t *testing.T) {
+	testCases := []struct {
+		Name      string
+		Requested model.StringSlicePipeDelimited
+		Expected  model.StringSlicePipeDelimited
+	}{
+		{
+			Name:      "ShouldGrantTheRequestedResource",
+			Requested: model.StringSlicePipeDelimited{"https://api.example.com"},
+			Expected:  model.StringSlicePipeDelimited{"https://api.example.com"},
+		},
+		{
+			Name:      "ShouldGrantNothingWhenNoneRequested",
+			Requested: nil,
+			Expected:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			consent := &model.OAuth2ConsentSession{RequestedResource: tc.Requested}
+
+			consent.GrantResource()
+
+			assert.Equal(t, tc.Expected, consent.GrantedResource)
+		})
+	}
 }
 
 func MustParseRequestURI(t *testing.T, uri string) (parsed *url.URL) {

--- a/internal/oidc/claims.go
+++ b/internal/oidc/claims.go
@@ -845,6 +845,10 @@ func GrantScopeAudienceConsent(r oauthelia2.Requester, consent *model.OAuth2Cons
 	for _, audience := range consent.GrantedAudience {
 		r.GrantAudience(audience)
 	}
+
+	for _, resource := range consent.GrantedResource {
+		r.GrantResource(resource)
+	}
 }
 
 // GetAudienceFromClaims retrieves the various formats of the 'aud' claim and returns them as a []string.

--- a/internal/oidc/claims_test.go
+++ b/internal/oidc/claims_test.go
@@ -1594,6 +1594,7 @@ func TestGrantScopeAudienceConsent(t *testing.T) {
 		expected         bool
 		expectedScope    oauthelia2.Arguments
 		expectedAudience oauthelia2.Arguments
+		expectedResource oauthelia2.Arguments
 	}{
 		{
 			"ShouldGrant",
@@ -1601,10 +1602,12 @@ func TestGrantScopeAudienceConsent(t *testing.T) {
 			&model.OAuth2ConsentSession{
 				GrantedScopes:   []string{"abc"},
 				GrantedAudience: []string{"ad"},
+				GrantedResource: []string{"https://api.example.com"},
 			},
 			true,
 			[]string{"abc"},
 			[]string{"ad"},
+			[]string{"https://api.example.com"},
 		},
 		{
 			"ShouldNotGrant",
@@ -1612,8 +1615,10 @@ func TestGrantScopeAudienceConsent(t *testing.T) {
 			&model.OAuth2ConsentSession{
 				GrantedScopes:   []string{},
 				GrantedAudience: []string{},
+				GrantedResource: []string{},
 			},
 			true,
+			nil,
 			nil,
 			nil,
 		},
@@ -1624,6 +1629,7 @@ func TestGrantScopeAudienceConsent(t *testing.T) {
 			true,
 			nil,
 			nil,
+			nil,
 		},
 		{
 			"ShouldNotGrantNilRequest",
@@ -1631,8 +1637,10 @@ func TestGrantScopeAudienceConsent(t *testing.T) {
 			&model.OAuth2ConsentSession{
 				GrantedScopes:   []string{},
 				GrantedAudience: []string{},
+				GrantedResource: []string{},
 			},
 			false,
+			nil,
 			nil,
 			nil,
 		},
@@ -1646,6 +1654,7 @@ func TestGrantScopeAudienceConsent(t *testing.T) {
 				require.NotNil(t, tc.ar)
 				assert.Equal(t, tc.expectedScope, tc.ar.GetGrantedScopes())
 				assert.Equal(t, tc.expectedAudience, tc.ar.GetGrantedAudience())
+				assert.Equal(t, tc.expectedResource, tc.ar.GetGrantedResource())
 			} else {
 				assert.Nil(t, tc.ar)
 			}

--- a/internal/oidc/client.go
+++ b/internal/oidc/client.go
@@ -546,6 +546,7 @@ func (c *RegisteredClient) GetConsentResponseBody(session RequesterFormSession, 
 	if session != nil {
 		body.Scopes = session.GetRequestedScopes()
 		body.Audience = session.GetRequestedAudience()
+		body.Resource = session.GetRequestedResource()
 
 		var (
 			claims *ClaimsRequests

--- a/internal/oidc/client_test.go
+++ b/internal/oidc/client_test.go
@@ -462,6 +462,29 @@ func TestClient_GetConsentResponseBody(t *testing.T) {
 			},
 		},
 		{
+			"ShouldHandleRequestedResource",
+			nil,
+			&model.OAuth2ConsentSession{
+				RequestedScopes:   []string{oidc.ScopeOpenID, oidc.ScopeProfile},
+				RequestedAudience: []string{"https://example.com"},
+				RequestedResource: []string{"https://api.example.com", "https://api.example.com/v2"},
+			},
+			url.Values{
+				oidc.FormParameterState:        []string{"123"},
+				oidc.FormParameterScope:        []string{fmt.Sprintf("%s %s", oidc.ScopeOpenID, oidc.ScopeProfile)},
+				oidc.FormParameterResponseType: []string{oidc.ResponseTypeAuthorizationCodeFlow},
+			},
+			time.Unix(19000000000, 0),
+			false,
+			oidc.ConsentGetResponseBody{
+				ClientID:          myclient,
+				ClientDescription: myclientname,
+				Scopes:            []string{oidc.ScopeOpenID, oidc.ScopeProfile},
+				Audience:          []string{"https://example.com"},
+				Resource:          []string{"https://api.example.com", "https://api.example.com/v2"},
+			},
+		},
+		{
 			"ShouldHandleStandardPreConfiguration",
 			&oidc.RegisteredClient{
 				ID:            myclient,

--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -275,6 +275,7 @@ func ConsentGrantImplicit(consent *model.OAuth2ConsentSession, claims []string, 
 // requirements around consent like not allowing access to a refresh token unless the user has explicitly consented.
 func ConsentGrant(consent *model.OAuth2ConsentSession, explicit bool, claims []string) {
 	consent.GrantAudience()
+	consent.GrantResource()
 	consent.GrantClaims(claims)
 
 	if explicit {

--- a/internal/oidc/session_test.go
+++ b/internal/oidc/session_test.go
@@ -445,12 +445,14 @@ func TestConsentGrant(t *testing.T) {
 			consent := &model.OAuth2ConsentSession{
 				RequestedScopes:   tc.requestedScopes,
 				RequestedAudience: model.StringSlicePipeDelimited{"https://example.com"},
+				RequestedResource: model.StringSlicePipeDelimited{"https://api.example.com"},
 			}
 
 			oidc.ConsentGrant(consent, tc.explicit, tc.claims)
 
 			assert.Equal(t, model.StringSlicePipeDelimited(tc.expectedScopes), consent.GrantedScopes)
 			assert.Equal(t, model.StringSlicePipeDelimited{"https://example.com"}, consent.GrantedAudience)
+			assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, consent.GrantedResource)
 
 			if tc.expectedClaims != nil {
 				assert.Equal(t, model.StringSlicePipeDelimited(tc.expectedClaims), consent.GrantedClaims)

--- a/internal/oidc/store_test.go
+++ b/internal/oidc/store_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -142,6 +143,127 @@ func TestOpenIDConnectStore_IsValidClientID(t *testing.T) {
 
 	assert.True(t, validClient)
 	assert.False(t, invalidClient)
+}
+
+func TestOAuth2SessionGrantedResourceRoundTripsThroughStore(t *testing.T) {
+	ctx := context.Background()
+
+	provider, err := storage.NewSQLiteProvider(&schema.Configuration{
+		Storage: schema.Storage{
+			EncryptionKey: "authelia-test-key-not-a-secret-authelia-test-key-not-a-secret",
+			Local: &schema.StorageLocal{
+				Path: filepath.Join(t.TempDir(), "db.sqlite3"),
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, provider.StartupCheck())
+
+	s := oidc.NewStore(&schema.Configuration{
+		IdentityProviders: schema.IdentityProviders{
+			OIDC: &schema.IdentityProvidersOpenIDConnect{
+				IssuerCertificateChain: schema.X509CertificateChain{},
+				IssuerPrivateKey:       x509PrivateKeyRSA2048,
+				Clients: []schema.IdentityProvidersOpenIDConnectClient{
+					{
+						ID:                  myclient,
+						Name:                myclientname,
+						AuthorizationPolicy: onefactor,
+						Scopes:              []string{oidc.ScopeOpenID, oidc.ScopeProfile},
+						Secret:              tOpenIDConnectPlainTextClientSecret,
+					},
+				},
+			},
+		},
+	}, provider)
+
+	requester := &oauthelia2.Request{
+		ID:                "req-resource-e2e",
+		Client:            &oidc.RegisteredClient{ID: myclient},
+		RequestedScope:    oauthelia2.Arguments{oidc.ScopeOpenID},
+		RequestedAudience: oauthelia2.Arguments{"aud-a"},
+		Session:           &oidc.Session{},
+	}
+
+	consent := &model.OAuth2ConsentSession{
+		GrantedScopes:   model.StringSlicePipeDelimited{oidc.ScopeOpenID},
+		GrantedAudience: model.StringSlicePipeDelimited{"aud-a"},
+		GrantedResource: model.StringSlicePipeDelimited{"https://api.example.com"},
+	}
+
+	oidc.GrantScopeAudienceConsent(requester, consent)
+
+	require.NoError(t, s.CreateAccessTokenSession(ctx, "sig-resource-e2e", requester))
+
+	loaded, err := s.GetAccessTokenSession(ctx, "sig-resource-e2e", &oidc.Session{})
+
+	require.NoError(t, err)
+	assert.Equal(t, oauthelia2.Arguments{oidc.ScopeOpenID}, loaded.GetGrantedScopes())
+	assert.Equal(t, oauthelia2.Arguments{"aud-a"}, loaded.GetGrantedAudience())
+	assert.Equal(t, oauthelia2.Arguments{"https://api.example.com"}, loaded.GetGrantedResource())
+}
+
+func TestOAuth2DeviceCodeSessionGrantedResourceRoundTripsThroughStore(t *testing.T) {
+	ctx := context.Background()
+
+	provider, err := storage.NewSQLiteProvider(&schema.Configuration{
+		Storage: schema.Storage{
+			EncryptionKey: "authelia-test-key-not-a-secret-authelia-test-key-not-a-secret",
+			Local: &schema.StorageLocal{
+				Path: filepath.Join(t.TempDir(), "db.sqlite3"),
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NoError(t, provider.StartupCheck())
+
+	s := oidc.NewStore(&schema.Configuration{
+		IdentityProviders: schema.IdentityProviders{
+			OIDC: &schema.IdentityProvidersOpenIDConnect{
+				IssuerCertificateChain: schema.X509CertificateChain{},
+				IssuerPrivateKey:       x509PrivateKeyRSA2048,
+				Clients: []schema.IdentityProvidersOpenIDConnectClient{
+					{
+						ID:                  myclient,
+						Name:                myclientname,
+						AuthorizationPolicy: onefactor,
+						Scopes:              []string{oidc.ScopeOpenID, oidc.ScopeProfile},
+						Secret:              tOpenIDConnectPlainTextClientSecret,
+					},
+				},
+			},
+		},
+	}, provider)
+
+	requester := &oauthelia2.DeviceAuthorizeRequest{
+		Request: oauthelia2.Request{
+			ID:                "req-resource-e2e-device",
+			Client:            &oidc.RegisteredClient{ID: myclient},
+			RequestedScope:    oauthelia2.Arguments{oidc.ScopeOpenID},
+			RequestedAudience: oauthelia2.Arguments{"aud-a"},
+			Session:           &oidc.Session{},
+		},
+		DeviceCodeSignature: "sig-resource-e2e-device",
+	}
+
+	consent := &model.OAuth2ConsentSession{
+		GrantedScopes:   model.StringSlicePipeDelimited{oidc.ScopeOpenID},
+		GrantedAudience: model.StringSlicePipeDelimited{"aud-a"},
+		GrantedResource: model.StringSlicePipeDelimited{"https://api.example.com"},
+	}
+
+	oidc.GrantScopeAudienceConsent(requester, consent)
+
+	require.NoError(t, s.CreateDeviceCodeSession(ctx, requester.DeviceCodeSignature, requester))
+
+	loaded, err := s.GetDeviceCodeSession(ctx, requester.DeviceCodeSignature, &oidc.Session{})
+
+	require.NoError(t, err)
+	assert.Equal(t, oauthelia2.Arguments{oidc.ScopeOpenID}, loaded.GetGrantedScopes())
+	assert.Equal(t, oauthelia2.Arguments{"aud-a"}, loaded.GetGrantedAudience())
+	assert.Equal(t, oauthelia2.Arguments{"https://api.example.com"}, loaded.GetGrantedResource())
 }
 
 func TestStoreSuite(t *testing.T) {

--- a/internal/oidc/types.go
+++ b/internal/oidc/types.go
@@ -305,6 +305,7 @@ type ConsentGetResponseBody struct {
 	ClientDescription string   `json:"client_description"`
 	Scopes            []string `json:"scopes"`
 	Audience          []string `json:"audience"`
+	Resource          []string `json:"resource"`
 	PreConfiguration  bool     `json:"pre_configuration"`
 	Claims            []string `json:"claims"`
 	EssentialClaims   []string `json:"essential_claims"`
@@ -1123,9 +1124,11 @@ type RequesterFormSession interface {
 
 	GetRequestedScopes() []string
 	GetRequestedAudience() []string
+	GetRequestedResource() []string
 
 	GetGrantedScopes() []string
 	GetGrantedAudience() []string
+	GetGrantedResource() []string
 }
 
 // Number is a constraint which permits any integer or floating point type.

--- a/internal/storage/migrations/mysql/V0029.OAuth2Resource.down.sql
+++ b/internal/storage/migrations/mysql/V0029.OAuth2Resource.down.sql
@@ -1,0 +1,31 @@
+ALTER TABLE oauth2_access_token_session
+    DROP COLUMN requested_resource,
+    DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_authorization_code_session
+    DROP COLUMN requested_resource,
+    DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_openid_connect_session
+    DROP COLUMN requested_resource,
+    DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_pkce_request_session
+    DROP COLUMN requested_resource,
+    DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_refresh_token_session
+    DROP COLUMN requested_resource,
+    DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_device_code_session
+    DROP COLUMN requested_resource,
+    DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_consent_session
+    DROP COLUMN requested_resource,
+    DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_par_context DROP COLUMN resource;
+
+ALTER TABLE oauth2_consent_preconfiguration DROP COLUMN resource;

--- a/internal/storage/migrations/mysql/V0029.OAuth2Resource.up.sql
+++ b/internal/storage/migrations/mysql/V0029.OAuth2Resource.up.sql
@@ -1,0 +1,31 @@
+ALTER TABLE oauth2_access_token_session
+    ADD COLUMN requested_resource TEXT NULL,
+    ADD COLUMN granted_resource TEXT NULL;
+
+ALTER TABLE oauth2_authorization_code_session
+    ADD COLUMN requested_resource TEXT NULL,
+    ADD COLUMN granted_resource TEXT NULL;
+
+ALTER TABLE oauth2_openid_connect_session
+    ADD COLUMN requested_resource TEXT NULL,
+    ADD COLUMN granted_resource TEXT NULL;
+
+ALTER TABLE oauth2_pkce_request_session
+    ADD COLUMN requested_resource TEXT NULL,
+    ADD COLUMN granted_resource TEXT NULL;
+
+ALTER TABLE oauth2_refresh_token_session
+    ADD COLUMN requested_resource TEXT NULL,
+    ADD COLUMN granted_resource TEXT NULL;
+
+ALTER TABLE oauth2_device_code_session
+    ADD COLUMN requested_resource TEXT NULL,
+    ADD COLUMN granted_resource TEXT NULL;
+
+ALTER TABLE oauth2_consent_session
+    ADD COLUMN requested_resource TEXT NULL,
+    ADD COLUMN granted_resource TEXT NULL;
+
+ALTER TABLE oauth2_par_context ADD COLUMN resource TEXT NULL;
+
+ALTER TABLE oauth2_consent_preconfiguration ADD COLUMN resource TEXT NULL;

--- a/internal/storage/migrations/postgres/V0029.OAuth2Resource.down.sql
+++ b/internal/storage/migrations/postgres/V0029.OAuth2Resource.down.sql
@@ -1,0 +1,24 @@
+ALTER TABLE oauth2_access_token_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_access_token_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_authorization_code_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_authorization_code_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_openid_connect_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_openid_connect_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_pkce_request_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_pkce_request_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_refresh_token_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_refresh_token_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_device_code_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_device_code_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_consent_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_consent_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_par_context DROP COLUMN resource;
+
+ALTER TABLE oauth2_consent_preconfiguration DROP COLUMN resource;

--- a/internal/storage/migrations/postgres/V0029.OAuth2Resource.up.sql
+++ b/internal/storage/migrations/postgres/V0029.OAuth2Resource.up.sql
@@ -1,0 +1,24 @@
+ALTER TABLE oauth2_access_token_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_access_token_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_authorization_code_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_authorization_code_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_openid_connect_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_openid_connect_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_pkce_request_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_pkce_request_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_refresh_token_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_refresh_token_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_device_code_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_device_code_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_consent_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_consent_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_par_context ADD COLUMN resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_consent_preconfiguration ADD COLUMN resource TEXT NULL;

--- a/internal/storage/migrations/sqlite/V0029.OAuth2Resource.down.sql
+++ b/internal/storage/migrations/sqlite/V0029.OAuth2Resource.down.sql
@@ -1,0 +1,24 @@
+ALTER TABLE oauth2_access_token_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_access_token_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_authorization_code_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_authorization_code_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_openid_connect_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_openid_connect_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_pkce_request_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_pkce_request_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_refresh_token_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_refresh_token_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_device_code_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_device_code_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_consent_session DROP COLUMN requested_resource;
+ALTER TABLE oauth2_consent_session DROP COLUMN granted_resource;
+
+ALTER TABLE oauth2_par_context DROP COLUMN resource;
+
+ALTER TABLE oauth2_consent_preconfiguration DROP COLUMN resource;

--- a/internal/storage/migrations/sqlite/V0029.OAuth2Resource.up.sql
+++ b/internal/storage/migrations/sqlite/V0029.OAuth2Resource.up.sql
@@ -1,0 +1,24 @@
+ALTER TABLE oauth2_access_token_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_access_token_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_authorization_code_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_authorization_code_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_openid_connect_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_openid_connect_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_pkce_request_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_pkce_request_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_refresh_token_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_refresh_token_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_device_code_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_device_code_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_consent_session ADD COLUMN requested_resource TEXT NULL DEFAULT '';
+ALTER TABLE oauth2_consent_session ADD COLUMN granted_resource TEXT NULL DEFAULT '';
+
+ALTER TABLE oauth2_par_context ADD COLUMN resource TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE oauth2_consent_preconfiguration ADD COLUMN resource TEXT NULL;

--- a/internal/storage/migrations_test.go
+++ b/internal/storage/migrations_test.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// This is the latest schema version for the purpose of tests.
-	LatestVersion = 28
+	LatestVersion = 29
 )
 
 func TestShouldObtainCorrectMigrations(t *testing.T) {

--- a/internal/storage/sql_provider.go
+++ b/internal/storage/sql_provider.go
@@ -1175,14 +1175,14 @@ func (p *SQLProvider) SaveOAuth2ConsentPreConfiguration(ctx context.Context, con
 	case providerPostgres:
 		err = p.conn(ctx).GetContext(ctx, &insertedID, p.sqlInsertOAuth2ConsentPreConfiguration,
 			config.ClientID, config.Subject, config.CreatedAt, config.ExpiresAt,
-			config.Revoked, config.Scopes, config.Audience,
+			config.Revoked, config.Scopes, config.Audience, config.Resource,
 			config.RequestedClaims, config.SignatureClaims, config.GrantedClaims)
 	default:
 		var result sql.Result
 
 		if result, err = p.conn(ctx).ExecContext(ctx, p.sqlInsertOAuth2ConsentPreConfiguration,
 			config.ClientID, config.Subject, config.CreatedAt, config.ExpiresAt,
-			config.Revoked, config.Scopes, config.Audience,
+			config.Revoked, config.Scopes, config.Audience, config.Resource,
 			config.RequestedClaims, config.SignatureClaims, config.GrantedClaims); err == nil {
 			insertedID, err = result.LastInsertId()
 		}
@@ -1215,7 +1215,8 @@ func (p *SQLProvider) SaveOAuth2ConsentSession(ctx context.Context, consent *mod
 	if _, err = p.conn(ctx).ExecContext(ctx, p.sqlInsertOAuth2ConsentSession,
 		consent.ChallengeID, consent.ClientID, consent.Subject, consent.Authorized, consent.Granted,
 		consent.RequestedAt, consent.ExpiresAt, consent.RespondedAt, consent.Form,
-		consent.RequestedScopes, consent.GrantedScopes, consent.RequestedAudience, consent.GrantedAudience, consent.GrantedClaims, consent.PreConfiguration); err != nil {
+		consent.RequestedScopes, consent.GrantedScopes, consent.RequestedAudience, consent.GrantedAudience,
+		consent.RequestedResource, consent.GrantedResource, consent.GrantedClaims, consent.PreConfiguration); err != nil {
 		return fmt.Errorf("error inserting oauth2 consent session with challenge id '%s' for subject '%s': %w", consent.ChallengeID.String(), consent.Subject.UUID.String(), err)
 	}
 
@@ -1231,11 +1232,11 @@ func (p *SQLProvider) SaveOAuth2ConsentSessionResponse(ctx context.Context, cons
 	var result sql.Result
 
 	if consent.ID != 0 {
-		if result, err = p.conn(ctx).ExecContext(ctx, p.sqlUpdateOAuth2ConsentSessionResponseByID, consent.Subject, consent.RespondedAt, authorized, consent.GrantedScopes, consent.GrantedAudience, consent.GrantedClaims, consent.PreConfiguration, consent.ID); err != nil {
+		if result, err = p.conn(ctx).ExecContext(ctx, p.sqlUpdateOAuth2ConsentSessionResponseByID, consent.Subject, consent.RespondedAt, authorized, consent.GrantedScopes, consent.GrantedAudience, consent.GrantedResource, consent.GrantedClaims, consent.PreConfiguration, consent.ID); err != nil {
 			return fmt.Errorf("error updating oauth2 consent session (authorized  '%t') with id '%d' and challenge id '%s' for subject '%s': %w", authorized, consent.ID, consent.ChallengeID, consent.Subject.UUID, err)
 		}
 	} else {
-		if result, err = p.conn(ctx).ExecContext(ctx, p.sqlUpdateOAuth2ConsentSessionResponseByChallengeID, consent.Subject, consent.RespondedAt, authorized, consent.GrantedScopes, consent.GrantedAudience, consent.GrantedClaims, consent.PreConfiguration, consent.ChallengeID); err != nil {
+		if result, err = p.conn(ctx).ExecContext(ctx, p.sqlUpdateOAuth2ConsentSessionResponseByChallengeID, consent.Subject, consent.RespondedAt, authorized, consent.GrantedScopes, consent.GrantedAudience, consent.GrantedResource, consent.GrantedClaims, consent.PreConfiguration, consent.ChallengeID); err != nil {
 			return fmt.Errorf("error updating oauth2 consent session (authorized  '%t') with challenge id '%s' for subject '%s': %w", authorized, consent.ChallengeID, consent.Subject.UUID, err)
 		}
 	}
@@ -1301,6 +1302,7 @@ func (p *SQLProvider) SaveOAuth2Session(ctx context.Context, sessionType OAuth2S
 		session.ChallengeID, session.RequestID, session.ClientID, session.Signature,
 		session.Subject, session.RequestedAt, session.RequestedScopes, session.GrantedScopes,
 		session.RequestedAudience, session.GrantedAudience,
+		session.RequestedResource, session.GrantedResource,
 		session.Active, session.Revoked, session.Form, session.Session,
 	}
 
@@ -1494,6 +1496,7 @@ func (p *SQLProvider) SaveOAuth2DeviceCodeSession(ctx context.Context, session *
 		session.Status, session.Subject, session.RequestedAt, session.CheckedAt,
 		session.RequestedScopes, session.GrantedScopes,
 		session.RequestedAudience, session.GrantedAudience,
+		session.RequestedResource, session.GrantedResource,
 		session.Active, session.Revoked, session.Form, session.Session); err != nil {
 		return fmt.Errorf("error inserting oauth2 device code session with signature '%s' and user code signature '%s' for subject '%s' and request id '%s': %w", session.Signature, session.UserCodeSignature, session.Subject.String, session.RequestID, err)
 	}
@@ -1511,7 +1514,8 @@ func (p *SQLProvider) UpdateOAuth2DeviceCodeSession(ctx context.Context, session
 
 	if result, err = p.conn(ctx).ExecContext(ctx, p.sqlUpdateOAuth2DeviceCodeSession,
 		session.ChallengeID, session.RequestID, session.ClientID, session.Status, session.Subject, session.RequestedAt,
-		session.CheckedAt, session.RequestedScopes, session.RequestedAudience, session.GrantedScopes, session.GrantedAudience,
+		session.CheckedAt, session.RequestedScopes, session.RequestedAudience, session.RequestedResource,
+		session.GrantedScopes, session.GrantedAudience, session.GrantedResource,
 		session.Active, session.Revoked, session.Form, session.Session, session.Signature); err != nil {
 		return fmt.Errorf("error updating oauth2 device code session with signature '%s': %w", session.Signature, err)
 	}
@@ -1531,7 +1535,8 @@ func (p *SQLProvider) UpdateOAuth2DeviceCodeSessionData(ctx context.Context, ses
 
 	if _, err = p.conn(ctx).ExecContext(ctx, p.sqlUpdateOAuth2DeviceCodeSessionData,
 		session.ChallengeID, session.ClientID, session.Status, session.Subject,
-		session.RequestedScopes, session.RequestedAudience, session.GrantedScopes, session.GrantedAudience,
+		session.RequestedScopes, session.RequestedAudience, session.RequestedResource,
+		session.GrantedScopes, session.GrantedAudience, session.GrantedResource,
 		session.Form, session.Session, session.Signature); err != nil {
 		return fmt.Errorf("error updating oauth2 device code session data with signature '%s': %w", session.Signature, err)
 	}
@@ -1591,7 +1596,7 @@ func (p *SQLProvider) SaveOAuth2PushedAuthorizationSession(ctx context.Context, 
 	}
 
 	if _, err = p.conn(ctx).ExecContext(ctx, p.sqlInsertOAuth2PARContext,
-		par.Signature, par.RequestID, par.ClientID, par.RequestedAt, par.Scopes, par.Audience, par.HandledResponseTypes,
+		par.Signature, par.RequestID, par.ClientID, par.RequestedAt, par.Scopes, par.Audience, par.Resource, par.HandledResponseTypes,
 		par.ResponseMode, par.DefaultResponseMode, par.Revoked, par.Form, par.Session); err != nil {
 		return fmt.Errorf("error inserting oauth2 pushed authorization request session data for with signature '%s' and request id '%s': %w", par.Signature, par.RequestID, err)
 	}
@@ -1642,7 +1647,7 @@ func (p *SQLProvider) UpdateOAuth2PushedAuthorizationSession(ctx context.Context
 	var result sql.Result
 
 	if result, err = p.conn(ctx).ExecContext(ctx, p.sqlUpdateOAuth2PARContext,
-		par.Signature, par.RequestID, par.ClientID, par.RequestedAt, par.Scopes, par.Audience, par.HandledResponseTypes,
+		par.Signature, par.RequestID, par.ClientID, par.RequestedAt, par.Scopes, par.Audience, par.Resource, par.HandledResponseTypes,
 		par.ResponseMode, par.DefaultResponseMode, par.Revoked, par.Form, par.Session, par.ID); err != nil {
 		return fmt.Errorf("error updating oauth2 pushed authorization request session data with id '%d' and signature '%s' and request id '%s': %w", par.ID, par.Signature, par.RequestID, err)
 	}

--- a/internal/storage/sql_provider_mock_test.go
+++ b/internal/storage/sql_provider_mock_test.go
@@ -1657,7 +1657,8 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 					gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("boom"))
 			},
 			invoke: func(p *storage.SQLProvider) error {
@@ -1674,7 +1675,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 				db.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), 5,
+					gomock.Any(), gomock.Any(), gomock.Any(), 5,
 				).Return(nil, errors.New("boom"))
 			},
 			invoke: func(p *storage.SQLProvider) error {
@@ -1691,7 +1692,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 				db.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(),
 					"sig", "req", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("boom"))
 			},
 			invoke: func(p *storage.SQLProvider) error {
@@ -1705,7 +1706,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 				db.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(),
 					"sig", "req", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), 9,
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), 9,
 				).Return(nil, errors.New("boom"))
 			},
 			invoke: func(p *storage.SQLProvider) error {
@@ -1722,6 +1723,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("boom"))
 			},
@@ -1736,7 +1738,8 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 				db.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(),
 					gomock.Any(), "req", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), "sig",
 				).Return(nil, errors.New("boom"))
 			},
@@ -1751,7 +1754,8 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 				db.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), "sig",
 				).Return(nil, errors.New("boom"))
 			},
@@ -1941,7 +1945,7 @@ func TestSQLProviderRemainingExecErrors(t *testing.T) {
 				db.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(),
 					"client", uuid.Nil, gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("boom"))
 			},

--- a/internal/storage/sql_provider_queries.go
+++ b/internal/storage/sql_provider_queries.go
@@ -431,30 +431,30 @@ const (
 
 const (
 	queryFmtSelectOAuth2ConsentPreConfigurations = `
-		SELECT id, client_id, subject, created_at, expires_at, revoked, scopes, audience, requested_claims, signature_claims, granted_claims
+		SELECT id, client_id, subject, created_at, expires_at, revoked, scopes, audience, resource, requested_claims, signature_claims, granted_claims
 		FROM %s
 		WHERE client_id = ? AND subject = ? AND
 			  revoked = FALSE AND (expires_at IS NULL OR expires_at >= ?);`
 
 	queryFmtInsertOAuth2ConsentPreConfiguration = `
-		INSERT INTO %s (client_id, subject, created_at, expires_at, revoked, scopes, audience, requested_claims, signature_claims, granted_claims)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+		INSERT INTO %s (client_id, subject, created_at, expires_at, revoked, scopes, audience, resource, requested_claims, signature_claims, granted_claims)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 
 	queryFmtInsertOAuth2ConsentPreConfigurationPostgreSQL = `
-		INSERT INTO %s (client_id, subject, created_at, expires_at, revoked, scopes, audience, requested_claims, signature_claims, granted_claims)
-		VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		INSERT INTO %s (client_id, subject, created_at, expires_at, revoked, scopes, audience, resource, requested_claims, signature_claims, granted_claims)
+		VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		RETURNING id;`
 
 	queryFmtSelectOAuth2ConsentSessionByChallengeID = `
 		SELECT id, challenge_id, client_id, subject, authorized, granted, requested_at, expires_at, responded_at,
-		form_data, requested_scopes, granted_scopes, requested_audience, granted_audience, granted_claims, preconfiguration
+		form_data, requested_scopes, granted_scopes, requested_audience, granted_audience, requested_resource, granted_resource, granted_claims, preconfiguration
 		FROM %s
 		WHERE challenge_id = ?;`
 
 	queryFmtInsertOAuth2ConsentSession = `
 		INSERT INTO %s (challenge_id, client_id, subject, authorized, granted, requested_at, expires_at, responded_at,
-		form_data, requested_scopes, granted_scopes, requested_audience, granted_audience, granted_claims, preconfiguration)
-		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+		form_data, requested_scopes, granted_scopes, requested_audience, granted_audience, requested_resource, granted_resource, granted_claims, preconfiguration)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 
 	queryFmtUpdateOAuth2ConsentSessionResponseByID = `
 		UPDATE %s
@@ -464,6 +464,7 @@ const (
 			authorized = ?,
 			granted_scopes = ?,
 			granted_audience = ?,
+			granted_resource = ?,
 			granted_claims = ?,
 			preconfiguration = ?
 		WHERE id = ? AND responded_at IS NULL;`
@@ -476,6 +477,7 @@ const (
 			authorized = ?,
 			granted_scopes = ?,
 			granted_audience = ?,
+			granted_resource = ?,
 			granted_claims = ?,
 			preconfiguration = ?
 		WHERE challenge_id = ? AND responded_at IS NULL;`
@@ -488,6 +490,7 @@ const (
 	queryFmtSelectOAuth2Session = `
 		SELECT id, challenge_id, request_id, client_id, signature, subject, requested_at,
 		requested_scopes, granted_scopes, requested_audience, granted_audience,
+		requested_resource, granted_resource,
 		active, revoked, form_data, session_data
 		FROM %s
 		WHERE signature = ? AND revoked = FALSE;`
@@ -495,15 +498,17 @@ const (
 	queryFmtInsertOAuth2Session = `
 		INSERT INTO %s (challenge_id, request_id, client_id, signature, subject, requested_at,
 		requested_scopes, granted_scopes, requested_audience, granted_audience,
+		requested_resource, granted_resource,
 		active, revoked, form_data, session_data)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 
 	//nolint:gosec // Not a Credential.
 	queryFmtInsertOAuth2RefreshTokenSession = `
 		INSERT INTO %s (challenge_id, request_id, client_id, signature, subject, requested_at,
 		requested_scopes, granted_scopes, requested_audience, granted_audience,
+		requested_resource, granted_resource,
 		active, revoked, form_data, session_data, access_signature)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 
 	queryFmtSelectOAuth2RefreshTokenSessionAccessSignature = `
 		SELECT access_signature
@@ -533,6 +538,7 @@ const (
 	queryFmtSelectOAuth2DeviceCodeSession = `
 		SELECT id, challenge_id, request_id, client_id, signature, user_code_signature, status, subject,
 		requested_at, checked_at, requested_scopes, granted_scopes, requested_audience, granted_audience,
+		requested_resource, granted_resource,
 		active, revoked, form_data, session_data
 		FROM %s
 		WHERE signature = ? AND revoked = FALSE;`
@@ -540,6 +546,7 @@ const (
 	queryFmtSelectOAuth2DeviceCodeSessionByUserCode = `
 		SELECT id, challenge_id, request_id, client_id, signature, user_code_signature, status, subject,
 		requested_at, checked_at, requested_scopes, granted_scopes, requested_audience, granted_audience,
+		requested_resource, granted_resource,
 		active, revoked, form_data, session_data
 		FROM %s
 		WHERE user_code_signature = ? AND revoked = FALSE;`
@@ -547,8 +554,9 @@ const (
 	queryFmtInsertOAuth2DeviceCodeSession = `
 		INSERT INTO %s (challenge_id, request_id, client_id, signature, user_code_signature, status, subject,
 		requested_at, checked_at, requested_scopes, granted_scopes, requested_audience, granted_audience,
+		requested_resource, granted_resource,
 		active, revoked, form_data, session_data)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 
 	queryFmtUpdateOAuth2DeviceCodeSession = `
 		UPDATE %s
@@ -562,8 +570,10 @@ const (
 			checked_at = ?,
 			requested_scopes = ?,
 			requested_audience = ?,
+			requested_resource = ?,
 			granted_scopes = ?,
 			granted_audience = ?,
+			granted_resource = ?,
 			active = ?,
 			revoked = ?,
 			form_data = ?,
@@ -579,28 +589,30 @@ const (
 			subject = ?,
 			requested_scopes = ?,
 			requested_audience = ?,
+			requested_resource = ?,
 			granted_scopes = ?,
 			granted_audience = ?,
+			granted_resource = ?,
 			form_data = ?,
 			session_data = ?
 		WHERE signature = ?;`
 
 	queryFmtSelectOAuth2PARContext = `
-		SELECT id, signature, request_id, client_id, requested_at, scopes, audience,
+		SELECT id, signature, request_id, client_id, requested_at, scopes, audience, resource,
 		handled_response_types, response_mode, response_mode_default, revoked,
 		form_data, session_data
 		FROM %s
 		WHERE signature = ?;`
 
 	queryFmtInsertOAuth2PARContext = `
-		INSERT INTO %s (signature, request_id, client_id, requested_at, scopes, audience,
+		INSERT INTO %s (signature, request_id, client_id, requested_at, scopes, audience, resource,
 		handled_response_types, response_mode, response_mode_default, revoked,
 		form_data, session_data)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 
 	queryFmtUpdateOAuth2PARContext = `
 	UPDATE %s
-	SET signature = ?, request_id = ?, client_id = ?, requested_at = ?, scopes = ?, audience = ?,
+	SET signature = ?, request_id = ?, client_id = ?, requested_at = ?, scopes = ?, audience = ?, resource = ?,
 	    handled_response_types = ?, response_mode = ?, response_mode_default = ?, revoked = ?,
 	    form_data = ?, session_data = ?
 	WHERE id = ?;`

--- a/internal/storage/sql_provider_schema_test.go
+++ b/internal/storage/sql_provider_schema_test.go
@@ -224,11 +224,11 @@ func TestSchemaMigrateToRowScopedAAD(t *testing.T) {
 				Secret:    totpSecret,
 			}))
 
-			require.NoError(t, provider.SaveOAuth2Session(ctx, OAuth2SessionTypeAccessToken, model.OAuth2Session{
+			saveLegacyOAuth2AccessTokenSession(t, ctx, provider, model.OAuth2Session{
 				RequestID: "req-123",
 				Signature: "sig-123",
 				Session:   sessionData,
-			}))
+			})
 
 			provider.keys.encryption, provider.aad = key, aad
 
@@ -284,11 +284,11 @@ func TestSchemaMigrateUpToColumnScopedFromLegacy(t *testing.T) {
 		Secret:    totpSecret,
 	}))
 
-	require.NoError(t, provider.SaveOAuth2Session(ctx, OAuth2SessionTypeAccessToken, model.OAuth2Session{
+	saveLegacyOAuth2AccessTokenSession(t, ctx, provider, model.OAuth2Session{
 		RequestID: "req-123",
 		Signature: "sig-123",
 		Session:   sessionData,
-	}))
+	})
 
 	provider.keys.encryption, provider.aad = key, aad
 
@@ -320,10 +320,9 @@ func TestSchemaMigrateUpToColumnScopedFromLegacy(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, totpSecret, totp.Secret)
 
-	session, err := provider.LoadOAuth2Session(ctx, OAuth2SessionTypeAccessToken, "sig-123")
+	decrypted := loadLegacyOAuth2AccessTokenSessionData(t, ctx, provider, "sig-123")
 
-	require.NoError(t, err)
-	assert.Equal(t, sessionData, session.Session)
+	assert.Equal(t, sessionData, decrypted)
 
 	require.NoError(t, provider.Close())
 }
@@ -507,4 +506,48 @@ func TestSchemaMigrateDownFromRowScopedAAD(t *testing.T) {
 			}
 		})
 	}
+}
+
+// saveLegacyOAuth2AccessTokenSession inserts an OAuth2.0 access token session using only the columns that predate
+// the resource indicator columns added by a later migration. It exists so tests that pin the schema at an older
+// version can still write a row without relying on provider.SaveOAuth2Session, which always targets the current
+// (latest) column set.
+func saveLegacyOAuth2AccessTokenSession(t *testing.T, ctx context.Context, provider *SQLiteProvider, session model.OAuth2Session) {
+	t.Helper()
+
+	var err error
+
+	session.Session, err = utils.Encrypt(session.Session, provider.aad.Get(OAuth2SessionTypeAccessToken.AAD(), columnSessionData, session.Signature), provider.keys.encryption)
+	require.NoError(t, err)
+
+	query := fmt.Sprintf(`
+		INSERT INTO %s (challenge_id, request_id, client_id, signature, subject, requested_at,
+		requested_scopes, granted_scopes, requested_audience, granted_audience,
+		active, revoked, form_data, session_data)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`, tableOAuth2AccessTokenSession)
+
+	_, err = provider.db.ExecContext(ctx, query,
+		session.ChallengeID, session.RequestID, session.ClientID, session.Signature,
+		session.Subject, session.RequestedAt, session.RequestedScopes, session.GrantedScopes,
+		session.RequestedAudience, session.GrantedAudience,
+		session.Active, session.Revoked, session.Form, session.Session)
+	require.NoError(t, err)
+}
+
+// loadLegacyOAuth2AccessTokenSessionData reads and decrypts the session_data column of an OAuth2.0 access token
+// session directly, without going through provider.LoadOAuth2Session, whose SELECT always targets the current
+// (latest) column set and so cannot be used against a schema pinned at an older version.
+func loadLegacyOAuth2AccessTokenSessionData(t *testing.T, ctx context.Context, provider *SQLiteProvider, signature string) []byte {
+	t.Helper()
+
+	var encrypted []byte
+
+	query := fmt.Sprintf(`SELECT session_data FROM %s WHERE signature = ?;`, tableOAuth2AccessTokenSession)
+
+	require.NoError(t, provider.db.GetContext(ctx, &encrypted, query, signature))
+
+	decrypted, err := utils.Decrypt(encrypted, provider.aad.Get(OAuth2SessionTypeAccessToken.AAD(), columnSessionData, signature), provider.keys.encryption)
+	require.NoError(t, err)
+
+	return decrypted
 }

--- a/internal/storage/sql_provider_test.go
+++ b/internal/storage/sql_provider_test.go
@@ -786,7 +786,18 @@ func TestSQLProviderOAuth2ConsentSession(t *testing.T) {
 		loaded, err := provider.LoadOAuth2ConsentSessionByChallengeID(ctx, challengeID)
 		require.NoError(t, err)
 
+		loaded.GrantedScopes = model.StringSlicePipeDelimited{"openid", "profile"}
+		loaded.GrantedAudience = model.StringSlicePipeDelimited{"aud-a"}
+		loaded.GrantedResource = model.StringSlicePipeDelimited{"https://api.example.com"}
+
 		require.NoError(t, provider.SaveOAuth2ConsentSessionResponse(ctx, loaded, true))
+
+		reloaded, err := provider.LoadOAuth2ConsentSessionByChallengeID(ctx, challengeID)
+		require.NoError(t, err)
+		require.NotNil(t, reloaded)
+		assert.Equal(t, model.StringSlicePipeDelimited{"openid", "profile"}, reloaded.GrantedScopes)
+		assert.Equal(t, model.StringSlicePipeDelimited{"aud-a"}, reloaded.GrantedAudience)
+		assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, reloaded.GrantedResource)
 	})
 
 	t.Run("ShouldSaveConsentGranted", func(t *testing.T) {
@@ -1402,6 +1413,209 @@ func TestSQLProviderOAuth2SessionAllTypes(t *testing.T) {
 			assert.False(t, loaded.Active)
 		})
 	}
+}
+
+func TestSQLProviderOAuth2ResourceColumns(t *testing.T) {
+	provider := newTestSQLiteProvider(t)
+	require.NoError(t, provider.StartupCheck())
+
+	ctx := context.Background()
+
+	testCases := []struct {
+		Name   string
+		table  string
+		column string
+	}{
+		{"ShouldHaveAccessTokenSessionRequestedResource", "oauth2_access_token_session", "requested_resource"},
+		{"ShouldHaveAccessTokenSessionGrantedResource", "oauth2_access_token_session", "granted_resource"},
+		{"ShouldHaveAuthorizationCodeSessionRequestedResource", "oauth2_authorization_code_session", "requested_resource"},
+		{"ShouldHaveAuthorizationCodeSessionGrantedResource", "oauth2_authorization_code_session", "granted_resource"},
+		{"ShouldHaveOpenIDConnectSessionRequestedResource", "oauth2_openid_connect_session", "requested_resource"},
+		{"ShouldHaveOpenIDConnectSessionGrantedResource", "oauth2_openid_connect_session", "granted_resource"},
+		{"ShouldHavePKCERequestSessionRequestedResource", "oauth2_pkce_request_session", "requested_resource"},
+		{"ShouldHavePKCERequestSessionGrantedResource", "oauth2_pkce_request_session", "granted_resource"},
+		{"ShouldHaveRefreshTokenSessionRequestedResource", "oauth2_refresh_token_session", "requested_resource"},
+		{"ShouldHaveRefreshTokenSessionGrantedResource", "oauth2_refresh_token_session", "granted_resource"},
+		{"ShouldHaveDeviceCodeSessionRequestedResource", "oauth2_device_code_session", "requested_resource"},
+		{"ShouldHaveDeviceCodeSessionGrantedResource", "oauth2_device_code_session", "granted_resource"},
+		{"ShouldHaveConsentSessionRequestedResource", "oauth2_consent_session", "requested_resource"},
+		{"ShouldHaveConsentSessionGrantedResource", "oauth2_consent_session", "granted_resource"},
+		{"ShouldHaveParContextResource", "oauth2_par_context", "resource"},
+		{"ShouldHaveConsentPreConfigurationResource", "oauth2_consent_preconfiguration", "resource"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var n int
+
+			err := provider.db.GetContext(ctx, &n, "SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?", tc.table, tc.column)
+
+			require.NoError(t, err)
+			assert.Equal(t, 1, n)
+		})
+	}
+}
+
+func TestSQLProviderOAuth2ResourceRoundTrip(t *testing.T) {
+	provider := newTestSQLiteProvider(t)
+	require.NoError(t, provider.StartupCheck())
+
+	ctx := context.Background()
+
+	t.Run("ShouldRoundTripConsentSessionResource", func(t *testing.T) {
+		challenge, err := uuid.NewRandom()
+		require.NoError(t, err)
+
+		subject, err := uuid.NewRandom()
+		require.NoError(t, err)
+
+		require.NoError(t, provider.SaveUserOpaqueIdentifier(ctx, model.UserOpaqueIdentifier{
+			Service:    "openid",
+			SectorID:   "example.com",
+			Username:   "resource-consent",
+			Identifier: subject,
+		}))
+
+		consent := model.OAuth2ConsentSession{
+			ChallengeID:       challenge,
+			ClientID:          "test-client",
+			Subject:           uuid.NullUUID{UUID: subject, Valid: true},
+			RequestedAt:       time.Unix(1700000000, 0),
+			ExpiresAt:         time.Unix(1700003600, 0),
+			Form:              "",
+			RequestedScopes:   model.StringSlicePipeDelimited{"openid"},
+			GrantedScopes:     model.StringSlicePipeDelimited{"openid"},
+			RequestedAudience: model.StringSlicePipeDelimited{"aud-a"},
+			GrantedAudience:   model.StringSlicePipeDelimited{"aud-a"},
+			RequestedResource: model.StringSlicePipeDelimited{"https://api.example.com"},
+			GrantedResource:   model.StringSlicePipeDelimited{"https://api.example.com"},
+		}
+
+		require.NoError(t, provider.SaveOAuth2ConsentSession(ctx, &consent))
+
+		loaded, err := provider.LoadOAuth2ConsentSessionByChallengeID(ctx, challenge)
+
+		require.NoError(t, err)
+		require.NotNil(t, loaded)
+		assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, loaded.RequestedResource)
+		assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, loaded.GrantedResource)
+		assert.Equal(t, model.StringSlicePipeDelimited{"aud-a"}, loaded.RequestedAudience)
+	})
+
+	t.Run("ShouldRoundTripOAuth2SessionResource", func(t *testing.T) {
+		sig, err := uuid.NewRandom()
+		require.NoError(t, err)
+
+		session := model.OAuth2Session{
+			ChallengeID:       model.MustNullUUID(model.NewRandomNullUUID()),
+			RequestID:         "req-" + sig.String(),
+			ClientID:          "test-client",
+			Signature:         sig.String(),
+			Subject:           sql.NullString{Valid: true, String: "john"},
+			Active:            true,
+			RequestedScopes:   model.StringSlicePipeDelimited{"openid"},
+			GrantedScopes:     model.StringSlicePipeDelimited{"openid"},
+			RequestedAudience: model.StringSlicePipeDelimited{"aud-a"},
+			GrantedAudience:   model.StringSlicePipeDelimited{"aud-a"},
+			RequestedResource: model.StringSlicePipeDelimited{"https://api.example.com"},
+			GrantedResource:   model.StringSlicePipeDelimited{"https://api.example.com"},
+			Session:           []byte("{}"),
+		}
+
+		require.NoError(t, provider.SaveOAuth2Session(ctx, OAuth2SessionTypeAccessToken, session))
+
+		loaded, err := provider.LoadOAuth2Session(ctx, OAuth2SessionTypeAccessToken, sig.String())
+
+		require.NoError(t, err)
+		require.NotNil(t, loaded)
+		assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, loaded.RequestedResource)
+		assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, loaded.GrantedResource)
+		assert.Equal(t, model.StringSlicePipeDelimited{"aud-a"}, loaded.RequestedAudience)
+	})
+
+	t.Run("ShouldRoundTripDeviceCodeSessionResource", func(t *testing.T) {
+		session := &model.OAuth2DeviceCodeSession{
+			Signature:         "dev-resource-sig",
+			RequestID:         "dev-resource-req",
+			ClientID:          "test-client",
+			UserCodeSignature: "dev-resource-user-code",
+			Active:            true,
+			RequestedScopes:   model.StringSlicePipeDelimited{"openid"},
+			GrantedScopes:     model.StringSlicePipeDelimited{"openid"},
+			RequestedAudience: model.StringSlicePipeDelimited{"aud-a"},
+			GrantedAudience:   model.StringSlicePipeDelimited{"aud-a"},
+			RequestedResource: model.StringSlicePipeDelimited{"https://api.example.com"},
+			GrantedResource:   model.StringSlicePipeDelimited{"https://api.example.com"},
+			Session:           []byte("{}"),
+			RequestedAt:       time.Unix(1700000000, 0),
+		}
+
+		require.NoError(t, provider.SaveOAuth2DeviceCodeSession(ctx, session))
+
+		loaded, err := provider.LoadOAuth2DeviceCodeSession(ctx, "dev-resource-sig")
+
+		require.NoError(t, err)
+		require.NotNil(t, loaded)
+		assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, loaded.RequestedResource)
+		assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, loaded.GrantedResource)
+		assert.Equal(t, model.StringSlicePipeDelimited{"aud-a"}, loaded.RequestedAudience)
+	})
+
+	t.Run("ShouldRoundTripPushedAuthorizationSessionResource", func(t *testing.T) {
+		par := model.OAuth2PushedAuthorizationSession{
+			Signature:   "par-resource-sig",
+			RequestID:   "par-resource-req",
+			ClientID:    "test-client",
+			RequestedAt: time.Unix(1700000000, 0),
+			Audience:    model.StringSlicePipeDelimited{"aud-a"},
+			Resource:    model.StringSlicePipeDelimited{"https://api.example.com"},
+			Session:     []byte("{}"),
+		}
+
+		require.NoError(t, provider.SaveOAuth2PushedAuthorizationSession(ctx, par))
+
+		loaded, err := provider.LoadOAuth2PushedAuthorizationSession(ctx, "par-resource-sig")
+
+		require.NoError(t, err)
+		require.NotNil(t, loaded)
+		assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, loaded.Resource)
+		assert.Equal(t, model.StringSlicePipeDelimited{"aud-a"}, loaded.Audience)
+	})
+
+	t.Run("ShouldRoundTripConsentPreConfigResource", func(t *testing.T) {
+		subject, err := uuid.NewRandom()
+		require.NoError(t, err)
+
+		config := model.OAuth2ConsentPreConfig{
+			ClientID:  "test-client-resource",
+			Subject:   subject,
+			CreatedAt: time.Unix(1700000000, 0),
+			Scopes:    model.StringSlicePipeDelimited{"openid"},
+			Audience:  model.StringSlicePipeDelimited{"aud-a"},
+			Resource:  model.StringSlicePipeDelimited{"https://api.example.com"},
+		}
+
+		id, err := provider.SaveOAuth2ConsentPreConfiguration(ctx, config)
+
+		require.NoError(t, err)
+		assert.Greater(t, id, int64(0))
+
+		rows, err := provider.LoadOAuth2ConsentPreConfigurations(ctx, "test-client-resource", subject, time.Unix(1700000000, 0))
+
+		require.NoError(t, err)
+		require.NotNil(t, rows)
+
+		defer rows.Close()
+
+		require.True(t, rows.Next())
+
+		loaded, err := rows.Get()
+
+		require.NoError(t, err)
+		require.NotNil(t, loaded)
+		assert.Equal(t, model.StringSlicePipeDelimited{"https://api.example.com"}, loaded.Resource)
+		assert.Equal(t, model.StringSlicePipeDelimited{"aud-a"}, loaded.Audience)
+	})
 }
 
 func newTestSQLiteProvider(t *testing.T) *SQLiteProvider {

--- a/web/src/services/ConsentOpenIDConnect.ts
+++ b/web/src/services/ConsentOpenIDConnect.ts
@@ -25,6 +25,7 @@ export interface ConsentGetResponseBody {
     client_description: string;
     scopes: string[];
     audience: string[];
+    resource: null | string[];
     pre_configuration: boolean;
     claims: null | string[];
     essential_claims: null | string[];

--- a/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormView.test.tsx
+++ b/web/src/views/ConsentPortal/OpenIDConnect/DecisionFormView.test.tsx
@@ -117,6 +117,7 @@ it("renders consent form with scopes, claims, and pre-configuration when consent
         essential_claims: [],
         pre_configuration: true,
         require_login: false,
+        resource: [],
         scopes: ["openid", "profile"],
     });
 


### PR DESCRIPTION
This fixes an issue where the resource indicators were not recorded or granted in any scenario. This is a result of the audience and resource concepts being partially split in authelia.com/provider/oauth2 v0.3.0.

Fixes #12970