### PR TITLE
fix(oidc): client credentials subject foreign key violation

### DIFF
--- a/internal/model/oidc.go
+++ b/internal/model/oidc.go
@@ -71,7 +71,7 @@ func NewOAuth2SessionFromRequest(signature string, r oauthelia2.Requester) (sess
 		return nil, fmt.Errorf("failed to create new *model.OAuth2Session: the session type OpenIDSession was expected but the type '%T' was used", r.GetSession())
 	}
 
-	subject = sql.NullString{String: s.GetSubject()}
+	subject = sql.NullString{String: s.GetStorageSubject()}
 
 	subject.Valid = len(subject.String) > 0
 
@@ -127,7 +127,7 @@ func NewOAuth2DeviceCodeSessionFromRequest(r oauthelia2.DeviceAuthorizeRequester
 		return nil, fmt.Errorf("failed to create new *model.OAuth2DeviceCodeSession: the session type OpenIDSession was expected but the type '%T' was used", r.GetSession())
 	}
 
-	subject = sql.NullString{String: s.GetSubject()}
+	subject = sql.NullString{String: s.GetStorageSubject()}
 
 	subject.Valid = len(subject.String) > 0
 
@@ -728,4 +728,5 @@ type OpenIDSession interface {
 	oauthelia2.Session
 
 	GetChallengeID() uuid.NullUUID
+	GetStorageSubject() (subject string)
 }

--- a/internal/model/oidc_test.go
+++ b/internal/model/oidc_test.go
@@ -16,6 +16,7 @@ import (
 
 	oauthelia2 "authelia.com/provider/oauth2"
 	"authelia.com/provider/oauth2/handler/openid"
+	"authelia.com/provider/oauth2/token/jwt"
 
 	"github.com/authelia/authelia/v4/internal/mocks"
 	"github.com/authelia/authelia/v4/internal/model"
@@ -31,7 +32,18 @@ func TestNewOAuth2SessionFromRequest(t *testing.T) {
 		},
 	}
 
+	sessionClientCredentials := &oidc.Session{
+		ClientID:          "client_id",
+		ClientCredentials: true,
+		DefaultSession: &openid.DefaultSession{
+			Claims: &jwt.IDTokenClaims{
+				Subject: "client_id",
+			},
+		},
+	}
+
 	sessionBytes, _ := json.Marshal(session)
+	sessionClientCredentialsBytes, _ := json.Marshal(sessionClientCredentials)
 
 	testCases := []struct {
 		name      string
@@ -87,6 +99,30 @@ func TestNewOAuth2SessionFromRequest(t *testing.T) {
 				GrantedScopes:   model.StringSlicePipeDelimited{},
 				Active:          true,
 				Session:         sessionBytes,
+			},
+			"",
+		},
+		{
+			"ShouldNewUpClientCredentialsWithNullSubject",
+			"abc",
+			&oauthelia2.Request{
+				ID: "example",
+				Client: &oauthelia2.DefaultClient{
+					ID: "client_id",
+				},
+				Session:        sessionClientCredentials,
+				RequestedScope: oauthelia2.Arguments{"authelia.bearer.authz"},
+				GrantedScope:   oauthelia2.Arguments{"authelia.bearer.authz"},
+			},
+			&model.OAuth2Session{
+				RequestID:       "example",
+				ClientID:        "client_id",
+				Signature:       "abc",
+				Subject:         sql.NullString{},
+				RequestedScopes: model.StringSlicePipeDelimited{"authelia.bearer.authz"},
+				GrantedScopes:   model.StringSlicePipeDelimited{"authelia.bearer.authz"},
+				Active:          true,
+				Session:         sessionClientCredentialsBytes,
 			},
 			"",
 		},

--- a/internal/oidc/session.go
+++ b/internal/oidc/session.go
@@ -74,7 +74,9 @@ type Session struct {
 	Extra                 map[string]any  `json:"extra"`
 }
 
-// GetSubject returns the subject, if set. This is optional and only used during token introspection.
+// GetSubject returns the subject, if set. This is optional and only used during token introspection and to determine
+// the 'sub' claim of tokens. It falls back to the client identifier for the Client Credentials Flow which has no
+// end-user. Use GetStorageSubject when persisting the subject of a session.
 func (s *Session) GetSubject() string {
 	if s == nil {
 		return ""
@@ -89,6 +91,19 @@ func (s *Session) GetSubject() string {
 	}
 
 	return ""
+}
+
+// GetStorageSubject returns the subject of the authenticated end-user, if any, for storage purposes.
+//
+// Unlike GetSubject this never falls back to the client identifier as the Client Credentials Flow does not have an
+// end-user. The storage layer records this value in columns which have a foreign key relationship with the
+// user_opaque_identifier table, so anything other than an opaque identifier of a known user must be NULL.
+func (s *Session) GetStorageSubject() (subject string) {
+	if s == nil {
+		return ""
+	}
+
+	return s.DefaultSession.GetSubject()
 }
 
 // ValidIssuer returns true if the issuer is valid for this session, false otherwise.

--- a/internal/oidc/session_test.go
+++ b/internal/oidc/session_test.go
@@ -502,3 +502,38 @@ func TestConsentGrantImplicit(t *testing.T) {
 		})
 	}
 }
+
+func TestSession_GetStorageSubject(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     *oidc.Session
+		expected string
+	}{
+		{
+			"ShouldReturnEmptyWhenSessionNil",
+			nil,
+			"",
+		},
+		{
+			"ShouldReturnEmptyWhenDefaultSessionNil",
+			&oidc.Session{},
+			"",
+		},
+		{
+			"ShouldReturnSubject",
+			&oidc.Session{DefaultSession: &openid.DefaultSession{Subject: "john"}},
+			"john",
+		},
+		{
+			"ShouldNotReturnClientIDForClientCredentials",
+			&oidc.Session{ClientID: "example", ClientCredentials: true, DefaultSession: &openid.DefaultSession{Claims: &jwt.IDTokenClaims{Subject: "example"}}},
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.have.GetStorageSubject())
+		})
+	}
+}

--- a/internal/oidc/util_blackbox_test.go
+++ b/internal/oidc/util_blackbox_test.go
@@ -2,6 +2,7 @@ package oidc_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/url"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/text/language"
 
 	oauthelia2 "authelia.com/provider/oauth2"
@@ -19,6 +21,7 @@ import (
 
 	"github.com/authelia/authelia/v4/internal/clock"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
+	"github.com/authelia/authelia/v4/internal/model"
 	"github.com/authelia/authelia/v4/internal/oidc"
 )
 
@@ -612,6 +615,38 @@ func TestHydrateClientCredentialsFlowSessionWithAccessRequest(t *testing.T) {
 			assert.Equal(t, tc.expected, session)
 		})
 	}
+}
+
+func TestHydrateClientCredentialsFlowSessionStorageSubject(t *testing.T) {
+	ctx := &TestContext{
+		Context: context.Background(),
+		Clock:   clock.NewFixed(time.Unix(1000, 0).UTC()),
+		IssuerURLFunc: func() (issuerURL *url.URL, err error) {
+			return url.ParseRequestURI("https://auth.example.com")
+		},
+	}
+
+	client := &oidc.RegisteredClient{ID: "23add1af-8de6-4b3c-af5a-9b944d81b073"}
+
+	session := &oidc.Session{DefaultSession: &openid.DefaultSession{}}
+
+	require.NoError(t, oidc.HydrateClientCredentialsFlowSessionWithAccessRequest(ctx, client, session))
+
+	assert.Equal(t, client.ID, session.GetSubject())
+	assert.Equal(t, client.ID, session.GetJWTClaims().(*fjwt.JWTClaims).Subject)
+
+	requester := &oauthelia2.AccessRequest{
+		Request: oauthelia2.Request{
+			ID:      "63cf1164-7853-4b23-addd-5cf6ab583de0",
+			Client:  client,
+			Session: session,
+		},
+	}
+
+	actual, err := model.NewOAuth2SessionFromRequest("cRUYb9-yb-BqCEmnBDBzTIzHCcGSBv0Kh_HrqxTFmm4", requester)
+
+	require.NoError(t, err)
+	assert.Equal(t, sql.NullString{}, actual.Subject)
 }
 
 func TestInitializeSessionDefaults(t *testing.T) {


### PR DESCRIPTION
The Client Credentials Flow has no end-user so the session subject is deliberately empty, but Session.GetSubject falls back to the client id for the token 'sub' claim and Token Introspection. Storage used the same method, writing the client id into columns with a foreign key on user_opaque_identifier, so the token endpoint returned a 500 on backends which enforce them. Sessions are now persisted with GetStorageSubject which never falls back, restoring the NULL subject.

Fixes #13018