### PR TITLE
refactor(logging): replace the abandoned logrus-stack hook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ toolchain go1.27.1
 require (
 	authelia.com/provider/oauth2 v0.3.0
 	cel.dev/cel-go v0.32.0
-	github.com/Gurpartap/logrus-stack v0.0.0-20170710170904-89c00d8a28f4
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/authelia/jsonschema v0.1.7
 	github.com/authelia/otp v1.0.4
@@ -74,7 +73,6 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.3 // indirect
 	github.com/go-crypt/x v0.4.16 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
 filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
 github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
-github.com/Gurpartap/logrus-stack v0.0.0-20170710170904-89c00d8a28f4 h1:vdT7QwBhJJEVNFMBNhRSFDRCB6O16T28VhvqRgqFyn8=
-github.com/Gurpartap/logrus-stack v0.0.0-20170710170904-89c00d8a28f4/go.mod h1:SvXOG8ElV28oAiG9zv91SDe5+9PfIr7PPccpr8YyXNs=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktpoUAgOJK3OTFc/xug0PCXYCqU0FgDKI=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
@@ -48,8 +46,6 @@ github.com/duosecurity/duo_api_golang v0.3.0 h1:addmixrtUzagTEp2PttJdzFg2LRSINpp
 github.com/duosecurity/duo_api_golang v0.3.0/go.mod h1:hJ6IPTuCAvWv+i9ubnPZB3VpVRuj/+SAblWFcI0mjEU=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
-github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/fasthttp/router v1.5.4 h1:oxdThbBwQgsDIYZ3wR1IavsNl6ZS9WdjKukeMikOnC8=
 github.com/fasthttp/router v1.5.4/go.mod h1:3/hysWq6cky7dTfzaaEPZGdptwjwx0qzTgFCKEWRjgc=
 github.com/fasthttp/session/v2 v2.5.9 h1:elCeQKGr1W0P7t3r35JX4OqqN9SWEGyYrxDNKPtBfHs=

--- a/internal/logging/const.go
+++ b/internal/logging/const.go
@@ -72,6 +72,17 @@ const (
 	FieldGranted             = "granted"
 	FieldStatus              = "status"
 	FieldProvider            = "provider"
+	FieldCaller              = "caller"
+	FieldStack               = "stack"
+)
+
+// Stack trace hook values.
+const (
+	stackSkipFrames       = 8
+	stackSkipFramesFields = 6
+	stackMaxDepth         = 32
+
+	pathPackageLogrus = "github.com/sirupsen/logrus"
 )
 
 var (

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 
-	logrus_stack "github.com/Gurpartap/logrus-stack"
 	"github.com/sirupsen/logrus"
 
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
@@ -44,7 +43,7 @@ func initializeStackTracer(config schema.Log) {
 
 	// Ensure the stack trace hook is only initialized once.
 	stacktrace.Do(func() {
-		logrus.AddHook(logrus_stack.NewHook(callerLevels, stackLevels))
+		logrus.AddHook(stackHook{CallerLevels: callerLevels, StackLevels: stackLevels})
 	})
 }
 

--- a/internal/logging/stack.go
+++ b/internal/logging/stack.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+type stackFrame struct {
+	File string
+	Line int
+	Name string
+}
+
+// String provides the standard file:line representation.
+func (f stackFrame) String() string {
+	return f.File + ":" + strconv.Itoa(f.Line) + " " + f.Name
+}
+
+type stackTrace []stackFrame
+
+// String provides the standard multi-line stack trace with the function names aligned.
+func (s stackTrace) String() string {
+	var width int
+
+	for _, frame := range s {
+		if n := len(frame.File) + len(strconv.Itoa(frame.Line)) + 1; n > width {
+			width = n
+		}
+	}
+
+	buf := &strings.Builder{}
+
+	for i, frame := range s {
+		if i != 0 {
+			buf.WriteRune('\n')
+		}
+
+		line := strconv.Itoa(frame.Line)
+
+		buf.WriteString(frame.File)
+		buf.WriteRune(':')
+		buf.WriteString(line)
+		buf.WriteString(strings.Repeat(" ", width-len(frame.File)-len(line)))
+		buf.WriteString(frame.Name)
+	}
+
+	return buf.String()
+}
+
+type stackHook struct {
+	CallerLevels []logrus.Level
+	StackLevels  []logrus.Level
+}
+
+// Levels provides the levels to filter.
+func (hook stackHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire is called by logrus when something is logged.
+func (hook stackHook) Fire(entry *logrus.Entry) error {
+	skip := stackSkipFrames
+
+	if len(entry.Data) != 0 {
+		skip = stackSkipFramesFields
+	}
+
+	frames := stackCallers(skip)
+
+	if len(frames) == 0 {
+		return nil
+	}
+
+	if slices.Contains(hook.CallerLevels, entry.Level) {
+		entry.Data[FieldCaller] = frames[0]
+	}
+
+	if slices.Contains(hook.StackLevels, entry.Level) {
+		entry.Data[FieldStack] = frames
+	}
+
+	return nil
+}
+
+func stackCallers(skip int) (frames stackTrace) {
+	pcs := make([]uintptr, stackMaxDepth)
+
+	n := runtime.Callers(skip+2, pcs)
+
+	frames = make(stackTrace, 0, n)
+
+	for _, pc := range pcs[:n] {
+		fn := runtime.FuncForPC(pc)
+
+		if fn == nil {
+			continue
+		}
+
+		file, line := fn.FileLine(pc - 1)
+
+		if strings.Contains(file, pathPackageLogrus) {
+			continue
+		}
+
+		frames = append(frames, stackFrame{File: file, Line: line, Name: stackStripPackage(fn.Name())})
+	}
+
+	return frames
+}
+
+func stackStripPackage(name string) string {
+	slash := strings.LastIndex(name, "/")
+
+	if slash == -1 {
+		slash = 0
+	}
+
+	dot := strings.Index(name[slash:], ".")
+
+	if dot == -1 {
+		return name
+	}
+
+	return name[slash+dot+1:]
+}

--- a/internal/logging/stack_test.go
+++ b/internal/logging/stack_test.go
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2026 Authelia
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackFrameString(t *testing.T) {
+	frame := stackFrame{File: "/srv/authelia/internal/logging/stack.go", Line: 42, Name: "Fire"}
+
+	assert.Equal(t, "/srv/authelia/internal/logging/stack.go:42 Fire", frame.String())
+}
+
+func TestStackTraceStringAlignsNames(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     stackTrace
+		expected string
+	}{
+		{
+			"ShouldRenderEmpty",
+			stackTrace{},
+			"",
+		},
+		{
+			"ShouldRenderSingleFrameWithSingleSpace",
+			stackTrace{{File: "a.go", Line: 1, Name: "One"}},
+			"a.go:1 One",
+		},
+		{
+			"ShouldPadShorterFramesSoNamesAlign",
+			stackTrace{
+				{File: "short.go", Line: 1, Name: "One"},
+				{File: "muchlonger.go", Line: 100, Name: "Two"},
+			},
+			"short.go:1        One\nmuchlonger.go:100 Two",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.have.String())
+		})
+	}
+}
+
+func TestStackStripPackage(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     string
+		expected string
+	}{
+		{"ShouldStripModulePath", "github.com/authelia/authelia/v4/internal/logging.Fire", "Fire"},
+		{"ShouldStripBuiltinPackage", "runtime.goexit", "goexit"},
+		{"ShouldRetainMethodReceiver", "github.com/authelia/authelia/v4/internal/logging.stackHook.Fire", "stackHook.Fire"},
+		{"ShouldReturnNameWithoutSeparator", "goexit", "goexit"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, stackStripPackage(tc.have))
+		})
+	}
+}
+
+func TestStackHookLevels(t *testing.T) {
+	assert.Equal(t, logrus.AllLevels, stackHook{}.Levels())
+}
+
+func fireStackHook(t *testing.T, hook stackHook, fields logrus.Fields) logrus.Fields {
+	t.Helper()
+
+	logger := logrus.New()
+	logger.SetOutput(&bytes.Buffer{})
+	logger.SetLevel(logrus.TraceLevel)
+	logger.AddHook(hook)
+
+	var captured logrus.Fields
+
+	logger.AddHook(&stackCaptureHook{fields: &captured})
+
+	if fields == nil {
+		logger.Error("example")
+	} else {
+		logger.WithFields(fields).Error("example")
+	}
+
+	return captured
+}
+
+type stackCaptureHook struct {
+	fields *logrus.Fields
+}
+
+func (h *stackCaptureHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *stackCaptureHook) Fire(entry *logrus.Entry) error {
+	fields := logrus.Fields{}
+
+	for k, v := range entry.Data {
+		fields[k] = v
+	}
+
+	*h.fields = fields
+
+	return nil
+}
+
+func TestStackHookFire(t *testing.T) {
+	testCases := []struct {
+		name      string
+		hook      stackHook
+		fields    logrus.Fields
+		hasCaller bool
+		hasStack  bool
+	}{
+		{
+			"ShouldSetNeitherWhenLevelNotConfigured",
+			stackHook{},
+			nil,
+			false,
+			false,
+		},
+		{
+			"ShouldSetCallerOnly",
+			stackHook{CallerLevels: logrus.AllLevels},
+			nil,
+			true,
+			false,
+		},
+		{
+			"ShouldSetStackOnly",
+			stackHook{StackLevels: []logrus.Level{logrus.ErrorLevel}},
+			nil,
+			false,
+			true,
+		},
+		{
+			"ShouldSetBoth",
+			stackHook{CallerLevels: logrus.AllLevels, StackLevels: []logrus.Level{logrus.ErrorLevel}},
+			nil,
+			true,
+			true,
+		},
+		{
+			"ShouldSetBothWithFields",
+			stackHook{CallerLevels: logrus.AllLevels, StackLevels: []logrus.Level{logrus.ErrorLevel}},
+			logrus.Fields{"k": "v"},
+			true,
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := fireStackHook(t, tc.hook, tc.fields)
+
+			caller, ok := fields[FieldCaller]
+			assert.Equal(t, tc.hasCaller, ok)
+
+			if tc.hasCaller {
+				frame, ok := caller.(stackFrame)
+				require.True(t, ok)
+
+				assert.Equal(t, "stack_test.go", frame.File[strings.LastIndex(frame.File, "/")+1:])
+				assert.NotEmpty(t, frame.Name)
+			}
+
+			trace, ok := fields[FieldStack]
+			assert.Equal(t, tc.hasStack, ok)
+
+			if tc.hasStack {
+				frames, ok := trace.(stackTrace)
+				require.True(t, ok)
+				require.NotEmpty(t, frames)
+
+				assert.Equal(t, "stack_test.go", frames[0].File[strings.LastIndex(frames[0].File, "/")+1:])
+
+				for _, frame := range frames {
+					assert.NotContains(t, frame.File, pathPackageLogrus)
+				}
+			}
+		})
+	}
+}
+
+func TestStackHookJSONShape(t *testing.T) {
+	fields := fireStackHook(t, stackHook{CallerLevels: logrus.AllLevels, StackLevels: []logrus.Level{logrus.ErrorLevel}}, nil)
+
+	data, err := json.Marshal(fields[FieldCaller])
+	require.NoError(t, err)
+
+	caller := map[string]any{}
+	require.NoError(t, json.Unmarshal(data, &caller))
+
+	assert.Contains(t, caller, "File")
+	assert.Contains(t, caller, "Line")
+	assert.Contains(t, caller, "Name")
+
+	if data, err = json.Marshal(fields[FieldStack]); err != nil {
+		require.NoError(t, err)
+	}
+
+	var trace []map[string]any
+
+	require.NoError(t, json.Unmarshal(data, &trace))
+	require.NotEmpty(t, trace)
+
+	assert.Contains(t, trace[0], "File")
+	assert.Contains(t, trace[0], "Line")
+	assert.Contains(t, trace[0], "Name")
+}


### PR DESCRIPTION
`github.com/Gurpartap/logrus-stack` has had no commits since July 2017. Implement the hook locally, which also drops `github.com/facebookgo/stack` as nothing else requires it.

Output is unchanged: `stackFrame` and `stackTrace` keep the exported `File`, `Line` and `Name` fields so `caller` and `stack` render identically under both the text and JSON formatters. `StripGOPATH` is not carried over as it never matches under module builds.