### PR TITLE
ci(renovate): bump the netlify hugo version alongside hugo-extended

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -13,7 +13,22 @@
     ":semanticPrefixFixDepsChoreOthers",
     "workarounds:all"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^docs/netlify\\.toml$/"
+      ],
+      "matchStrings": [
+        "HUGO_VERSION = \"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "hugo-extended",
+      "datasourceTemplate": "npm",
+      "versioningTemplate": "npm"
+    }
+  ],
   "enabledManagers": [
+    "custom.regex",
     "docker-compose",
     "dockerfile",
     "github-actions",


### PR DESCRIPTION
Renovate only updates `hugo-extended` in `docs/package.json` and `docs/pnpm-lock.yaml`, so `HUGO_VERSION` in `docs/netlify.toml` has to be bumped by hand on every release and was missed for v0.166.0, leaving Netlify building with an older Hugo than CI.

Add a regex custom manager that tracks `HUGO_VERSION` as the `hugo-extended` npm package. Because the dependency name, datasource, and versioning match the npm manager, both updates share the same branch topic and land in a single pull request.