### PR TITLE
ci(buildkite): only report fixable vulnerabilities in grype scans

### DIFF
--- a/.buildkite/steps/grypescans.sh
+++ b/.buildkite/steps/grypescans.sh
@@ -7,7 +7,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../libs/common.sh"
 ciTag="${BUILDKITE_TAG}"
 dockerImageName="authelia/authelia"
 masterBranch="master"
-grypeCmd=(grype -f low)
+grypeCmd=(grype -f low --only-fixed)
 
 if [[ "${CI_PRIVATE}" == "true" ]]; then
   dockerImageName="${dockerImageName}-cve"


### PR DESCRIPTION
Adds `--only-fixed` to the `grype` invocation in `grypescans.sh` so both the registry image scan and the CDX SBOM scans only fail on vulnerabilities that have a fix available upstream. Unfixed CVEs are noise for us: there is no action we can take to resolve them.