### PR TITLE
fix(suites): restore single log group in suite test output

### DIFF
--- a/cmd/authelia-scripts/cmd/externalsuites.go
+++ b/cmd/authelia-scripts/cmd/externalsuites.go
@@ -124,7 +124,7 @@ func cmdSuitesExternalTestRun(_ *cobra.Command, args []string) {
 	}
 
 	testCmdLine := fmt.Sprintf(
-		"go test -count=1 -json -tags=externalsuites ./internal/suites -timeout %s %s-run '^(%s)$'",
+		"go test -count=1 -v -json -tags=externalsuites ./internal/suites -timeout %s %s-run '^(%s)$'",
 		timeout, failfast, entrypoint,
 	)
 

--- a/cmd/authelia-scripts/cmd/suites.go
+++ b/cmd/authelia-scripts/cmd/suites.go
@@ -329,7 +329,7 @@ func runSuiteTests(suiteName string, withEnv bool) error {
 		fail = "-failfast"
 	}
 
-	testCmdLine := fmt.Sprintf("go test -count=1 -json ./internal/suites -timeout %s %s ", timeout, fail)
+	testCmdLine := fmt.Sprintf("go test -count=1 -v -json ./internal/suites -timeout %s %s ", timeout, fail)
 
 	if testPattern != "" {
 		testCmdLine += fmt.Sprintf("-run '%s'", testPattern)

--- a/internal/suites/utils.go
+++ b/internal/suites/utils.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -210,7 +210,7 @@ func (s *BaseSuite) SetupLogging() {
 
 	log.SetLevel(l)
 
-	if f := flag.Lookup("test.v"); f != nil && f.Value.String() == "test2json" {
+	if isTest2JSON() {
 		log.SetOutput(&test2JSONWriter{out: os.Stderr})
 	}
 
@@ -219,6 +219,14 @@ func (s *BaseSuite) SetupLogging() {
 	})
 
 	s.T().Setenv("SUITE_SETUP_LOGGING", t)
+}
+
+// isTest2JSON returns true if the test binary output is being converted by cmd/internal/test2json. The
+// go command injects -test.v=test2json when -json is used, however the flag cannot be read back via the
+// flag package as -v appends a second -test.v=true which takes precedence, so the arguments are checked
+// directly.
+func isTest2JSON() bool {
+	return slices.Contains(os.Args, "-test.v=test2json")
 }
 
 // markEscape is the escape mark consumed by cmd/internal/test2json. Control bytes a test writes directly


### PR DESCRIPTION
Dropping `-v` from the `go test` invocations left `-test.v=test2json` as the effective value, which puts the `testing` package itself into test2json mode. In that mode it never flushes a subtest result to its parent so that the JSON stream shows subtests as they finish, meaning every `--- PASS: TestXSuite/TestShouldY` line is emitted unindented at the start of a line instead of being grouped and indented under the parent's `--- PASS: TestXSuite` line at the end of the run. Buildkite treats any line beginning with `---` as a collapsible log group header, so the suite output went from one collapsed group to one per test.

Restore `-v` so the parent flushing behaviour and the original layout come back, and detect test2json by looking for the `-test.v=test2json` argument the go command injects alongside `-json` rather than by reading the flag value, which `-v` overrides with `-test.v=true`. The escaping performed by `test2JSONWriter` is unaffected: `cmd/internal/test2json` un-escapes the escape mark regardless of what the test binary was told, so the log colours preserved by c004538983bbd65d8cdb585f6464c29b5a1dbae2 continue to render.