### PR TITLE
build(deps): move govalidator to the /v12 module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ toolchain go1.27.1
 require (
 	authelia.com/provider/oauth2 v0.3.0
 	cel.dev/cel-go v0.32.0
-	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
+	github.com/asaskevich/govalidator/v12 v12.0.0
 	github.com/authelia/jsonschema v0.1.7
 	github.com/authelia/otp v1.0.4
 	github.com/duosecurity/duo_api_golang v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktp
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
-github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
-github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/asaskevich/govalidator/v12 v12.0.0 h1:AiTFC1ZWG/16bcgVZ8zXDJmMQhMovYztWFlj4I9iyUQ=
+github.com/asaskevich/govalidator/v12 v12.0.0/go.mod h1:Rly4eyDYE9One4VdXKFelwC93WbOMTTjl5gSwwP2F8o=
 github.com/authelia/jsonschema v0.1.7 h1:RbtTeTG7GiWIrx2A+3O+b33jr/mLlSmqGYyk1w5gLNA=
 github.com/authelia/jsonschema v0.1.7/go.mod h1:9l5WAhb73MyveI+xnNGK2Q367ynzLRAYHrN/PPcxptM=
 github.com/authelia/otp v1.0.4 h1:wVCsa9Tm/Vnx53WtaQbqgkNB9eUXQNnuaG0QzuRuHWI=

--- a/internal/authentication/file_user_provider_database.go
+++ b/internal/authentication/file_user_provider_database.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/asaskevich/govalidator"
+	"github.com/asaskevich/govalidator/v12"
 	"github.com/go-crypt/crypt"
 	"github.com/go-crypt/crypt/algorithm"
 	"go.yaml.in/yaml/v4"

--- a/internal/middlewares/authelia_context.go
+++ b/internal/middlewares/authelia_context.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/asaskevich/govalidator"
+	"github.com/asaskevich/govalidator/v12"
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/golang-jwt/jwt/v5"


### PR DESCRIPTION
`github.com/asaskevich/govalidator` moved to a `/v12` module path in August 2024, leaving the unsuffixed path pinned here stuck on a March 2023 pseudo-version which neither Renovate nor `go get -u` can advance past a major path rename.

`ValidateStruct`, `typeCheck`, `checkRequired` and `isEmptyValue` are byte-identical across the two versions, so this is inert for us. The intervening changes are new validators and `IsURL` fixes we do not call.