### PR TITLE
ci(reviewdog): harden typos runner against silent aborts

### DIFF
--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -8,6 +8,8 @@
 #                            discovered via git ls-files + shebang scan and
 #                            passed in. Any flag-style arguments (--format=...)
 #                            are forwarded to shellcheck.
+#   lint.sh typos ...        Run typos, reporting an abnormal exit as a finding
+#                            so reviewdog does not discard the reason.
 #   lint.sh -flag ...        Anything else is forwarded to reviewdog.
 
 set -uo pipefail
@@ -56,6 +58,28 @@ run_shellcheck() {
   fi
 }
 
+run_typos() {
+  local err rc
+  err=$(mktemp)
+  typos --threads 4 --format brief "$@" 2>"${err}"
+  rc=$?
+
+  # 0 is clean and 2 is typos found; anything else is typos itself failing.
+  # reviewdog discards a runner's stderr and any stdout that does not match the
+  # errorformat, so re-emit the reason as a finding or it is lost entirely.
+  if [ ${rc} -ne 0 ] && [ ${rc} -ne 2 ]; then
+    if [ -s "${err}" ]; then
+      sed -e "s|^|.reviewdog.yml:1:1: typos failed (exit ${rc}): |" "${err}"
+    else
+      echo ".reviewdog.yml:1:1: typos failed (exit ${rc}) without writing a reason"
+    fi
+  fi
+
+  rm -f "${err}"
+
+  return ${rc}
+}
+
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
 if [[ $# -eq 0 ]]; then
@@ -82,6 +106,9 @@ if [[ $# -eq 0 ]]; then
 elif [[ $1 == "shellcheck" ]]; then
   shift
   run_shellcheck "$@"
+elif [[ $1 == "typos" ]]; then
+  shift
+  run_typos "$@"
 else
   reviewdog "$@"
 fi

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -56,7 +56,7 @@ pre-commit:
             run: trufflehog --fail --log-level=-1 filesystem -x .trufflehog . && echo "0 issues."
 
           - name: typos
-            run: typos -w --format brief && echo "0 issues."
+            run: typos -w --threads 4 --format brief && echo "0 issues."
             stage_fixed: true
 
           - name: yamllint

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -27,7 +27,7 @@ runner:
     level: error
 
   typos:
-    cmd: typos --format brief .
+    cmd: .buildkite/steps/lint.sh typos .
     errorformat:
       - '%f:%l:%c: %m'
     level: error


### PR DESCRIPTION
The `typos` runner intermittently dies with `signal: aborted (core dumped)` on the Buildkite agents, and reviewdog reports only `typos failed with zero findings: The command itself failed`. reviewdog discards a runner's stderr along with any stdout line that does not match the `errorformat`, so whatever `typos` wrote on its way out never reaches the build log, leaving nothing to diagnose.

Route the runner through `.buildkite/steps/lint.sh typos`, matching the existing `shellcheck` subcommand. The wrapper captures stderr and, on any exit code other than `0` (clean) or `2` (typos found), re-emits each line as an `errorformat` matching finding against `.reviewdog.yml`. A `SIGABRT` now surfaces as `typos failed (exit 134): <reason>` instead of as an empty failure.

Cap `--threads` at `4` in both the wrapper and the lefthook job. `typos` defaults to one thread per logical CPU and runs alongside five other linters in the same step, which makes an in-process allocator abort the most likely explanation for the crash. The whole repository still scans in under a tenth of a second.