### PR TITLE
fix(notification): smtp ipv6 literal addresses

### DIFF
--- a/internal/configuration/schema/types_address.go
+++ b/internal/configuration/schema/types_address.go
@@ -362,6 +362,18 @@ func (a *Address) Hostname() string {
 	return a.url.Hostname()
 }
 
+// HostnameLiteral returns the output of the Hostname func except IPv6 addresses are returned in the RFC3986 IP-literal
+// format i.e. surrounded by square brackets. This makes the value safe to directly join with a port.
+func (a *Address) HostnameLiteral() string {
+	hostname := a.Hostname()
+
+	if strings.Contains(hostname, ":") {
+		return "[" + hostname + "]"
+	}
+
+	return hostname
+}
+
 // SetHostname sets the hostname preserving the port.
 func (a *Address) SetHostname(hostname string) {
 	if !a.valid || a.url == nil {

--- a/internal/configuration/schema/types_address_test.go
+++ b/internal/configuration/schema/types_address_test.go
@@ -905,6 +905,51 @@ func TestAddress_SocketHostname(t *testing.T) {
 	}
 }
 
+func TestAddress_HostnameLiteral(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     Address
+		expected string
+	}{
+		{
+			"ShouldReturnHostname",
+			Address{true, false, -1, 80, nil, &url.URL{Scheme: AddressSchemeTCP, Host: "examplea:80"}},
+			"examplea",
+		},
+		{
+			"ShouldReturnIPv4",
+			Address{true, false, -1, 80, nil, &url.URL{Scheme: AddressSchemeTCP, Host: "127.0.0.1:80"}},
+			"127.0.0.1",
+		},
+		{
+			"ShouldReturnIPv6WithBrackets",
+			Address{true, false, -1, 80, nil, &url.URL{Scheme: AddressSchemeTCP, Host: "[::1]:80"}},
+			"[::1]",
+		},
+		{
+			"ShouldReturnIPv6ExpandedWithBrackets",
+			Address{true, false, -1, 80, nil, &url.URL{Scheme: AddressSchemeTCP, Host: "[2001:db8::1]:80"}},
+			"[2001:db8::1]",
+		},
+		{
+			"ShouldReturnNothingInvalid",
+			Address{false, false, -1, 80, nil, &url.URL{Scheme: AddressSchemeTCP, Host: "[::1]:80"}},
+			"",
+		},
+		{
+			"ShouldReturnNothingNil",
+			Address{true, false, -1, 80, nil, nil},
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.have.HostnameLiteral())
+		})
+	}
+}
+
 func TestAddress_Path(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/internal/notification/smtp_auth.go
+++ b/internal/notification/smtp_auth.go
@@ -20,7 +20,7 @@ func NewOpportunisticSMTPAuth(config *schema.NotifierSMTP, preference ...mail.SM
 	return &OpportunisticSMTPAuth{
 		username:          config.Username,
 		password:          config.Password,
-		host:              config.Address.Hostname(),
+		host:              config.Address.HostnameLiteral(),
 		satPreference:     preference,
 		disableRequireTLS: config.DisableRequireTLS,
 	}

--- a/internal/notification/smtp_notifier.go
+++ b/internal/notification/smtp_notifier.go
@@ -218,7 +218,7 @@ type StandardSMTPClientFactory struct {
 
 // GetClient returns a new SMTPClient.
 func (f *StandardSMTPClientFactory) GetClient() (client SMTPClient, err error) {
-	if client, err = gomail.NewClient(f.config.Address.Hostname(), f.opts...); err != nil {
+	if client, err = gomail.NewClient(f.config.Address.HostnameLiteral(), f.opts...); err != nil {
 		return nil, err
 	}
 

--- a/internal/notification/smtp_notifier_test.go
+++ b/internal/notification/smtp_notifier_test.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	th "html/template"
 	"net/mail"
+	"strings"
 	"testing"
 	tt "text/template"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -83,6 +85,59 @@ func TestNewSMTPNotifier(t *testing.T) {
 			if tc.validate != nil {
 				tc.validate(t, notifier)
 			}
+		})
+	}
+}
+
+func TestStandardSMTPClientFactory_GetClient(t *testing.T) {
+	testCases := []struct {
+		name     string
+		address  *schema.AddressSMTP
+		expected string
+	}{
+		{
+			"ShouldHandleHostname",
+			schema.NewSMTPAddress("submission", "example.com", 587),
+			"example.com:587",
+		},
+		{
+			"ShouldHandleIPv4",
+			schema.NewSMTPAddress("smtp", "127.0.0.1", 1025),
+			"127.0.0.1:1025",
+		},
+		{
+			"ShouldHandleIPv6",
+			schema.NewSMTPAddress("smtp", "[::1]", 1025),
+			"[::1]:1025",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &schema.NotifierSMTP{
+				Address:    tc.address,
+				Identifier: "localhost",
+				Username:   "admin",
+				Password:   "password",
+				Timeout:    time.Second * 5,
+				TLS:        &schema.TLS{},
+			}
+
+			notifier := NewSMTPNotifier(config, nil)
+			require.NotNil(t, notifier)
+
+			client, err := notifier.factory.GetClient()
+			require.NoError(t, err)
+			require.NotNil(t, client)
+
+			assert.Equal(t, tc.expected, client.ServerAddr())
+
+			host := strings.TrimSuffix(client.ServerAddr(), fmt.Sprintf(":%d", tc.address.Port()))
+
+			auth, ok := NewOpportunisticSMTPAuth(config).(*OpportunisticSMTPAuth)
+			require.True(t, ok)
+
+			assert.Equal(t, host, auth.host)
 		})
 	}
 }


### PR DESCRIPTION
The SMTP client was given the bare hostname, which drops the brackets from an IPv6 literal, and go-mail joins the host and port by simple concatenation, producing addresses like `::1:1025` that net.Dial rejects with `too many colons in address`.

Pass the RFC3986 IP-literal form instead, for both the client and the authentication host as go-mail uses the same value as the server name which PLAIN and LOGIN validate against.

Fixes #13041