### PR TITLE
fix(configuration): remove the website attribute

### DIFF
--- a/internal/configuration/schema/authentication.go
+++ b/internal/configuration/schema/authentication.go
@@ -294,7 +294,6 @@ var DefaultLDAPAuthenticationBackendConfigurationImplementationActiveDirectory =
 		FamilyName:        ldapAttrSurname,
 		GivenName:         ldapAttrGivenName,
 		MiddleName:        ldapAttrMiddleName,
-		Website:           "wWWHomePage",
 		Mail:              ldapAttrMail,
 		PhoneNumber:       "telephoneNumber",
 		StreetAddress:     "streetAddress",


### PR DESCRIPTION
This removes the website attribute from Active Directory, requiring it to be manually specified.

Fixes #12969