### PR TITLE
docs: publish webhook payload json schemas

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -25,6 +25,7 @@ path = [
 	"docs/static/.well-known/matrix/server",
 	"docs/static/images/contributors/**",
 	"docs/static/keys/**",
+	"docs/static/schemas/webhooks/**",
 	"internal/configuration/test_resources/**",
 	"internal/storage/migrations/**",
 	"internal/suites/common/pki/**",

--- a/docs/static/schemas/webhooks/v1/envelope-batch.json
+++ b/docs/static/schemas/webhooks/v1/envelope-batch.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/envelope-batch.json",
+  "$defs": {
+    "Envelope": {
+      "properties": {
+        "specversion": {
+          "type": "string",
+          "title": "Spec Version"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "title": "ID",
+          "description": "A UUIDv7. Unique per occurrence and stable across delivery retries."
+        },
+        "type": {
+          "type": "string",
+          "title": "Type"
+        },
+        "source": {
+          "type": "string",
+          "format": "uri",
+          "title": "Source",
+          "description": "The issuer URL of the Authelia instance."
+        },
+        "time": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Time"
+        },
+        "datacontenttype": {
+          "type": "string",
+          "title": "Data Content Type"
+        },
+        "dataschema": {
+          "type": "string",
+          "format": "uri",
+          "title": "Data Schema",
+          "description": "Always an https://www.authelia.com/schemas/webhooks/ URI. Mandatory in this profile."
+        },
+        "autheliaversion": {
+          "type": "string",
+          "title": "Authelia Version"
+        },
+        "subject": {
+          "type": "string",
+          "title": "Subject"
+        },
+        "data": {
+          "title": "Data"
+        }
+      },
+      "type": "object",
+      "required": [
+        "specversion",
+        "id",
+        "type",
+        "source",
+        "time",
+        "datacontenttype",
+        "dataschema",
+        "autheliaversion",
+        "data"
+      ],
+      "description": "Envelope is the CloudEvents 1.0 structured mode representation of an Event."
+    }
+  },
+  "items": {
+    "$ref": "#/$defs/Envelope"
+  },
+  "type": "array",
+  "description": "EnvelopeBatch is the CloudEvents 1.0 batched content mode representation, which is a JSON array of envelopes."
+}

--- a/docs/static/schemas/webhooks/v1/envelope.json
+++ b/docs/static/schemas/webhooks/v1/envelope.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/envelope.json",
+  "properties": {
+    "specversion": {
+      "type": "string",
+      "title": "Spec Version"
+    },
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "title": "ID",
+      "description": "A UUIDv7. Unique per occurrence and stable across delivery retries."
+    },
+    "type": {
+      "type": "string",
+      "title": "Type"
+    },
+    "source": {
+      "type": "string",
+      "format": "uri",
+      "title": "Source",
+      "description": "The issuer URL of the Authelia instance."
+    },
+    "time": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Time"
+    },
+    "datacontenttype": {
+      "type": "string",
+      "title": "Data Content Type"
+    },
+    "dataschema": {
+      "type": "string",
+      "format": "uri",
+      "title": "Data Schema",
+      "description": "Always an https://www.authelia.com/schemas/webhooks/ URI. Mandatory in this profile."
+    },
+    "autheliaversion": {
+      "type": "string",
+      "title": "Authelia Version"
+    },
+    "subject": {
+      "type": "string",
+      "title": "Subject"
+    },
+    "data": {
+      "title": "Data"
+    }
+  },
+  "type": "object",
+  "required": [
+    "specversion",
+    "id",
+    "type",
+    "source",
+    "time",
+    "datacontenttype",
+    "dataschema",
+    "autheliaversion",
+    "data"
+  ],
+  "description": "Envelope is the CloudEvents 1.0 structured mode representation of an Event."
+}

--- a/docs/static/schemas/webhooks/v1/security.authentication.failed.json
+++ b/docs/static/schemas/webhooks/v1/security.authentication.failed.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/security.authentication.failed.json",
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "stage": {
+      "type": "string",
+      "enum": [
+        "first_factor",
+        "second_factor"
+      ],
+      "title": "Stage"
+    },
+    "method": {
+      "type": "string",
+      "enum": [
+        "password",
+        "totp",
+        "webauthn",
+        "duo"
+      ],
+      "title": "Method"
+    },
+    "reason": {
+      "type": "string",
+      "enum": [
+        "invalid_credentials",
+        "user_not_found",
+        "banned",
+        "internal_error"
+      ],
+      "title": "Reason",
+      "description": "The failure classification. Present on failures only."
+    }
+  },
+  "type": "object",
+  "required": [
+    "username",
+    "stage",
+    "method"
+  ],
+  "description": "DataAuthentication is the payload for the security.authentication.* events."
+}

--- a/docs/static/schemas/webhooks/v1/security.authentication.succeeded.json
+++ b/docs/static/schemas/webhooks/v1/security.authentication.succeeded.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/security.authentication.succeeded.json",
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "stage": {
+      "type": "string",
+      "enum": [
+        "first_factor",
+        "second_factor"
+      ],
+      "title": "Stage"
+    },
+    "method": {
+      "type": "string",
+      "enum": [
+        "password",
+        "totp",
+        "webauthn",
+        "duo"
+      ],
+      "title": "Method"
+    },
+    "reason": {
+      "type": "string",
+      "enum": [
+        "invalid_credentials",
+        "user_not_found",
+        "banned",
+        "internal_error"
+      ],
+      "title": "Reason",
+      "description": "The failure classification. Present on failures only."
+    }
+  },
+  "type": "object",
+  "required": [
+    "username",
+    "stage",
+    "method"
+  ],
+  "description": "DataAuthentication is the payload for the security.authentication.* events."
+}

--- a/docs/static/schemas/webhooks/v1/security.ban.applied.json
+++ b/docs/static/schemas/webhooks/v1/security.ban.applied.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/security.ban.applied.json",
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "target": {
+      "type": "string",
+      "title": "Target",
+      "description": "The banned value, a username or an IP address."
+    },
+    "target_type": {
+      "type": "string",
+      "enum": [
+        "user",
+        "ip"
+      ],
+      "title": "Target Type"
+    },
+    "expires": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Expires",
+      "description": "When the ban expires. Present on applied only."
+    }
+  },
+  "type": "object",
+  "required": [
+    "username",
+    "target",
+    "target_type"
+  ],
+  "description": "DataBan is the payload for the security.ban.* events."
+}

--- a/docs/static/schemas/webhooks/v1/security.ban.expired.json
+++ b/docs/static/schemas/webhooks/v1/security.ban.expired.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/security.ban.expired.json",
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "target": {
+      "type": "string",
+      "title": "Target",
+      "description": "The banned value, a username or an IP address."
+    },
+    "target_type": {
+      "type": "string",
+      "enum": [
+        "user",
+        "ip"
+      ],
+      "title": "Target Type"
+    },
+    "expires": {
+      "type": "string",
+      "format": "date-time",
+      "title": "Expires",
+      "description": "When the ban expires. Present on applied only."
+    }
+  },
+  "type": "object",
+  "required": [
+    "username",
+    "target",
+    "target_type"
+  ],
+  "description": "DataBan is the payload for the security.ban.* events."
+}

--- a/docs/static/schemas/webhooks/v1/user.credential.totp.added.json
+++ b/docs/static/schemas/webhooks/v1/user.credential.totp.added.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/user.credential.totp.added.json",
+  "$defs": {
+    "Notification": {
+      "properties": {
+        "sent": {
+          "type": "boolean",
+          "title": "Sent",
+          "description": "Whether the notification was successfully handed to the notifier."
+        },
+        "suppressed": {
+          "type": "boolean",
+          "title": "Suppressed",
+          "description": "Whether the notification was never handed to a notifier because the notifier is disabled. Sent is false and error is empty in that case."
+        },
+        "recipients": {
+          "items": {
+            "$ref": "#/$defs/Recipient"
+          },
+          "type": "array",
+          "title": "Recipients"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "error": {
+          "type": "string",
+          "title": "Error",
+          "description": "The delivery error when sent is false."
+        },
+        "values": {
+          "$ref": "#/$defs/NotificationValues",
+          "title": "Values"
+        }
+      },
+      "type": "object",
+      "required": [
+        "sent"
+      ],
+      "description": "Notification describes a notification produced by an occurrence."
+    },
+    "NotificationValues": {
+      "properties": {
+        "body_prefix": {
+          "type": "string",
+          "title": "Body Prefix"
+        },
+        "body_event": {
+          "type": "string",
+          "title": "Body Event"
+        },
+        "body_suffix": {
+          "type": "string",
+          "title": "Body Suffix"
+        },
+        "domain": {
+          "type": "string",
+          "title": "Domain"
+        },
+        "details": {
+          "type": "object",
+          "title": "Details"
+        },
+        "link_url": {
+          "type": "string",
+          "title": "Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "link_text": {
+          "type": "string",
+          "title": "Link Text"
+        },
+        "revocation_link_url": {
+          "type": "string",
+          "title": "Revocation Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "one_time_code": {
+          "type": "string",
+          "title": "One Time Code",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        }
+      },
+      "type": "object",
+      "description": "NotificationValues are the template attribute values of a notification."
+    },
+    "Recipient": {
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The address the notification was addressed to."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username the address belongs to when known."
+        },
+        "display_name": {
+          "type": "string",
+          "title": "Display Name",
+          "description": "The display name recorded in the authentication backend."
+        }
+      },
+      "type": "object",
+      "required": [
+        "email"
+      ],
+      "description": "Recipient describes one addressee of a notification."
+    }
+  },
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "The description of the credential."
+    },
+    "notification": {
+      "$ref": "#/$defs/Notification",
+      "title": "Notification"
+    }
+  },
+  "type": "object",
+  "required": [
+    "username"
+  ],
+  "description": "DataUserCredential is the payload for the user.credential.* events."
+}

--- a/docs/static/schemas/webhooks/v1/user.credential.totp.removed.json
+++ b/docs/static/schemas/webhooks/v1/user.credential.totp.removed.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/user.credential.totp.removed.json",
+  "$defs": {
+    "Notification": {
+      "properties": {
+        "sent": {
+          "type": "boolean",
+          "title": "Sent",
+          "description": "Whether the notification was successfully handed to the notifier."
+        },
+        "suppressed": {
+          "type": "boolean",
+          "title": "Suppressed",
+          "description": "Whether the notification was never handed to a notifier because the notifier is disabled. Sent is false and error is empty in that case."
+        },
+        "recipients": {
+          "items": {
+            "$ref": "#/$defs/Recipient"
+          },
+          "type": "array",
+          "title": "Recipients"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "error": {
+          "type": "string",
+          "title": "Error",
+          "description": "The delivery error when sent is false."
+        },
+        "values": {
+          "$ref": "#/$defs/NotificationValues",
+          "title": "Values"
+        }
+      },
+      "type": "object",
+      "required": [
+        "sent"
+      ],
+      "description": "Notification describes a notification produced by an occurrence."
+    },
+    "NotificationValues": {
+      "properties": {
+        "body_prefix": {
+          "type": "string",
+          "title": "Body Prefix"
+        },
+        "body_event": {
+          "type": "string",
+          "title": "Body Event"
+        },
+        "body_suffix": {
+          "type": "string",
+          "title": "Body Suffix"
+        },
+        "domain": {
+          "type": "string",
+          "title": "Domain"
+        },
+        "details": {
+          "type": "object",
+          "title": "Details"
+        },
+        "link_url": {
+          "type": "string",
+          "title": "Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "link_text": {
+          "type": "string",
+          "title": "Link Text"
+        },
+        "revocation_link_url": {
+          "type": "string",
+          "title": "Revocation Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "one_time_code": {
+          "type": "string",
+          "title": "One Time Code",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        }
+      },
+      "type": "object",
+      "description": "NotificationValues are the template attribute values of a notification."
+    },
+    "Recipient": {
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The address the notification was addressed to."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username the address belongs to when known."
+        },
+        "display_name": {
+          "type": "string",
+          "title": "Display Name",
+          "description": "The display name recorded in the authentication backend."
+        }
+      },
+      "type": "object",
+      "required": [
+        "email"
+      ],
+      "description": "Recipient describes one addressee of a notification."
+    }
+  },
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "The description of the credential."
+    },
+    "notification": {
+      "$ref": "#/$defs/Notification",
+      "title": "Notification"
+    }
+  },
+  "type": "object",
+  "required": [
+    "username"
+  ],
+  "description": "DataUserCredential is the payload for the user.credential.* events."
+}

--- a/docs/static/schemas/webhooks/v1/user.credential.webauthn.added.json
+++ b/docs/static/schemas/webhooks/v1/user.credential.webauthn.added.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/user.credential.webauthn.added.json",
+  "$defs": {
+    "Notification": {
+      "properties": {
+        "sent": {
+          "type": "boolean",
+          "title": "Sent",
+          "description": "Whether the notification was successfully handed to the notifier."
+        },
+        "suppressed": {
+          "type": "boolean",
+          "title": "Suppressed",
+          "description": "Whether the notification was never handed to a notifier because the notifier is disabled. Sent is false and error is empty in that case."
+        },
+        "recipients": {
+          "items": {
+            "$ref": "#/$defs/Recipient"
+          },
+          "type": "array",
+          "title": "Recipients"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "error": {
+          "type": "string",
+          "title": "Error",
+          "description": "The delivery error when sent is false."
+        },
+        "values": {
+          "$ref": "#/$defs/NotificationValues",
+          "title": "Values"
+        }
+      },
+      "type": "object",
+      "required": [
+        "sent"
+      ],
+      "description": "Notification describes a notification produced by an occurrence."
+    },
+    "NotificationValues": {
+      "properties": {
+        "body_prefix": {
+          "type": "string",
+          "title": "Body Prefix"
+        },
+        "body_event": {
+          "type": "string",
+          "title": "Body Event"
+        },
+        "body_suffix": {
+          "type": "string",
+          "title": "Body Suffix"
+        },
+        "domain": {
+          "type": "string",
+          "title": "Domain"
+        },
+        "details": {
+          "type": "object",
+          "title": "Details"
+        },
+        "link_url": {
+          "type": "string",
+          "title": "Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "link_text": {
+          "type": "string",
+          "title": "Link Text"
+        },
+        "revocation_link_url": {
+          "type": "string",
+          "title": "Revocation Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "one_time_code": {
+          "type": "string",
+          "title": "One Time Code",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        }
+      },
+      "type": "object",
+      "description": "NotificationValues are the template attribute values of a notification."
+    },
+    "Recipient": {
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The address the notification was addressed to."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username the address belongs to when known."
+        },
+        "display_name": {
+          "type": "string",
+          "title": "Display Name",
+          "description": "The display name recorded in the authentication backend."
+        }
+      },
+      "type": "object",
+      "required": [
+        "email"
+      ],
+      "description": "Recipient describes one addressee of a notification."
+    }
+  },
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "The description of the credential."
+    },
+    "notification": {
+      "$ref": "#/$defs/Notification",
+      "title": "Notification"
+    }
+  },
+  "type": "object",
+  "required": [
+    "username"
+  ],
+  "description": "DataUserCredential is the payload for the user.credential.* events."
+}

--- a/docs/static/schemas/webhooks/v1/user.credential.webauthn.removed.json
+++ b/docs/static/schemas/webhooks/v1/user.credential.webauthn.removed.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/user.credential.webauthn.removed.json",
+  "$defs": {
+    "Notification": {
+      "properties": {
+        "sent": {
+          "type": "boolean",
+          "title": "Sent",
+          "description": "Whether the notification was successfully handed to the notifier."
+        },
+        "suppressed": {
+          "type": "boolean",
+          "title": "Suppressed",
+          "description": "Whether the notification was never handed to a notifier because the notifier is disabled. Sent is false and error is empty in that case."
+        },
+        "recipients": {
+          "items": {
+            "$ref": "#/$defs/Recipient"
+          },
+          "type": "array",
+          "title": "Recipients"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "error": {
+          "type": "string",
+          "title": "Error",
+          "description": "The delivery error when sent is false."
+        },
+        "values": {
+          "$ref": "#/$defs/NotificationValues",
+          "title": "Values"
+        }
+      },
+      "type": "object",
+      "required": [
+        "sent"
+      ],
+      "description": "Notification describes a notification produced by an occurrence."
+    },
+    "NotificationValues": {
+      "properties": {
+        "body_prefix": {
+          "type": "string",
+          "title": "Body Prefix"
+        },
+        "body_event": {
+          "type": "string",
+          "title": "Body Event"
+        },
+        "body_suffix": {
+          "type": "string",
+          "title": "Body Suffix"
+        },
+        "domain": {
+          "type": "string",
+          "title": "Domain"
+        },
+        "details": {
+          "type": "object",
+          "title": "Details"
+        },
+        "link_url": {
+          "type": "string",
+          "title": "Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "link_text": {
+          "type": "string",
+          "title": "Link Text"
+        },
+        "revocation_link_url": {
+          "type": "string",
+          "title": "Revocation Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "one_time_code": {
+          "type": "string",
+          "title": "One Time Code",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        }
+      },
+      "type": "object",
+      "description": "NotificationValues are the template attribute values of a notification."
+    },
+    "Recipient": {
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The address the notification was addressed to."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username the address belongs to when known."
+        },
+        "display_name": {
+          "type": "string",
+          "title": "Display Name",
+          "description": "The display name recorded in the authentication backend."
+        }
+      },
+      "type": "object",
+      "required": [
+        "email"
+      ],
+      "description": "Recipient describes one addressee of a notification."
+    }
+  },
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "The description of the credential."
+    },
+    "notification": {
+      "$ref": "#/$defs/Notification",
+      "title": "Notification"
+    }
+  },
+  "type": "object",
+  "required": [
+    "username"
+  ],
+  "description": "DataUserCredential is the payload for the user.credential.* events."
+}

--- a/docs/static/schemas/webhooks/v1/user.identity_verification.started.json
+++ b/docs/static/schemas/webhooks/v1/user.identity_verification.started.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/user.identity_verification.started.json",
+  "$defs": {
+    "Notification": {
+      "properties": {
+        "sent": {
+          "type": "boolean",
+          "title": "Sent",
+          "description": "Whether the notification was successfully handed to the notifier."
+        },
+        "suppressed": {
+          "type": "boolean",
+          "title": "Suppressed",
+          "description": "Whether the notification was never handed to a notifier because the notifier is disabled. Sent is false and error is empty in that case."
+        },
+        "recipients": {
+          "items": {
+            "$ref": "#/$defs/Recipient"
+          },
+          "type": "array",
+          "title": "Recipients"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "error": {
+          "type": "string",
+          "title": "Error",
+          "description": "The delivery error when sent is false."
+        },
+        "values": {
+          "$ref": "#/$defs/NotificationValues",
+          "title": "Values"
+        }
+      },
+      "type": "object",
+      "required": [
+        "sent"
+      ],
+      "description": "Notification describes a notification produced by an occurrence."
+    },
+    "NotificationValues": {
+      "properties": {
+        "body_prefix": {
+          "type": "string",
+          "title": "Body Prefix"
+        },
+        "body_event": {
+          "type": "string",
+          "title": "Body Event"
+        },
+        "body_suffix": {
+          "type": "string",
+          "title": "Body Suffix"
+        },
+        "domain": {
+          "type": "string",
+          "title": "Domain"
+        },
+        "details": {
+          "type": "object",
+          "title": "Details"
+        },
+        "link_url": {
+          "type": "string",
+          "title": "Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "link_text": {
+          "type": "string",
+          "title": "Link Text"
+        },
+        "revocation_link_url": {
+          "type": "string",
+          "title": "Revocation Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "one_time_code": {
+          "type": "string",
+          "title": "One Time Code",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        }
+      },
+      "type": "object",
+      "description": "NotificationValues are the template attribute values of a notification."
+    },
+    "Recipient": {
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The address the notification was addressed to."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username the address belongs to when known."
+        },
+        "display_name": {
+          "type": "string",
+          "title": "Display Name",
+          "description": "The display name recorded in the authentication backend."
+        }
+      },
+      "type": "object",
+      "required": [
+        "email"
+      ],
+      "description": "Recipient describes one addressee of a notification."
+    }
+  },
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "action": {
+      "type": "string",
+      "title": "Action",
+      "description": "The action the verification authorizes."
+    },
+    "notification": {
+      "$ref": "#/$defs/Notification",
+      "title": "Notification"
+    }
+  },
+  "type": "object",
+  "required": [
+    "username"
+  ],
+  "description": "DataIdentityVerification is the payload for the user.identity_verification.started event."
+}

--- a/docs/static/schemas/webhooks/v1/user.password.changed.json
+++ b/docs/static/schemas/webhooks/v1/user.password.changed.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/user.password.changed.json",
+  "$defs": {
+    "Notification": {
+      "properties": {
+        "sent": {
+          "type": "boolean",
+          "title": "Sent",
+          "description": "Whether the notification was successfully handed to the notifier."
+        },
+        "suppressed": {
+          "type": "boolean",
+          "title": "Suppressed",
+          "description": "Whether the notification was never handed to a notifier because the notifier is disabled. Sent is false and error is empty in that case."
+        },
+        "recipients": {
+          "items": {
+            "$ref": "#/$defs/Recipient"
+          },
+          "type": "array",
+          "title": "Recipients"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "error": {
+          "type": "string",
+          "title": "Error",
+          "description": "The delivery error when sent is false."
+        },
+        "values": {
+          "$ref": "#/$defs/NotificationValues",
+          "title": "Values"
+        }
+      },
+      "type": "object",
+      "required": [
+        "sent"
+      ],
+      "description": "Notification describes a notification produced by an occurrence."
+    },
+    "NotificationValues": {
+      "properties": {
+        "body_prefix": {
+          "type": "string",
+          "title": "Body Prefix"
+        },
+        "body_event": {
+          "type": "string",
+          "title": "Body Event"
+        },
+        "body_suffix": {
+          "type": "string",
+          "title": "Body Suffix"
+        },
+        "domain": {
+          "type": "string",
+          "title": "Domain"
+        },
+        "details": {
+          "type": "object",
+          "title": "Details"
+        },
+        "link_url": {
+          "type": "string",
+          "title": "Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "link_text": {
+          "type": "string",
+          "title": "Link Text"
+        },
+        "revocation_link_url": {
+          "type": "string",
+          "title": "Revocation Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "one_time_code": {
+          "type": "string",
+          "title": "One Time Code",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        }
+      },
+      "type": "object",
+      "description": "NotificationValues are the template attribute values of a notification."
+    },
+    "Recipient": {
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The address the notification was addressed to."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username the address belongs to when known."
+        },
+        "display_name": {
+          "type": "string",
+          "title": "Display Name",
+          "description": "The display name recorded in the authentication backend."
+        }
+      },
+      "type": "object",
+      "required": [
+        "email"
+      ],
+      "description": "Recipient describes one addressee of a notification."
+    }
+  },
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "notification": {
+      "$ref": "#/$defs/Notification",
+      "title": "Notification"
+    }
+  },
+  "type": "object",
+  "required": [
+    "username"
+  ],
+  "description": "DataUserPassword is the payload for the user.password.changed and user.password.reset events."
+}

--- a/docs/static/schemas/webhooks/v1/user.password.reset.json
+++ b/docs/static/schemas/webhooks/v1/user.password.reset.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/user.password.reset.json",
+  "$defs": {
+    "Notification": {
+      "properties": {
+        "sent": {
+          "type": "boolean",
+          "title": "Sent",
+          "description": "Whether the notification was successfully handed to the notifier."
+        },
+        "suppressed": {
+          "type": "boolean",
+          "title": "Suppressed",
+          "description": "Whether the notification was never handed to a notifier because the notifier is disabled. Sent is false and error is empty in that case."
+        },
+        "recipients": {
+          "items": {
+            "$ref": "#/$defs/Recipient"
+          },
+          "type": "array",
+          "title": "Recipients"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "error": {
+          "type": "string",
+          "title": "Error",
+          "description": "The delivery error when sent is false."
+        },
+        "values": {
+          "$ref": "#/$defs/NotificationValues",
+          "title": "Values"
+        }
+      },
+      "type": "object",
+      "required": [
+        "sent"
+      ],
+      "description": "Notification describes a notification produced by an occurrence."
+    },
+    "NotificationValues": {
+      "properties": {
+        "body_prefix": {
+          "type": "string",
+          "title": "Body Prefix"
+        },
+        "body_event": {
+          "type": "string",
+          "title": "Body Event"
+        },
+        "body_suffix": {
+          "type": "string",
+          "title": "Body Suffix"
+        },
+        "domain": {
+          "type": "string",
+          "title": "Domain"
+        },
+        "details": {
+          "type": "object",
+          "title": "Details"
+        },
+        "link_url": {
+          "type": "string",
+          "title": "Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "link_text": {
+          "type": "string",
+          "title": "Link Text"
+        },
+        "revocation_link_url": {
+          "type": "string",
+          "title": "Revocation Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "one_time_code": {
+          "type": "string",
+          "title": "One Time Code",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        }
+      },
+      "type": "object",
+      "description": "NotificationValues are the template attribute values of a notification."
+    },
+    "Recipient": {
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The address the notification was addressed to."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username the address belongs to when known."
+        },
+        "display_name": {
+          "type": "string",
+          "title": "Display Name",
+          "description": "The display name recorded in the authentication backend."
+        }
+      },
+      "type": "object",
+      "required": [
+        "email"
+      ],
+      "description": "Recipient describes one addressee of a notification."
+    }
+  },
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "notification": {
+      "$ref": "#/$defs/Notification",
+      "title": "Notification"
+    }
+  },
+  "type": "object",
+  "required": [
+    "username"
+  ],
+  "description": "DataUserPassword is the payload for the user.password.changed and user.password.reset events."
+}

--- a/docs/static/schemas/webhooks/v1/user.session.elevation.requested.json
+++ b/docs/static/schemas/webhooks/v1/user.session.elevation.requested.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.authelia.com/schemas/webhooks/v1/user.session.elevation.requested.json",
+  "$defs": {
+    "Notification": {
+      "properties": {
+        "sent": {
+          "type": "boolean",
+          "title": "Sent",
+          "description": "Whether the notification was successfully handed to the notifier."
+        },
+        "suppressed": {
+          "type": "boolean",
+          "title": "Suppressed",
+          "description": "Whether the notification was never handed to a notifier because the notifier is disabled. Sent is false and error is empty in that case."
+        },
+        "recipients": {
+          "items": {
+            "$ref": "#/$defs/Recipient"
+          },
+          "type": "array",
+          "title": "Recipients"
+        },
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "error": {
+          "type": "string",
+          "title": "Error",
+          "description": "The delivery error when sent is false."
+        },
+        "values": {
+          "$ref": "#/$defs/NotificationValues",
+          "title": "Values"
+        }
+      },
+      "type": "object",
+      "required": [
+        "sent"
+      ],
+      "description": "Notification describes a notification produced by an occurrence."
+    },
+    "NotificationValues": {
+      "properties": {
+        "body_prefix": {
+          "type": "string",
+          "title": "Body Prefix"
+        },
+        "body_event": {
+          "type": "string",
+          "title": "Body Event"
+        },
+        "body_suffix": {
+          "type": "string",
+          "title": "Body Suffix"
+        },
+        "domain": {
+          "type": "string",
+          "title": "Domain"
+        },
+        "details": {
+          "type": "object",
+          "title": "Details"
+        },
+        "link_url": {
+          "type": "string",
+          "title": "Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "link_text": {
+          "type": "string",
+          "title": "Link Text"
+        },
+        "revocation_link_url": {
+          "type": "string",
+          "title": "Revocation Link URL",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        },
+        "one_time_code": {
+          "type": "string",
+          "title": "One Time Code",
+          "description": "Credential equivalent. Omitted unless the destination disables redaction."
+        }
+      },
+      "type": "object",
+      "description": "NotificationValues are the template attribute values of a notification."
+    },
+    "Recipient": {
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The address the notification was addressed to."
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username the address belongs to when known."
+        },
+        "display_name": {
+          "type": "string",
+          "title": "Display Name",
+          "description": "The display name recorded in the authentication backend."
+        }
+      },
+      "type": "object",
+      "required": [
+        "email"
+      ],
+      "description": "Recipient describes one addressee of a notification."
+    }
+  },
+  "properties": {
+    "username": {
+      "type": "string",
+      "title": "Username",
+      "description": "The username the occurrence concerns."
+    },
+    "display_name": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "The display name recorded in the authentication backend."
+    },
+    "emails": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "title": "Emails",
+      "description": "The email addresses recorded in the authentication backend."
+    },
+    "remote_ip": {
+      "type": "string",
+      "title": "Remote IP",
+      "description": "The client address which caused the occurrence."
+    },
+    "notification": {
+      "$ref": "#/$defs/Notification",
+      "title": "Notification"
+    }
+  },
+  "type": "object",
+  "required": [
+    "username"
+  ],
+  "description": "DataSessionElevation is the payload for the user.session.elevation.requested event."
+}


### PR DESCRIPTION
Publishes the v1 JSON Schema documents for the webhook payloads: one per event type, one for the CloudEvents envelope, and one for the batched array. Receivers dereference these from the dataschema attribute of every event, and the OpenAPI webhooks section references them, so they must resolve before the subsystem ships.

The documents are generated from the Go payload types. This branch carries the output alone, so regenerate them from the branch which owns the generator rather than editing them here.