### PR TITLE
ci(reviewdog): fail the linting step on runner errors

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -60,7 +60,7 @@ env:
 
 steps:
   - label: ":service_dog: Linting"
-    command: "lint.sh -reporter=${LINT_REPORTER} -filter-mode=nofilter -fail-level=error"
+    command: "lint.sh -reporter=${LINT_REPORTER} -filter-mode=nofilter -fail-level=error -fail-on-error"
     if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.message !~ /\[(skip test|test skip)\]/
 
   - label: ":chrome: External Tests"

--- a/web/src/hooks/PasswordVisibility.test.ts
+++ b/web/src/hooks/PasswordVisibility.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { act, renderHook } from "@testing-library/react";
 
 import { usePasswordVisibility } from "@hooks/PasswordVisibility";

--- a/web/src/hooks/PasswordVisibility.ts
+++ b/web/src/hooks/PasswordVisibility.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useCallback, useState } from "react";
 
 export const usePasswordVisibility = () => {


### PR DESCRIPTION
The linting step has been unable to fail since `-fail-on-error` was replaced with `-fail-level=error` when reviewdog was re-enabled, so a failing runner has only ever shown up as a GitHub check while Buildkite reported the step as passing. Build 58544 is an example: the `reuse` runner reported `conclusion=failure` for two files missing SPDX headers and the step still exited 0.

`-reporter=github-check` reports through the doghouse server, and that path decides the exit code solely on `opt.failOnError`; `opt.failLevel` is only plumbed into the reporters that comment directly. Pass both flags so the deprecated one gates the step under `github-check` while `-fail-level=error` keeps gating the `local` reporter used by the private pipeline.