### PR TITLE
ci(reviewdog): report a typos abort as one multiline finding

### DIFF
--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -71,9 +71,11 @@ run_typos() {
   # 0 is clean and 2 is typos found; anything else is typos itself failing.
   # reviewdog discards a runner's stderr and any stdout that does not match the
   # errorformat, so re-emit the reason as a finding or it is lost entirely.
+  # Only the first line is given a position: the rest are continuation lines for
+  # the runner's %C errorformat, which keeps the reason as a single finding.
   if [ ${rc} -ne 0 ] && [ ${rc} -ne 2 ]; then
     if [ -s "${err}" ]; then
-      sed -e "s|^|.reviewdog.yml:1:1: typos failed (exit ${rc}): |" "${err}"
+      sed -e "1s|^|.reviewdog.yml:1:1: typos failed (exit ${rc}): |" "${err}"
     else
       echo ".reviewdog.yml:1:1: typos failed (exit ${rc}) without writing a reason"
     fi

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -33,7 +33,8 @@ runner:
   typos:
     cmd: .buildkite/steps/lint.sh typos .
     errorformat:
-      - '%f:%l:%c: %m'
+      - '%E%f:%l:%c: %m'
+      - '%C%.%#'
     level: error
 
   yamllint:


### PR DESCRIPTION
`typos` aborts with `SIGABRT` when `std::fs::canonicalize` fails for an entry the walker handed it: `report_result` reports the error and substitutes `PathBuf::default()`, and `ConfigEngine::policy` then panics on that empty path with `` `walk()` should be called first `` (crate-ci/typos#1444, fix proposed in crate-ci/typos#1577). reviewdog runs every runner in `.reviewdog.yml` concurrently in the same checkout, so a file removed by another linter mid-walk is enough to trigger it, as it was on #13100.

The wrapper prefixed every stderr line with a position so none of them were discarded, which turned one crash into one finding per line: the failing check carried 81 summary entries and 30 annotations, all of them fragments of a single backtrace.

Prefix only the first line and let the rest match a `%C` continuation, as the `golangci` runner already does. reviewdog puts the `%m` capture of the `%E` line in `Diagnostic.Message` and the whole entry in `Diagnostic.OriginalOutput`, which `service/github/check.go` sends as an annotation's `raw_details`, so the crash becomes a single finding whose reason is the first line and whose full backtrace stays intact one click away. Ordinary typo findings are unaffected because an `%E` match terminates the preceding entry.

The `%C%.%#` line is required rather than cosmetic: with `%E` alone the entry is never terminated and reviewdog emits nothing at all.