### PR TITLE
docs: add notification events reference

### DIFF
--- a/docs/content/configuration/notifications/events.md
+++ b/docs/content/configuration/notifications/events.md
@@ -1,0 +1,94 @@
+---
+# SPDX-FileCopyrightText: 2026 Authelia
+#
+# SPDX-License-Identifier: Apache-2.0
+
+title: "Events"
+description: "A reference of every notification Authelia sends."
+summary: "Authelia sends a fixed set of notifications. This section lists each one, when it is sent, and which template renders it."
+date: 2026-09-10T10:00:00+10:00
+draft: false
+images: []
+weight: 108400
+toc: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  noindex: false # false (default) or true
+---
+
+Authelia sends a fixed set of notifications. Every notification is addressed to the email address recorded for the user
+in the [authentication backend](../first-factor/introduction.md), is rendered from one of three
+[templates](../../reference/guides/notification-templates.md), and is delivered by whichever
+[notifier](introduction.md) you have configured.
+
+Authelia does not send marketing, digest, or administrative messages, and there is no per-event configuration option to
+enable or disable an individual notification.
+
+## Events
+
+|            Event            |             Subject             |         Template          |
+| :-------------------------: | :-----------------------------: | :-----------------------: |
+|  Password reset requested   |      `Reset your password`      | `IdentityVerificationJWT` |
+| Session elevation requested |     `Confirm your identity`     | `IdentityVerificationOTC` |
+|  Password reset completed   | `Password changed successfully` |          `Event`          |
+|      Password changed       | `Password changed successfully` |          `Event`          |
+|  Second factor registered   |  `Second Factor Method Added`   |          `Event`          |
+|    Second factor removed    | `Second Factor Method Removed`  |          `Event`          |
+
+The subject line is also used as the `{{ .Title }}` placeholder within the template.
+
+### Password reset requested
+
+Sent when a user requests a password reset from the sign-in portal. The notification contains a single-use link which
+proves the recipient controls the mailbox, and a second link which revokes the request.
+
+This notification is sent whether or not the requested user exists, from the perspective of the requester: the portal
+always responds identically in order to prevent user enumeration. No notification is sent when the user does not exist.
+
+### Session elevation requested
+
+Sent when a user attempts an operation which requires an elevated session, such as managing their credentials, and
+[identity validation](../identity-validation/introduction.md) requires them to confirm their identity. The notification
+contains a One-Time Code rather than a link, and a link which revokes the elevation request.
+
+### Password reset completed
+
+Sent to the user after their password has been successfully changed via the password reset flow.
+
+### Password changed
+
+Sent to the user after they have successfully changed their own password from the settings area.
+
+### Second factor registered
+
+Sent when a user registers a new second factor method. The body names which method was registered, either a
+One-Time Password or a WebAuthn Credential, and in the case of a WebAuthn Credential the description the user gave it.
+
+### Second factor removed
+
+Sent when a user removes a registered second factor method. As with registration, the body names the method and, for a
+WebAuthn Credential, its description.
+
+## Delivery
+
+What a recipient actually receives depends on the configured notifier.
+
+|                  Notifier                  |                                          Delivery                                           |
+| :----------------------------------------: | :-----------------------------------------------------------------------------------------: |
+|              [SMTP](smtp.md)               |           A multipart message containing both the plaintext and HTML renderings.            |
+| [SMTP](smtp.md) with `disable_html_emails` |                                The plaintext rendering only.                                |
+|           [Filesystem](file.md)            | The plaintext rendering only, preceded by a header naming the date, recipient, and subject. |
+
+The [filesystem](file.md) notifier is intended for testing and development. It writes every notification to a single
+file rather than delivering it to the user, so a deployment using it sends the user nothing.
+
+## Customizing
+
+The content of each notification is controlled by its template. To override one, set
+[template_path](introduction.md#template_path) and provide a file named after the template with either a `.html` or
+`.txt` extension.
+
+See the [Notification Templates](../../reference/guides/notification-templates.md) reference guide for the available
+templates, the placeholder variables each one accepts, and the functions available within them.

--- a/docs/content/reference/guides/notification-templates.md
+++ b/docs/content/reference/guides/notification-templates.md
@@ -51,18 +51,21 @@ HTML `IdentityVerificationJWT` template.
 
 In template files, you can use the following placeholders which are automatically injected into the templates:
 
-|         Placeholder         |                    Templates                     |                                                                  Description                                                                   |
-| :-------------------------: | :----------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------: |
-|      `{{ .LinkURL }}`       | IdentityVerificationJWT, IdentityVerificationOTC |                                            The URL associated with the notification if applicable.                                             |
-|      `{{ .LinkText }}`      | IdentityVerificationJWT, IdentityVerificationOTC |                                 The display value for the URL associated with the notification if applicable.                                  |
-| `{{ .RevocationLinkURL }}`  | IdentityVerificationJWT, IdentityVerificationOTC |                                       The Revocation URL associated with the notification if applicable.                                       |
-| `{{ .RevocationLinkText }}` | IdentityVerificationJWT, IdentityVerificationOTC |                            The display value for the Revocation URL associated with the notification if applicable.                            |
-|     `{{ .BodyPrefix }}`     |                      Event                       |                                                           Prefix for the body event.                                                           |
-|     `{{ .BodyEvent }}`      |                      Event                       |                                                             The event description.                                                             |
-|       `{{ .Title }}`        |                       All                        | A predefined title for the email. <br> It will be `"Reset your password"` or `"Password changed successfully"`, depending on the current step. |
-|    `{{ .DisplayName }}`     |                       All                        |                                                     The name of the user, i.e. `John Doe`                                                      |
-|      `{{ .RemoteIP }}`      |                       All                        |                                      The remote IP address (client) that initiated the request or event.                                       |
-|       `{{ .Domain }}`       |                       All                        |                                                       The relevant domain for Authelia.                                                        |
+|         Placeholder         |                    Templates                     |                                                                           Description                                                                           |
+| :-------------------------: | :----------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|       `{{ .Title }}`        |                       All                        | A predefined title for the email, matching the subject line. See [Events](../../configuration/notifications/events.md) for the value sent by each notification. |
+|    `{{ .DisplayName }}`     |                       All                        |                                                              The name of the user, i.e. `John Doe`                                                              |
+|      `{{ .RemoteIP }}`      |                       All                        |                                               The remote IP address (client) that initiated the request or event.                                               |
+|       `{{ .Domain }}`       | IdentityVerificationJWT, IdentityVerificationOTC |                                                                The relevant domain for Authelia.                                                                |
+|      `{{ .LinkURL }}`       |             IdentityVerificationJWT              |                                                            The URL associated with the notification.                                                            |
+|      `{{ .LinkText }}`      |             IdentityVerificationJWT              |                                                 The display value for the URL associated with the notification.                                                 |
+| `{{ .RevocationLinkURL }}`  | IdentityVerificationJWT, IdentityVerificationOTC |                                                      The Revocation URL associated with the notification.                                                       |
+| `{{ .RevocationLinkText }}` | IdentityVerificationJWT, IdentityVerificationOTC |                                           The display value for the Revocation URL associated with the notification.                                            |
+|    `{{ .OneTimeCode }}`     |             IdentityVerificationOTC              |                                                The One-Time Code the user must supply to confirm their identity.                                                |
+|     `{{ .BodyPrefix }}`     |                      Event                       |                                                                   Prefix for the body event.                                                                    |
+|     `{{ .BodyEvent }}`      |                      Event                       |                                                                     The event description.                                                                      |
+|     `{{ .BodySuffix }}`     |                      Event                       |                                                                   Suffix for the body event.                                                                    |
+|      `{{ .Details }}`       |                      Event                       |                                          A map of additional details about the event, such as the action and category.                                          |
 
 ## Examples
 


### PR DESCRIPTION
There was no single place listing the notifications Authelia sends. The `Notification Templates` guide documents overriding a template and its placeholders, but not which notifications exist, what triggers them, or what subject each carries. Operators had to read the handlers to find out.

Adds `configuration/notifications/events.md` covering all six events with their subject and template, plus what each notifier delivers: SMTP sends both renderings, `disable_html_emails` and the filesystem notifier send plaintext only.

The second commit fixes the placeholder table in the templates guide, which is wrong in three places. `Domain` is listed for all templates but `EmailEventValues` has no such field. `LinkURL` and `LinkText` are listed against `IdentityVerificationOTC`, which carries neither. `OneTimeCode`, `BodySuffix` and `Details` are undocumented. Drop that commit if you'd rather it went separately.

Fixes #10393.