### PR TITLE
ci(buildkite): refactor integration pipeline triggers

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
-
 set +u
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/../libs/common.sh"
+
 INTEGRATION() {
-  if [[ "${BUILDKITE_BRANCH}" =~ ^renovate- ]]; then
-    sed -i "s/${CONTAINER}/${CONTAINER}:renovate/" "${FILE}"
-  elif [[ "${BUILDKITE_BRANCH}" != "master" ]] && [[ ! "${BUILDKITE_BRANCH}" =~ .*:.* ]]; then
-    sed -i "s/${CONTAINER}/${CONTAINER}:${BUILDKITE_BRANCH}/" "${FILE}"
-  elif [[ "${BUILDKITE_BRANCH}" != "master" ]] && [[ "${BUILDKITE_BRANCH}" =~ .*:.* ]]; then
-    sed -i "s/${CONTAINER}/${CONTAINER}:PR${BUILDKITE_PULL_REQUEST}/" "${FILE}"
+  resolve_tag_suffix
+
+  if [[ -n "${TAG_SUFFIX}" ]]; then
+    sed -i "s/${CONTAINER}/${CONTAINER}:${TAG_SUFFIX}/" "${FILE}"
+    echo "Integration container tag: ${CONTAINER}:${TAG_SUFFIX}"
+  else
+    echo "Integration container tag: ${CONTAINER} (no suffix applied)"
   fi
 }
 

--- a/.buildkite/integration.sh
+++ b/.buildkite/integration.sh
@@ -1,20 +1,17 @@
 #!/usr/bin/env bash
 set -u
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/libs/common.sh"
+
 DIRECTORY="unset"
 GROUP="unset"
 PREFIX="authelia/"
-TAG="unset"
+CREATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+SOURCE="https://github.com/authelia/authelia"
 
-if [[ "${BUILDKITE_BRANCH}" =~ ^renovate- ]]; then
-  TAG="renovate"
-elif [[ "${BUILDKITE_BRANCH}" != "master" ]] && [[ ! "${BUILDKITE_BRANCH}" =~ .*:.* ]]; then
-  TAG="${BUILDKITE_BRANCH}"
-elif [[ "${BUILDKITE_BRANCH}" != "master" ]] && [[ "${BUILDKITE_BRANCH}" =~ .*:.* ]]; then
-  TAG="PR${BUILDKITE_PULL_REQUEST}"
-elif [[ "${BUILDKITE_BRANCH}" == "master" ]] && [[ "${BUILDKITE_PULL_REQUEST}" == "false" ]]; then
-  TAG="latest"
-fi
+resolve_tag_suffix
+TAG="${TAG_SUFFIX:-unset}"
 
 if [[ "${BUILDKITE_PIPELINE_NAME}" == "integration-duo" ]]; then
   DIRECTORY="internal/suites/example/compose/duo-api"
@@ -27,12 +24,24 @@ elif [[ "${BUILDKITE_PIPELINE_NAME}" == "integration-samba" ]]; then
   GROUP="samba-deployments"
 fi
 
+REVISION=$(git log -1 --format=%H -- "${DIRECTORY}")
+
 cat << EOF
 steps:
   - label: ":docker: Build and Deploy"
     commands:
       - "cd ${DIRECTORY}"
-      - "docker build --tag ${PREFIX}${BUILDKITE_PIPELINE_NAME}:${TAG} --platform linux/amd64,linux/arm64 --provenance mode=max,reproducible=true --sbom true --builder buildx --pull --push ."
+      - "docker build \
+        --tag ${PREFIX}${BUILDKITE_PIPELINE_NAME}:${TAG} \
+        --label org.opencontainers.image.created=${CREATED} \
+        --label org.opencontainers.image.revision=${REVISION} \
+        --label org.opencontainers.image.source=${SOURCE} \
+        --label com.authelia.ci.build-url=${BUILDKITE_BUILD_URL} \
+        --platform linux/amd64,linux/arm64 \
+        --provenance mode=max,reproducible=true \
+        --sbom true \
+        --builder buildx \
+        --pull --push ."
     concurrency: 1
     concurrency_group: "${GROUP}"
     agents:

--- a/.buildkite/libs/common.sh
+++ b/.buildkite/libs/common.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# .buildkite/libs/common.sh
+#
+# Shared helpers for the pipeline generator and the pre-command hook.
+# Source with a BASH_SOURCE-relative path so it works regardless of CWD:
+#   source "$(dirname "${BASH_SOURCE[0]}")/libs/common.sh"        # from .buildkite/
+#   source "$(dirname "${BASH_SOURCE[0]}")/../libs/common.sh"     # from .buildkite/hooks/
+#
+# BASE_REF, BASE_REF_OK, and TAG_SUFFIX below are intentionally left as
+# globals rather than returned via stdout; each caller reads them
+# straight after calling the corresponding resolve_*() function. Since
+# every caller lives in a different sourcing file, shellcheck can't see
+# that usage when linting this file in isolation and reports SC2034 on
+# each of them; disabled file-wide since it's a false positive here.
+# shellcheck disable=SC2034
+
+changed() {
+  local base_ref="${1}"
+  local path_pattern="${2}"
+  git diff --name-only "${base_ref}" | grep -q "^${path_pattern}"
+}
+
+bypass_check() {
+  local base_ref="${1}"
+  local regex="${2}"
+  git diff --name-only "${base_ref}" | sed -rn "${regex}" && echo true || echo false
+}
+
+# Resolves the ref to diff against. Sets BASE_REF and BASE_REF_OK as globals
+# (rather than returning via stdout) so callers get both without a second
+# git invocation. BASE_REF_OK="false" means fork-point resolution failed
+# (e.g. shallow clone with no reflog) callers should treat that as
+# "unknown" rather than "unchanged".
+resolve_base_ref() {
+  BASE_REF=""
+  BASE_REF_OK="false"
+
+  if [[ "${BUILDKITE_BRANCH}" == "master" ]]; then
+    BASE_REF="HEAD~1"
+    BASE_REF_OK="true"
+    return
+  fi
+
+  if BASE_REF=$(git merge-base origin/master HEAD 2>/dev/null); then
+    BASE_REF_OK="true"
+  fi
+}
+
+# Computes the branch/PR-derived tag suffix shared by integration.sh,
+# INTEGRATION() in hooks/pre-command, and steps/grypescans.sh.
+#
+# Sets TAG_SUFFIX as a global. Empty means "no case matched"; the
+# caller decides what that means (pre-command treats it as "leave the
+# file's existing tag alone"; integration.sh/grypescans.sh fall back to
+# their own defaults).
+#
+# $1 - value to use for TAG_SUFFIX on a master, non-PR build. Defaults
+#      to "latest", since an untagged image reference and an explicit
+#      ":latest" tag resolve to the same image callers only need to
+#      override this when they explicitly want the literal "master"
+#      tag instead (grypescans.sh does).
+# $2 - "true" (default) to collapse renovate-* branches to the literal
+#      suffix "renovate", matching the image tag integration.sh actually
+#      builds under. Pass "false" to fall through to the literal branch
+#      name instead; grypescans.sh scans the main "authelia/authelia"
+#      image, which is tagged with the full branch name even on
+#      renovate branches, so it must not collapse here.
+#
+# Does NOT check BUILDKITE_TAG integration.sh and INTEGRATION() never
+# run on tag builds (see pipeline.sh's BUILD_* gating), and
+# grypescans.sh checks BUILDKITE_TAG itself before falling back here.
+resolve_tag_suffix() {
+  local master_value="${1:-latest}"
+  local collapse_renovate="${2:-true}"
+  TAG_SUFFIX=""
+
+  if [[ "${collapse_renovate}" == "true" ]] && [[ "${BUILDKITE_BRANCH}" =~ ^renovate- ]]; then
+    TAG_SUFFIX="renovate"
+  elif [[ "${BUILDKITE_BRANCH}" != "master" ]] && [[ ! "${BUILDKITE_BRANCH}" =~ .*:.* ]]; then
+    TAG_SUFFIX="${BUILDKITE_BRANCH}"
+  elif [[ "${BUILDKITE_BRANCH}" != "master" ]] && [[ "${BUILDKITE_BRANCH}" =~ .*:.* ]]; then
+    TAG_SUFFIX="PR${BUILDKITE_PULL_REQUEST}"
+  elif [[ "${BUILDKITE_BRANCH}" == "master" ]] && [[ "${BUILDKITE_PULL_REQUEST}" == "false" ]]; then
+    TAG_SUFFIX="${master_value}"
+  fi
+}

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
-DIVERGED=$(git merge-base --fork-point origin/master > /dev/null; echo $?)
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/libs/common.sh"
 
 BYPASS_REGEX='/^(CODE_OF_CONDUCT\.md|CONTRIBUTING\.md|README\.md|SECURITY\.md|crowdin\.yml|\.all-contributorsrc|\.editorconfig|\.github\/.*|docs\/.*|cmd\/authelia-gen\/templates\/.*|examples\/.*)/!{q1}'
-
-changed() {
-  git diff --name-only "${1}" | grep -q "^${2}"
-}
-
-bypass_check() {
-  git diff --name-only "${1}" | sed -rn "${BYPASS_REGEX}" && echo true || echo false
-}
 
 BUILD_DUO="false"
 BUILD_HAPROXY="false"
@@ -20,17 +13,13 @@ CI_MERGE_QUEUE_BYPASS="false"
 CI_PRIVATE="false"
 LINT_REPORTER="github-check"
 
-if [[ ${DIVERGED} == 0 ]] && [[ ${BUILDKITE_TAG} == "" ]]; then
-  if [[ ${BUILDKITE_BRANCH} == "master" ]]; then
-    BASE_REF="HEAD~1"
-  else
-    BASE_REF=$(git merge-base --fork-point origin/master)
-  fi
+resolve_base_ref
 
+if [[ "${BASE_REF_OK}" == "true" ]] && [[ "${BUILDKITE_TAG}" == "" ]]; then
   changed "${BASE_REF}" "internal/suites/example/compose/duo-api/Dockerfile" && BUILD_DUO="true"
   changed "${BASE_REF}" "internal/suites/example/compose/haproxy/Dockerfile" && BUILD_HAPROXY="true"
   changed "${BASE_REF}" "internal/suites/example/compose/samba/Dockerfile" && BUILD_SAMBA="true"
-  CI_BYPASS=$(bypass_check "${BASE_REF}")
+  CI_BYPASS=$(bypass_check "${BASE_REF}" "${BYPASS_REGEX}")
 
   if [[ ${CI_BYPASS} == "true" ]]; then
     buildkite-agent annotate --style "info" --context "ctx-info" < .buildkite/annotations/bypass
@@ -45,7 +34,7 @@ fi
 if [[ ${BUILDKITE_BRANCH} =~ ^gh-readonly-queue/.* ]]; then
   CI_BYPASS="true"
   CI_MERGE_QUEUE="true"
-  CI_MERGE_QUEUE_BYPASS=$(bypass_check "HEAD^..HEAD")
+  CI_MERGE_QUEUE_BYPASS=$(bypass_check "HEAD^..HEAD" "${BYPASS_REGEX}")
   buildkite-agent annotate --style "info" --context "ctx-info" < .buildkite/annotations/merge-queue
 fi
 

--- a/.buildkite/steps/grypescans.sh
+++ b/.buildkite/steps/grypescans.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-ciBranch="${BUILDKITE_BRANCH}"
-ciPullRequest="${BUILDKITE_PULL_REQUEST}"
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/../libs/common.sh"
+
 ciTag="${BUILDKITE_TAG}"
 dockerImageName="authelia/authelia"
 masterBranch="master"
-publicRepoRegex='.*:.*'
 grypeCmd=(grype -f low)
 
 if [[ "${CI_PRIVATE}" == "true" ]]; then
@@ -17,12 +17,9 @@ IMAGE=""
 if [[ "${CI_MERGE_QUEUE}" != "true" ]]; then
   if [[ -n "${ciTag}" ]]; then
     IMAGE="${dockerImageName}:${ciTag/v}"
-  elif [[ "${ciBranch}" != "${masterBranch}" && ! "${ciBranch}" =~ ${publicRepoRegex} ]]; then
-    IMAGE="${dockerImageName}:${ciBranch}"
-  elif [[ "${ciBranch}" != "${masterBranch}" && "${ciBranch}" =~ ${publicRepoRegex} ]]; then
-    IMAGE="${dockerImageName}:PR${ciPullRequest}"
-  elif [[ "${ciBranch}" == "${masterBranch}" && "${ciPullRequest}" == "false" ]]; then
-    IMAGE="${dockerImageName}:${masterBranch}"
+  else
+    resolve_tag_suffix "${masterBranch}" "false"
+    [[ -n "${TAG_SUFFIX}" ]] && IMAGE="${dockerImageName}:${TAG_SUFFIX}"
   fi
 fi
 


### PR DESCRIPTION
This change factorises common functions in the Buildkite pipeline and fixes random missed triggers from a failed divergence check against a `git merge-base --fork-point`.