### PR TITLE
refactor: add progress logging for aad migrations

### DIFF
--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -70,6 +70,8 @@ const (
 	logFmtMigrationFromTo   = "Storage schema migration from %s to %s is being attempted"
 	logFmtMigrationComplete = "Storage schema migration from %s to %s is complete"
 	logFmtErrClosingConn    = "Error occurred closing SQL connection: %v"
+
+	logFmtEncryptionChangeKeyTableComplete = "Finished re-encrypting %d row(s) in table '%s'"
 )
 
 const (

--- a/internal/storage/sql_provider_encryption.go
+++ b/internal/storage/sql_provider_encryption.go
@@ -227,6 +227,8 @@ func schemaEncryptionChangeKeyOneTimeCode(ctx context.Context, provider *SQLProv
 		}
 	}
 
+	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, tableOneTimeCode)
+
 	return nil
 }
 
@@ -266,6 +268,8 @@ func schemaEncryptionChangeKeyTOTP(ctx context.Context, provider *SQLProvider, c
 			return fmt.Errorf("error updating TOTP configuration secret with id '%d': %w", c.ID, err)
 		}
 	}
+
+	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, tableTOTPConfigurations)
 
 	return nil
 }
@@ -317,6 +321,8 @@ func schemaEncryptionChangeKeyWebAuthn(ctx context.Context, provider *SQLProvide
 		}
 	}
 
+	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, tableWebAuthnCredentials)
+
 	return nil
 }
 
@@ -350,6 +356,8 @@ func schemaEncryptionChangeKeyCachedData(ctx context.Context, provider *SQLProvi
 			return fmt.Errorf("error updating cached data encrypted columns with id '%d': %w", d.ID, err)
 		}
 	}
+
+	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, len(caches), tableCachedData)
 
 	return nil
 }
@@ -387,6 +395,8 @@ func schemaEncryptionChangeKeyOpenIDConnect(typeOAuth2Session OAuth2SessionType)
 				return fmt.Errorf("error updating oauth2 %s session data with id '%d': %w", typeOAuth2Session.String(), s.ID, err)
 			}
 		}
+
+		provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, typeOAuth2Session.Table())
 
 		return nil
 	}
@@ -434,6 +444,8 @@ func schemaEncryptionChangeKeyEncryption(ctx context.Context, provider *SQLProvi
 			return fmt.Errorf("error updating encryption value with id '%d': %w", c.ID, err)
 		}
 	}
+
+	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, tableEncryption)
 
 	return nil
 }

--- a/internal/storage/sql_provider_encryption.go
+++ b/internal/storage/sql_provider_encryption.go
@@ -227,7 +227,7 @@ func schemaEncryptionChangeKeyOneTimeCode(ctx context.Context, provider *SQLProv
 		}
 	}
 
-	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, tableOneTimeCode)
+	provider.log.Debugf(logFmtEncryptionChangeKeyTableComplete, count, tableOneTimeCode)
 
 	return nil
 }
@@ -269,7 +269,7 @@ func schemaEncryptionChangeKeyTOTP(ctx context.Context, provider *SQLProvider, c
 		}
 	}
 
-	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, tableTOTPConfigurations)
+	provider.log.Debugf(logFmtEncryptionChangeKeyTableComplete, count, tableTOTPConfigurations)
 
 	return nil
 }
@@ -321,7 +321,7 @@ func schemaEncryptionChangeKeyWebAuthn(ctx context.Context, provider *SQLProvide
 		}
 	}
 
-	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, tableWebAuthnCredentials)
+	provider.log.Debugf(logFmtEncryptionChangeKeyTableComplete, count, tableWebAuthnCredentials)
 
 	return nil
 }
@@ -357,7 +357,7 @@ func schemaEncryptionChangeKeyCachedData(ctx context.Context, provider *SQLProvi
 		}
 	}
 
-	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, len(caches), tableCachedData)
+	provider.log.Debugf(logFmtEncryptionChangeKeyTableComplete, len(caches), tableCachedData)
 
 	return nil
 }
@@ -396,7 +396,7 @@ func schemaEncryptionChangeKeyOpenIDConnect(typeOAuth2Session OAuth2SessionType)
 			}
 		}
 
-		provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, typeOAuth2Session.Table())
+		provider.log.Debugf(logFmtEncryptionChangeKeyTableComplete, count, typeOAuth2Session.Table())
 
 		return nil
 	}
@@ -445,7 +445,7 @@ func schemaEncryptionChangeKeyEncryption(ctx context.Context, provider *SQLProvi
 		}
 	}
 
-	provider.log.Infof(logFmtEncryptionChangeKeyTableComplete, count, tableEncryption)
+	provider.log.Debugf(logFmtEncryptionChangeKeyTableComplete, count, tableEncryption)
 
 	return nil
 }


### PR DESCRIPTION
This adds progress logging for the AAD migration which can take a long time for larger databases.