### PR TITLE
fix(web): webauthn description error never shows

### DIFF
--- a/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialEditDialog.test.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialEditDialog.test.tsx
@@ -181,12 +181,41 @@ describe("description field", () => {
         expect(handleClose).not.toHaveBeenCalled();
     });
 
-    it("leaves the field valid after an empty update attempt", async () => {
+    it("marks the field invalid after an empty update attempt", async () => {
         render(<WebAuthnCredentialEditDialog open={true} credential={credential} handleClose={vi.fn()} />);
 
         fireEvent.keyDown(screen.getByLabelText("Description"), { key: "Enter" });
 
-        await waitFor(() => expect(screen.getByLabelText("Description")).not.toHaveAttribute("aria-invalid", "true"));
+        await waitFor(() => expect(screen.getByLabelText("Description")).toHaveAttribute("aria-invalid", "true"));
+    });
+
+    it("rejects a description that is only whitespace", async () => {
+        const { updateUserWebAuthnCredential } = await import("@services/WebAuthn");
+
+        const handleClose = vi.fn();
+        render(<WebAuthnCredentialEditDialog open={true} credential={credential} handleClose={handleClose} />);
+
+        fireEvent.change(screen.getByLabelText("Description"), { target: { value: "   " } });
+        fireEvent.keyDown(screen.getByLabelText("Description"), { key: "Enter" });
+
+        await waitFor(() => expect(screen.getByLabelText("Description")).toHaveAttribute("aria-invalid", "true"));
+        expect(updateUserWebAuthnCredential).not.toHaveBeenCalled();
+        expect(handleClose).not.toHaveBeenCalled();
+    });
+
+    it("trims the description before updating", async () => {
+        const { updateUserWebAuthnCredential } = await import("@services/WebAuthn");
+        vi.mocked(updateUserWebAuthnCredential).mockResolvedValue({ data: { status: "OK" } } as any);
+
+        render(<WebAuthnCredentialEditDialog open={true} credential={credential} handleClose={vi.fn()} />);
+
+        fireEvent.change(screen.getByLabelText("Description"), { target: { value: "  Renamed  " } });
+
+        await act(async () => {
+            fireEvent.keyDown(screen.getByLabelText("Description"), { key: "Enter" });
+        });
+
+        expect(updateUserWebAuthnCredential).toHaveBeenCalledWith("abc123", "Renamed");
     });
 
     it("truncates a description longer than 30 characters", async () => {

--- a/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialEditDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialEditDialog.tsx
@@ -37,12 +37,16 @@ const WebAuthnCredentialEditDialog = function (props: Props) {
     };
 
     const handleUpdate = () => {
-        if (credentialDescription.length === 0) {
+        const description = credentialDescription.trim();
+
+        if (description.length === 0) {
             setErrorDescription(true);
-        } else {
-            handleEdit(credentialDescription).catch(console.error);
-            props.handleClose();
+
+            return;
         }
+
+        handleEdit(description).catch(console.error);
+        props.handleClose();
         handleReset();
     };
 
@@ -146,7 +150,7 @@ const WebAuthnCredentialEditDialog = function (props: Props) {
                         id={"dialog-update"}
                         variant={"ghost"}
                         color={"primary"}
-                        disabled={credentialDescription.length === 0}
+                        disabled={credentialDescription.trim().length === 0}
                         onClick={handleUpdate}
                     >
                         {translate("Update")}

--- a/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialRegisterDialog.test.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialRegisterDialog.test.tsx
@@ -123,6 +123,22 @@ describe("description validation", () => {
         expect(getOptionsMock).not.toHaveBeenCalled();
     });
 
+    it("rejects a description that is only whitespace", async () => {
+        renderDialog();
+
+        fireEvent.change(getDescription(), { target: { value: "   " } });
+
+        clickNext();
+
+        await waitFor(() =>
+            expect(mocks.createErrorNotification).toHaveBeenCalledWith(
+                "The Description must be more than 1 character and less than 64 characters",
+            ),
+        );
+        expect(getDescription()).toHaveAttribute("aria-invalid", "true");
+        expect(getOptionsMock).not.toHaveBeenCalled();
+    });
+
     it("rejects a description longer than 64 characters", async () => {
         renderDialog();
 

--- a/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialRegisterDialog.tsx
+++ b/web/src/views/Settings/TwoFactorAuthentication/WebAuthnCredentialRegisterDialog.tsx
@@ -130,7 +130,9 @@ const WebAuthnCredentialRegisterDialog = function (props: Props) {
         }
 
         (async function () {
-            if (description.length === 0 || description.length > 64) {
+            const trimmed = description.trim();
+
+            if (trimmed.length === 0 || trimmed.length > 64) {
                 setErrorDescription(true);
                 createErrorNotification(
                     translate("The Description must be more than 1 character and less than 64 characters"),
@@ -139,7 +141,7 @@ const WebAuthnCredentialRegisterDialog = function (props: Props) {
                 return;
             }
 
-            const res = await getWebAuthnRegistrationOptions(description);
+            const res = await getWebAuthnRegistrationOptions(trimmed);
 
             switch (res.status) {
                 case 200:


### PR DESCRIPTION
This is a fix for the fact the error description never shows when the provided description was empty.