### PR TITLE
fix(oidc): client auth config strategy

### DIFF
--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -981,7 +981,7 @@ func (c *Config) GetTokenEndpointClientAuthStrategy(ctx context.Context) (strate
 // GetRevocationEndpointClientAuthStrategy returns the Revocation Endpoint client authentication strategy.
 func (c *Config) GetRevocationEndpointClientAuthStrategy(ctx context.Context) (strategy oauthelia2.EndpointClientAuthStrategy) {
 	if c.Strategy.RevocationEndpointClientAuth == nil {
-		c.Strategy.RevocationEndpointClientAuth = &oauthelia2.TokenEndpointClientAuthStrategy{}
+		c.Strategy.RevocationEndpointClientAuth = &oauthelia2.RevocationEndpointClientAuthStrategy{}
 	}
 
 	return c.Strategy.RevocationEndpointClientAuth
@@ -990,7 +990,7 @@ func (c *Config) GetRevocationEndpointClientAuthStrategy(ctx context.Context) (s
 // GetIntrospectionEndpointClientAuthStrategy returns the Introspection Endpoint client authentication strategy.
 func (c *Config) GetIntrospectionEndpointClientAuthStrategy(ctx context.Context) (strategy oauthelia2.EndpointClientAuthStrategy) {
 	if c.Strategy.IntrospectionEndpointClientAuth == nil {
-		c.Strategy.IntrospectionEndpointClientAuth = &oauthelia2.TokenEndpointClientAuthStrategy{}
+		c.Strategy.IntrospectionEndpointClientAuth = &oauthelia2.IntrospectionEndpointClientAuthStrategy{}
 	}
 
 	return c.Strategy.IntrospectionEndpointClientAuth

--- a/internal/suites/OIDC/configuration.yml
+++ b/internal/suites/OIDC/configuration.yml
@@ -97,11 +97,13 @@ identity_providers:
         grant_types:
           - 'client_credentials'
         token_endpoint_auth_method: 'client_secret_post'
+        introspection_endpoint_auth_method: 'client_secret_post'
       - client_id: 'client-credentials-jwt'
         client_secret: '$pbkdf2-sha512$310000$EniFUo2z8Yjw3op3lrtuyA$xhopyOyffx2TqsQvEhoMSo1sxywIvJV8HZw/zdf62xtyryY/nkNkdcUV82r.xtd5NuyvZo7DPkOlcffM/Wvsmw'  # yamllint disable-line rule:line-length
         grant_types:
           - 'client_credentials'
         token_endpoint_auth_method: 'client_secret_post'
+        introspection_endpoint_auth_method: 'client_secret_post'
         access_token_signed_response_alg: 'RS256'
         requested_audience_mode: 'implicit'
         audience:


### PR DESCRIPTION
This fixes an issue where the client auth strategy was incorrectly returned for introspection and revocation.

Fixes #12974