### PR TITLE
feat(oidc): redirect to consent completion when flow is unusable

### DIFF
--- a/internal/handlers/const.go
+++ b/internal/handlers/const.go
@@ -52,6 +52,11 @@ const (
 	queryArgSubflow   = "subflow"
 	queryArgUserCode  = oidc.FormParameterUserCode
 	queryArgFlowID    = oidc.FormParameterFlowID
+
+	queryArgError            = oidc.FrontendQueryArgError
+	queryArgErrorDescription = oidc.FrontendQueryArgErrorDescription
+	queryArgErrorHint        = oidc.FrontendQueryArgErrorHint
+	queryArgErrorDebug       = oidc.FrontendQueryArgErrorDebug
 )
 
 var (

--- a/internal/handlers/handler_firstfactor_password_test.go
+++ b/internal/handlers/handler_firstfactor_password_test.go
@@ -835,7 +835,7 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectCantParseUUID(
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
+	assertConsentCompletionRedirect(s.T(), s.mock, "", "")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Error occurred parsing the consent session flow id", map[string]any{"error": "invalid UUID length: 55", "flow": "openid_connect", "flow_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaa-9107-4067-8d31-407ca59eb69c", "subflow": ""})
 }
 
@@ -877,7 +877,7 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectCantGetConsent
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
+	assertConsentCompletionRedirect(s.T(), s.mock, "", "")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Error occurred loading the consent session", map[string]any{"error": "failed to obtain", "flow": "openid_connect", "flow_id": "d1ba0ad8-9107-4067-8d31-407ca59eb69c", "subflow": ""})
 }
 
@@ -919,7 +919,7 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectConsentSession
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
+	assertConsentCompletionRedirect(s.T(), s.mock, "", "")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Failed to process consent session as it has already been responded to", map[string]any{"flow": "openid_connect", "flow_id": "d1ba0ad8-9107-4067-8d31-407ca59eb69c", "subflow": ""})
 }
 
@@ -964,7 +964,7 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectCantGetClient(
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
+	assertConsentCompletionRedirect(s.T(), s.mock, "", "")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Error occurred loading the client for the consent session", map[string]any{"error": "invalid_client", "client_id": "abc", "flow": "openid_connect", "flow_id": "d1ba0ad8-9107-4067-8d31-407ca59eb69c", "subflow": ""})
 }
 
@@ -1081,7 +1081,7 @@ func (s *FirstFactorRedirectionSuite) TestShouldReplyOpenIDConnectFormRequiresLo
 
 	FirstFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
+	assertConsentCompletionRedirect(s.T(), s.mock, "", "")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Error occurred getting the original form from the consent session", map[string]any{"error": "invalid URL escape \"%1\"", "client_id": "abc", "flow": "openid_connect", "flow_id": "d1ba0ad8-9107-4067-8d31-407ca59eb69c", "subflow": "", "username": "test"})
 }
 

--- a/internal/handlers/handler_sign_password_test.go
+++ b/internal/handlers/handler_sign_password_test.go
@@ -118,7 +118,7 @@ func (s *HandlerSignPasswordSuite) TestShouldHandleOpenIDConnect() {
 
 	SecondFactorPasswordPOST(nil)(s.mock.Ctx)
 
-	s.mock.Assert200KO(s.T(), "Authentication failed. Check your credentials.")
+	assertConsentCompletionRedirect(s.T(), s.mock, "", "")
 	s.mock.AssertLogEntryAdvanced(s.T(), 0, logrus.ErrorLevel, "Error occurred parsing the consent session flow id", map[string]any{"error": "invalid UUID length: 3", "flow": "openid_connect", "flow_id": "abc", "subflow": ""})
 }
 

--- a/internal/handlers/response.go
+++ b/internal/handlers/response.go
@@ -180,6 +180,50 @@ func handleFlowResponseOpenIDConnect(ctx *middlewares.AutheliaCtx, userSession *
 	}
 }
 
+func handleFlowResponseOpenIDConnectError(ctx *middlewares.AutheliaCtx, log *logrus.Entry, subflow string, rfc *oauthelia2.RFC6749Error) {
+	var (
+		issuer *url.URL
+		err    error
+	)
+
+	if issuer, err = ctx.IssuerURL(); err != nil {
+		ctx.SetJSONError(messageAuthenticationFailed)
+
+		log.WithError(err).Error("Error occurred determining the issuer preventing a redirection to the consent completion endpoint")
+
+		return
+	}
+
+	// The OpenID Connect 1.0 provider is only configured when the Authorization Server is enabled, however the flow
+	// parameters which lead here are supplied by the client and are handled regardless.
+	debug := ctx.Providers.OpenIDConnect != nil && ctx.Providers.OpenIDConnect.GetSendDebugMessagesToClients(ctx)
+
+	cause := rfc.HintField
+
+	if len(cause) == 0 {
+		cause = rfc.DescriptionField
+	}
+
+	// Every cause is reported to the user as the same generic error so the response can't be used to determine the
+	// state of a flow which isn't theirs. The specific cause is carried in the debug field, which is only included in
+	// the response when enable_client_debug_messages is enabled.
+	targetURL := oidc.ConsentCompletionURL(issuer, oidc.ErrFlowCouldNotContinue.WithDebugf("%s: %s", rfc.ErrorField, cause), debug)
+
+	query := targetURL.Query()
+
+	query.Set(queryArgFlow, flowNameOpenIDConnect)
+
+	if len(subflow) != 0 {
+		query.Set(queryArgSubflow, subflow)
+	}
+
+	targetURL.RawQuery = query.Encode()
+
+	if err = ctx.SetJSONBody(redirectResponse{Redirect: targetURL.String()}); err != nil {
+		log.WithError(err).Error("Error occurred marshaling JSON response body for consent completion redirection")
+	}
+}
+
 func handleFlowResponseOpenIDConnectNoSubflow(ctx *middlewares.AutheliaCtx, userSession *session.UserSession, id, subflow string) {
 	var (
 		flowID  uuid.UUID
@@ -187,45 +231,39 @@ func handleFlowResponseOpenIDConnectNoSubflow(ctx *middlewares.AutheliaCtx, user
 		consent *model.OAuth2ConsentSession
 		err     error
 	)
-	if flowID, err = uuid.Parse(id); err != nil {
-		ctx.SetJSONError(messageAuthenticationFailed)
 
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlowID: id, logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow}).
-			Error("Error occurred parsing the consent session flow id")
+	log := ctx.GetLogger().WithFields(map[string]any{logging.FieldFlowID: id, logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow})
+
+	if flowID, err = uuid.Parse(id); err != nil {
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oidc.ErrConsentMalformedChallengeID)
+
+		log.WithError(err).Error("Error occurred parsing the consent session flow id")
 
 		return
 	}
 
 	if consent, err = ctx.Providers.StorageProvider.LoadOAuth2ConsentSessionByChallengeID(ctx, flowID); err != nil {
-		ctx.SetJSONError(messageAuthenticationFailed)
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oidc.ErrConsentCouldNotLookup)
 
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow}).
-			Error("Error occurred loading the consent session")
+		log.WithError(err).Error("Error occurred loading the consent session")
 
 		return
 	}
 
 	if consent.Responded() {
-		ctx.SetJSONError(messageAuthenticationFailed)
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oidc.ErrConsentCouldNotPerform)
 
-		ctx.GetLogger().
-			WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow}).
-			Error("Failed to process consent session as it has already been responded to")
+		log.Error("Failed to process consent session as it has already been responded to")
 
 		return
 	}
 
-	if client, err = ctx.Providers.OpenIDConnect.GetRegisteredClient(ctx, consent.ClientID); err != nil {
-		ctx.SetJSONError(messageAuthenticationFailed)
+	log = log.WithField(logging.FieldClientID, consent.ClientID)
 
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldClientID: consent.ClientID}).
-			Error("Error occurred loading the client for the consent session")
+	if client, err = ctx.Providers.OpenIDConnect.GetRegisteredClient(ctx, consent.ClientID); err != nil {
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oauthelia2.ErrInvalidClient)
+
+		log.WithError(err).Error("Error occurred loading the client for the consent session")
 
 		return
 	}
@@ -233,12 +271,12 @@ func handleFlowResponseOpenIDConnectNoSubflow(ctx *middlewares.AutheliaCtx, user
 	if userSession.IsAnonymous() {
 		ctx.SetJSONError(messageAuthenticationFailed)
 
-		ctx.GetLogger().
-			WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldClientID: client.GetID()}).
-			Error("Failed to redirect for consent as the user is anonymous")
+		log.Error("Failed to redirect for consent as the user is anonymous")
 
 		return
 	}
+
+	log = log.WithField(logging.FieldUsername, userSession.Username)
 
 	var (
 		issuer *url.URL
@@ -248,21 +286,15 @@ func handleFlowResponseOpenIDConnectNoSubflow(ctx *middlewares.AutheliaCtx, user
 	if issuer, err = ctx.IssuerURL(); err != nil {
 		ctx.SetJSONError(messageAuthenticationFailed)
 
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldClientID: client.GetID(), logging.FieldUsername: userSession.Username}).
-			Error("Error occurred determining the issuer")
+		log.WithError(err).Error("Error occurred determining the issuer")
 
 		return
 	}
 
 	if form, err = consent.GetForm(); err != nil {
-		ctx.SetJSONError(messageAuthenticationFailed)
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oidc.ErrConsentMalformedForm)
 
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldClientID: client.GetID(), logging.FieldUsername: userSession.Username}).
-			Error("Error occurred getting the original form from the consent session")
+		log.WithError(err).Error("Error occurred getting the original form from the consent session")
 
 		return
 	}
@@ -277,10 +309,7 @@ func handleFlowResponseOpenIDConnectNoSubflow(ctx *middlewares.AutheliaCtx, user
 		targetURL.RawQuery = query.Encode()
 
 		if err = ctx.SetJSONBody(redirectResponse{Redirect: targetURL.String()}); err != nil {
-			ctx.GetLogger().
-				WithError(err).
-				WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldClientID: client.GetID(), logging.FieldUsername: userSession.Username}).
-				Error("Error occurred marshaling JSON response body for consent redirection")
+			log.WithError(err).Error("Error occurred marshaling JSON response body for consent redirection")
 		}
 
 		return
@@ -296,15 +325,10 @@ func handleFlowResponseOpenIDConnectNoSubflow(ctx *middlewares.AutheliaCtx, user
 		targetURL.RawQuery = form.Encode()
 
 		if err = ctx.SetJSONBody(redirectResponse{Redirect: targetURL.String()}); err != nil {
-			ctx.GetLogger().
-				WithError(err).
-				WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldClientID: client.GetID(), logging.FieldUsername: userSession.Username}).
-				Error("Error occurred marshaling JSON response body for consent redirection")
+			log.WithError(err).Error("Error occurred marshaling JSON response body for consent redirection")
 		}
 	default:
-		ctx.GetLogger().
-			WithFields(map[string]any{logging.FieldFlowID: flowID.String(), logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldClientID: client.GetID(), logging.FieldUsername: userSession.Username}).
-			Info("OpenID Connect 1.0 client requires 2FA")
+		log.Info("OpenID Connect 1.0 client requires 2FA")
 
 		ctx.ReplyOK()
 
@@ -321,26 +345,24 @@ func handleFlowResponseOpenIDConnectDeviceAuthSubflow(ctx *middlewares.AutheliaC
 		err       error
 	)
 
+	log := ctx.GetLogger().WithFields(map[string]any{logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow})
+
 	if userSession.IsAnonymous() {
 		ctx.SetJSONError(messageAuthenticationFailed)
 
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow}).
-			Error("Failed to handle flow response as the user is anonymous")
+		log.Error("Failed to handle flow response as the user is anonymous")
 
 		return
 	}
+
+	log = log.WithField(logging.FieldUsername, userSession.Username)
 
 	level := userSession.AuthenticationLevel(ctx.Configuration.WebAuthn.EnablePasskey2FA)
 
 	if issuer, err = ctx.IssuerURL(); err != nil {
 		ctx.SetJSONError(messageAuthenticationFailed)
 
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow}).
-			Error("Error occurred determining the issuer preventing a successful flow response")
+		log.WithError(err).Error("Error occurred determining the issuer preventing a successful flow response")
 
 		return
 	}
@@ -350,54 +372,45 @@ func handleFlowResponseOpenIDConnectDeviceAuthSubflow(ctx *middlewares.AutheliaC
 
 		return
 	} else if n > 32 {
-		ctx.GetLogger().
-			WithFields(map[string]any{logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldUsername: userSession.Username}).
-			Error("Failed to handle flow response as the user code is too long")
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oidc.ErrDeviceCodeMalformedUserCode)
 
-		ctx.SetJSONError(messageOperationFailed)
+		log.Error("Failed to handle flow response as the user code is too long")
 
 		return
 	}
 
 	if signature, err = ctx.Providers.OpenIDConnect.Strategy.Core.RFC8628UserCodeSignature(ctx, userCode); err != nil {
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldUsername: userSession.Username}).
-			Error("Error occurred determining the signature of the user code session preventing a successful flow response")
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oidc.ErrDeviceCodeCouldNotDetermineSignature)
 
-		ctx.SetJSONError(messageOperationFailed)
+		log.WithError(err).Error("Error occurred determining the signature of the user code session preventing a successful flow response")
 
 		return
 	}
+
+	log = log.WithField(logging.FieldSignature, signature)
 
 	if device, err = ctx.Providers.StorageProvider.LoadOAuth2DeviceCodeSessionByUserCode(ctx, signature); err != nil {
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldUsername: userSession.Username, logging.FieldSignature: signature}).
-			Error("Error occurred using the signature of the user code session to retrieve the device code session preventing a successful flow response")
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oidc.ErrDeviceCodeCouldNotLookup)
 
-		ctx.SetJSONError(messageOperationFailed)
+		log.WithError(err).Error("Error occurred using the signature of the user code session to retrieve the device code session preventing a successful flow response")
 
 		return
 	}
 
-	if device.Subject.Valid || device.ChallengeID.Valid || device.Status != int(oauthelia2.DeviceAuthorizeStatusNew) {
-		ctx.GetLogger().
-			WithFields(map[string]any{logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldUsername: userSession.Username, logging.FieldSignature: signature, logging.FieldClientID: device.ClientID, logging.FieldSessionID: device.ID, logging.FieldSubject: device.Subject, logging.FieldFlowID: device.ChallengeID, logging.FieldStatus: device.Status}).
-			Error("Failed to handle flow response as the device code session is in an invalid state")
+	log = log.WithFields(map[string]any{logging.FieldClientID: device.ClientID, logging.FieldSessionID: device.ID, logging.FieldSubject: device.Subject, logging.FieldFlowID: device.ChallengeID, logging.FieldStatus: device.Status})
 
-		ctx.SetJSONError(messageOperationFailed)
+	if device.Subject.Valid || device.ChallengeID.Valid || device.Status != int(oauthelia2.DeviceAuthorizeStatusNew) {
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oidc.ErrDeviceCodeCouldNotPerform)
+
+		log.Error("Failed to handle flow response as the device code session is in an invalid state")
 
 		return
 	}
 
 	if client, err = ctx.Providers.OpenIDConnect.GetRegisteredClient(ctx, device.ClientID); err != nil {
-		ctx.SetJSONError(messageAuthenticationFailed)
+		handleFlowResponseOpenIDConnectError(ctx, log, subflow, oauthelia2.ErrInvalidClient)
 
-		ctx.GetLogger().
-			WithError(err).
-			WithFields(map[string]any{logging.FieldFlow: flowNameOpenIDConnect, logging.FieldSubflow: subflow, logging.FieldUsername: userSession.Username, logging.FieldSignature: signature, logging.FieldClientID: device.ClientID}).
-			Error("Error occurred loading the client for the device code session")
+		log.WithError(err).Error("Error occurred loading the client for the device code session")
 
 		return
 	}

--- a/internal/handlers/response_flow_test.go
+++ b/internal/handlers/response_flow_test.go
@@ -150,7 +150,7 @@ func TestHandleFlowResponseOpenIDConnectDeviceAuthSubflow(t *testing.T) {
 
 		handleFlowResponse(mock.Ctx, userSession, "", flowNameOpenIDConnect, flowOpenIDConnectSubFlowNameDeviceAuthorization, strings.Repeat("A", 33))
 
-		mock.Assert200KO(t, messageOperationFailed)
+		assertConsentCompletionRedirect(t, mock, flowOpenIDConnectSubFlowNameDeviceAuthorization, "")
 
 		AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Failed to handle flow response as the user code is too long", nil)
 	})
@@ -167,7 +167,7 @@ func TestHandleFlowResponseOpenIDConnectDeviceAuthSubflow(t *testing.T) {
 
 		handleFlowResponse(mock.Ctx, userSession, "", flowNameOpenIDConnect, flowOpenIDConnectSubFlowNameDeviceAuthorization, "ABCDEFGH")
 
-		mock.Assert200KO(t, messageOperationFailed)
+		assertConsentCompletionRedirect(t, mock, flowOpenIDConnectSubFlowNameDeviceAuthorization, "")
 
 		AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Error occurred using the signature of the user code session to retrieve the device code session preventing a successful flow response", "sql: no rows in result set")
 	})
@@ -292,7 +292,7 @@ func TestHandleFlowResponseOpenIDConnectDeviceAuthSubflowDeviceState(t *testing.
 
 			handleFlowResponse(mock.Ctx, &userSession, "", flowNameOpenIDConnect, flowOpenIDConnectSubFlowNameDeviceAuthorization, userCode)
 
-			mock.Assert200KO(t, messageOperationFailed)
+			assertConsentCompletionRedirect(t, mock, flowOpenIDConnectSubFlowNameDeviceAuthorization, "")
 
 			AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Failed to handle flow response as the device code session is in an invalid state", nil)
 		})
@@ -311,8 +311,31 @@ func TestHandleFlowResponseOpenIDConnectDeviceAuthSubflowDeviceState(t *testing.
 
 		handleFlowResponse(mock.Ctx, &userSession, "", flowNameOpenIDConnect, flowOpenIDConnectSubFlowNameDeviceAuthorization, userCode)
 
-		mock.Assert200KO(t, messageAuthenticationFailed)
+		assertConsentCompletionRedirect(t, mock, flowOpenIDConnectSubFlowNameDeviceAuthorization, "")
 
 		AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Error occurred loading the client for the device code session", regexpAnyError)
 	})
+}
+
+func assertConsentCompletionRedirect(t *testing.T, mock *mocks.MockAutheliaCtx, subflow, debug string) {
+	t.Helper()
+
+	body := redirectResponse{}
+
+	mock.GetResponseData(t, &body)
+
+	target, err := url.Parse(body.Redirect)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, oidc.FrontendEndpointPathConsentCompletion, target.Path)
+
+	query := target.Query()
+
+	assert.Equal(t, oidc.ErrFlowCouldNotContinue.ErrorField, query.Get(queryArgError))
+	assert.Equal(t, oidc.ErrFlowCouldNotContinue.DescriptionField, query.Get(queryArgErrorDescription))
+	assert.Equal(t, oidc.ErrFlowCouldNotContinue.HintField, query.Get(queryArgErrorHint))
+	assert.Equal(t, debug, query.Get(queryArgErrorDebug))
+	assert.Equal(t, flowNameOpenIDConnect, query.Get(queryArgFlow))
+	assert.Equal(t, subflow, query.Get(queryArgSubflow))
 }

--- a/internal/handlers/response_test.go
+++ b/internal/handlers/response_test.go
@@ -5,7 +5,9 @@
 package handlers
 
 import (
+	"database/sql"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
 	"go.uber.org/mock/gomock"
+
+	oauthelia2 "authelia.com/provider/oauth2"
 
 	"github.com/authelia/authelia/v4/internal/authorization"
 	"github.com/authelia/authelia/v4/internal/configuration/schema"
@@ -375,8 +379,178 @@ func TestHandleFlowResponseOpenIDConnectNoSubflow(t *testing.T) {
 
 		handleFlowResponse(mock.Ctx, &userSession, consent.ChallengeID.String(), flowNameOpenIDConnect, "", "")
 
-		mock.Assert200KO(t, messageAuthenticationFailed)
+		assertConsentCompletionRedirect(t, mock, "", "")
 
 		AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Error occurred getting the original form from the consent session", regexpAnyError)
+	})
+
+	t.Run("ShouldHandleMalformedFlowID", func(t *testing.T) {
+		mock := mocks.NewMockAutheliaCtx(t)
+		defer mock.Close()
+
+		userSession := newTestOIDCUserSession(1)
+
+		handleFlowResponse(mock.Ctx, &userSession, "not-a-uuid", flowNameOpenIDConnect, "", "")
+
+		assertConsentCompletionRedirect(t, mock, "", "")
+
+		AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Error occurred parsing the consent session flow id", regexpAnyError)
+	})
+
+	t.Run("ShouldHandleUnknownConsentSession", func(t *testing.T) {
+		mock := mocks.NewMockAutheliaCtx(t)
+		defer mock.Close()
+
+		flowID := uuid.Must(uuid.NewRandom())
+
+		mock.StorageMock.EXPECT().
+			LoadOAuth2ConsentSessionByChallengeID(gomock.Any(), flowID).
+			Return(nil, sql.ErrNoRows)
+
+		userSession := newTestOIDCUserSession(1)
+
+		handleFlowResponse(mock.Ctx, &userSession, flowID.String(), flowNameOpenIDConnect, "", "")
+
+		assertConsentCompletionRedirect(t, mock, "", "")
+
+		AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Error occurred loading the consent session", "sql: no rows in result set")
+	})
+
+	t.Run("ShouldHandleConsentSessionAlreadyRespondedTo", func(t *testing.T) {
+		mock := mocks.NewMockAutheliaCtx(t)
+		defer mock.Close()
+
+		config := newTestOIDCConfig(t)
+		config.Clients = []schema.IdentityProvidersOpenIDConnectClient{newTestOIDCAuthorizationCodeClient(t)}
+
+		setupTestOIDCProvider(t, mock, config)
+
+		consent := newConsent(t, mock)
+		consent.SetRespondedAt(mock.Ctx.GetClock().Now().Add(-time.Minute), 0)
+
+		mock.StorageMock.EXPECT().
+			LoadOAuth2ConsentSessionByChallengeID(gomock.Any(), consent.ChallengeID).
+			Return(consent, nil)
+
+		userSession := newTestOIDCUserSession(1)
+
+		handleFlowResponse(mock.Ctx, &userSession, consent.ChallengeID.String(), flowNameOpenIDConnect, "", "")
+
+		assertConsentCompletionRedirect(t, mock, "", "")
+
+		AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Failed to process consent session as it has already been responded to", nil)
+	})
+
+	t.Run("ShouldHandleUnregisteredClient", func(t *testing.T) {
+		mock := mocks.NewMockAutheliaCtx(t)
+		defer mock.Close()
+
+		config := newTestOIDCConfig(t)
+		config.Clients = nil
+
+		setupTestOIDCProvider(t, mock, config)
+
+		consent := newConsent(t, mock)
+
+		mock.StorageMock.EXPECT().
+			LoadOAuth2ConsentSessionByChallengeID(gomock.Any(), consent.ChallengeID).
+			Return(consent, nil)
+
+		userSession := newTestOIDCUserSession(1)
+
+		handleFlowResponse(mock.Ctx, &userSession, consent.ChallengeID.String(), flowNameOpenIDConnect, "", "")
+
+		assertConsentCompletionRedirect(t, mock, "", "")
+
+		AssertLogEntryMessageAndError(t, mock.Hook.LastEntry(), "Error occurred loading the client for the consent session", regexpAnyError)
+	})
+}
+
+func TestHandleFlowResponseOpenIDConnectErrorDebug(t *testing.T) {
+	setup := func(t *testing.T, debug bool) *mocks.MockAutheliaCtx {
+		t.Helper()
+
+		mock := mocks.NewMockAutheliaCtx(t)
+
+		config := newTestOIDCConfig(t)
+		config.Clients = []schema.IdentityProvidersOpenIDConnectClient{newTestOIDCAuthorizationCodeClient(t)}
+		config.EnableClientDebugMessages = debug
+
+		setupTestOIDCProvider(t, mock, config)
+
+		return mock
+	}
+
+	respondedConsent := func(t *testing.T, mock *mocks.MockAutheliaCtx) *model.OAuth2ConsentSession {
+		t.Helper()
+
+		consent := newTestOIDCConsentSession(t, mock, uuid.Must(uuid.NewRandom()))
+		consent.SetRespondedAt(mock.Ctx.GetClock().Now().Add(-time.Minute), 0)
+
+		mock.StorageMock.EXPECT().
+			LoadOAuth2ConsentSessionByChallengeID(gomock.Any(), consent.ChallengeID).
+			Return(consent, nil)
+
+		return consent
+	}
+
+	t.Run("ShouldExcludeSpecificCauseWhenDebugDisabled", func(t *testing.T) {
+		mock := setup(t, false)
+		defer mock.Close()
+
+		consent := respondedConsent(t, mock)
+
+		userSession := newTestOIDCUserSession(1)
+
+		handleFlowResponse(mock.Ctx, &userSession, consent.ChallengeID.String(), flowNameOpenIDConnect, "", "")
+
+		assertConsentCompletionRedirect(t, mock, "", "")
+	})
+
+	t.Run("ShouldIncludeSpecificCauseWhenDebugEnabled", func(t *testing.T) {
+		mock := setup(t, true)
+		defer mock.Close()
+
+		consent := respondedConsent(t, mock)
+
+		userSession := newTestOIDCUserSession(1)
+
+		handleFlowResponse(mock.Ctx, &userSession, consent.ChallengeID.String(), flowNameOpenIDConnect, "", "")
+
+		assertConsentCompletionRedirect(t, mock, "", "invalid_request: "+oidc.ErrConsentCouldNotPerform.HintField)
+	})
+
+	t.Run("ShouldFallBackToDescriptionWhenCauseHasNoHint", func(t *testing.T) {
+		mock := mocks.NewMockAutheliaCtx(t)
+		defer mock.Close()
+
+		config := newTestOIDCConfig(t)
+		config.Clients = nil
+		config.EnableClientDebugMessages = true
+
+		setupTestOIDCProvider(t, mock, config)
+
+		consent := newTestOIDCConsentSession(t, mock, uuid.Must(uuid.NewRandom()))
+
+		mock.StorageMock.EXPECT().
+			LoadOAuth2ConsentSessionByChallengeID(gomock.Any(), consent.ChallengeID).
+			Return(consent, nil)
+
+		userSession := newTestOIDCUserSession(1)
+
+		handleFlowResponse(mock.Ctx, &userSession, consent.ChallengeID.String(), flowNameOpenIDConnect, "", "")
+
+		assertConsentCompletionRedirect(t, mock, "", "invalid_client: "+oauthelia2.ErrInvalidClient.DescriptionField)
+	})
+
+	t.Run("ShouldIncludeSpecificCauseForDeviceSubflowWhenDebugEnabled", func(t *testing.T) {
+		mock := setup(t, true)
+		defer mock.Close()
+
+		userSession := newTestOIDCUserSession(1)
+
+		handleFlowResponse(mock.Ctx, &userSession, "", flowNameOpenIDConnect, flowOpenIDConnectSubFlowNameDeviceAuthorization, strings.Repeat("A", 33))
+
+		assertConsentCompletionRedirect(t, mock, flowOpenIDConnectSubFlowNameDeviceAuthorization, "invalid_request: "+oidc.ErrDeviceCodeMalformedUserCode.HintField)
 	})
 }

--- a/internal/oidc/const.go
+++ b/internal/oidc/const.go
@@ -317,7 +317,19 @@ const (
 	FrontendEndpointPathConsent                    = "/consent/openid"
 	FrontendEndpointPathConsentDecision            = FrontendEndpointPathConsent + "/decision"
 	FrontendEndpointPathConsentDeviceAuthorization = FrontendEndpointPathConsent + "/" + EndpointDeviceAuthorization
+)
 
+// Query parameters of the frontend consent completion endpoint.
+const (
+	FrontendQueryArgError            = "error"
+	FrontendQueryArgErrorDescription = "error_description"
+	FrontendQueryArgErrorStatusCode  = "error_status_code"
+	FrontendQueryArgErrorHint        = "error_hint"
+	FrontendQueryArgErrorDebug       = "error_debug"
+)
+
+// Paths.
+const (
 	EndpointPathWellKnownOpenIDConfiguration      = "/.well-known/openid-configuration"
 	EndpointPathWellKnownOAuthAuthorizationServer = "/.well-known/oauth-authorization-server"
 	EndpointPathJWKs                              = "/jwks.json"

--- a/internal/oidc/errors.go
+++ b/internal/oidc/errors.go
@@ -39,6 +39,27 @@ var (
 	// ErrConsentMalformedChallengeID is sent when the Consent ID is not a UUID.
 	ErrConsentMalformedChallengeID = oauthelia2.ErrServerError.WithHint("Malformed consent session challenge ID.")
 
+	// ErrFlowCouldNotContinue is shown to the user when a login flow can't be continued. It deliberately describes the
+	// range of problems which lead here rather than which one occurred, so that it can't be used to determine whether a
+	// particular flow exists, has expired, or has already been responded to. The specific cause is recorded in the log
+	// and is only included in the debug field of the response when enable_client_debug_messages is enabled.
+	ErrFlowCouldNotContinue = oauthelia2.ErrInvalidRequest.WithHint("Could not continue the login flow. The request may have already been completed, may have expired, may have been superseded by a newer request, or may otherwise no longer be valid. Return to the application you are signing in to and try again.")
+
+	// ErrConsentMalformedForm is sent when the original authorization request form of a Consent Session cannot be decoded.
+	ErrConsentMalformedForm = oauthelia2.ErrServerError.WithHint("Malformed consent session request form data.")
+
+	// ErrDeviceCodeMalformedUserCode is sent when the user code of a Device Code Session is not a plausible user code.
+	ErrDeviceCodeMalformedUserCode = oauthelia2.ErrInvalidRequest.WithHint("Malformed device code session user code.")
+
+	// ErrDeviceCodeCouldNotLookup is sent when the Device Code Session for a user code can't be retrieved.
+	ErrDeviceCodeCouldNotLookup = oauthelia2.ErrInvalidRequest.WithHint("Failed to lookup the device code session. The user code is unknown or has expired.")
+
+	// ErrDeviceCodeCouldNotDetermineSignature is sent when the signature of a user code can't be determined.
+	ErrDeviceCodeCouldNotDetermineSignature = oauthelia2.ErrServerError.WithHint("Could not determine the signature of the device code session user code.")
+
+	// ErrDeviceCodeCouldNotPerform is sent when the Device Code Session can't be performed for varying reasons.
+	ErrDeviceCodeCouldNotPerform = oauthelia2.ErrInvalidRequest.WithHint("Could not perform the device authorization. The device code session has already been responded to, has expired, or otherwise does not appear to be valid for the authorization request.")
+
 	// ErrClientAuthorizationUserAccessDenied is sent when the user is denied access to a client.
 	ErrClientAuthorizationUserAccessDenied = oauthelia2.ErrAccessDenied.WithHint("The user was denied access to this client.")
 
@@ -72,38 +93,47 @@ func (s *RedirectAuthorizeErrorFieldResponseStrategy) WriteErrorFieldResponse(ct
 		return
 	}
 
-	if rfc == nil {
-		rfc = oauthelia2.ErrServerError
-	}
-
-	location := issuer.JoinPath(FrontendEndpointPathConsentCompletion)
-
-	query := location.Query()
-
-	if len(rfc.ErrorField) != 0 {
-		query.Set("error", rfc.ErrorField)
-	}
-
-	if len(rfc.DescriptionField) != 0 {
-		query.Set("error_description", rfc.DescriptionField)
-	}
-
-	if rfc.CodeField != 0 {
-		query.Set("error_status_code", strconv.Itoa(rfc.CodeField))
-	}
-
-	if len(rfc.HintField) != 0 {
-		query.Set("error_hint", rfc.HintField)
-	}
-
-	if s.Config.GetSendDebugMessagesToClients(ctx) && len(rfc.DebugField) != 0 {
-		query.Set("error_debug", rfc.DebugField)
-	}
-
-	location.RawQuery = query.Encode()
+	location := ConsentCompletionURL(issuer, rfc, s.Config.GetSendDebugMessagesToClients(ctx))
 
 	rw.Header().Set(fasthttp.HeaderCacheControl, "no-store")
 	rw.Header().Set(fasthttp.HeaderPragma, "no-cache")
 	rw.Header().Set(fasthttp.HeaderLocation, location.String())
 	rw.WriteHeader(http.StatusFound)
+}
+
+// ConsentCompletionURL returns the frontend consent completion URL for the given issuer with the fields of the given
+// error encoded into the query. A nil error is treated as a generic server error and the debug field is only included
+// when debug is true.
+func ConsentCompletionURL(issuer *url.URL, rfc *oauthelia2.RFC6749Error, debug bool) (location *url.URL) {
+	if rfc == nil {
+		rfc = oauthelia2.ErrServerError
+	}
+
+	location = issuer.JoinPath(FrontendEndpointPathConsentCompletion)
+
+	query := location.Query()
+
+	if len(rfc.ErrorField) != 0 {
+		query.Set(FrontendQueryArgError, rfc.ErrorField)
+	}
+
+	if len(rfc.DescriptionField) != 0 {
+		query.Set(FrontendQueryArgErrorDescription, rfc.DescriptionField)
+	}
+
+	if rfc.CodeField != 0 {
+		query.Set(FrontendQueryArgErrorStatusCode, strconv.Itoa(rfc.CodeField))
+	}
+
+	if len(rfc.HintField) != 0 {
+		query.Set(FrontendQueryArgErrorHint, rfc.HintField)
+	}
+
+	if debug && len(rfc.DebugField) != 0 {
+		query.Set(FrontendQueryArgErrorDebug, rfc.DebugField)
+	}
+
+	location.RawQuery = query.Encode()
+
+	return location
 }

--- a/internal/oidc/errors_test.go
+++ b/internal/oidc/errors_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -127,4 +129,80 @@ func (c *testErrorContext) IssuerURL() (*url.URL, error) {
 	}
 
 	return c.issuer, nil
+}
+
+func TestConsentCompletionURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		rfc      *oauthelia2.RFC6749Error
+		debug    bool
+		expected url.Values
+	}{
+		{
+			"ShouldEncodeAllPopulatedFields",
+			&oauthelia2.RFC6749Error{
+				ErrorField:       "invalid_request",
+				DescriptionField: "The request is otherwise malformed.",
+				CodeField:        http.StatusBadRequest,
+				HintField:        "Could not perform consent.",
+			},
+			false,
+			url.Values{
+				"error":             []string{"invalid_request"},
+				"error_description": []string{"The request is otherwise malformed."},
+				"error_status_code": []string{"400"},
+				"error_hint":        []string{"Could not perform consent."},
+			},
+		},
+		{
+			"ShouldOmitEmptyFields",
+			&oauthelia2.RFC6749Error{ErrorField: "server_error"},
+			false,
+			url.Values{"error": []string{"server_error"}},
+		},
+		{
+			"ShouldIncludeDebugWhenEnabled",
+			&oauthelia2.RFC6749Error{ErrorField: "server_error", DebugField: "internal debug info"},
+			true,
+			url.Values{"error": []string{"server_error"}, "error_debug": []string{"internal debug info"}},
+		},
+		{
+			"ShouldExcludeDebugWhenDisabled",
+			&oauthelia2.RFC6749Error{ErrorField: "server_error", DebugField: "internal debug info"},
+			false,
+			url.Values{"error": []string{"server_error"}},
+		},
+		{
+			"ShouldDefaultToServerErrorWhenNil",
+			nil,
+			false,
+			url.Values{
+				"error":             []string{oauthelia2.ErrServerError.ErrorField},
+				"error_description": []string{oauthelia2.ErrServerError.DescriptionField},
+				"error_status_code": []string{strconv.Itoa(oauthelia2.ErrServerError.CodeField)},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			issuer := &url.URL{Scheme: "https", Host: "auth.example.com"}
+
+			actual := ConsentCompletionURL(issuer, tc.rfc, tc.debug)
+
+			assert.True(t, strings.HasPrefix(actual.String(), "https://auth.example.com"+FrontendEndpointPathConsentCompletion+"?"), "unexpected URL: %s", actual)
+			assert.Equal(t, tc.expected, actual.Query())
+
+			assert.Equal(t, "", issuer.Path, "the issuer must not be mutated")
+		})
+	}
+
+	t.Run("ShouldRespectIssuerBasePath", func(t *testing.T) {
+		issuer := &url.URL{Scheme: "https", Host: "auth.example.com", Path: "/auth"}
+
+		actual := ConsentCompletionURL(issuer, oauthelia2.ErrInvalidRequest, false)
+
+		assert.Equal(t, "/auth"+FrontendEndpointPathConsentCompletion, actual.Path)
+		assert.Equal(t, "/auth", issuer.Path, "the issuer must not be mutated")
+	})
 }


### PR DESCRIPTION
A stale or already answered flow_id produced a credential failure even though the password check had already succeeded, so the portal told the user their username or password was wrong. Errors reached after authentication succeeds now redirect to the consent completion page, which offers a way back without a flow_id.

The page reports one generic message covering the range of causes, so it cannot be used to determine whether a given flow exists, has expired, or has already been answered. The specific cause is recorded in the log and is only sent in the debug field when enable_client_debug_messages is enabled.

Closes #12843, Closes #12871