### PR TITLE
ci(reviewdog): drop the pull request number from the lint step

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -60,7 +60,7 @@ env:
 
 steps:
   - label: ":service_dog: Linting"
-    command: "lint.sh -reporter=${LINT_REPORTER} -filter-mode=nofilter -fail-level=error -fail-on-error"
+    command: "CI_PULL_REQUEST= lint.sh -reporter=${LINT_REPORTER} -filter-mode=nofilter -fail-level=error -fail-on-error"
     if: build.branch !~ /^(v[0-9]+\.[0-9]+\.[0-9]+)$\$/ && build.message !~ /\[(skip test|test skip)\]/
 
   - label: ":chrome: External Tests"


### PR DESCRIPTION
The linting step posts via `-reporter=github-check`, which hands the results to the doghouse server, and the server fetches the raw pull request diff whenever it is given a pull request number. GitHub answers that request with `406 Sorry, the diff exceeded the maximum number of files (300)` once a pull request is large enough, which aborts the post with `fail to parse diff` and fails the whole step even though every runner completed successfully.

The diff is dead weight here. The step runs with `-filter-mode=nofilter`, so `FilterCheck` reports every diagnostic and never consults the file diffs, and the check run itself is keyed on the head SHA rather than the pull request, so the annotations land in exactly the same place either way. Clearing `CI_PULL_REQUEST` for the step skips the fetch entirely, which removes the 300 file cliff and one API round trip per runner without losing any annotation. It is cleared inline on the command rather than via step `env` because the node environment hook exports it after the job environment is applied and would otherwise put the value back. This must be revisited if the filter mode ever becomes diff scoped.