### PR TITLE
fix(web): block cancellation while dialog is closing

### DIFF
--- a/web/src/views/Settings/Common/SecondFactorDialog.test.tsx
+++ b/web/src/views/Settings/Common/SecondFactorDialog.test.tsx
@@ -383,6 +383,41 @@ describe("edge cases", () => {
         expect(screen.getByTestId("success-icon")).toBeInTheDocument();
 
         expect(handleClosed).not.toHaveBeenCalled();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1500);
+        });
+
+        expect(handleClosed).toHaveBeenCalledTimes(1);
+        expect(handleClosed).toHaveBeenCalledWith(true, true);
+    });
+
+    it("ignores a cancellation while the success delay is pending", async () => {
+        vi.useFakeTimers();
+
+        const handleClosed = vi.fn();
+        renderDialog({ handleClosed });
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("One-Time Password"));
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId("otp-success"));
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByText("Cancel"));
+        });
+
+        expect(handleClosed).not.toHaveBeenCalled();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1500);
+        });
+
+        expect(handleClosed).toHaveBeenCalledTimes(1);
+        expect(handleClosed).toHaveBeenCalledWith(true, true);
     });
 
     it("renders success when reaching the completion step from the push method", async () => {

--- a/web/src/views/Settings/Common/SecondFactorDialog.tsx
+++ b/web/src/views/Settings/Common/SecondFactorDialog.tsx
@@ -109,6 +109,9 @@ const SecondFactorDialog = function (props: Props) {
     );
 
     const handleCancelled = () => {
+        // A success is already scheduled to close the dialog, so a cancellation must not report a conflicting result.
+        if (closing) return;
+
         handleClose(false, false);
     };
 
@@ -258,7 +261,12 @@ const SecondFactorDialog = function (props: Props) {
                 />
                 {renderContent()}
                 <DialogFooter>
-                    <Button variant={"outline"} color={"destructive"} disabled={loading} onClick={handleCancelled}>
+                    <Button
+                        variant={"outline"}
+                        color={"destructive"}
+                        disabled={loading || closing}
+                        onClick={handleCancelled}
+                    >
                         {translate("Cancel")}
                     </Button>
                 </DialogFooter>


### PR DESCRIPTION
This fixes an issue where the cancellation could modify state when the Second Factor Dialog was already closing.