### PR TITLE
fix(suites): preserve log colours under go test -json

### DIFF
--- a/cmd/authelia-scripts/cmd/externalsuites.go
+++ b/cmd/authelia-scripts/cmd/externalsuites.go
@@ -124,7 +124,7 @@ func cmdSuitesExternalTestRun(_ *cobra.Command, args []string) {
 	}
 
 	testCmdLine := fmt.Sprintf(
-		"go test -count=1 -v -json -tags=externalsuites ./internal/suites -timeout %s %s-run '^(%s)$'",
+		"go test -count=1 -json -tags=externalsuites ./internal/suites -timeout %s %s-run '^(%s)$'",
 		timeout, failfast, entrypoint,
 	)
 

--- a/cmd/authelia-scripts/cmd/suites.go
+++ b/cmd/authelia-scripts/cmd/suites.go
@@ -329,7 +329,7 @@ func runSuiteTests(suiteName string, withEnv bool) error {
 		fail = "-failfast"
 	}
 
-	testCmdLine := fmt.Sprintf("go test -count=1 -v -json ./internal/suites -timeout %s %s ", timeout, fail)
+	testCmdLine := fmt.Sprintf("go test -count=1 -json ./internal/suites -timeout %s %s ", timeout, fail)
 
 	if testPattern != "" {
 		testCmdLine += fmt.Sprintf("-run '%s'", testPattern)

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -209,11 +210,43 @@ func (s *BaseSuite) SetupLogging() {
 
 	log.SetLevel(l)
 
+	if f := flag.Lookup("test.v"); f != nil && f.Value.String() == "test2json" {
+		log.SetOutput(&test2JSONWriter{out: os.Stderr})
+	}
+
 	log.SetFormatter(&log.TextFormatter{
 		ForceColors: true,
 	})
 
 	s.T().Setenv("SUITE_SETUP_LOGGING", t)
+}
+
+// markEscape is the escape mark consumed by cmd/internal/test2json. Control bytes a test writes directly
+// to stderr rather than via t.Log must be escaped with it, otherwise test2json elides them, stripping the
+// ESC from ANSI sequences and leaving the remainder as literal text in the log.
+const markEscape = 0x1b
+
+// test2JSONWriter escapes the test2json escape mark so ANSI sequences survive `go test -json`.
+type test2JSONWriter struct {
+	out io.Writer
+}
+
+func (w *test2JSONWriter) Write(p []byte) (n int, err error) {
+	buf := make([]byte, 0, len(p))
+
+	for _, b := range p {
+		if b == markEscape {
+			buf = append(buf, markEscape)
+		}
+
+		buf = append(buf, b)
+	}
+
+	if _, err = w.out.Write(buf); err != nil {
+		return 0, err
+	}
+
+	return len(p), nil
 }
 
 // SetupEnvironment configures the environment for this suite.


### PR DESCRIPTION
Go 1.27 gave `cmd/internal/test2json` a framing protocol that claims ESC (`\x1b`) as its own escape mark, eliding it from any output a test writes directly to stdout or stderr. The suite logger sets `ForceColors` on the logrus `TextFormatter` and writes straight to stderr, so its ANSI sequences lost their introducer and rendered in the Buildkite logs as literal text such as `[2;36mDEBU[0m[0000] Checking Suite HighAvailability for .env file`. Output emitted via `t.Log` was unaffected because the `testing` package already escapes its own control bytes.

Wrap the logger output in `test2JSONWriter`, which doubles each ESC so that the un-escaping performed by test2json yields the original byte. The writer is only installed when `-test.v=test2json` is set, so running the suites directly against a terminal is unchanged.

Drop `-v` from the `go test` invocations in `authelia-scripts`. It is redundant with `-json`, which already implies verbose, and the `-test.v=true` it appends overrides the `-test.v=test2json` the toolchain injects, leaving the suite unable to detect that its output is being converted.