### PR TITLE
ci: fix duplicate artifacts in slsa provenance from job retries

### DIFF
--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -40,7 +40,8 @@ jobs:
 
           echo "Polling for artifact metadata..."
           while true; do
-            state=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" "${build_url}" | jq -r '.state')
+            state=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" "${build_url}?exclude_jobs=true" \
+              | jq -r '.state')
             if [ "${state}" = "passed" ]; then
               break
             elif [ "${initial}" = "true" ]; then
@@ -52,10 +53,15 @@ jobs:
           done
           echo "Artifact metadata retrieved"
 
+          passed_job_ids=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" "${build_url}" \
+            | jq -c '[.jobs[] | select(.state == "passed") | .id]')
+
           hashes=$(curl -s -H "Authorization: Bearer ${BUILDKITE_TOKEN}" \
-            "${build_url}/artifacts?per_page=100" | jq -r '
-              .[]
+            "${build_url}/artifacts?per_page=100" | jq -r --argjson job_ids "${passed_job_ids}" '
+              ($job_ids | map({(.): true}) | add // {}) as $good
+              | .[]
               | select(.filename | test("\\.(deb|tar\\.gz)$"))
+              | select($good[.job_id] // false)
               | "\(.sha256sum) \(.filename)"
             ' | base64 -w0)
 


### PR DESCRIPTION
When the Buildkite unit test step fails transiently (e.g. a flaky test) and gets automatically retried, its artifacts are uploaded twice under the same build, once from the failed attempt, once from the successful retry. SLSA Provenance saw both, producing two different hashes for the same filename.

Artifact hash collection is now filtered to only jobs that reached a "passed" state, excluding hashes from failed or retried-away attempts.