### PR TITLE
refactor: install pnpm via shell script

### DIFF
--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -5,10 +5,14 @@ FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f
 
 WORKDIR /node/src/app
 
+ENV \
+    SHELL="/bin/sh" \
+    PNPM_HOME="/usr/local"
+
 COPY --link web ./
 
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-	npm install -g pnpm@12 && \
+	ENV="/root/.profile" sh -c 'wget -qO- https://get.pnpm.io/install.sh | sh -' && \
 	pnpm install --frozen-lockfile --ignore-scripts --store-dir /pnpm/store && \
 	pnpm coverage
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,10 +5,14 @@ FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f
 
 WORKDIR /node/src/app
 
+ENV \
+    SHELL="/bin/sh" \
+    PNPM_HOME="/usr/local"
+
 COPY --link web ./
 
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-	npm install -g pnpm@12 && \
+	ENV="/root/.profile" sh -c 'wget -qO- https://get.pnpm.io/install.sh | sh -' && \
 	pnpm install --frozen-lockfile --ignore-scripts --store-dir /pnpm/store && \
 	pnpm coverage
 

--- a/internal/suites/example/compose/authelia/Dockerfile.frontend
+++ b/internal/suites/example/compose/authelia/Dockerfile.frontend
@@ -3,7 +3,11 @@ FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f
 ARG USER_ID
 ARG GROUP_ID
 
-RUN npm install -g pnpm@12 && \
+ENV \
+    SHELL="/bin/sh" \
+    PNPM_HOME="/usr/local"
+
+RUN ENV="/root/.profile" sh -c 'wget -qO- https://get.pnpm.io/install.sh | sh -' && \
     deluser node && \
     if getent group ${GROUP_ID} >/dev/null; then delgroup "$(getent group ${GROUP_ID} | cut -d: -f1)"; fi && \
     if getent passwd ${USER_ID} >/dev/null; then deluser "$(getent passwd ${USER_ID} | cut -d: -f1)"; fi && \

--- a/internal/suites/example/compose/duo-api/Dockerfile
+++ b/internal/suites/example/compose/duo-api/Dockerfile
@@ -2,9 +2,13 @@ FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f
 
 WORKDIR /usr/app/src
 
+ENV \
+    SHELL="/bin/sh" \
+    PNPM_HOME="/usr/local"
+
 COPY --link package.json pnpm-lock.yaml ./
 
-RUN npm install -g pnpm && pnpm install --frozen-lockfile --prod
+RUN ENV="/root/.profile" sh -c 'wget -qO- https://get.pnpm.io/install.sh | sh -' && pnpm install --frozen-lockfile --prod
 
 EXPOSE 3000
 


### PR DESCRIPTION
This change prevents us from having to pin dependencies in multiple areas by installing pnpm from the provided CI install script.